### PR TITLE
Surface a dying stdio MCP server's stderr instead of 'Connection closed'

### DIFF
--- a/src/mcp/mcp-client-stderr.test.ts
+++ b/src/mcp/mcp-client-stderr.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { McpClient } from "./mcp-client.js";
+import { McpConnectError } from "./mcp-errors.js";
+import type { McpServerConfig } from "./mcp-types.js";
+
+/** Spawns a real child that dies the way issue #23 describes. */
+function serverThatDies(script: string): McpServerConfig {
+  return {
+    name: "broken",
+    enabled: true,
+    transport: {
+      kind: "stdio",
+      command: process.execPath,
+      args: ["-e", script],
+    },
+  } as McpServerConfig;
+}
+
+describe("McpClient stdio failure diagnostics", () => {
+  it("reports the child's stderr instead of a bare 'Connection closed'", async () => {
+    const client = new McpClient(
+      serverThatDies(
+        "console.error(\"Error [ERR_REQUIRE_ESM]: require() of ES Module /srv/tool.js not supported\"); process.exit(1);",
+      ),
+    );
+
+    await expect(client.connect()).rejects.toThrow(McpConnectError);
+    await client.connect().catch((err: McpConnectError) => {
+      expect(err.server).toBe("broken");
+      expect(err.message).toContain("server stderr:");
+      expect(err.message).toContain("ERR_REQUIRE_ESM");
+    });
+  }, 20_000);
+
+  it("leaves the message alone when the server dies silently", async () => {
+    const client = new McpClient(serverThatDies("process.exit(1);"));
+
+    await client.connect().catch((err: McpConnectError) => {
+      expect(err).toBeInstanceOf(McpConnectError);
+      expect(err.message).not.toContain("server stderr:");
+    });
+  }, 20_000);
+});

--- a/src/mcp/mcp-client.ts
+++ b/src/mcp/mcp-client.ts
@@ -21,6 +21,11 @@ import {
 import { resourceClassFor } from "../agent/tool-resource-class.js";
 import { McpConnectError, McpRequestError, scrubErrorMessage } from "./mcp-errors.js";
 import {
+  attachStderrTail,
+  formatStderrTail,
+  type StderrTail,
+} from "./mcp-stderr-tail.js";
+import {
   qualifyMcpToolName,
   splitMcpToolName,
 } from "./mcp-resource-class.js";
@@ -63,6 +68,8 @@ export interface McpClientDeps {
 const CLIENT_NAME = "atomic-agent";
 const CLIENT_VERSION = "0.1.0";
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+/** Grace for a dying child's stderr to arrive after the transport closes. */
+const STDERR_SETTLE_MS = 250;
 const DEFAULT_TOOL_CALL_TIMEOUT_MS = 60_000;
 
 /**
@@ -124,8 +131,14 @@ export class McpClient {
       );
     }
     this.connecting = true;
+    let stderrTail: StderrTail = { read: () => "", settle: async () => {} };
     try {
       const transport = this.buildTransport();
+      // Attached before `client.connect()` starts the child: the SDK hands
+      // out a PassThrough up front precisely so early output is not lost.
+      stderrTail = attachStderrTail(
+        transport instanceof StdioClientTransport ? transport.stderr : null,
+      );
       const client = new Client(
         { name: CLIENT_NAME, version: CLIENT_VERSION },
         {
@@ -148,13 +161,11 @@ export class McpClient {
             this.config.name,
             `connect timeout after ${DEFAULT_CONNECT_TIMEOUT_MS}ms`,
           ),
-      ).catch((err) => {
+      ).catch(async (err) => {
         // Best-effort cleanup; the transport may be half-constructed.
         // Swallow secondary errors so the original cause propagates.
         client.close().catch(() => {});
-        throw err instanceof McpConnectError
-          ? err
-          : new McpConnectError(this.config.name, scrubErrorMessage(err));
+        throw await this.connectError(err, stderrTail);
       });
 
       this.client = client;
@@ -162,10 +173,29 @@ export class McpClient {
     } catch (err) {
       throw err instanceof McpConnectError
         ? err
-        : new McpConnectError(this.config.name, scrubErrorMessage(err));
+        : await this.connectError(err, stderrTail);
     } finally {
       this.connecting = false;
     }
+  }
+
+  /**
+   * Wrap a connect failure, appending whatever the server printed on
+   * stderr. `Connection closed` alone never says *why* a stdio server
+   * refused to start; its last stderr lines usually do.
+   */
+  private async connectError(
+    err: unknown,
+    stderrTail: StderrTail,
+  ): Promise<McpConnectError> {
+    const base =
+      err instanceof McpConnectError ? err.message : scrubErrorMessage(err);
+    await stderrTail.settle(STDERR_SETTLE_MS);
+    const tail = formatStderrTail(stderrTail.read());
+    return new McpConnectError(
+      this.config.name,
+      tail ? `${base} · server stderr: ${tail}` : base,
+    );
   }
 
   /**

--- a/src/mcp/mcp-stderr-tail.test.ts
+++ b/src/mcp/mcp-stderr-tail.test.ts
@@ -1,0 +1,85 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+
+import { attachStderrTail, formatStderrTail } from "./mcp-stderr-tail.js";
+
+describe("attachStderrTail", () => {
+  it("captures output and settles when the stream ends", async () => {
+    const stream = new PassThrough();
+    const tail = attachStderrTail(stream);
+
+    stream.write("first\n");
+    stream.end("second\n");
+    await tail.settle(1000);
+
+    expect(tail.read()).toBe("first\nsecond\n");
+  });
+
+  it("settles on the timeout when the server stays alive", async () => {
+    const tail = attachStderrTail(new PassThrough());
+    const started = Date.now();
+    await tail.settle(30);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(20);
+  });
+
+  it("keeps only the last 4000 chars so a chatty server cannot grow it", async () => {
+    const stream = new PassThrough();
+    const tail = attachStderrTail(stream);
+    stream.write("x".repeat(5000));
+    stream.end("TAIL");
+    await tail.settle(1000);
+
+    expect(tail.read()).toHaveLength(4000);
+    expect(tail.read().endsWith("TAIL")).toBe(true);
+  });
+
+  it("tolerates a missing stream and a stream error", async () => {
+    expect(attachStderrTail(null).read()).toBe("");
+    await expect(attachStderrTail(undefined).settle(5)).resolves.toBeUndefined();
+
+    const stream = new PassThrough();
+    const tail = attachStderrTail(stream);
+    stream.emit("error", new Error("EPIPE"));
+    expect(tail.read()).toBe("");
+  });
+});
+
+describe("formatStderrTail", () => {
+  it("picks the cause out of a Node crash dump, not the trailing noise", () => {
+    const dump = [
+      "node:internal/modules/cjs/loader:1433",
+      "  throw err;",
+      "  ^",
+      "",
+      "Error [ERR_REQUIRE_ESM]: require() of ES Module /srv/tool.js not supported.",
+      "    at Module._compile (node:internal/modules/cjs/loader:1234:14)",
+      "  code: 'ERR_REQUIRE_ESM'",
+      "}",
+      "",
+      "Node.js v22.23.1",
+    ].join("\n");
+
+    const out = formatStderrTail(dump);
+    expect(out).toContain("ERR_REQUIRE_ESM");
+    expect(out).toContain("require() of ES Module");
+    expect(out).not.toContain("Node.js v22");
+    expect(out).not.toContain("at Module._compile");
+  });
+
+  it("falls back to the last lines when nothing looks like a cause", () => {
+    expect(formatStderrTail("usage: my-server [opts]\nsee --help\n")).toBe(
+      "usage: my-server [opts] / see --help",
+    );
+  });
+
+  it("strips ANSI colour and clips long output", () => {
+    const coloured = "\u001B[31mENOENT: no such file\u001B[0m";
+    expect(formatStderrTail(coloured)).toBe("ENOENT: no such file");
+    expect(formatStderrTail(`Error: ${"y".repeat(400)}`, 3, 50)).toHaveLength(50);
+  });
+
+  it("returns empty for a silent server", () => {
+    expect(formatStderrTail("")).toBe("");
+    expect(formatStderrTail("\n  \n")).toBe("");
+  });
+});

--- a/src/mcp/mcp-stderr-tail.ts
+++ b/src/mcp/mcp-stderr-tail.ts
@@ -1,0 +1,102 @@
+/**
+ * Stdio MCP servers report why they died on stderr — `ERR_REQUIRE_ESM`,
+ * `ERR_UNKNOWN_FILE_EXTENSION`, `Cannot find module`, a missing API key.
+ * The transport pipes that stream, but nothing used to read it, so the
+ * operator was left with `MCP error -32000: Connection closed`.
+ *
+ * Reading it also drains the pipe: an unread `stderr: "pipe"` fills the
+ * OS buffer and stalls a chatty server.
+ */
+
+import type { EventEmitter } from "node:events";
+
+/** Enough for a Node stack trace, small enough to hold per server forever. */
+const MAX_TAIL_CHARS = 4000;
+
+const ANSI_RE = /\u001B\[[0-9;]*[A-Za-z]/g;
+
+export type StderrTail = {
+  /** Everything captured so far, clipped to the last `MAX_TAIL_CHARS`. */
+  read(): string;
+  /**
+   * Resolve once the stream ends (the child exited) or `ms` elapses. A
+   * dying server loses the race between its stderr and the transport's
+   * `Connection closed`, so the failure path waits briefly before it
+   * reports.
+   */
+  settle(ms: number): Promise<void>;
+};
+
+/** Start consuming `stream` into a bounded tail. */
+export function attachStderrTail(
+  stream: EventEmitter | null | undefined,
+): StderrTail {
+  if (!stream) return { read: () => "", settle: async () => {} };
+
+  let tail = "";
+  let ended = false;
+  let notifyEnd: (() => void) | null = null;
+  const markEnded = (): void => {
+    ended = true;
+    notifyEnd?.();
+  };
+
+  stream.on("data", (chunk: Buffer | string) => {
+    tail = (tail + String(chunk)).slice(-MAX_TAIL_CHARS);
+  });
+  stream.on("end", markEnded);
+  stream.on("close", markEnded);
+  // A broken pipe on a server that already died must not take the agent down.
+  stream.on("error", () => {});
+
+  return {
+    read: () => tail,
+    settle: (ms) =>
+      new Promise<void>((resolve) => {
+        if (ended) {
+          resolve();
+          return;
+        }
+        const finish = (): void => {
+          clearTimeout(timer);
+          notifyEnd = null;
+          resolve();
+        };
+        const timer = setTimeout(finish, ms);
+        timer.unref?.();
+        notifyEnd = finish;
+      }),
+  };
+}
+
+/** Stack frames and the decoration Node wraps its crash dumps in. */
+const NOISE_RE = /^(at\s|[\^{}()[\]]+$|Node\.js v|\.\.\.|throw\b)/;
+
+/** Lines an operator actually needs: the cause, not the frames around it. */
+const CAUSE_RE =
+  /(error|exception|traceback|cannot|unable|missing|denied|refused|not found|no such|ERR_|ENOENT|EACCES)/i;
+
+/**
+ * Condense a tail into one operator-facing line, ANSI stripped and
+ * clipped. Prefers cause-shaped lines — a Node crash dump ends with
+ * `}` / `Node.js v22`, so the plain last lines say nothing. Empty when
+ * the server printed nothing.
+ */
+export function formatStderrTail(
+  tail: string,
+  maxLines = 3,
+  maxChars = 300,
+): string {
+  const all = tail
+    .replace(ANSI_RE, "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !NOISE_RE.test(line));
+  const causes = all.filter((line) => CAUSE_RE.test(line));
+  const lines = (causes.length > 0 ? causes : all).slice(-maxLines);
+  if (lines.length === 0) return "";
+  const joined = lines.join(" / ");
+  return joined.length > maxChars
+    ? `${joined.slice(0, maxChars - 1)}…`
+    : joined;
+}


### PR DESCRIPTION
Refs #23.

## What the issue reports vs. what this repo does

#23 points at `src/mcp/loader.ts` and an `atomic.config.ts` `tools: [{ path }]` plugin loader that dynamically `import()`s MCP servers in-process. Neither exists here: MCP servers are configured as `stdio | streamable_http | sse` (`src/config/config-schema.ts`) and stdio servers are **spawned as child processes** via the SDK's `StdioClientTransport` — nothing is ever imported into the agent's module graph, so there is no ESM/CJS resolution path to fix as described.

The failure *class* is real, though, and lands on users exactly as reported — just from the child, not from our loader. A server that dies at boot with `ERR_REQUIRE_ESM`, `ERR_UNKNOWN_FILE_EXTENSION`, `Cannot find module` or a missing API key prints the reason on stderr and exits. `buildTransport()` asks for `stderr: "pipe"`, but nothing read that stream, so all the operator saw was:

```
MCP error -32000: Connection closed
```

Reproduced before the change with a CJS server requiring an ESM graph — that exact message, cause discarded.

## Change

- **`src/mcp/mcp-stderr-tail.ts`** (new) — consumes the piped stderr into a bounded 4 KB tail, attached *before* `client.connect()` starts the child (the SDK hands out its `PassThrough` up front precisely so early output is not lost). Stream errors are swallowed: a broken pipe on a server that already died must not take the agent down.
- **Connect failures append the cause** — `formatStderrTail` prefers cause-shaped lines and drops stack frames and the `}` / `Node.js v22.x` decoration Node's crash dump ends with, so the message carries the diagnosis rather than the noise around it.
- **250 ms settle on the failure path only** — a dying child loses the race between its stderr and the transport's close event. A healthy connect never waits.
- **The pipe now gets drained** — an unread `stderr: "pipe"` fills the OS buffer and stalls a server that logs heavily. Fixed as a side effect of reading it.

The message flows through `McpConnectError` → `McpManager` `lastError` → status badge and `mcp.server_down` log, so every existing surface improves without further wiring.

After:

```
MCP error -32000: Connection closed · server stderr: Error [ERR_REQUIRE_ASYNC_MODULE]:
require() cannot be used on an ESM graph with top-level await. Use import() instead.
/ code: 'ERR_REQUIRE_ASYNC_MODULE'
```

## Verification

10 new tests: tail capture, 4 KB bound, settle-on-end vs. settle-on-timeout, null/error streams, Node crash-dump parsing, ANSI stripping, clipping, silent-server no-op — plus two that spawn a **real** child process and assert the connect error carries its stderr (and that a silent death adds nothing). Full suite: 3289 passing, unchanged pre-existing failures on `main`; `tsc` clean.

## Note for maintainers

I left this as `Refs` rather than `Closes` — if #23 was really asking for an in-process plugin loader (`atomic.config.ts` `tools[].path`), that is a feature request and a separate piece of work. This fixes the diagnostic failure that the reported error class actually produces today.