### PR TITLE
fix(release): enable linux-arm64 SEA build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,12 @@ jobs:
           # windows-2022 ships MSVC build tools so `better-sqlite3` rebuilds
           # natively during `npm ci`.
           - { slug: win32-x64, os: windows-2022 }
-          # Still disabled (own runner-availability / cost considerations,
-          # unrelated to the Windows fix):
+          # linux-arm64 re-enabled (#43): GitHub-hosted ubuntu-24.04-arm is
+          # available; BUNDLE_TARGETS / install.sh / fetch-assets already know
+          # the slug. Without this job the one-line installer 404s on ARM Linux.
+          - { slug: linux-arm64, os: ubuntu-24.04-arm }
+          # Still disabled (runner-availability / cost; out of scope for #43):
           # - { slug: darwin-x64, os: macos-13 }
-          # - { slug: linux-arm64, os: ubuntu-24.04-arm }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     permissions:

--- a/src/bundling/release-matrix-alignment.test.ts
+++ b/src/bundling/release-matrix-alignment.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { BUNDLE_TARGETS } from "../../scripts/bundle-targets.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const RELEASE_YML = resolve(REPO_ROOT, ".github/workflows/release.yml");
+
+/**
+ * Pin the release workflow's build matrix against first-class install targets.
+ *
+ * linux-arm64 has lived in BUNDLE_TARGETS / install.sh / fetch-assets forces
+ * for a long time, but release.yml had the runner entry commented out for cost.
+ * That combination silently 404s the one-line installer on ARM Linux (#43).
+ */
+function uncommentedSlugLines(yml: string): string[] {
+  return yml
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => {
+      const trimmed = line.trimStart();
+      return !trimmed.startsWith("#") && /slug:\s*[\w-]+/.test(trimmed);
+    });
+}
+
+function parseSlug(line: string): string | null {
+  const m = line.match(/slug:\s*([A-Za-z0-9_-]+)/);
+  return m?.[1] ?? null;
+}
+
+describe("release matrix alignment", () => {
+  it("lists linux-arm64 in BUNDLE_TARGETS (source of truth)", () => {
+    expect(BUNDLE_TARGETS.some((t) => t.slug === "linux-arm64")).toBe(true);
+  });
+
+  it("enables linux-arm64 on ubuntu-24.04-arm in release.yml (#43)", () => {
+    const yml = readFileSync(RELEASE_YML, "utf8");
+    const activeSlugs = uncommentedSlugLines(yml)
+      .map(parseSlug)
+      .filter((s): s is string => Boolean(s));
+
+    expect(activeSlugs, "release.yml active matrix slugs").toContain("linux-arm64");
+
+    // Prefer the GitHub-hosted ARM runner callout, not a self-hosted label.
+    const armLines = uncommentedSlugLines(yml).filter((l) => l.includes("linux-arm64"));
+    expect(armLines.length).toBeGreaterThan(0);
+    expect(armLines.some((l) => l.includes("ubuntu-24.04-arm"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Installer 404s on ARM Linux because `linux-arm64` was commented out of the release matrix while BUNDLE_TARGETS/install.sh already support it. Re-enable the `ubuntu-24.04-arm` job.

Closes #43.

Tested: `npx vitest run src/bundling/release-matrix-alignment.test.ts` — 2 passed