### PR TITLE
fix(agent): soft-fail persistent tool-call parse errors

### DIFF
--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -155,7 +155,7 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(result.session.stepCount).toBe(1);
   });
 
-  it("throws and marks the session as failed when the LLM emits invalid tool JSON", async () => {
+  it("soft-fails invalid tool JSON after repair instead of killing the session", async () => {
     const registry = buildDefaultToolRegistry();
     const loop = new AgentLoop({
       registry,
@@ -172,9 +172,11 @@ describe("AgentLoop end-to-end with mock LLM", () => {
       maxSteps: 3,
       signal: new AbortController().signal,
     });
-    expect(result.reason).toBe("failed");
-    expect(result.session.status).toBe("failed");
-    expect(result.session.lastError).toMatch(/tool-call/);
+    expect(result.reason).toBe("reply");
+    expect(result.session.status).toBe("pending");
+    expect(result.session.lastError == null).toBe(true);
+    const last = result.session.turns.at(-1);
+    expect(last?.kind).toBe("assistant_reply");
   });
 
   it("recovers via a one-shot parser retry when the first completion is malformed", async () => {
@@ -795,11 +797,12 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(stepErrors[0]?.category).toBe("model");
   });
 
-  it("classifies persistent parse failure as GrammarError after one retry", async () => {
+  it("soft-fails persistent parse failure with a graceful reply after one retry", async () => {
     const registry = buildDefaultToolRegistry();
     let llmCalls = 0;
     const stepErrors: Array<{ category: string }> = [];
     const parseRetries: number[] = [];
+    const loopFailed: unknown[] = [];
     const loop = new AgentLoop({
       registry,
       slotManager: new SlotManager(2),
@@ -819,6 +822,8 @@ describe("AgentLoop end-to-end with mock LLM", () => {
           event.event.type === "parse_retry"
         ) {
           parseRetries.push(event.event.attempt);
+        } else if (event.type === "loop_failed") {
+          loopFailed.push(event);
         }
       },
     });
@@ -828,11 +833,18 @@ describe("AgentLoop end-to-end with mock LLM", () => {
       maxSteps: 3,
       signal: new AbortController().signal,
     });
-    expect(result.reason).toBe("failed");
-    expect(result.session.status).toBe("failed");
+    // Issue #37: small-model junk must not hard-fail the session.
+    expect(result.reason).toBe("reply");
+    expect(result.session.status).not.toBe("failed");
     expect(llmCalls).toBe(2);
     expect(parseRetries).toHaveLength(1);
     expect(stepErrors[0]?.category).toBe("grammar");
+    expect(loopFailed).toHaveLength(0);
+    const last = result.session.turns.at(-1);
+    expect(last?.kind).toBe("assistant_reply");
+    if (last?.kind === "assistant_reply") {
+      expect(last.text).toContain("not a valid tool call");
+    }
   });
 
   it("classifies a missing tool call as ToolExecutionError", async () => {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -13,6 +13,7 @@ import type { ModelProfileManager } from "../llm/model-profile-manager.js";
 import type { ToolRegistry } from "../tools/tool-registry.js";
 import {
   CancelledError,
+  GrammarError,
   LlmFailure,
   classifyFailure,
 } from "../llm/index.js";
@@ -46,6 +47,7 @@ import {
   formatRepeatNotice,
   formatWanderingRedirect,
   formatForcedLoopReply,
+  formatForcedGrammarReply,
 } from "./loop-detector.js";
 import type { BatchLoopSignal } from "./batch-executor.js";
 import { getConfig } from "../config/index.js";
@@ -659,6 +661,74 @@ export class AgentLoop {
       } catch (err) {
         runError = err instanceof Error ? err : new Error(String(err));
         const category = classifyFailure(err);
+        // `cancelled` is user-initiated — close the turn cleanly.
+        const cancelled =
+          err instanceof CancelledError ||
+          (err instanceof LlmFailure && err.category === "cancelled") ||
+          category === "cancelled";
+        if (cancelled) {
+          this.deps.logger?.error("agent loop failed", {
+            sessionId: state.id,
+            stepIndex: i,
+            error: runError.message,
+            category,
+          });
+          this.deps.onEvent?.({
+            type: "loop_failed",
+            error: runError,
+            category,
+          });
+          this.deps.metrics?.recordLlmFailure({
+            sessionId: state.id,
+            category,
+          });
+          state = { ...state, status: "cancelled" };
+          this.deps.onEvent?.({ type: "loop_completed", reason: "cancelled" });
+          state = incrementTurnCount(state);
+          const durationMs = Date.now() - turnStartedAt;
+          this.deps.onEvent?.({
+            type: "turn_finished",
+            turnIndex,
+            reason: "cancelled",
+            stepCount: stepsTaken,
+            durationMs,
+          });
+          return { session: state, reason: "cancelled", stepCount: stepsTaken };
+        }
+
+        // Persistent tool-call parse / batch-validation failure after the
+        // one-shot repair. Mirror the loop-breaker contract: end the turn
+        // with a synthetic reply so multi-turn chat survives small/local
+        // models dumping degenerate junk (issue #37). Still record the
+        // failure metric + step_error (already emitted by executeStep);
+        // do NOT emit loop_failed or mark the session failed.
+        const isGrammar =
+          err instanceof GrammarError ||
+          (err instanceof LlmFailure && err.category === "grammar") ||
+          category === "grammar";
+        if (isGrammar) {
+          this.deps.metrics?.recordLlmFailure({
+            sessionId: state.id,
+            category: "grammar",
+          });
+          const replyText = formatForcedGrammarReply(runError.message);
+          state = recordTurn(state, assistantReplyTurn(replyText));
+          this.deps.onEvent?.({
+            type: "llm_event",
+            event: { type: "assistant_reply", text: replyText },
+          });
+          this.deps.logger?.warn(
+            "tool-call parse failed after repair; forcing graceful reply",
+            {
+              sessionId: state.id,
+              stepIndex: i,
+              error: runError.message,
+            },
+          );
+          reason = "reply";
+          break;
+        }
+
         this.deps.logger?.error("agent loop failed", {
           sessionId: state.id,
           stepIndex: i,
@@ -674,27 +744,6 @@ export class AgentLoop {
           sessionId: state.id,
           category,
         });
-        // `cancelled` is user-initiated and should close the turn
-        // cleanly without marking the session as failed. Everything
-        // else keeps the existing failed-terminal contract.
-        const cancelled =
-          err instanceof CancelledError ||
-          (err instanceof LlmFailure && err.category === "cancelled") ||
-          category === "cancelled";
-        if (cancelled) {
-          state = { ...state, status: "cancelled" };
-          this.deps.onEvent?.({ type: "loop_completed", reason: "cancelled" });
-          state = incrementTurnCount(state);
-          const durationMs = Date.now() - turnStartedAt;
-          this.deps.onEvent?.({
-            type: "turn_finished",
-            turnIndex,
-            reason: "cancelled",
-            stepCount: stepsTaken,
-            durationMs,
-          });
-          return { session: state, reason: "cancelled", stepCount: stepsTaken };
-        }
         // Symmetric with the cancelled path above: set terminal state,
         // emit `loop_completed` + `turn_finished`, increment turnCount,
         // and RETURN — never throw. Callers (CLI / TUI / task-runner /

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -21,6 +21,7 @@ export {
   formatRepeatNotice,
   formatVetoInstruction,
   formatForcedLoopReply,
+  formatForcedGrammarReply,
   BATCH_LOOP_LABEL,
   LOOP_VETO_DENIED_REASON,
   LOOP_WARNING_BUCKET_SIZE,

--- a/src/agent/loop-detector.test.ts
+++ b/src/agent/loop-detector.test.ts
@@ -4,6 +4,7 @@ import {
   BATCH_LOOP_LABEL,
   LOOP_VETO_DENIED_REASON,
   ToolLoopTracker,
+  formatForcedGrammarReply,
   formatForcedLoopReply,
   formatRepeatNotice,
   formatVetoInstruction,
@@ -301,6 +302,15 @@ describe("loop notice formatters", () => {
     expect(reply).toContain("browser.click");
     expect(reply).toContain("4");
     expect(reply.toLowerCase()).toContain("best answer");
+  });
+
+  it("formatForcedGrammarReply keeps the reason short and actionable", () => {
+    const reply = formatForcedGrammarReply(
+      "tool-call JSON value is incomplete",
+    );
+    expect(reply).toContain("tool-call JSON value is incomplete");
+    expect(reply.toLowerCase()).toContain("not a valid tool call");
+    expect(reply.toLowerCase()).toContain("stronger model");
   });
 
   it("formatWanderingRedirect is an actionable redirect", () => {

--- a/src/agent/loop-detector.ts
+++ b/src/agent/loop-detector.ts
@@ -625,6 +625,23 @@ export function formatForcedLoopReply(tool: string, count: number): string {
   ].join(" ");
 }
 
+/**
+ * Synthetic assistant reply when the model failed to emit a parseable
+ * tool-call array even after the one-shot repair pass. Mirrors the
+ * loop-breaker "session stays usable" contract — a small/local model
+ * jellyfish of degenerate junk must not hard-fail multi-turn chat.
+ */
+export function formatForcedGrammarReply(reason: string): string {
+  const trimmed = reason.trim().replace(/\s+/g, " ");
+  const short =
+    trimmed.length > 160 ? `${trimmed.slice(0, 157)}…` : trimmed || "parse failed";
+  return [
+    `(stopped: model output was not a valid tool call after one repair — ${short}).`,
+    "I could not run tools for this turn.",
+    "Please rephrase or try a stronger model if this keeps happening.",
+  ].join(" ");
+}
+
 function formatLoopGuidance(
   tool: string,
   count: number,

--- a/src/llm/grammar/tool-call-grammar.test.ts
+++ b/src/llm/grammar/tool-call-grammar.test.ts
@@ -348,6 +348,24 @@ first thought
     expect(out.args).toEqual({});
   });
 
+  it("skips false-start bracket junk before a real tool-call array", () => {
+    // Repro shape from #37: degenerate reasoningized text emits tokens
+    // like `[SFC]` before the actual grammar-constrained array.
+    const raw =
+      'noise [SFC] more` junk [{"tool":"reply","args":{"text":"hi"}}]';
+    const batch = parseToolCalls(raw);
+    expect(batch.calls).toHaveLength(1);
+    expect(batch.calls[0]?.tool).toBe("reply");
+    expect(batch.calls[0]?.args).toEqual({ text: "hi" });
+  });
+
+  it("skips an incomplete object start before a later valid root", () => {
+    const raw =
+      '{ "tool": "reply", "args": {"text": "half" [{"tool":"reply","args":{"text":"ok"}}]';
+    const batch = parseToolCalls(raw);
+    expect(batch.calls[0]?.args).toEqual({ text: "ok" });
+  });
+
   it("rejects non-JSON input", () => {
     expect(() => parseToolCall("not json")).toThrow(ToolCallParseError);
   });

--- a/src/llm/grammar/tool-call-grammar.ts
+++ b/src/llm/grammar/tool-call-grammar.ts
@@ -310,35 +310,69 @@ function peelTrailingToolJson(text: string): {
   }
 }
 
+/**
+ * Locate a balanced JSON value in `raw` after skipping leading noise.
+ * Small / degenerate models often emit false-start brackets inside
+ * reasoning garbage (`[SFC]`, half-open `{...`) before a real tool-call
+ * array. Prefer the first candidate that BOTH balances and `JSON.parse`s;
+ * fall back to a clear incomplete/not-found error when nothing works.
+ */
 function extractJsonRoot(raw: string): ExtractedRoot {
   const input = raw.trim();
   if (input.length === 0) {
     throw new ToolCallParseError("tool-call body is empty");
   }
 
-  let start = -1;
-  let kind: "object" | "array" | null = null;
-  let depthCurly = 0;
-  let depthSquare = 0;
+  let sawOpen = false;
+  let sawIncomplete = false;
+
+  for (let start = 0; start < input.length; start += 1) {
+    const open = input[start]!;
+    if (open !== "{" && open !== "[") {
+      continue;
+    }
+    sawOpen = true;
+    const kind: "object" | "array" = open === "{" ? "object" : "array";
+    const extracted = tryExtractBalancedRoot(input, start, kind);
+    if (extracted === null) {
+      sawIncomplete = true;
+      continue;
+    }
+    try {
+      JSON.parse(extracted.jsonText);
+      return extracted;
+    } catch {
+      // unbalanced-escape / truncated-but-closed junk; try next start
+      continue;
+    }
+  }
+
+  if (!sawOpen) {
+    throw new ToolCallParseError("tool-call JSON value not found");
+  }
+  if (sawIncomplete) {
+    throw new ToolCallParseError("tool-call JSON value is incomplete");
+  }
+  throw new ToolCallParseError("tool-call JSON value not found");
+}
+
+/**
+ * Bracket-count from a known open at `start`. Returns null when the root
+ * never closes (incomplete). Nested braces/brackets are tracked with
+ * string-escape awareness identical to the pre-scan single-pass parser.
+ */
+function tryExtractBalancedRoot(
+  input: string,
+  start: number,
+  kind: "object" | "array",
+): ExtractedRoot | null {
+  let depthCurly = kind === "object" ? 1 : 0;
+  let depthSquare = kind === "array" ? 1 : 0;
   let inString = false;
   let escaped = false;
 
-  for (let idx = 0; idx < input.length; idx += 1) {
+  for (let idx = start + 1; idx < input.length; idx += 1) {
     const ch = input[idx]!;
-    if (start === -1) {
-      if (ch === "{") {
-        start = idx;
-        kind = "object";
-        depthCurly = 1;
-      } else if (ch === "[") {
-        start = idx;
-        kind = "array";
-        depthSquare = 1;
-      } else if (!/\s/.test(ch)) {
-        continue;
-      }
-      continue;
-    }
 
     if (inString) {
       if (escaped) {
@@ -377,11 +411,7 @@ function extractJsonRoot(raw: string): ExtractedRoot {
       }
     }
   }
-
-  if (start === -1) {
-    throw new ToolCallParseError("tool-call JSON value not found");
-  }
-  throw new ToolCallParseError("tool-call JSON value is incomplete");
+  return null;
 }
 
 function escapeRegex(text: string): string {


### PR DESCRIPTION
After one parse repair, small models (e.g. Qwen 3.5 4B on #37) still failed the whole session on junk completions. Soft-fail with a synthetic reply (same pattern as the loop breaker) so multi-turn stays usable, and skip false-start brackets like [SFC] before a real tool-call root.

Closes #37

Tested: npx vitest run tool-call-grammar + loop-detector + agent-loop + step-executor → 135 passed

Agent-Owner: sera
