### PR TITLE
fix(browser): clear stale Chromium Singleton locks before relaunch

### DIFF
--- a/src/tools/browser/clear-stale-chrome-locks.test.ts
+++ b/src/tools/browser/clear-stale-chrome-locks.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CHROME_LOCK_BASENAMES,
+  clearStaleChromeLocks,
+  readChromeSingletonLockPid,
+} from "./clear-stale-chrome-locks.js";
+
+describe("readChromeSingletonLockPid", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-locks-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("parses symlink targets of the form host-pid", () => {
+    fs.symlinkSync("127.0.0.1-4242", path.join(dir, "SingletonLock"));
+    expect(readChromeSingletonLockPid(dir)).toBe(4242);
+  });
+
+  it("parses plain text pid files", () => {
+    fs.writeFileSync(path.join(dir, "SingletonLock"), "99999\n");
+    expect(readChromeSingletonLockPid(dir)).toBe(99999);
+  });
+
+  it("returns null when missing", () => {
+    expect(readChromeSingletonLockPid(dir)).toBeNull();
+  });
+});
+
+describe("clearStaleChromeLocks", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-locks-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function plantLocks(pidPayload: string | null): void {
+    for (const base of CHROME_LOCK_BASENAMES) {
+      if (base === "SingletonLock" && pidPayload !== null) {
+        fs.symlinkSync(pidPayload, path.join(dir, base));
+      } else if (base !== "SingletonLock") {
+        fs.writeFileSync(path.join(dir, base), "x");
+      }
+    }
+  }
+
+  it("removes companion locks when SingletonLock is absent", () => {
+    fs.writeFileSync(path.join(dir, "SingletonSocket"), "x");
+    fs.writeFileSync(path.join(dir, "DevToolsActivePort"), "9222");
+    const result = clearStaleChromeLocks(dir);
+    expect(result.removed).toEqual(
+      expect.arrayContaining(["SingletonSocket", "DevToolsActivePort"]),
+    );
+    expect(fs.existsSync(path.join(dir, "SingletonSocket"))).toBe(false);
+  });
+
+  it("removes locks when owner pid is dead", () => {
+    // PIDs this high are almost never live on a developer workstation;
+    // if somehow alive the test still asserts kept/removed consistency.
+    const deadPid = 2147483000;
+    plantLocks(`127.0.0.1-${deadPid}`);
+    const result = clearStaleChromeLocks(dir);
+    if (!result.reasons.some((r) => r.includes("not alive"))) {
+      // Extremely unlikely: pid is alive — skip destructive assertion.
+      return;
+    }
+    expect(result.removed.length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(dir, "SingletonLock"))).toBe(false);
+  });
+
+  it("keeps locks when owner pid is this process (live) and processLooksLikeChromium is conservative", () => {
+    // We stub processLooksLikeChromium via keep-path by making SingletonLock
+    // point at our own PID, then mock kill(0). Our process is alive; on
+    // platforms where processLooksLikeChromium returns true for node,
+    // locks are kept — on others they clear. Either way the API is total.
+    plantLocks(`host-${process.pid}`);
+    const result = clearStaleChromeLocks(dir);
+    expect(Array.isArray(result.removed)).toBe(true);
+    expect(Array.isArray(result.kept)).toBe(true);
+    expect(result.reasons.length).toBeGreaterThan(0);
+  });
+
+  it("is a no-op on a missing directory", () => {
+    const missing = path.join(dir, "nope");
+    const result = clearStaleChromeLocks(missing);
+    expect(result.removed).toEqual([]);
+    expect(result.reasons).toContain("userDataDir missing");
+  });
+});

--- a/src/tools/browser/clear-stale-chrome-locks.test.ts
+++ b/src/tools/browser/clear-stale-chrome-locks.test.ts
@@ -62,17 +62,49 @@ describe("clearStaleChromeLocks", () => {
   });
 
   it("removes locks when owner pid is dead", () => {
-    // PIDs this high are almost never live on a developer workstation;
-    // if somehow alive the test still asserts kept/removed consistency.
     const deadPid = 2147483000;
     plantLocks(`127.0.0.1-${deadPid}`);
-    const result = clearStaleChromeLocks(dir);
-    if (!result.reasons.some((r) => r.includes("not alive"))) {
-      // Extremely unlikely: pid is alive — skip destructive assertion.
-      return;
-    }
+    // Inject the liveness check so the assertion is deterministic regardless
+    // of what PIDs happen to be live on the host running the suite.
+    const result = clearStaleChromeLocks(dir, { isAlive: () => false });
+    expect(result.reasons.some((r) => r.includes("not alive"))).toBe(true);
     expect(result.removed.length).toBeGreaterThan(0);
     expect(fs.existsSync(path.join(dir, "SingletonLock"))).toBe(false);
+  });
+
+  it("keeps locks when the owner pid is a live Chromium process", () => {
+    plantLocks("host-4242");
+    const result = clearStaleChromeLocks(dir, {
+      isAlive: () => true,
+      probe: () => "chromium",
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.kept.length).toBeGreaterThan(0);
+    expect(fs.lstatSync(path.join(dir, "SingletonLock")).isSymbolicLink()).toBe(true);
+  });
+
+  it("clears locks when the owner pid is alive but is not a browser", () => {
+    plantLocks("host-4242");
+    const result = clearStaleChromeLocks(dir, {
+      isAlive: () => true,
+      probe: () => "other",
+    });
+    expect(result.removed.length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(dir, "SingletonLock"))).toBe(false);
+  });
+
+  it("fails open: keeps locks when a live pid's identity probe fails", () => {
+    // Regression: a failed probe (no /proc, ps timeout) must NOT be read as
+    // "not chromium → clear" — a live browser could lose its locks.
+    plantLocks("host-4242");
+    const result = clearStaleChromeLocks(dir, {
+      isAlive: () => true,
+      probe: () => "unknown",
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.kept.length).toBeGreaterThan(0);
+    expect(result.reasons.some((r) => r.includes("identity unknown"))).toBe(true);
+    expect(fs.lstatSync(path.join(dir, "SingletonLock")).isSymbolicLink()).toBe(true);
   });
 
   it("keeps locks when owner pid is this process (live) and processLooksLikeChromium is conservative", () => {

--- a/src/tools/browser/clear-stale-chrome-locks.ts
+++ b/src/tools/browser/clear-stale-chrome-locks.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+/**
+ * Chromium locks under a persistent `--user-data-dir` that survive an
+ * abrupt parent exit (SIGINT before `PlaywrightBackend.shutdown()` finishes,
+ * kill -9, OOM, gasket timeout). On the next launch Chromium sees a live
+ * SingletonLock owned by a dead PID and refuses to start — browser tools
+ * then fail until the profile is manually cleaned.
+ *
+ * Safe policy: only remove lock files when the owner PID is missing or not
+ * a Chromium/Chrome process. Never touch locks held by a living browser.
+ *
+ * Related: https://github.com/AtomicBot-ai/atomic-agent/issues/22
+ */
+
+/** File basenames Chromium uses as single-instance / CDP rendezvous markers. */
+export const CHROME_LOCK_BASENAMES = [
+  "SingletonLock",
+  "SingletonSocket",
+  "SingletonCookie",
+  "DevToolsActivePort",
+] as const;
+
+export interface ClearStaleChromeLocksResult {
+  removed: string[];
+  kept: string[];
+  reasons: string[];
+}
+
+/**
+ * Read the PID Chromium wrote into `SingletonLock`.
+ * Formats seen in the wild:
+ *   - symlink target `127.0.0.1-12345` (host-pid)
+ *   - plain text `12345` or `hostname-12345`
+ * Returns null when the file is missing or unparseable.
+ */
+export function readChromeSingletonLockPid(userDataDir: string): number | null {
+  const lockPath = path.join(userDataDir, "SingletonLock");
+  try {
+    let payload: string | null = null;
+    try {
+      payload = fs.readlinkSync(lockPath);
+    } catch {
+      if (!fs.existsSync(lockPath)) return null;
+      payload = fs.readFileSync(lockPath, "utf8").trim();
+    }
+    if (!payload) return null;
+    // strip optional host prefix: "hostname-12345" or "127.0.0.1-12345"
+    const m = payload.trim().match(/(?:^|-)(\d+)\s*$/);
+    if (!m || m[1] === undefined) return null;
+    const pid = Number(m[1]);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when `pid` is alive (signal 0 succeeds). */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort: does the live PID look like a Chromium-family browser?
+ * Used only to avoid deleting locks while a real Chrome still holds them
+ * under a recycled PID race (extremely rare). On failure we treat as
+ * "unknown → keep locks" when the PID is alive.
+ */
+export function processLooksLikeChromium(pid: number): boolean {
+  try {
+    if (process.platform === "linux") {
+      const comm = fs.readFileSync(`/proc/${pid}/comm`, "utf8").trim().toLowerCase();
+      return /chrome|chromium|msedge|brave|electron/.test(comm);
+    }
+    if (process.platform === "darwin") {
+      const out = execFileSync("ps", ["-p", String(pid), "-o", "comm="], {
+        encoding: "utf8",
+        timeout: 1000,
+      }).trim().toLowerCase();
+      return /chrome|chromium|msedge|brave|google chrome|electron|helper/.test(out);
+    }
+    // Windows: keep conservative — if alive, do not clear.
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clear Chromium single-instance lock files when safe.
+ *
+ * - No SingletonLock → remove companion lock names if present (orphans).
+ * - SingletonLock with dead PID → remove all lock basenames.
+ * - SingletonLock with live non-Chrome PID → remove (stale PID recycle cleaning).
+ * - SingletonLock with live Chromium PID → keep everything.
+ */
+export function clearStaleChromeLocks(
+  userDataDir: string,
+  opts: { now?: () => number } = {},
+): ClearStaleChromeLocksResult {
+  void opts; // reserved for future mtime grace windows
+  const removed: string[] = [];
+  const kept: string[] = [];
+  const reasons: string[] = [];
+
+  if (!fs.existsSync(userDataDir)) {
+    return { removed, kept, reasons: ["userDataDir missing"] };
+  }
+
+  const pid = readChromeSingletonLockPid(userDataDir);
+  let shouldClear = false;
+
+  if (pid === null) {
+    // No owner PID — companion locks alone are always safe to drop.
+    shouldClear = true;
+    reasons.push("no parseable SingletonLock pid");
+  } else if (!isProcessAlive(pid)) {
+    shouldClear = true;
+    reasons.push(`pid ${pid} not alive`);
+  } else if (!processLooksLikeChromium(pid)) {
+    shouldClear = true;
+    reasons.push(`pid ${pid} alive but not chromium-family`);
+  } else {
+    shouldClear = false;
+    reasons.push(`pid ${pid} looks like a live chromium holder`);
+  }
+
+  for (const base of CHROME_LOCK_BASENAMES) {
+    const full = path.join(userDataDir, base);
+    if (!fs.existsSync(full) && !isSymlink(full)) {
+      continue;
+    }
+    if (!shouldClear) {
+      kept.push(base);
+      continue;
+    }
+    try {
+      fs.rmSync(full, { force: true });
+      removed.push(base);
+    } catch (err) {
+      reasons.push(
+        `failed to remove ${base}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      kept.push(base);
+    }
+  }
+
+  return { removed, kept, reasons };
+}
+
+function isSymlink(p: string): boolean {
+  try {
+    return fs.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}

--- a/src/tools/browser/clear-stale-chrome-locks.ts
+++ b/src/tools/browser/clear-stale-chrome-locks.ts
@@ -68,28 +68,44 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 /**
- * Best-effort: does the live PID look like a Chromium-family browser?
- * Used only to avoid deleting locks while a real Chrome still holds them
- * under a recycled PID race (extremely rare). On failure we treat as
- * "unknown → keep locks" when the PID is alive.
+ * Result of probing a live PID's identity.
+ *   - "chromium": the process is a Chromium-family browser → keep its locks.
+ *   - "other": we successfully probed and it is NOT a browser → safe to clear.
+ *   - "unknown": the probe itself failed (no /proc access, ps timeout,
+ *     unexpected platform) → we cannot tell, so fail open and keep locks.
+ *
+ * The "other" vs "unknown" split matters: a failed probe must never be read
+ * as "not chromium → clear", or a live browser could have its locks pulled
+ * out from under it.
  */
-export function processLooksLikeChromium(pid: number): boolean {
+export type ProcessKind = "chromium" | "other" | "unknown";
+
+const CHROMIUM_COMM = /chrome|chromium|msedge|brave|google chrome|electron|helper/;
+
+/**
+ * Best-effort: probe whether the live PID looks like a Chromium-family
+ * browser. Distinguishes a successful "not a browser" answer from a probe
+ * that could not run at all — see {@link ProcessKind}.
+ */
+export function processLooksLikeChromium(pid: number): ProcessKind {
   try {
     if (process.platform === "linux") {
       const comm = fs.readFileSync(`/proc/${pid}/comm`, "utf8").trim().toLowerCase();
-      return /chrome|chromium|msedge|brave|electron/.test(comm);
+      return CHROMIUM_COMM.test(comm) ? "chromium" : "other";
     }
     if (process.platform === "darwin") {
       const out = execFileSync("ps", ["-p", String(pid), "-o", "comm="], {
         encoding: "utf8",
         timeout: 1000,
       }).trim().toLowerCase();
-      return /chrome|chromium|msedge|brave|google chrome|electron|helper/.test(out);
+      return CHROMIUM_COMM.test(out) ? "chromium" : "other";
     }
-    // Windows: keep conservative — if alive, do not clear.
-    return true;
+    // Windows: no cheap probe here — stay conservative and keep locks.
+    return "unknown";
   } catch {
-    return false;
+    // Probe failed (permission denied, ps timeout, ENOENT). We cannot tell,
+    // so fail open: treat as unknown and keep the locks.
+    return "unknown";
   }
 }
 
@@ -103,9 +119,17 @@ export function processLooksLikeChromium(pid: number): boolean {
  */
 export function clearStaleChromeLocks(
   userDataDir: string,
-  opts: { now?: () => number } = {},
+  opts: {
+    now?: () => number;
+    /** Liveness check override (defaults to {@link isProcessAlive}). */
+    isAlive?: (pid: number) => boolean;
+    /** Identity probe override (defaults to {@link processLooksLikeChromium}). */
+    probe?: (pid: number) => ProcessKind;
+  } = {},
 ): ClearStaleChromeLocksResult {
-  void opts; // reserved for future mtime grace windows
+  void opts.now; // reserved for future mtime grace windows
+  const isAlive = opts.isAlive ?? isProcessAlive;
+  const probe = opts.probe ?? processLooksLikeChromium;
   const removed: string[] = [];
   const kept: string[] = [];
   const reasons: string[] = [];
@@ -121,15 +145,23 @@ export function clearStaleChromeLocks(
     // No owner PID — companion locks alone are always safe to drop.
     shouldClear = true;
     reasons.push("no parseable SingletonLock pid");
-  } else if (!isProcessAlive(pid)) {
+  } else if (!isAlive(pid)) {
     shouldClear = true;
     reasons.push(`pid ${pid} not alive`);
-  } else if (!processLooksLikeChromium(pid)) {
-    shouldClear = true;
-    reasons.push(`pid ${pid} alive but not chromium-family`);
   } else {
-    shouldClear = false;
-    reasons.push(`pid ${pid} looks like a live chromium holder`);
+    const kind = probe(pid);
+    if (kind === "other") {
+      shouldClear = true;
+      reasons.push(`pid ${pid} alive but not chromium-family`);
+    } else if (kind === "chromium") {
+      shouldClear = false;
+      reasons.push(`pid ${pid} looks like a live chromium holder`);
+    } else {
+      // "unknown" — probe failed. Fail open: keep the locks rather than risk
+      // clearing a live browser we simply could not identify.
+      shouldClear = false;
+      reasons.push(`pid ${pid} alive but identity unknown (probe failed) — keeping locks`);
+    }
   }
 
   for (const base of CHROME_LOCK_BASENAMES) {

--- a/src/tools/browser/index.ts
+++ b/src/tools/browser/index.ts
@@ -31,6 +31,12 @@ export {
   markChromeProfileCleanExit,
 } from "./decorate-chrome-profile.js";
 export type { DecorateChromeProfileOptions } from "./decorate-chrome-profile.js";
+export {
+  CHROME_LOCK_BASENAMES,
+  clearStaleChromeLocks,
+  readChromeSingletonLockPid,
+} from "./clear-stale-chrome-locks.js";
+export type { ClearStaleChromeLocksResult } from "./clear-stale-chrome-locks.js";
 export { findChromeExecutable } from "./find-chrome-executable.js";
 export type {
   BrowserExecutable,
@@ -42,7 +48,11 @@ export {
   stopChrome,
 } from "./spawn-chrome.js";
 export type { RunningChrome, SpawnChromeInput } from "./spawn-chrome.js";
-export { summariseAriaSnapshot } from "./aria-compressor.js";
+export {
+  DEFAULT_ARIA_MAX_CHARS,
+  packLinesToCharBudget,
+  summariseAriaSnapshot,
+} from "./aria-compressor.js";
 export type {
   AriaCompressionOptions,
   AriaSnapshotSummary,

--- a/src/tools/browser/index.ts
+++ b/src/tools/browser/index.ts
@@ -48,11 +48,7 @@ export {
   stopChrome,
 } from "./spawn-chrome.js";
 export type { RunningChrome, SpawnChromeInput } from "./spawn-chrome.js";
-export {
-  DEFAULT_ARIA_MAX_CHARS,
-  packLinesToCharBudget,
-  summariseAriaSnapshot,
-} from "./aria-compressor.js";
+export { summariseAriaSnapshot } from "./aria-compressor.js";
 export type {
   AriaCompressionOptions,
   AriaSnapshotSummary,

--- a/src/tools/browser/playwright-backend.ts
+++ b/src/tools/browser/playwright-backend.ts
@@ -7,6 +7,7 @@ import type { BrowserChannel } from "../../config/index.js";
 import { loadPlaywrightCore } from "../../native/load-playwright-core.js";
 import { summariseAriaSnapshot } from "./aria-compressor.js";
 import { buildChromeLaunchArgs } from "./build-chrome-launch-args.js";
+import { clearStaleChromeLocks } from "./clear-stale-chrome-locks.js";
 import {
   decorateChromeProfile,
   markChromeProfileCleanExit,
@@ -294,6 +295,9 @@ export class PlaywrightBackend implements BrowserBackend {
           "Install one, or set ATOMIC_AGENT_BROWSER_EXECUTABLE_PATH to the binary path.",
       );
     }
+    // Drop locks left by a previous hard kill / SIGINT so Chromium can
+    // re-bind the profile (see clear-stale-chrome-locks.ts + #22).
+    clearStaleChromeLocks(this.options.userDataDir);
     decorateChromeProfile(this.options.userDataDir);
     const cdpPort = await pickAvailableLoopbackPort();
     const args = buildChromeLaunchArgs({


### PR DESCRIPTION
## Summary
Hard kills / SIGINT before `PlaywrightBackend.shutdown()` finishes leave Chromium `SingletonLock` (and friends) under the persistent `user-data-dir`. The next `browser.*` launch then fails until manual cleanup.

## Fix
- New `clearStaleChromeLocks(userDataDir)` with PID-aware policy:
  - dead owner PID → remove locks
  - live Chromium-family holder → keep
  - orphan companion locks without SingletonLock → remove
- Called in `launchOwnChrome()` before `decorateChromeProfile` / spawn
- Unit tests for parse + clear paths

## Test plan
- [x] `vitest run src/tools/browser/clear-stale-chrome-locks.test.ts`
- [ ] Manual: start browser task, Ctrl+C mid-run, relaunch browser tool without deleting profile

Fixes #22

Agent-Owner: sera