### PR TITLE
fix(browser): gate non-http(s) URLs in browser.tabs new

### DIFF
--- a/src/tools/browser/browser-tools.test.ts
+++ b/src/tools/browser/browser-tools.test.ts
@@ -366,6 +366,30 @@ describe("browser tools on a fake backend", () => {
     expect(backend.readyCalls).toBe(0);
   });
 
+  it("tabs new proceeds to the backend when a non-http(s) URL is approved", async () => {
+    const gate = new ApprovalGate({
+      emit: (req) =>
+        setImmediate(() =>
+          gate.resolve({ approvalId: req.approvalId, approved: true }),
+        ),
+    });
+    const tool = buildBrowserTabsTool(backend, {
+      approvals: gate,
+      approvalRequired: true,
+    });
+    const result = await tool.run(
+      { action: "new", url: "file:///etc/hosts" },
+      CTX,
+    );
+    expect(result.status).toBe("ok");
+    // url survives the await and reaches the backend intact
+    expect(backend.lastTabs).toEqual({
+      action: "new",
+      url: "file:///etc/hosts",
+    });
+    expect(backend.readyCalls).toBe(1);
+  });
+
   it("tabs new with javascript: URL is gated the same way", async () => {
     const gate = new ApprovalGate({
       emit: (req) => gate.reject(req.approvalId, "denied js scheme"),

--- a/src/tools/browser/browser-tools.test.ts
+++ b/src/tools/browser/browser-tools.test.ts
@@ -326,10 +326,71 @@ describe("browser tools on a fake backend", () => {
   });
 
   it("tabs list rendering includes the active marker", async () => {
-    const tool = buildBrowserTabsTool(backend);
+    const tool = buildBrowserTabsTool(backend, autoApprove());
     const result = await tool.run({ action: "list" }, CTX);
     expect(result.status).toBe("ok");
     expect(result.summary).toContain("*[0] Example");
+  });
+
+  it("tabs new with http(s) URL does not require approval", async () => {
+    const gate = new ApprovalGate({
+      emit: (req) => gate.reject(req.approvalId, "should not be called"),
+    });
+    const tool = buildBrowserTabsTool(backend, {
+      approvals: gate,
+      approvalRequired: true,
+    });
+    const result = await tool.run(
+      { action: "new", url: "https://example.com/docs" },
+      CTX,
+    );
+    expect(result.status).toBe("ok");
+    expect(backend.lastTabs).toEqual({
+      action: "new",
+      url: "https://example.com/docs",
+    });
+  });
+
+  it("tabs new requires approval for non-http(s) schemes", async () => {
+    const gate = new ApprovalGate({
+      emit: (req) => gate.reject(req.approvalId, "denied file scheme"),
+    });
+    const tool = buildBrowserTabsTool(backend, {
+      approvals: gate,
+      approvalRequired: true,
+    });
+    await expect(
+      tool.run({ action: "new", url: "file:///etc/passwd" }, CTX),
+    ).rejects.toMatchObject({ name: "ApprovalDeniedError" });
+    expect(backend.lastTabs).toBeNull();
+    expect(backend.readyCalls).toBe(0);
+  });
+
+  it("tabs new with javascript: URL is gated the same way", async () => {
+    const gate = new ApprovalGate({
+      emit: (req) => gate.reject(req.approvalId, "denied js scheme"),
+    });
+    const tool = buildBrowserTabsTool(backend, {
+      approvals: gate,
+      approvalRequired: true,
+    });
+    await expect(
+      tool.run({ action: "new", url: "javascript:alert(1)" }, CTX),
+    ).rejects.toMatchObject({ name: "ApprovalDeniedError" });
+    expect(backend.lastTabs).toBeNull();
+  });
+
+  it("tabs list never hits the URL approval gate", async () => {
+    const gate = new ApprovalGate({
+      emit: (req) => gate.reject(req.approvalId, "list must not ask"),
+    });
+    const tool = buildBrowserTabsTool(backend, {
+      approvals: gate,
+      approvalRequired: true,
+    });
+    const result = await tool.run({ action: "list" }, CTX);
+    expect(result.status).toBe("ok");
+    expect(backend.lastTabs?.action).toBe("list");
   });
 
   it("buildBrowserTools registers all browser tools", () => {

--- a/src/tools/browser/index.ts
+++ b/src/tools/browser/index.ts
@@ -70,7 +70,7 @@ export function buildBrowserTools(
     buildBrowserTypeTool(backend),
     buildBrowserReadAriaTool(backend),
     buildBrowserSearchTool(backend),
-    buildBrowserTabsTool(backend),
+    buildBrowserTabsTool(backend, dangerous),
     buildBrowserScrollTool(backend),
   ];
 }

--- a/src/tools/browser/tabs.ts
+++ b/src/tools/browser/tabs.ts
@@ -1,14 +1,22 @@
 import { compressToolResult } from "../../compressor/result-compressor.js";
 import type { ToolDefinition } from "../tool-registry.js";
 import type { BrowserBackend, TabsInput } from "./browser-backend.js";
+import { isSafeUrl } from "./navigate.js";
+import {
+  requireApproval,
+  type DangerousToolOptions,
+} from "../../approval/dangerous-tool.js";
 
-export function buildBrowserTabsTool(backend: BrowserBackend): ToolDefinition {
+export function buildBrowserTabsTool(
+  backend: BrowserBackend,
+  options: DangerousToolOptions,
+): ToolDefinition {
   return {
     name: "browser.tabs",
     description:
-      "Manage browser tabs: list, switch, close, or open a new one.",
+      "Manage browser tabs: list, switch, close, or open a new one. Opening a new tab with a non-http(s) URL requires approval (same gate as browser.navigate).",
     readonly: false,
-    async run(rawArgs) {
+    async run(rawArgs, ctx) {
       const action = rawArgs.action;
       if (
         action !== "list" &&
@@ -24,9 +32,27 @@ export function buildBrowserTabsTool(backend: BrowserBackend): ToolDefinition {
       if (typeof rawArgs.index === "number" && Number.isInteger(rawArgs.index)) {
         input.index = rawArgs.index;
       }
-      if (typeof rawArgs.url === "string") {
+      if (typeof rawArgs.url === "string" && rawArgs.url.length > 0) {
         input.url = rawArgs.url;
       }
+
+      // Mirror browser.navigate: tabs.new with a URL is the same danger surface
+      // (file://, javascript:, data:, chrome://). Without this gate the model
+      // can exfiltrate local files or execute script by opening a secondary tab.
+      if (action === "new" && input.url !== undefined && !isSafeUrl(input.url)) {
+        await requireApproval(
+          options,
+          {
+            sessionId: ctx.sessionId,
+            tool: "browser.tabs",
+            reason: "non-http(s) URL requested for new tab",
+            preview: input.url,
+            affectedResources: [input.url],
+          },
+          ctx.signal,
+        );
+      }
+
       await backend.ensureReady();
       const result = await backend.tabs(input);
       const rendered = result.tabs


### PR DESCRIPTION
## Summary

- Gate `browser.tabs` `action: "new"` the same way as `browser.navigate`: non-`http(s)` schemes require operator approval via `isSafeUrl` + `requireApproval`.
- Prevents `file://` / `javascript:` / `data:` / etc. from opening in a secondary tab without the approval gate.

## Motivation

Closes #29.

`browser.navigate` already blocks dangerous schemes behind the approval gate. `browser.tabs` with `action: "new"` + a `url` skipped that check and forwarded straight into `page.goto`, so a model could open local files or script URLs through a second tool path. This mirrors the navigate contract at the tool layer (no Playwright backend behaviour change).

## Verification

- `npx vitest run src/tools/browser/browser-tools.test.ts` — **32 passed**
- New coverage:
  - `tabs new` + https does **not** request approval
  - `tabs new` + `file://` → `ApprovalDeniedError`, backend never called
  - `tabs new` + `javascript:` → same
  - `tabs list` never hits the URL gate
- Did **not** change: Playwright spawn/attach, ARIA compression, lock cleanup

## Commit

- Conventional + DCO (`Signed-off-by: Bartok9 <danielrpike9@gmail.com>`)

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h