### PR TITLE
Stop reasoning brackets from crashing the tool-call parser (fixes #37)

### DIFF
--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -155,13 +155,13 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(result.session.stepCount).toBe(1);
   });
 
-  it("throws and marks the session as failed when the LLM emits invalid tool JSON", async () => {
+  it("marks the session as failed when the LLM emits a botched tool call", async () => {
     const registry = buildDefaultToolRegistry();
     const loop = new AgentLoop({
       registry,
       slotManager: new SlotManager(2),
       grammar: 'root ::= "ok"',
-      llmComplete: async () => makeCompletion("not a json"),
+      llmComplete: async () => makeCompletion('[{"tool":"reply","args":{'),
       toolDescriptors: TOOLS,
       capabilities: CAPS,
       skillCatalog: SKILLS,
@@ -175,6 +175,31 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(result.reason).toBe("failed");
     expect(result.session.status).toBe("failed");
     expect(result.session.lastError).toMatch(/tool-call/);
+  });
+
+  it("degrades to a plain reply when the LLM answers in prose instead of a tool call", async () => {
+    const registry = buildDefaultToolRegistry();
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => makeCompletion("Hi! How can I help?"),
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const session = createEmptySessionState({ id: "s-prose", workingDir });
+    const result = await loop.runTurn(session, {
+      userMessage: "hi",
+      maxSteps: 3,
+      signal: new AbortController().signal,
+    });
+    expect(result.reason).toBe("reply");
+    expect(result.session.status).toBe("pending");
+    expect(result.session.turns.at(-1)).toMatchObject({
+      kind: "assistant_reply",
+      text: "Hi! How can I help?",
+    });
   });
 
   it("recovers via a one-shot parser retry when the first completion is malformed", async () => {
@@ -806,7 +831,7 @@ describe("AgentLoop end-to-end with mock LLM", () => {
       grammar: 'root ::= "ok"',
       llmComplete: async () => {
         llmCalls += 1;
-        return makeCompletion("not valid json at all");
+        return makeCompletion('[{"tool":"reply","args":{"text":');
       },
       toolDescriptors: TOOLS,
       capabilities: CAPS,

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -12,6 +12,7 @@ import { REPAIR_MAX_TOKENS } from "./step-executor.js";
 import { buildGrammar } from "../llm/grammar/build-grammar.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import { DEFAULT_TOOL_DESCRIPTORS } from "../prompt/tool-descriptors.js";
+import { replyTool } from "../tools/conversation/reply.js";
 import type {
   CapabilitiesSummary,
   SkillCatalogEntry,
@@ -1296,5 +1297,64 @@ describe("executeStep skill.view short-circuit", () => {
     expect(outcome.toolResults).toHaveLength(1);
     expect(outcome.toolResults[0]!.status).toBe("ok");
     expect(outcome.toolResults[0]!.summary).toContain("already loaded");
+  });
+});
+
+describe("executeStep unparseable-completion fallback", () => {
+  const grammarsDir = join(process.cwd(), "grammars");
+
+  async function runQwenStep(content: string) {
+    const registry = new ToolRegistry();
+    registry.register(replyTool);
+    const grammar = await buildGrammar(QWEN_THINK_PROFILE, grammarsDir);
+    return executeStep(
+      {
+        session: createEmptySessionState({ id: "s-fallback", workingDir: "/w" }),
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "hi",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async () => ({
+          content,
+          reasoningContent: "",
+          stop: true,
+          truncated: false,
+          timing: {
+            promptMs: 1,
+            predictedMs: 1,
+            promptTokens: 20,
+            predictedTokens: 5,
+          },
+          cacheHitTokens: 0,
+          slotId: 0,
+          modelId: "mock",
+        }),
+        grammar,
+        profile: QWEN_THINK_PROFILE,
+      },
+    );
+  }
+
+  it("degrades prose after a closed think block to a reply", async () => {
+    // The `<think>` open tag is prefilled by the prompt, so the
+    // completion starts inside the reasoning block.
+    const outcome = await runQwenStep("thinking about it</think>Hi there!");
+    expect(outcome.terminal).toBe("turn");
+    expect(outcome.toolCalls).toHaveLength(1);
+    expect(outcome.toolCalls[0]!.tool).toBe("reply");
+    expect(outcome.toolCalls[0]!.args).toEqual({ text: "Hi there!" });
+    expect(outcome.toolResults[0]!.status).toBe("ok");
+  });
+
+  it("still fails when the model never left its think block (issue #37)", async () => {
+    await expect(
+      runQwenStep("[SFC] 分析中 rambling that never closes"),
+    ).rejects.toThrow(/tool-call/);
   });
 });

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -582,11 +582,27 @@ async function executeStepInner(
         rawLength: completion.content.length,
         raw: completion.content,
       });
-      throw new GrammarError(
-        parsed.error.message,
-        rawPreview(completion.content),
-        { cause: parsed.error },
-      );
+      // Last resort: the model talked instead of emitting a call (small
+      // models routinely answer "hi" in plain prose even under the
+      // grammar). Wrap that prose as a `reply` so the turn closes with
+      // the model's text — same degradation the `native_tools` path
+      // already applies — instead of failing the whole loop. Only
+      // reasoning came back? Then there is no answer to deliver and the
+      // `GrammarError` still stands.
+      const fallback = replyFallbackBatch(completion, deps.profile);
+      if (fallback === null) {
+        throw new GrammarError(
+          parsed.error.message,
+          rawPreview(completion.content),
+          { cause: parsed.error },
+        );
+      }
+      deps.logger?.warn("degrading unparseable completion to a reply", {
+        sessionId: ctx.session.id,
+        stepIndex: ctx.stepIndex,
+        reason: parsed.error.message,
+      });
+      parsed = { ok: true, batch: fallback };
     }
   }
   const batch = parsed.batch;
@@ -969,6 +985,41 @@ function tryParseToolCalls(
       error: err instanceof Error ? err : new Error(String(err)),
     };
   }
+}
+
+/**
+ * Wrap a completion's non-reasoning prose as a length-1 `reply` batch.
+ * Returns `null` when the completion carries nothing but reasoning (a
+ * model that degenerated inside its think block has no answer to
+ * deliver, so the caller keeps its `GrammarError`).
+ */
+function replyFallbackBatch(
+  completion: CompletionResult,
+  profile: ModelProfile,
+): ToolCallBatch | null {
+  const extracted = extractReasoning(
+    normalizeContent(completion, profile),
+    getReasoningTagOptions(profile),
+  );
+  const text = extracted.body.trim();
+  if (text.length === 0) return null;
+  // Only prose degrades. A body that opens a JSON value means the model
+  // did try to emit a call and botched it (or the batch failed
+  // validation) — echoing that literal back at the user would be worse
+  // than the `GrammarError`.
+  if (text.startsWith("{") || text.startsWith("[")) return null;
+  const reasoning = resolveReasoning(completion, profile);
+  return {
+    kind: "batch",
+    calls: [
+      {
+        tool: "reply",
+        args: { text },
+        ...(reasoning.length > 0 ? { reasoning } : {}),
+      },
+    ],
+    ...(reasoning.length > 0 ? { reasoning } : {}),
+  };
 }
 
 function buildLlmStreamParams(args: {

--- a/src/llm/grammar/tool-call-grammar.test.ts
+++ b/src/llm/grammar/tool-call-grammar.test.ts
@@ -395,6 +395,43 @@ first thought
     expect(out.args.args).toEqual(["-n", "5"]);
   });
 
+  it("ignores bracket runs in prose that are not JSON (issue #37)", () => {
+    const raw = `<think>
+[SFC] 分析中 [1] — what should I answer? {not json either}
+</think>
+[{"tool":"reply","args":{"text":"hi"}}]`;
+    const out = parseToolCall(raw);
+    expect(out.tool).toBe("reply");
+    expect(out.args).toEqual({ text: "hi" });
+  });
+
+  it("peels the real call out of an unclosed think block full of brackets", () => {
+    const raw = `<think>
+rambling [SFC] more rambling
+[{"tool":"reply","args":{"text":"hi"}}]`;
+    const extracted = extractReasoning(raw);
+    expect(extracted.body).toBe('[{"tool":"reply","args":{"text":"hi"}}]');
+    expect(parseToolCall(raw).tool).toBe("reply");
+  });
+
+  it("survives an unmatched brace in the reasoning before the call", () => {
+    const raw = `<think>
+a stray { brace, then the answer
+[{"tool":"reply","args":{"text":"hi"}}]`;
+    const out = parseToolCall(raw);
+    expect(out.tool).toBe("reply");
+    expect(out.args).toEqual({ text: "hi" });
+  });
+
+  it("prefers the emitted call over one rehearsed inside the reasoning", () => {
+    const raw = `<think>
+maybe [{"tool":"finish","args":{"summary":"no"}}] — actually no
+</think>
+[{"tool":"reply","args":{"text":"yes"}}]`;
+    const out = parseToolCall(raw);
+    expect(out.tool).toBe("reply");
+  });
+
   it("extracts JSON when prose precedes and args strings contain braces", () => {
     const raw = `preamble
 {"tool":"finish","args":{"summary":"literal {}"}}`;

--- a/src/llm/grammar/tool-call-grammar.ts
+++ b/src/llm/grammar/tool-call-grammar.ts
@@ -310,78 +310,149 @@ function peelTrailingToolJson(text: string): {
   }
 }
 
+interface RootSpan extends ExtractedRoot {
+  /** Bracket nesting depth the span sits at; `0` is top level. */
+  depth: number;
+  /** Memoised `JSON.parse` result — filled in by `spanValue`. */
+  parsed?: { ok: boolean; value: unknown };
+}
+
+/**
+ * Lazily `JSON.parse` a span. Parsing is deferred because the healthy
+ * path (one top-level call, arbitrarily nested args) would otherwise
+ * re-parse every nested object of every completion on every step.
+ */
+function spanValue(span: RootSpan): { ok: boolean; value: unknown } {
+  if (span.parsed === undefined) {
+    try {
+      span.parsed = { ok: true, value: JSON.parse(span.jsonText) };
+    } catch {
+      span.parsed = { ok: false, value: undefined };
+    }
+  }
+  return span.parsed;
+}
+
+/**
+ * Pick the tool-call JSON root out of a completion that may also carry
+ * prose. Reasoning text routinely contains bracket runs (`[SFC]`,
+ * `[1]`, a rehearsed `{...}`), so the first balanced span is NOT
+ * necessarily the call — preference order is:
+ *
+ *  1. the LAST top-level span that parses and looks like a tool call
+ *     (the model's final answer wins over anything it rehearsed while
+ *     thinking) — widened to nested spans only when NO top-level span
+ *     parses, which is how a stray unmatched `{` in the prose stops
+ *     swallowing the call that follows it,
+ *  2. the first top-level span that parses at all,
+ *  3. the first top-level span (so the caller's `JSON.parse` produces
+ *     the familiar `invalid tool-call JSON: ...` message).
+ *
+ * Spans close in inner-to-outer order, so an enclosing array always
+ * lands after its own entries and rule 1 keeps the whole batch.
+ */
 function extractJsonRoot(raw: string): ExtractedRoot {
   const input = raw.trim();
   if (input.length === 0) {
     throw new ToolCallParseError("tool-call body is empty");
   }
 
-  let start = -1;
-  let kind: "object" | "array" | null = null;
-  let depthCurly = 0;
-  let depthSquare = 0;
+  const { spans, sawOpen } = collectRootSpans(input);
+  const roots = spans.filter((span) => span.depth === 0);
+  // Nested spans are only in play when the top level never closed —
+  // otherwise a malformed batch (`[{...}, 42]`) would silently degrade
+  // to whichever entry happens to be well-formed, dropping calls the
+  // model asked for.
+  const eligible = roots.some((span) => spanValue(span).ok) ? roots : spans;
+  for (let idx = eligible.length - 1; idx >= 0; idx -= 1) {
+    const span = eligible[idx]!;
+    const { ok, value } = spanValue(span);
+    if (ok && looksLikeToolCallRoot(value)) {
+      return { jsonText: span.jsonText, kind: span.kind };
+    }
+  }
+  const parsable = roots.find((span) => spanValue(span).ok) ?? roots[0];
+  if (parsable !== undefined) {
+    return { jsonText: parsable.jsonText, kind: parsable.kind };
+  }
+  if (!sawOpen) {
+    throw new ToolCallParseError("tool-call JSON value not found");
+  }
+  throw new ToolCallParseError("tool-call JSON value is incomplete");
+}
+
+/**
+ * Single left-to-right pass collecting every balanced `{...}` / `[...]`
+ * span, with string-escape awareness. Spans are reported in closing
+ * order (inner before enclosing) and tagged with their nesting depth.
+ * A closer that does not match its opener drops the whole pending run —
+ * it was never JSON.
+ *
+ * Quotes only open a string INSIDE a bracket run: an odd quote in the
+ * surrounding prose must not swallow the tool call that follows it.
+ *
+ * ponytail: an odd quote INSIDE an abandoned run (a model rehearsing
+ * `{"tool": ...` in its reasoning and never closing it) still shifts
+ * every later quote and hides the real call. Recovering from that needs
+ * a re-scan seeded after each unmatched opener — add it if traces ever
+ * show it.
+ */
+function collectRootSpans(input: string): { spans: RootSpan[]; sawOpen: boolean } {
+  const spans: RootSpan[] = [];
+  const stack: { kind: "object" | "array"; start: number }[] = [];
+  let sawOpen = false;
   let inString = false;
   let escaped = false;
 
   for (let idx = 0; idx < input.length; idx += 1) {
     const ch = input[idx]!;
-    if (start === -1) {
-      if (ch === "{") {
-        start = idx;
-        kind = "object";
-        depthCurly = 1;
-      } else if (ch === "[") {
-        start = idx;
-        kind = "array";
-        depthSquare = 1;
-      } else if (!/\s/.test(ch)) {
-        continue;
-      }
-      continue;
-    }
-
     if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (ch === "\\") {
-        escaped = true;
-      } else if (ch === '"') {
-        inString = false;
-      }
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
       continue;
     }
-
     if (ch === '"') {
-      inString = true;
+      if (stack.length > 0) inString = true;
       continue;
     }
-    if (ch === "{") {
-      depthCurly += 1;
+    if (ch === "{" || ch === "[") {
+      sawOpen = true;
+      stack.push({ kind: ch === "{" ? "object" : "array", start: idx });
       continue;
     }
-    if (ch === "}") {
-      depthCurly -= 1;
-      if (kind === "object" && depthCurly === 0 && depthSquare === 0) {
-        return { jsonText: input.slice(start, idx + 1), kind: "object" };
-      }
+    if (ch !== "}" && ch !== "]") continue;
+    const open = stack.pop();
+    const expected = ch === "}" ? "object" : "array";
+    if (open === undefined) continue;
+    if (open.kind !== expected) {
+      stack.length = 0;
       continue;
     }
-    if (ch === "[") {
-      depthSquare += 1;
-      continue;
-    }
-    if (ch === "]") {
-      depthSquare -= 1;
-      if (kind === "array" && depthSquare === 0 && depthCurly === 0) {
-        return { jsonText: input.slice(start, idx + 1), kind: "array" };
-      }
-    }
+    spans.push({
+      jsonText: input.slice(open.start, idx + 1),
+      kind: open.kind,
+      depth: stack.length,
+    });
   }
+  return { spans, sawOpen };
+}
 
-  if (start === -1) {
-    throw new ToolCallParseError("tool-call JSON value not found");
+/** Shape gate: a call object, or a non-empty array of call objects. */
+function looksLikeToolCallRoot(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every(isToolCallObject);
   }
-  throw new ToolCallParseError("tool-call JSON value is incomplete");
+  return isToolCallObject(value);
+}
+
+function isToolCallObject(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return ["tool", "name", "action"].some((key) => {
+    const name = record[key];
+    return typeof name === "string" && name.trim().length > 0;
+  });
 }
 
 function escapeRegex(text: string): string {


### PR DESCRIPTION
Fixes #37.

## What broke

With Qwen 3.5 4B, a plain `hi` ended the turn with `agent loop failed`:

```
tool-call parse failed, repairing once
invalid tool-call JSON: Unexpected token 'S', "[SFC]" is not valid JSON
tool-call JSON value is incomplete
```

Two independent defects stacked up.

**1. The parser took the first bracket run it saw, not the tool call.**
`extractJsonRoot` scanned for the first balanced `{...}` / `[...]` span and returned it without ever checking it was JSON. Reasoning prose is full of bracket runs (`[SFC]`, a citation `[1]`, a rehearsed `{...}`), and on an unclosed `<think>` block `peelTrailingToolJson` runs that scan across the entire reasoning body — so `[SFC]` won and the real trailing `[{"tool":...}]` was never looked at. This bites any model whose reasoning leaks into `content`, not just Qwen.

One pass now collects every balanced span with its nesting depth, and picks in order:

1. the **last top-level** span that parses *and* looks like a tool call — the emitted call beats anything rehearsed while thinking (spans close inner-to-outer, so an enclosing array always lands after its own entries and the whole batch is kept);
2. the first top-level span that parses at all;
3. the first top-level span — so genuinely malformed output keeps its existing error message.

Nested spans join the candidate set **only when no top-level span parses**. That rescues a stray unmatched `{` in the reasoning without letting a malformed batch (`[{...}, 42]`) silently degrade to whichever entry happens to be well-formed — dropping a call the model asked for would be worse than erroring. Parsing is lazy, so the healthy path doesn't re-parse every nested args object on every step. A quote outside a bracket run no longer opens a JSON string, so stray prose quotes can't swallow the call.

**2. Unparseable output always killed the turn.**
After the one-shot repair, any parse failure became a `GrammarError` → `loop_failed` → `status: "failed"`, even when the model had simply answered in prose instead of emitting a call — which small models do constantly. That now degrades to a length-1 `reply` carrying the model's text, the same fallback the `native_tools` transport has always applied.

Deliberately still failing:
- a body that opens `{` or `[` — the model tried to emit a call and botched it; echoing the literal at the user is worse than the error;
- a reasoning-only completion — there is no answer to deliver. For a `qwen-think` profile this is the whole-completion-inside-`<think>` case from the issue: pages of degenerate text are not an answer, and the error message is now accurate (`tool-call body is empty`) instead of the misleading `"[SFC]" is not valid JSON`. Qwen that *closes* `</think>` and then answers in prose is rescued.

## Tests

- four parser regressions: bracket runs in prose, an unclosed `<think>` block whose reasoning contains `[SFC]`, an unmatched brace before the call, and a rehearsed call losing to the emitted one;
- `qwen-think` step coverage for both sides of the fallback: prose after `</think>` becomes a `reply`; a think block that never closes still raises;
- new agent-loop test: a prose completion lands as an `assistant_reply` with `reason: "reply"`.

Two agent-loop tests encoded the old fail-fast contract using prose completions (`"not a json"`); they now assert the same failure with a botched JSON body, which is the case that still fails.

Full suite: 8 pre-existing failures on `main` (TUI / sidecar / fs-glob), byte-identical with this branch.
