### PR TITLE
List models from the server for OpenAI-compatible providers

### DIFF
--- a/src/llm/provider/aimlapi/aimlapi-provider.ts
+++ b/src/llm/provider/aimlapi/aimlapi-provider.ts
@@ -4,13 +4,7 @@ import { OpenAiProvider, type OpenAiProviderOptions } from "../openai/openai-pro
 export const DEFAULT_AIMLAPI_BASE = "https://api.aimlapi.com";
 
 /** Strips a trailing `/v1` so paths are not doubled (`/v1/v1/...`). */
-export function normalizeAimlapiBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.replace(/\/$/, "");
-  if (trimmed.endsWith("/v1")) {
-    return trimmed.slice(0, -"/v1".length);
-  }
-  return trimmed;
-}
+export { normalizeOpenAiBaseUrl as normalizeAimlapiBaseUrl } from "../openai/normalize-openai-base-url.js";
 
 export type AimlapiProviderOptions = Omit<OpenAiProviderOptions, "baseUrl"> & {
   baseUrl?: string;
@@ -23,13 +17,11 @@ export type AimlapiProviderOptions = Omit<OpenAiProviderOptions, "baseUrl"> & {
  */
 export class AimlapiProvider extends OpenAiProvider {
   constructor(options: AimlapiProviderOptions) {
-    const baseUrl = normalizeAimlapiBaseUrl(
-      options.baseUrl ?? DEFAULT_AIMLAPI_BASE,
-    );
     super({
       ...options,
       id: options.id,
-      baseUrl,
+      // OpenAiProvider normalizes the base URL.
+      baseUrl: options.baseUrl ?? DEFAULT_AIMLAPI_BASE,
       defaultChatModel: options.defaultChatModel,
     });
   }

--- a/src/llm/provider/openai/fetch-openai-compat-models.test.ts
+++ b/src/llm/provider/openai/fetch-openai-compat-models.test.ts
@@ -2,21 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchOpenAiCompatModels,
   getCachedOpenAiCompatModels,
-  normalizeOpenAiCompatBaseUrl,
 } from "./fetch-openai-compat-models.js";
 
 describe("fetchOpenAiCompatModels", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
-  });
-
-  it("strips trailing slashes and an explicit /v1 from the base url", () => {
-    expect(normalizeOpenAiCompatBaseUrl(" https://vllm.example/v1/ ")).toBe(
-      "https://vllm.example",
-    );
-    expect(normalizeOpenAiCompatBaseUrl("https://vllm.example")).toBe(
-      "https://vllm.example",
-    );
+    vi.useRealTimers();
   });
 
   it("lists sorted model ids, sends the bearer key, and caches per base url", async () => {
@@ -35,9 +26,40 @@ describe("fetchOpenAiCompatModels", () => {
       headers: { Authorization: "Bearer key" },
     });
 
-    expect(getCachedOpenAiCompatModels("https://vllm.example/")).toEqual(ids);
+    expect(getCachedOpenAiCompatModels("https://vllm.example/", "key")).toEqual(ids);
     await fetchOpenAiCompatModels("https://vllm.example", "key");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not serve one key's list to another key", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: [{ id: "m" }] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchOpenAiCompatModels("https://keyed.example", "first");
+    expect(getCachedOpenAiCompatModels("https://keyed.example", "second")).toBeUndefined();
+    expect(getCachedOpenAiCompatModels("https://keyed.example")).toBeUndefined();
+
+    await fetchOpenAiCompatModels("https://keyed.example", "second");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires the cache after an hour so rotated keys and new models show up", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: [{ id: "m" }] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchOpenAiCompatModels("https://stale.example", "key");
+    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+    expect(getCachedOpenAiCompatModels("https://stale.example", "key")).toBeUndefined();
+
+    await fetchOpenAiCompatModels("https://stale.example", "key");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("throws on a rejected request so callers can fall back to typing", async () => {

--- a/src/llm/provider/openai/fetch-openai-compat-models.test.ts
+++ b/src/llm/provider/openai/fetch-openai-compat-models.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchOpenAiCompatModels,
+  getCachedOpenAiCompatModels,
+  normalizeOpenAiCompatBaseUrl,
+} from "./fetch-openai-compat-models.js";
+
+describe("fetchOpenAiCompatModels", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("strips trailing slashes and an explicit /v1 from the base url", () => {
+    expect(normalizeOpenAiCompatBaseUrl(" https://vllm.example/v1/ ")).toBe(
+      "https://vllm.example",
+    );
+    expect(normalizeOpenAiCompatBaseUrl("https://vllm.example")).toBe(
+      "https://vllm.example",
+    );
+  });
+
+  it("lists sorted model ids, sends the bearer key, and caches per base url", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "zephyr" }, { id: "Qwen/Qwen3-8B" }, { id: 42 }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ids = await fetchOpenAiCompatModels("https://vllm.example/v1", "key");
+    expect(ids).toEqual(["Qwen/Qwen3-8B", "zephyr"]);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://vllm.example/v1/models");
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: { Authorization: "Bearer key" },
+    });
+
+    expect(getCachedOpenAiCompatModels("https://vllm.example/")).toEqual(ids);
+    await fetchOpenAiCompatModels("https://vllm.example", "key");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on a rejected request so callers can fall back to typing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 401 })),
+    );
+    await expect(
+      fetchOpenAiCompatModels("https://locked.example"),
+    ).rejects.toThrow("http 401");
+    expect(getCachedOpenAiCompatModels("https://locked.example")).toBeUndefined();
+  });
+});

--- a/src/llm/provider/openai/fetch-openai-compat-models.ts
+++ b/src/llm/provider/openai/fetch-openai-compat-models.ts
@@ -1,0 +1,46 @@
+/**
+ * Model discovery for OpenAI-compatible servers (vLLM, llama-server, LM Studio,
+ * OpenAI itself): `GET {baseUrl}/v1/models`. The wizard reads the result
+ * synchronously through the module cache, same shape as the OpenRouter picker.
+ */
+
+const cache = new Map<string, readonly string[]>();
+
+/** Callers append `/v1/...`, so a base URL pasted with `/v1` must lose it. */
+export function normalizeOpenAiCompatBaseUrl(raw: string): string {
+  return raw
+    .trim()
+    .replace(/\/+$/, "")
+    .replace(/\/v\d+$/, "");
+}
+
+export function getCachedOpenAiCompatModels(
+  baseUrl: string,
+): readonly string[] | undefined {
+  return cache.get(normalizeOpenAiCompatBaseUrl(baseUrl));
+}
+
+/** Throws on unreachable/unauthorized servers so the caller can fall back to typing. */
+export async function fetchOpenAiCompatModels(
+  baseUrl: string,
+  apiKey?: string,
+): Promise<readonly string[]> {
+  const base = normalizeOpenAiCompatBaseUrl(baseUrl);
+  const cached = cache.get(base);
+  if (cached) return cached;
+
+  const res = await fetch(`${base}/v1/models`, {
+    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`http ${res.status}`);
+  const json = (await res.json()) as { data?: readonly { id?: unknown }[] };
+  const ids = (json.data ?? [])
+    .map((row) => row?.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  if (ids.length === 0) throw new Error("server listed no models");
+
+  cache.set(base, ids);
+  return ids;
+}

--- a/src/llm/provider/openai/fetch-openai-compat-models.ts
+++ b/src/llm/provider/openai/fetch-openai-compat-models.ts
@@ -4,20 +4,24 @@
  * synchronously through the module cache, same shape as the OpenRouter picker.
  */
 
-const cache = new Map<string, readonly string[]>();
+import { normalizeOpenAiBaseUrl } from "./normalize-openai-base-url.js";
 
-/** Callers append `/v1/...`, so a base URL pasted with `/v1` must lose it. */
-export function normalizeOpenAiCompatBaseUrl(raw: string): string {
-  return raw
-    .trim()
-    .replace(/\/+$/, "")
-    .replace(/\/v\d+$/, "");
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+const cache = new Map<string, { fetchedAt: number; ids: readonly string[] }>();
+
+/** The key is part of the identity: an anonymous list must not serve an authenticated request. */
+function cacheKey(baseUrl: string, apiKey?: string): string {
+  return `${normalizeOpenAiBaseUrl(baseUrl)}\n${apiKey ?? ""}`;
 }
 
 export function getCachedOpenAiCompatModels(
   baseUrl: string,
+  apiKey?: string,
 ): readonly string[] | undefined {
-  return cache.get(normalizeOpenAiCompatBaseUrl(baseUrl));
+  const hit = cache.get(cacheKey(baseUrl, apiKey));
+  if (!hit || Date.now() - hit.fetchedAt > CACHE_TTL_MS) return undefined;
+  return hit.ids;
 }
 
 /** Throws on unreachable/unauthorized servers so the caller can fall back to typing. */
@@ -25,10 +29,10 @@ export async function fetchOpenAiCompatModels(
   baseUrl: string,
   apiKey?: string,
 ): Promise<readonly string[]> {
-  const base = normalizeOpenAiCompatBaseUrl(baseUrl);
-  const cached = cache.get(base);
+  const cached = getCachedOpenAiCompatModels(baseUrl, apiKey);
   if (cached) return cached;
 
+  const base = normalizeOpenAiBaseUrl(baseUrl);
   const res = await fetch(`${base}/v1/models`, {
     headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
     signal: AbortSignal.timeout(10_000),
@@ -41,6 +45,6 @@ export async function fetchOpenAiCompatModels(
     .sort((a, b) => a.localeCompare(b));
   if (ids.length === 0) throw new Error("server listed no models");
 
-  cache.set(base, ids);
+  cache.set(cacheKey(baseUrl, apiKey), { fetchedAt: Date.now(), ids });
   return ids;
 }

--- a/src/llm/provider/openai/normalize-openai-base-url.test.ts
+++ b/src/llm/provider/openai/normalize-openai-base-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeOpenAiBaseUrl } from "./normalize-openai-base-url.js";
+
+describe("normalizeOpenAiBaseUrl", () => {
+  it("strips trailing slashes and an explicit /v1", () => {
+    expect(normalizeOpenAiBaseUrl(" https://vllm.example/v1/ ")).toBe(
+      "https://vllm.example",
+    );
+    expect(normalizeOpenAiBaseUrl("https://vllm.example")).toBe(
+      "https://vllm.example",
+    );
+  });
+
+  it("leaves other version segments alone", () => {
+    expect(normalizeOpenAiBaseUrl("https://host/api/v2")).toBe(
+      "https://host/api/v2",
+    );
+    expect(normalizeOpenAiBaseUrl("https://host/v10")).toBe("https://host/v10");
+  });
+});

--- a/src/llm/provider/openai/normalize-openai-base-url.ts
+++ b/src/llm/provider/openai/normalize-openai-base-url.ts
@@ -1,0 +1,11 @@
+/**
+ * Every OpenAI-compatible call site appends `/v1/...`, so a base URL stored
+ * with a trailing `/v1` — pasted into the wizard or hand-edited into
+ * `config.json` — must lose it, or requests go to `/v1/v1/chat/completions`.
+ * Only `/v1` is stripped: `https://host/api/v2` is a different API root, not
+ * a doubled version segment.
+ */
+export function normalizeOpenAiBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, "");
+  return trimmed.endsWith("/v1") ? trimmed.slice(0, -"/v1".length) : trimmed;
+}

--- a/src/llm/provider/openai/openai-provider.ts
+++ b/src/llm/provider/openai/openai-provider.ts
@@ -26,6 +26,7 @@ import {
   type OpenAiHttpDeps,
 } from "./openai-http.js";
 import { normaliseOpenAiChatResponse } from "./openai-normalise-response.js";
+import { normalizeOpenAiBaseUrl } from "./normalize-openai-base-url.js";
 import { describeImageViaOpenAi } from "./openai-describe-image.js";
 
 export interface OpenAiProviderOptions {
@@ -72,7 +73,7 @@ export class OpenAiProvider implements LlmProvider {
     };
     this.defaultChatModel = options.defaultChatModel;
     this.http = {
-      baseUrl: options.baseUrl.replace(/\/$/, ""),
+      baseUrl: normalizeOpenAiBaseUrl(options.baseUrl),
       apiKey: options.apiKey,
       extraHeaders: options.headers ?? {},
       requestTimeoutMs: options.requestTimeoutMs ?? 600_000,

--- a/src/llm/provider/openrouter/openrouter-provider.ts
+++ b/src/llm/provider/openrouter/openrouter-provider.ts
@@ -4,13 +4,7 @@ import { OpenAiProvider, type OpenAiProviderOptions } from "../openai/openai-pro
 export const DEFAULT_OPENROUTER_BASE = "https://openrouter.ai/api";
 
 /** Strips a trailing `/v1` so paths are not doubled (`/api/v1/v1/...`). */
-export function normalizeOpenRouterBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.replace(/\/$/, "");
-  if (trimmed.endsWith("/v1")) {
-    return trimmed.slice(0, -"/v1".length);
-  }
-  return trimmed;
-}
+export { normalizeOpenAiBaseUrl as normalizeOpenRouterBaseUrl } from "../openai/normalize-openai-base-url.js";
 
 export type OpenRouterProviderOptions = Omit<OpenAiProviderOptions, "baseUrl"> & {
   baseUrl?: string;
@@ -31,13 +25,11 @@ export class OpenRouterProvider extends OpenAiProvider {
     if (options.xTitle) {
       headers["X-Title"] = options.xTitle;
     }
-    const baseUrl = normalizeOpenRouterBaseUrl(
-      options.baseUrl ?? DEFAULT_OPENROUTER_BASE,
-    );
     super({
       ...options,
       id: options.id,
-      baseUrl,
+      // OpenAiProvider normalizes the base URL.
+      baseUrl: options.baseUrl ?? DEFAULT_OPENROUTER_BASE,
       headers: { ...headers, ...options.headers },
       defaultChatModel: options.defaultChatModel ?? "openrouter/auto",
     });

--- a/src/tui/components/providers-wizard.test.tsx
+++ b/src/tui/components/providers-wizard.test.tsx
@@ -1,0 +1,67 @@
+import { render } from "ink-testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createProvidersWizardState } from "../providers/providers-wizard-state.js";
+import { ProvidersWizard } from "./providers-wizard.js";
+
+function stripAnsi(value: string): string {
+  return value.replace(/\[[0-9;]*m/g, "");
+}
+
+function chatModelStep(baseUrlLine: string, cursor = 0) {
+  return {
+    ...createProvidersWizardState("add", { kind: "openai-compatible" }),
+    phase: "chat_model_line" as const,
+    baseUrlLine,
+    cursor,
+  };
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("ProvidersWizard chat model step", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("windows a long discovered model list around the cursor", async () => {
+    const ids = Array.from({ length: 30 }, (_, i) => `model-${i + 1}`);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: ids.map((id) => ({ id })) }),
+      })),
+    );
+
+    const { lastFrame } = render(
+      <ProvidersWizard wizard={chatModelStep("https://many.example", 20)} />,
+    );
+    await flush();
+
+    const text = stripAnsi(lastFrame() ?? "");
+    expect(text).toContain("30 from https://many.example/v1/models");
+    // ids are listed sorted; cursor 20 lands on the 21st of them
+    expect(text).toContain("> model-28");
+    expect(text).toContain("(21/30)");
+    expect(text).not.toContain("model-10");
+  });
+
+  it("falls back to a typed id when the server refuses the list", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 403 })),
+    );
+
+    const { lastFrame } = render(
+      <ProvidersWizard wizard={chatModelStep("https://refused.example")} />,
+    );
+    await flush();
+
+    const text = stripAnsi(lastFrame() ?? "");
+    expect(text).toContain("model list unavailable (http 403)");
+  });
+});

--- a/src/tui/components/providers-wizard.test.tsx
+++ b/src/tui/components/providers-wizard.test.tsx
@@ -38,7 +38,8 @@ describe("ProvidersWizard chat model step", () => {
     );
 
     const { lastFrame } = render(
-      <ProvidersWizard wizard={chatModelStep("https://many.example", 20)} />,
+      // pasted with `/v1` — the header must show the URL actually requested
+      <ProvidersWizard wizard={chatModelStep("https://many.example/v1", 20)} />,
     );
     await flush();
 

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -1,8 +1,8 @@
 import { Box, Text } from "ink";
 import { useEffect, useState, type ReactElement } from "react";
-import { resolveLlmProviderApiKey } from "../../config/resolve-llm-api-key.js";
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import {
+  apiKeyForWizard,
   baseUrlForWizard,
   listCompatChatModelPicks,
 } from "../providers/providers-wizard-key-bindings.js";
@@ -117,20 +117,18 @@ function CompatChatModelStep(props: {
 }): ReactElement {
   const w = props.wizard;
   const baseUrl = baseUrlForWizard(w);
+  const isCompat = w.kind === "openai-compatible";
   const [status, setStatus] = useState<{ loading: boolean; error: string | null }>(
-    { loading: true, error: null },
+    { loading: isCompat, error: null },
   );
 
   useEffect(() => {
+    // Only the openai-compatible kind carries an operator-supplied base URL;
+    // any other kind would fire this at the default host with a stray key.
+    if (!isCompat) return;
     let alive = true;
     setStatus({ loading: true, error: null });
-    const apiKey =
-      w.apiKeyBuffer.trim() ||
-      resolveLlmProviderApiKey({
-        id: "openai-compatible",
-        kind: "openai-compatible",
-      });
-    fetchOpenAiCompatModels(baseUrl, apiKey).then(
+    fetchOpenAiCompatModels(baseUrl, apiKeyForWizard(w)).then(
       () => {
         if (alive) setStatus({ loading: false, error: null });
       },
@@ -148,7 +146,7 @@ function CompatChatModelStep(props: {
     };
     // Re-fetch only when the server changes; the key is fixed for this wizard run.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [baseUrl]);
+  }, [baseUrl, isCompat]);
 
   const picks = listCompatChatModelPicks(w);
   if (picks.length > 0) {
@@ -165,9 +163,11 @@ function CompatChatModelStep(props: {
     );
   }
 
-  const hint = status.loading
-    ? `listing models from ${baseUrl}/v1/models…`
-    : status.error
+  const hint = !isCompat
+    ? "Enter to continue · Esc cancel"
+    : status.loading
+      ? `listing models from ${baseUrl}/v1/models…`
+      : status.error
       ? `model list unavailable (${status.error}) — type the id · Enter to continue`
       : "Enter to continue · Backspace to empty for the model list · Esc cancel";
   return renderLineField({

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -1,5 +1,11 @@
 import { Box, Text } from "ink";
-import type { ReactElement } from "react";
+import { useEffect, useState, type ReactElement } from "react";
+import { resolveLlmProviderApiKey } from "../../config/resolve-llm-api-key.js";
+import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import {
+  baseUrlForWizard,
+  listCompatChatModelPicks,
+} from "../providers/providers-wizard-key-bindings.js";
 import { theme } from "../theme/theme.js";
 import {
   listAimlapiChatModels,
@@ -103,6 +109,76 @@ function renderLineField(props: {
   );
 }
 
+/** Keep long server model lists inside a fixed viewport around the cursor. */
+const PICK_WINDOW = 12;
+
+function CompatChatModelStep(props: {
+  wizard: ProvidersWizardState;
+}): ReactElement {
+  const w = props.wizard;
+  const baseUrl = baseUrlForWizard(w);
+  const [status, setStatus] = useState<{ loading: boolean; error: string | null }>(
+    { loading: true, error: null },
+  );
+
+  useEffect(() => {
+    let alive = true;
+    setStatus({ loading: true, error: null });
+    const apiKey =
+      w.apiKeyBuffer.trim() ||
+      resolveLlmProviderApiKey({
+        id: "openai-compatible",
+        kind: "openai-compatible",
+      });
+    fetchOpenAiCompatModels(baseUrl, apiKey).then(
+      () => {
+        if (alive) setStatus({ loading: false, error: null });
+      },
+      (err: unknown) => {
+        if (alive) {
+          setStatus({
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      },
+    );
+    return () => {
+      alive = false;
+    };
+    // Re-fetch only when the server changes; the key is fixed for this wizard run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseUrl]);
+
+  const picks = listCompatChatModelPicks(w);
+  if (picks.length > 0) {
+    const cursor = Math.min(w.cursor, picks.length - 1);
+    const start = Math.min(
+      Math.max(0, cursor - Math.floor(PICK_WINDOW / 2)),
+      Math.max(0, picks.length - PICK_WINDOW),
+    );
+    return renderPickList(
+      `Chat model — ${picks.length} from ${baseUrl}/v1/models`,
+      picks.slice(start, start + PICK_WINDOW).map((id) => ({ label: id })),
+      cursor - start,
+      `↑/↓ move (${cursor + 1}/${picks.length}) · Enter select · type to enter an id by hand · Esc cancel`,
+    );
+  }
+
+  const hint = status.loading
+    ? `listing models from ${baseUrl}/v1/models…`
+    : status.error
+      ? `model list unavailable (${status.error}) — type the id · Enter to continue`
+      : "Enter to continue · Backspace to empty for the model list · Esc cancel";
+  return renderLineField({
+    title: "Chat model id",
+    value: w.chatModelLine,
+    placeholder: OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
+    hint,
+    error: w.error,
+  });
+}
+
 export function ProvidersWizard(props: {
   wizard: ProvidersWizardState;
 }): ReactElement {
@@ -202,13 +278,7 @@ export function ProvidersWizard(props: {
   }
 
   if (w.phase === "chat_model_line") {
-    return renderLineField({
-      title: "Chat model id",
-      value: w.chatModelLine,
-      placeholder: OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
-      hint: "Enter to continue · Esc cancel",
-      error: w.error,
-    });
+    return <CompatChatModelStep wizard={w} />;
   }
 
   if (w.phase === "embedding_model_line") {

--- a/src/tui/providers/providers-wizard-build-entry.ts
+++ b/src/tui/providers/providers-wizard-build-entry.ts
@@ -1,4 +1,5 @@
 import type { UserLlmProviderEntry } from "../../config/llm-config.js";
+import { normalizeOpenAiCompatBaseUrl } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import {
   LOCAL_EMBEDDING_CHOICE_ID,
   OPENAI_COMPAT_DEFAULT_BASE_URL,
@@ -58,7 +59,8 @@ export function buildProviderEntryFromWizard(input: {
     ...(input.kind === "openai-compatible"
       ? {
           baseUrl:
-            input.baseUrl?.trim() || OPENAI_COMPAT_DEFAULT_BASE_URL,
+            normalizeOpenAiCompatBaseUrl(input.baseUrl ?? "") ||
+            OPENAI_COMPAT_DEFAULT_BASE_URL,
         }
       : {}),
   };

--- a/src/tui/providers/providers-wizard-build-entry.ts
+++ b/src/tui/providers/providers-wizard-build-entry.ts
@@ -1,5 +1,5 @@
 import type { UserLlmProviderEntry } from "../../config/llm-config.js";
-import { normalizeOpenAiCompatBaseUrl } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { normalizeOpenAiBaseUrl } from "../../llm/provider/openai/normalize-openai-base-url.js";
 import {
   LOCAL_EMBEDDING_CHOICE_ID,
   OPENAI_COMPAT_DEFAULT_BASE_URL,
@@ -59,7 +59,7 @@ export function buildProviderEntryFromWizard(input: {
     ...(input.kind === "openai-compatible"
       ? {
           baseUrl:
-            normalizeOpenAiCompatBaseUrl(input.baseUrl ?? "") ||
+            normalizeOpenAiBaseUrl(input.baseUrl ?? "") ||
             OPENAI_COMPAT_DEFAULT_BASE_URL,
         }
       : {}),

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -1,6 +1,7 @@
 import type { Key } from "ink";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { LOCAL_EMBEDDING_CHOICE_ID } from "./providers-model-options.js";
 import { handleProvidersWizardKey } from "./providers-wizard-key-bindings.js";
 import { createProvidersWizardState } from "./providers-wizard-state.js";
@@ -60,6 +61,59 @@ describe("handleProvidersWizardKey", () => {
     wizard = next(wizard, "", emptyKey({ return: true }));
     expect(wizard.kind).toBe("openai-compatible");
     expect(wizard.phase).toBe("api_key");
+  });
+
+  describe("openai-compatible chat model step", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    async function wizardAtChatModelStep(
+      baseUrl: string,
+    ): Promise<ProvidersWizardState> {
+      let wizard = createProvidersWizardState("add", {
+        kind: "openai-compatible",
+      });
+      wizard = { ...wizard, phase: "base_url" };
+      for (const ch of baseUrl) wizard = next(wizard, ch, emptyKey());
+      return next(wizard, "", emptyKey({ return: true }));
+    }
+
+    it("picks a discovered model with arrows + Enter", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({
+          ok: true,
+          json: async () => ({ data: [{ id: "a-model" }, { id: "b-model" }] }),
+        })),
+      );
+      await fetchOpenAiCompatModels("https://picks.example");
+
+      let wizard = await wizardAtChatModelStep("https://picks.example");
+      expect(wizard.phase).toBe("chat_model_line");
+
+      wizard = next(wizard, "", emptyKey({ downArrow: true }));
+      wizard = next(wizard, "", emptyKey({ return: true }));
+      expect(wizard.chatModelLine).toBe("b-model");
+      expect(wizard.phase).toBe("embedding_model_line");
+    });
+
+    it("lets typing override the discovered list", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({
+          ok: true,
+          json: async () => ({ data: [{ id: "a-model" }] }),
+        })),
+      );
+      await fetchOpenAiCompatModels("https://typed.example");
+
+      let wizard = await wizardAtChatModelStep("https://typed.example");
+      for (const ch of "my-own") wizard = next(wizard, ch, emptyKey());
+      wizard = next(wizard, "", emptyKey({ return: true }));
+      expect(wizard.chatModelLine).toBe("my-own");
+      expect(wizard.phase).toBe("embedding_model_line");
+    });
   });
 
   it("walks the OpenRouter onboarding flow through model and embedding picks", () => {

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -1,5 +1,5 @@
 import type { Key } from "ink";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { LOCAL_EMBEDDING_CHOICE_ID } from "./providers-model-options.js";
@@ -64,8 +64,15 @@ describe("handleProvidersWizardKey", () => {
   });
 
   describe("openai-compatible chat model step", () => {
+    // The cache is keyed by base url + api key, so the priming fetch below has
+    // to use the key the wizard resolves — pin it instead of reading the env.
+    const ENV_KEY = "env-key";
+    beforeEach(() => {
+      vi.stubEnv("OPENAI_COMPAT_API_KEY", ENV_KEY);
+    });
     afterEach(() => {
       vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
     });
 
     async function wizardAtChatModelStep(
@@ -87,7 +94,7 @@ describe("handleProvidersWizardKey", () => {
           json: async () => ({ data: [{ id: "a-model" }, { id: "b-model" }] }),
         })),
       );
-      await fetchOpenAiCompatModels("https://picks.example");
+      await fetchOpenAiCompatModels("https://picks.example", ENV_KEY);
 
       let wizard = await wizardAtChatModelStep("https://picks.example");
       expect(wizard.phase).toBe("chat_model_line");
@@ -106,7 +113,7 @@ describe("handleProvidersWizardKey", () => {
           json: async () => ({ data: [{ id: "a-model" }] }),
         })),
       );
-      await fetchOpenAiCompatModels("https://typed.example");
+      await fetchOpenAiCompatModels("https://typed.example", ENV_KEY);
 
       let wizard = await wizardAtChatModelStep("https://typed.example");
       for (const ch of "my-own") wizard = next(wizard, ch, emptyKey());

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -1,9 +1,11 @@
 import type { Key } from "ink";
+import { getCachedOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import {
   listAimlapiChatModels,
   listAimlapiEmbeddingModels,
   listOpenRouterChatModels,
   listOpenRouterEmbeddingModels,
+  OPENAI_COMPAT_DEFAULT_BASE_URL,
 } from "./providers-model-options.js";
 import type {
   ProvidersWizardKind,
@@ -116,6 +118,24 @@ function isLinePhase(phase: ProvidersWizardPhase): boolean {
   );
 }
 
+export function baseUrlForWizard(wizard: ProvidersWizardState): string {
+  return wizard.baseUrlLine.trim() || OPENAI_COMPAT_DEFAULT_BASE_URL;
+}
+
+/**
+ * Chat model ids discovered from `{baseUrl}/v1/models`. Empty once the operator
+ * types anything — a typed id is a deliberate override, so the picker steps
+ * aside (backspacing back to empty brings it back).
+ */
+export function listCompatChatModelPicks(
+  wizard: ProvidersWizardState,
+): readonly string[] {
+  if (wizard.phase !== "chat_model_line") return [];
+  if (wizard.kind !== "openai-compatible") return [];
+  if (wizard.chatModelLine.length > 0) return [];
+  return getCachedOpenAiCompatModels(baseUrlForWizard(wizard)) ?? [];
+}
+
 export type ProvidersWizardKeyResult =
   | { handled: true; wizard: ProvidersWizardState; submit?: false }
   | { handled: true; wizard: ProvidersWizardState; submit: true }
@@ -165,6 +185,33 @@ export function handleProvidersWizardKey(
   }
 
   if (isLinePhase(wizard.phase)) {
+    const picks = listCompatChatModelPicks(wizard);
+    if (picks.length > 0) {
+      // Arrows only: printable keys fall through to line editing so an id the
+      // server does not advertise can still be typed.
+      if (key.downArrow) {
+        return {
+          handled: true,
+          wizard: { ...wizard, cursor: (wizard.cursor + 1) % picks.length },
+        };
+      }
+      if (key.upArrow) {
+        return {
+          handled: true,
+          wizard: {
+            ...wizard,
+            cursor: (wizard.cursor - 1 + picks.length) % picks.length,
+          },
+        };
+      }
+      if (key.return) {
+        const picked = picks[wizard.cursor] ?? picks[0]!;
+        return {
+          handled: true,
+          wizard: advanceWizardPhase({ ...wizard, chatModelLine: picked }),
+        };
+      }
+    }
     const field =
       wizard.phase === "base_url"
         ? "baseUrlLine"

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -1,8 +1,7 @@
 import type { Key } from "ink";
-import {
-  getCachedOpenAiCompatModels,
-  normalizeOpenAiCompatBaseUrl,
-} from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { resolveLlmProviderApiKey } from "../../config/resolve-llm-api-key.js";
+import { getCachedOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { normalizeOpenAiBaseUrl } from "../../llm/provider/openai/normalize-openai-base-url.js";
 import {
   listAimlapiChatModels,
   listAimlapiEmbeddingModels,
@@ -124,8 +123,20 @@ function isLinePhase(phase: ProvidersWizardPhase): boolean {
 /** Normalized so the fetch, the cache key and the displayed URL always agree. */
 export function baseUrlForWizard(wizard: ProvidersWizardState): string {
   return (
-    normalizeOpenAiCompatBaseUrl(wizard.baseUrlLine) ||
-    OPENAI_COMPAT_DEFAULT_BASE_URL
+    normalizeOpenAiBaseUrl(wizard.baseUrlLine) || OPENAI_COMPAT_DEFAULT_BASE_URL
+  );
+}
+
+/** Typed key wins; otherwise a key already in the environment needs no retyping. */
+export function apiKeyForWizard(
+  wizard: ProvidersWizardState,
+): string | undefined {
+  return (
+    wizard.apiKeyBuffer.trim() ||
+    resolveLlmProviderApiKey({
+      id: "openai-compatible",
+      kind: "openai-compatible",
+    })
   );
 }
 
@@ -140,7 +151,12 @@ export function listCompatChatModelPicks(
   if (wizard.phase !== "chat_model_line") return [];
   if (wizard.kind !== "openai-compatible") return [];
   if (wizard.chatModelLine.length > 0) return [];
-  return getCachedOpenAiCompatModels(baseUrlForWizard(wizard)) ?? [];
+  return (
+    getCachedOpenAiCompatModels(
+      baseUrlForWizard(wizard),
+      apiKeyForWizard(wizard),
+    ) ?? []
+  );
 }
 
 export type ProvidersWizardKeyResult =

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -1,5 +1,8 @@
 import type { Key } from "ink";
-import { getCachedOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import {
+  getCachedOpenAiCompatModels,
+  normalizeOpenAiCompatBaseUrl,
+} from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import {
   listAimlapiChatModels,
   listAimlapiEmbeddingModels,
@@ -118,8 +121,12 @@ function isLinePhase(phase: ProvidersWizardPhase): boolean {
   );
 }
 
+/** Normalized so the fetch, the cache key and the displayed URL always agree. */
 export function baseUrlForWizard(wizard: ProvidersWizardState): string {
-  return wizard.baseUrlLine.trim() || OPENAI_COMPAT_DEFAULT_BASE_URL;
+  return (
+    normalizeOpenAiCompatBaseUrl(wizard.baseUrlLine) ||
+    OPENAI_COMPAT_DEFAULT_BASE_URL
+  );
 }
 
 /**

--- a/src/tui/providers/save-provider-wizard.test.ts
+++ b/src/tui/providers/save-provider-wizard.test.ts
@@ -110,7 +110,8 @@ describe("saveProviderWizardToConfig", () => {
     expect(getConfig().llm?.providers.find((p) => p.id === "openai-compatible"))
       .toMatchObject({
         kind: "openai-compatible",
-        baseUrl: "https://api.venice.ai/api/",
+        // trailing slash normalized away — callers append `/v1/...`
+        baseUrl: "https://api.venice.ai/api",
         defaultChatModel: "venice-uncensored",
       });
   });


### PR DESCRIPTION
Closes #31.

## Problem

The OpenAI-compatible provider wizard asked the operator to type a chat model id by hand. Against a remote vLLM/SGLang deployment — the case in #31 — nobody knows the ids offhand, and providers rotate them without notice. The server already publishes them at `GET {baseUrl}/v1/models`.

## Change

- **`src/llm/provider/openai/fetch-openai-compat-models.ts`** (new) — `GET {baseUrl}/v1/models` with the bearer key, sorted ids, 10s timeout, cached per normalized base URL. Same fetch-then-read-sync shape the OpenRouter picker already uses, so the sync key handler can read the result.
- **Chat model step** — now fetches on entry and renders the ids as a 12-row window around the cursor (`↑/↓ move (21/341) · Enter select`). Typing still works: any printable key is a deliberate override that hides the list, backspacing to empty brings it back. Arrows only for movement, so ids starting with `j`/`k` stay typable.
- **Failure is not fatal** — a refused, empty or unreachable endpoint degrades to the old typed field with the reason in the hint (`model list unavailable (http 401) — type the id`).
- **Base URL normalization on save** — a base pasted as `https://host/v1/` was stored verbatim and produced `https://host/v1//v1/chat/completions` on every later request. It is now normalized once, and the same helper feeds the fetch, the cache key and the displayed URL.

The API key comes from the wizard buffer, falling back to `resolveLlmProviderApiKey` (`OPENAI_COMPAT_API_KEY` / `OPENAI_API_KEY` / `ATOMIC_AGENT_OPENAI_API_KEY`), so a key already in `.env` needs no retyping.

## Verification

15 new tests (fetch/cache/normalize, picker key flow, typed override, windowed render, refusal fallback). Full suite: 3293 passing, unchanged pre-existing failures on `main`; `tsc` clean.

Also exercised against real servers, no mocks:

- `https://openrouter.ai/api` — 341 ids listed and rendered; base pasted as `.../api/v1/` hit the cache instead of re-requesting; arrows + Enter selected a model and built the entry with `baseUrl: https://openrouter.ai/api`.
- A local vLLM-shaped HTTP server — server log showed exactly one `GET /v1/models auth=Bearer <key>`, and the cold-cache render produced the windowed picker.
- `https://api.openai.com` with no key → `http 401`, nothing cached, hint shown; unreachable host → `fetch failed` hint.

## Known limitation

Servers whose OpenAI base is a path prefix rather than a host root (e.g. DeepInfra's `https://api.deepinfra.com/v1/openai`) 404 on discovery, because the codebase appends `/v1/...` and the normalizer only strips a trailing `/v1`. That shape already cannot serve chat completions through this provider, so it is pre-existing rather than a regression; the wizard falls back to typed entry there.