### PR TITLE
Add placeholderRotationMs config to disable rotating prompt placeholders

### DIFF
--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -641,6 +641,11 @@ export interface AtomicAgentConfig {
    */
   tui: {
     theme: string;
+    /**
+     * Interval in ms for cycling rotating prompt placeholders. Set to `0`
+     * to disable the rotating suggestions entirely. Default `4000`.
+     */
+    placeholderRotationMs: number;
   };
   /**
    * Anonymous product analytics (PostHog). Mirrors
@@ -1271,6 +1276,11 @@ export interface UserConfigFile {
    */
   tui: {
     theme: string;
+    /**
+     * Interval in ms for cycling rotating prompt placeholders. Set to `0`
+     * to disable the rotating suggestions entirely. Default `4000`.
+     */
+    placeholderRotationMs: number;
   };
   /**
    * Anonymous product analytics (PostHog). Added in config v33. Older
@@ -1316,7 +1326,9 @@ export interface UserConfigFile {
 // v31: skills gains `clawhub` (ClawHub registry — the primary skill
 // marketplace). Older files inherit it enabled against the public registry
 // with suspicious skills hidden.
-export const USER_CONFIG_VERSION = 33 as const;
+// v34: tui gains `placeholderRotationMs` (disable rotating prompt
+// placeholders by setting to 0).
+export const USER_CONFIG_VERSION = 34 as const;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1429,6 +1441,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   30,
   31,
   32,
+  33,
   USER_CONFIG_VERSION,
 ];
 
@@ -1663,6 +1676,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
   },
   tui: {
     theme: "auto",
+    placeholderRotationMs: 4000,
   },
   analytics: {
     enabled: true,
@@ -3263,6 +3277,10 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
       theme: parseThemeName(
         tui.theme ?? USER_CONFIG_DEFAULTS.tui.theme,
         "tui.theme",
+      ),
+      placeholderRotationMs: parseNonNegativeInt(
+        tui.placeholderRotationMs ?? USER_CONFIG_DEFAULTS.tui.placeholderRotationMs,
+        "tui.placeholderRotationMs",
       ),
     },
     analytics: {

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -464,6 +464,7 @@ export function loadConfig(): AtomicAgentConfig {
     },
     tui: {
       theme: user.tui.theme,
+      placeholderRotationMs: user.tui.placeholderRotationMs,
     },
     analytics: {
       enabled: user.analytics.enabled,

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type ReactElement,
 } from "react";
+import { getConfig } from "../config/index.js";
 import { reduceTuiState } from "./agent-event-reducer.js";
 import type { TuiAction } from "./tui-action.js";
 import { handleAppKey } from "./app-key-bindings.js";
@@ -765,7 +766,11 @@ export function TuiApp({
           <PromptShell
             value={state.inputValue}
             placeholder="Type a message or `/` for commands…"
-            rotatingPlaceholders={PROMPT_PLACEHOLDERS}
+            rotatingPlaceholders={
+              getConfig().tui.placeholderRotationMs > 0
+                ? PROMPT_PLACEHOLDERS
+                : []
+            }
             model={promptLlm.model}
             provider={promptLlm.provider}
             leftSlot={promptLeftSlot}


### PR DESCRIPTION
## What

Add a  config option (default 4000ms) to control rotating prompt placeholders in the TUI.

Set to  to disable the rotating suggestions entirely.

## Config

-  (default ) — interval in ms for cycling rotating prompt placeholders
- Set to  to disable entirely
- Config version bumped 33 → 34 with auto-migration