### PR TITLE
feat(tui): add an External llama.cpp pane to the LLM tab

### DIFF
--- a/src/tui/commands/slash-commands.ts
+++ b/src/tui/commands/slash-commands.ts
@@ -69,11 +69,11 @@ export const SLASH_COMMANDS: readonly SlashCommandDef[] = [
   {
     name: "llm",
     description:
-      "open LLM Local/Cloud panel · `/llm provider <id>` switch text provider",
+      "open LLM Local/Cloud/External panel · `/llm provider <id>` switch text provider",
   },
   {
     name: "model",
-    description: "open the LLM Local/Cloud panel",
+    description: "open the LLM Local/Cloud/External panel",
   },
   {
     name: "mcp",

--- a/src/tui/components/llm-mode-rows.tsx
+++ b/src/tui/components/llm-mode-rows.tsx
@@ -27,11 +27,11 @@ export function LlmModeRows({
   if (fullViewHeight > maxRows) {
     return <WindowedRows rows={rows} state={state} maxRows={maxRows} />;
   }
-  return state.llmPanel.mode === "local" ? (
-    <LocalRows rows={rows} state={state} />
-  ) : (
-    <CloudRows rows={rows} state={state} />
-  );
+  if (state.llmPanel.mode === "local") return <LocalRows rows={rows} state={state} />;
+  if (state.llmPanel.mode === "external") {
+    return <ExternalRows rows={rows} state={state} />;
+  }
+  return <CloudRows rows={rows} state={state} />;
 }
 
 /** Human-readable section title for a row, used by the windowed view. */
@@ -50,6 +50,8 @@ function sectionTitle(kind: LlmPanelRow["kind"]): string {
     case "localDaemon":
     case "localBackend":
       return "Local runtime";
+    case "externalUrl":
+      return "External llama.cpp";
   }
 }
 
@@ -156,6 +158,32 @@ function CloudRows({
   );
 }
 
+/**
+ * A llama-server the operator runs themselves is just a base URL, so the
+ * pane is one row plus the hints that matter once you point at it: the
+ * managed daemon keeps its VRAM until you stop it (`s`), and the Local
+ * pane is where you go back to a managed model.
+ */
+function ExternalRows({
+  rows,
+  state,
+}: {
+  rows: readonly LlmPanelRow[];
+  state: TuiState;
+}): ReactElement {
+  return (
+    <Box flexDirection="column">
+      <RowsSection title="External llama.cpp" rows={rows} state={state} />
+      <Text color={theme.colors.muted}>
+        {"  "}managed daemon: {formatDaemon(state)} · s start/stop
+      </Text>
+      <Text color={theme.colors.muted}>
+        {"  "}← Local pane: pick a managed model to switch back
+      </Text>
+    </Box>
+  );
+}
+
 function RowsSection({
   title,
   rows,
@@ -235,7 +263,19 @@ function renderRowText(row: LlmPanelRow, state: TuiState): string {
       return `${row.providerId}/${row.modelId} [text]`;
     case "cloudEmbeddingModel":
       return `${row.providerId}/${row.modelId} [embedding]`;
+    case "externalUrl":
+      return `base URL ${row.url} [${externalStatus(row.active, state)}]`;
   }
+}
+
+/**
+ * Health only describes the *active* route, so an inactive external URL
+ * reports "not active" rather than borrowing the managed daemon's probe.
+ */
+function externalStatus(active: boolean, state: TuiState): string {
+  if (!active) return "not active";
+  const { status, latencyMs } = state.llmHealth;
+  return latencyMs === null ? status : `${status} · ${latencyMs}ms`;
 }
 
 function localModelStatus(model: Extract<LlmPanelRow, { kind: "localTextModel" }>["model"]): string {

--- a/src/tui/components/llm-panel-modals.tsx
+++ b/src/tui/components/llm-panel-modals.tsx
@@ -1,8 +1,9 @@
 import { Box, Text } from "ink";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { theme } from "../theme/theme.js";
 import type { TuiState } from "../tui-state.js";
 import { ProvidersWizard } from "./providers-wizard.js";
+import { parseExternalUrl } from "../llm-panel/llm-panel-modal-key-bindings.js";
 
 export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | null {
   if (state.providersPanel.wizard) {
@@ -43,6 +44,22 @@ export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | n
       </PromptBox>
     );
   }
+  if (state.llmPanel.externalUrlDraft !== null) {
+    const draft = state.llmPanel.externalUrlDraft;
+    const valid = parseExternalUrl(draft) !== null;
+    return (
+      <PromptBox tone="accent" title="External llama.cpp base URL">
+        <Text>
+          {draft}
+          <Text color={theme.colors.muted}>▏</Text>
+        </Text>
+        {valid ? null : <Text color={theme.colors.error}>invalid URL</Text>}
+        <Text color={theme.colors.muted}>
+          Saved after a /health probe succeeds. Enter save · Esc cancel
+        </Text>
+      </PromptBox>
+    );
+  }
   if (state.llmPanel.stopLocalDaemonsPrompt) {
     return (
       <PromptBox tone="accent" title="Stop local daemons now?">
@@ -63,7 +80,7 @@ function PromptBox({
 }: {
   tone: "accent" | "danger";
   title: string;
-  children: ReactElement | readonly ReactElement[];
+  children: ReactNode;
 }): ReactElement {
   const color = tone === "danger" ? theme.colors.error : theme.colors.accentSoft;
   return (

--- a/src/tui/components/llm-panel.tsx
+++ b/src/tui/components/llm-panel.tsx
@@ -7,6 +7,7 @@ import {
   selectLlmPanelRows,
 } from "../llm-panel/llm-panel-selectors.js";
 import type { LocalModelsPanelState } from "../local-models/local-models-panel-state.js";
+import { LLM_PANEL_MODES, type LlmPanelMode } from "../llm-panel/llm-panel-state.js";
 import { LlmModeRows } from "./llm-mode-rows.js";
 import { LlmPanelModals } from "./llm-panel-modals.js";
 
@@ -71,7 +72,7 @@ export function LlmPanel({
       <Box marginTop={useFull ? 1 : 0} flexDirection="column">
         <Text color={theme.colors.muted}>
           {useFull
-            ? "j/k move · Enter selected action · ←/→ switch Local/Cloud · n add provider · c configure · r refresh"
+            ? "j/k move · Enter selected action · ←/→ switch Local/Cloud/External · n add provider · c configure · r refresh"
             : "j/k · Enter · ←/→ mode · r"}
         </Text>
       </Box>
@@ -150,22 +151,32 @@ function RouteCard({
   );
 }
 
-function ModeHeader({ mode }: { mode: "local" | "cloud" }): ReactElement {
-  const switchHint =
-    mode === "local" ? "Press → to switch to Cloud" : "Press ← to switch to Local";
+const MODE_LABELS: Record<LlmPanelMode, string> = {
+  local: "Local",
+  cloud: "Cloud",
+  external: "External llama.cpp",
+};
+
+function ModeHeader({ mode }: { mode: LlmPanelMode }): ReactElement {
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Text>
         Mode:{" "}
-        <Text bold color={mode === "local" ? theme.colors.accentSoft : theme.colors.muted}>
-          Local
-        </Text>
-        <Text color={theme.colors.muted}> | </Text>
-        <Text bold color={mode === "cloud" ? theme.colors.accentSoft : theme.colors.muted}>
-          Cloud
-        </Text>
+        {LLM_PANEL_MODES.map((candidate, index) => (
+          <Text key={candidate}>
+            {index > 0 ? <Text color={theme.colors.muted}> | </Text> : null}
+            <Text
+              bold
+              color={
+                candidate === mode ? theme.colors.accentSoft : theme.colors.muted
+              }
+            >
+              {MODE_LABELS[candidate]}
+            </Text>
+          </Text>
+        ))}
       </Text>
-      <Text color={theme.colors.muted}>{switchHint}</Text>
+      <Text color={theme.colors.muted}>Press ←/→ to switch mode</Text>
     </Box>
   );
 }

--- a/src/tui/llm-panel/llm-panel-actions.ts
+++ b/src/tui/llm-panel/llm-panel-actions.ts
@@ -7,7 +7,9 @@ export type LlmPanelAction =
   | { type: "llm_cursor_set"; cursor: number; mode?: LlmPanelMode }
   | { type: "llm_focus_set"; focus: LlmPanelSection; cursor?: number }
   | { type: "llm_stop_local_daemons_prompt_opened"; providerId: string }
-  | { type: "llm_stop_local_daemons_prompt_closed" };
+  | { type: "llm_stop_local_daemons_prompt_closed" }
+  /** Opens (string), edits (string) or closes (`null`) the external URL editor. */
+  | { type: "llm_external_url_draft_set"; value: string | null };
 
 export function isLlmPanelAction(
   action: { type: string },
@@ -19,6 +21,7 @@ export function isLlmPanelAction(
     action.type === "llm_cursor_set" ||
     action.type === "llm_focus_set" ||
     action.type === "llm_stop_local_daemons_prompt_opened" ||
-    action.type === "llm_stop_local_daemons_prompt_closed"
+    action.type === "llm_stop_local_daemons_prompt_closed" ||
+    action.type === "llm_external_url_draft_set"
   );
 }

--- a/src/tui/llm-panel/llm-panel-external.test.ts
+++ b/src/tui/llm-panel/llm-panel-external.test.ts
@@ -1,0 +1,207 @@
+import type { Key } from "ink";
+import { describe, expect, it, vi } from "vitest";
+import type { TuiAction } from "../tui-action.js";
+import type { TuiAppCallbacks } from "../tui-app.js";
+import { createInitialTuiState, type TuiState } from "../tui-state.js";
+import { fakeSession } from "../test-fixtures.js";
+import { handleLlmPanelKey } from "./llm-panel-key-bindings.js";
+import { reduceLlmPanelAction } from "./llm-panel-reducer.js";
+import { selectLlmPanelRows } from "./llm-panel-selectors.js";
+
+function emptyKey(overrides: Partial<Key> = {}): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageDown: false,
+    pageUp: false,
+    return: false,
+    escape: false,
+    ctrl: false,
+    shift: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    meta: false,
+    ...overrides,
+  };
+}
+
+function callbacks(overrides: Partial<TuiAppCallbacks> = {}): TuiAppCallbacks {
+  return {
+    onApprovalDecision: vi.fn(),
+    onAbort: vi.fn(),
+    onQuit: vi.fn(),
+    onMessageSubmitted: vi.fn(),
+    ...overrides,
+  };
+}
+
+function externalState(overrides: Partial<TuiState> = {}): TuiState {
+  const base = createInitialTuiState(fakeSession());
+  return {
+    ...base,
+    uiMode: "debug" as const,
+    activeTab: "llm" as const,
+    session: { ...base.session, llamaUrl: "http://127.0.0.1:8080" },
+    llmPanel: { ...base.llmPanel, mode: "external" as const },
+    ...overrides,
+  };
+}
+
+/** Feed a key through the panel, returning what it dispatched. */
+function press(
+  input: string,
+  key: Key,
+  state: TuiState,
+  cbs: TuiAppCallbacks = callbacks(),
+): TuiAction[] {
+  const dispatched: TuiAction[] = [];
+  handleLlmPanelKey(input, key, {
+    state,
+    dispatch: (action) => dispatched.push(action),
+    callbacks: cbs,
+  });
+  return dispatched;
+}
+
+describe("external llama.cpp pane", () => {
+  it("cycles Local → Cloud → External → Local with →", () => {
+    let state = createInitialTuiState(fakeSession());
+    const seen: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      const [action] = press("]", emptyKey(), {
+        ...state,
+        uiMode: "debug",
+        activeTab: "llm",
+      });
+      state = reduceLlmPanelAction(state, action!) ?? state;
+      seen.push(state.llmPanel.mode);
+    }
+    expect(seen).toEqual(["cloud", "external", "local"]);
+  });
+
+  it("steps backwards with ←", () => {
+    const state = createInitialTuiState(fakeSession());
+    const [action] = press(
+      "",
+      emptyKey({ leftArrow: true }),
+      { ...state, uiMode: "debug", activeTab: "llm" },
+    );
+    expect(action).toEqual({ type: "llm_mode_set", mode: "external" });
+  });
+
+  it("shows the configured URL and reports inactive while managed mode is on", () => {
+    const rows = selectLlmPanelRows(externalState(), "external");
+    expect(rows).toEqual([
+      expect.objectContaining({
+        kind: "externalUrl",
+        url: "http://127.0.0.1:8080",
+        active: false,
+      }),
+    ]);
+  });
+
+  it("marks the row active once the route runs on an external URL", () => {
+    const base = externalState();
+    const rows = selectLlmPanelRows(
+      {
+        ...base,
+        localModelsPanel: { ...base.localModelsPanel, configMode: "external" },
+        providersPanel: {
+          ...base.providersPanel,
+          rows: [
+            {
+              id: "local-llama",
+              kind: "llama-server",
+              isActiveText: true,
+              isActiveEmbedding: false,
+              hasApiKey: false,
+              chatModel: "Qwen",
+              embeddingModel: null,
+            },
+          ],
+        },
+      },
+      "external",
+    );
+    expect(rows[0]).toMatchObject({ active: true, primaryAction: "current" });
+  });
+
+  it("Enter opens the URL editor seeded with the current URL", () => {
+    expect(press("", emptyKey({ return: true }), externalState())).toEqual([
+      { type: "llm_external_url_draft_set", value: "http://127.0.0.1:8080" },
+    ]);
+  });
+
+  it("types into the editor instead of firing panel hotkeys", () => {
+    const state = externalState();
+    state.llmPanel = { ...state.llmPanel, externalUrlDraft: "http://box" };
+    // `s` is the daemon start/stop hotkey outside the modal.
+    const onStop = vi.fn();
+    const dispatched = press(
+      "s",
+      emptyKey(),
+      state,
+      callbacks({ onLocalModelsDaemonStopRequested: onStop }),
+    );
+    expect(dispatched).toEqual([
+      { type: "llm_external_url_draft_set", value: "http://boxs" },
+    ]);
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it("persists a scheme-less URL on Enter and closes the editor", () => {
+    const state = externalState();
+    state.llmPanel = { ...state.llmPanel, externalUrlDraft: "192.168.1.50:8080" };
+    const onPersist = vi.fn();
+    const dispatched = press(
+      "",
+      emptyKey({ return: true }),
+      state,
+      callbacks({ onPersistLlamaUrl: onPersist }),
+    );
+    expect(dispatched).toEqual([{ type: "llm_external_url_draft_set", value: null }]);
+    expect(onPersist).toHaveBeenCalledWith("http://192.168.1.50:8080");
+  });
+
+  it("keeps the editor open and persists nothing when the URL is unparseable", () => {
+    const state = externalState();
+    state.llmPanel = { ...state.llmPanel, externalUrlDraft: "  " };
+    const onPersist = vi.fn();
+    const dispatched = press(
+      "",
+      emptyKey({ return: true }),
+      state,
+      callbacks({ onPersistLlamaUrl: onPersist }),
+    );
+    expect(dispatched).toEqual([]);
+    expect(onPersist).not.toHaveBeenCalled();
+  });
+
+  it("Esc closes the editor without persisting", () => {
+    const state = externalState();
+    state.llmPanel = { ...state.llmPanel, externalUrlDraft: "http://box" };
+    const onPersist = vi.fn();
+    const dispatched = press(
+      "",
+      emptyKey({ escape: true }),
+      state,
+      callbacks({ onPersistLlamaUrl: onPersist }),
+    );
+    expect(dispatched).toEqual([{ type: "llm_external_url_draft_set", value: null }]);
+    expect(onPersist).not.toHaveBeenCalled();
+  });
+
+  it("keeps a per-pane cursor", () => {
+    const state = externalState();
+    const next = reduceLlmPanelAction(state, {
+      type: "llm_cursor_set",
+      cursor: 3,
+      mode: "external",
+    });
+    expect(next?.llmPanel.externalCursor).toBe(3);
+    expect(next?.llmPanel.localCursor).toBe(state.llmPanel.localCursor);
+  });
+});

--- a/src/tui/llm-panel/llm-panel-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-key-bindings.ts
@@ -4,6 +4,7 @@ import type { TuiAppCallbacks } from "../tui-app.js";
 import type { TuiState } from "../tui-state.js";
 import { handleLlmModalKey } from "./llm-panel-modal-key-bindings.js";
 import { clampLlmCursor, selectLlmRowAt } from "./llm-panel-selectors.js";
+import { cursorFieldFor } from "./llm-panel-state.js";
 import {
   activateProviderEmbedding,
   openAddProvider,
@@ -59,7 +60,7 @@ export function handleLlmPanelKey(
     return true;
   }
   if (input === "[" || input === "]" || key.leftArrow || key.rightArrow) {
-    switchLlmMode(state, dispatch);
+    switchLlmMode(state, dispatch, input === "[" || key.leftArrow ? -1 : 1);
     return true;
   }
   if (input === "e") {
@@ -101,8 +102,6 @@ export function handleLlmPanelKey(
 }
 
 function activeCursor(state: TuiState): number {
-  return state.llmPanel.mode === "cloud"
-    ? state.llmPanel.cloudCursor
-    : state.llmPanel.localCursor;
+  return state.llmPanel[cursorFieldFor(state.llmPanel.mode)];
 }
 

--- a/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
@@ -3,6 +3,7 @@ import type { TuiAction } from "../tui-action.js";
 import type { TuiAppCallbacks } from "../tui-app.js";
 import type { TuiState } from "../tui-state.js";
 import { handleProvidersWizardKey } from "../providers/providers-wizard-key-bindings.js";
+import { normalizeLocalLlmBaseUrl } from "../persist-user-local-models-config.js";
 
 export function handleLlmModalKey(
   input: string,
@@ -88,6 +89,35 @@ export function handleLlmModalKey(
     return true;
   }
 
+  const urlDraft = state.llmPanel.externalUrlDraft;
+  if (urlDraft !== null) {
+    if (key.escape) {
+      dispatch({ type: "llm_external_url_draft_set", value: null });
+      return true;
+    }
+    if (key.return) {
+      const url = parseExternalUrl(urlDraft);
+      // Unparseable input keeps the editor open — it already renders an
+      // "invalid URL" hint, so closing here would swallow the mistake.
+      if (url === null) return true;
+      dispatch({ type: "llm_external_url_draft_set", value: null });
+      callbacks.onPersistLlamaUrl?.(url);
+      return true;
+    }
+    if (key.backspace || key.delete) {
+      dispatch({
+        type: "llm_external_url_draft_set",
+        value: urlDraft.slice(0, -1),
+      });
+      return true;
+    }
+    if (input && input.length > 0 && !key.ctrl && !key.meta) {
+      dispatch({ type: "llm_external_url_draft_set", value: urlDraft + input });
+      return true;
+    }
+    return true;
+  }
+
   if (state.llmPanel.stopLocalDaemonsPrompt) {
     const lower = input.toLowerCase();
     if (lower === "y") {
@@ -103,4 +133,17 @@ export function handleLlmModalKey(
   }
 
   return null;
+}
+
+/**
+ * Normalize a typed base URL (adds the `http://` scheme when omitted), or
+ * `null` when it is empty / unparseable. Shared with the modal renderer so
+ * the "invalid URL" hint and the Enter guard never disagree.
+ */
+export function parseExternalUrl(draft: string): string | null {
+  try {
+    return normalizeLocalLlmBaseUrl(draft);
+  } catch {
+    return null;
+  }
 }

--- a/src/tui/llm-panel/llm-panel-primary-actions.ts
+++ b/src/tui/llm-panel/llm-panel-primary-actions.ts
@@ -9,6 +9,7 @@ import { isCloudProviderKind } from "../providers/providers-orchestrator.js";
 import { createProvidersWizardState } from "../providers/providers-wizard-state.js";
 import type { LlmPanelRow } from "./llm-panel-selectors.js";
 import { isLocalTextActive } from "./llm-panel-selectors.js";
+import { nextMode } from "./llm-panel-reducer.js";
 
 export function triggerLlmPrimary(
   row: LlmPanelRow | null,
@@ -39,15 +40,19 @@ export function triggerLlmPrimary(
     case "cloudEmbeddingModel":
       triggerCloudEmbeddingModel(row, dispatch, callbacks);
       return;
+    case "externalUrl":
+      dispatch({ type: "llm_external_url_draft_set", value: row.url });
+      return;
   }
 }
 
+/** Move `delta` panes (right = +1, left = -1), wrapping at both ends. */
 export function switchLlmMode(
   state: TuiState,
   dispatch: (action: TuiAction) => void,
+  delta = 1,
 ): void {
-  const nextMode = state.llmPanel.mode === "local" ? "cloud" : "local";
-  dispatch({ type: "llm_mode_set", mode: nextMode });
+  dispatch({ type: "llm_mode_set", mode: nextMode(state.llmPanel.mode, delta) });
 }
 
 export function openProviderConfig(

--- a/src/tui/llm-panel/llm-panel-reducer.ts
+++ b/src/tui/llm-panel/llm-panel-reducer.ts
@@ -1,7 +1,7 @@
 import type { TuiAction } from "../tui-action.js";
 import type { TuiState } from "../tui-state.js";
 import { isLlmPanelAction } from "./llm-panel-actions.js";
-import type { LlmPanelMode } from "./llm-panel-state.js";
+import { cursorFieldFor, LLM_PANEL_MODES, type LlmPanelMode } from "./llm-panel-state.js";
 
 export function reduceLlmPanelAction(
   state: TuiState,
@@ -28,34 +28,30 @@ export function reduceLlmPanelAction(
     case "llm_mode_toggled":
       return {
         ...state,
-        llmPanel: { ...panel, mode: panel.mode === "local" ? "cloud" : "local" },
+        llmPanel: { ...panel, mode: nextMode(panel.mode, 1) },
       };
-    case "llm_cursor_set":
-      if ((action.mode ?? panel.mode) === "cloud") {
-        return {
-          ...state,
-          llmPanel: { ...panel, mode: "cloud", cloudCursor: Math.max(0, action.cursor) },
-        };
-      }
+    case "llm_cursor_set": {
+      const mode = action.mode ?? panel.mode;
       return {
         ...state,
         llmPanel: {
           ...panel,
-          mode: "local",
-          localCursor: Math.max(0, action.cursor),
+          mode,
+          [cursorFieldFor(mode)]: Math.max(0, action.cursor),
         },
       };
-    case "llm_focus_set":
+    }
+    case "llm_focus_set": {
+      const field = cursorFieldFor(action.focus);
       return {
         ...state,
         llmPanel: {
           ...panel,
           mode: action.focus,
-          ...(action.focus === "cloud"
-            ? { cloudCursor: Math.max(0, action.cursor ?? panel.cloudCursor) }
-            : { localCursor: Math.max(0, action.cursor ?? panel.localCursor) }),
+          [field]: Math.max(0, action.cursor ?? panel[field]),
         },
       };
+    }
     case "llm_stop_local_daemons_prompt_opened":
       return {
         ...state,
@@ -69,9 +65,21 @@ export function reduceLlmPanelAction(
         ...state,
         llmPanel: { ...panel, stopLocalDaemonsPrompt: null },
       };
+    case "llm_external_url_draft_set":
+      return {
+        ...state,
+        llmPanel: { ...panel, externalUrlDraft: action.value },
+      };
     default:
       return state;
   }
+}
+
+/** Step `delta` panes from `mode`, wrapping at both ends. */
+export function nextMode(mode: LlmPanelMode, delta: number): LlmPanelMode {
+  const at = LLM_PANEL_MODES.indexOf(mode);
+  const len = LLM_PANEL_MODES.length;
+  return LLM_PANEL_MODES[(at + delta + len) % len] ?? mode;
 }
 
 export function resolveModeFromActiveRoute(state: TuiState): LlmPanelMode | null {

--- a/src/tui/llm-panel/llm-panel-row-builders.ts
+++ b/src/tui/llm-panel/llm-panel-row-builders.ts
@@ -26,6 +26,34 @@ export function selectLocalRows(state: TuiState): readonly LlmPanelRow[] {
   return rows;
 }
 
+/**
+ * The External pane is a single row: an external llama.cpp *is* one base
+ * URL. Enter opens the editor pre-filled with the current URL; saving it
+ * is what flips `localModels.mode` to `external` (see
+ * `persistUserLocalLlmUrl`), so there is no separate "switch" action.
+ */
+export function selectExternalRows(state: TuiState): readonly LlmPanelRow[] {
+  const active =
+    state.localModelsPanel.configMode === "external" &&
+    state.providersPanel.rows.some(
+      (row) => row.id === "local-llama" && row.isActiveText,
+    );
+  return [
+    {
+      kind: "externalUrl",
+      id: "external-url",
+      mode: "external",
+      url: state.session.llamaUrl,
+      active,
+      available: true,
+      primaryAction: active ? "current" : "use",
+      enterEffect: active
+        ? "Enter: edit the base URL"
+        : "Enter: point the chat route at an external llama.cpp",
+    },
+  ];
+}
+
 export function selectCloudRows(state: TuiState): readonly LlmPanelRow[] {
   const providers = state.providersPanel.rows.filter(
     (row) => row.kind !== "llama-server",

--- a/src/tui/llm-panel/llm-panel-selectors.ts
+++ b/src/tui/llm-panel/llm-panel-selectors.ts
@@ -2,7 +2,12 @@ import type { EmbeddingModelRow, LocalModelRow } from "../local-models/local-mod
 import type { ProviderRow } from "../providers/providers-panel-state.js";
 import type { TuiState } from "../tui-state.js";
 import type { LlmPanelMode } from "./llm-panel-state.js";
-import { selectCloudRows, selectLocalRows } from "./llm-panel-row-builders.js";
+import {
+  selectCloudRows,
+  selectExternalRows,
+  selectLocalRows,
+} from "./llm-panel-row-builders.js";
+import { cursorFieldFor } from "./llm-panel-state.js";
 
 export type LlmPanelRow =
   | {
@@ -72,6 +77,16 @@ export type LlmPanelRow =
       available: boolean;
       primaryAction: "configure" | "use" | "current";
       enterEffect: string;
+    }
+  | {
+      kind: "externalUrl";
+      id: "external-url";
+      mode: "external";
+      url: string;
+      active: boolean;
+      available: boolean;
+      primaryAction: "edit" | "use" | "current";
+      enterEffect: string;
     };
 
 export interface LlmActiveRouteSummary {
@@ -95,7 +110,9 @@ export function selectLlmPanelRows(
   state: TuiState,
   mode: LlmPanelMode = state.llmPanel.mode,
 ): readonly LlmPanelRow[] {
-  return mode === "cloud" ? selectCloudRows(state) : selectLocalRows(state);
+  if (mode === "cloud") return selectCloudRows(state);
+  if (mode === "external") return selectExternalRows(state);
+  return selectLocalRows(state);
 }
 
 export function selectLlmRowAt(
@@ -114,9 +131,7 @@ export function clampLlmCursor(state: TuiState, cursor: number): number {
 }
 
 export function activeCursor(state: TuiState): number {
-  return state.llmPanel.mode === "cloud"
-    ? state.llmPanel.cloudCursor
-    : state.llmPanel.localCursor;
+  return state.llmPanel[cursorFieldFor(state.llmPanel.mode)];
 }
 
 export function selectLlmActiveRouteSummary(

--- a/src/tui/llm-panel/llm-panel-state.ts
+++ b/src/tui/llm-panel/llm-panel-state.ts
@@ -1,4 +1,12 @@
-export type LlmPanelMode = "local" | "cloud";
+/**
+ * Panes of the LLM tab. `local` browses the managed llama.cpp catalog,
+ * `cloud` the API providers, `external` the single base URL of a
+ * llama-server the operator runs themselves.
+ */
+export type LlmPanelMode = "local" | "cloud" | "external";
+
+/** Left-to-right pane order, used by the ←/→ pane switch. */
+export const LLM_PANEL_MODES: readonly LlmPanelMode[] = ["local", "cloud", "external"];
 
 export type LlmPanelSection = LlmPanelMode;
 
@@ -10,8 +18,15 @@ export interface LlmPanelState {
   mode: LlmPanelMode;
   localCursor: number;
   cloudCursor: number;
+  externalCursor: number;
   syncModeToActiveRoute: boolean;
   stopLocalDaemonsPrompt: LlmStopLocalDaemonsPrompt | null;
+  /**
+   * Buffer of the external base-URL editor. `null` when the editor is
+   * closed — a non-null value (including `""`) means the modal owns the
+   * keyboard.
+   */
+  externalUrlDraft: string | null;
 }
 
 export function createInitialLlmPanelState(): LlmPanelState {
@@ -19,7 +34,18 @@ export function createInitialLlmPanelState(): LlmPanelState {
     mode: "local",
     localCursor: 0,
     cloudCursor: 0,
+    externalCursor: 0,
     syncModeToActiveRoute: false,
     stopLocalDaemonsPrompt: null,
+    externalUrlDraft: null,
   };
+}
+
+/** Which `LlmPanelState` cursor field belongs to a pane. */
+export function cursorFieldFor(
+  mode: LlmPanelMode,
+): "localCursor" | "cloudCursor" | "externalCursor" {
+  if (mode === "cloud") return "cloudCursor";
+  if (mode === "external") return "externalCursor";
+  return "localCursor";
 }

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -39,6 +39,7 @@ import {
   startChatAndEmbeddingDaemons,
   startEmbeddingDaemon,
   stopChatAndEmbeddingDaemons,
+  stopDaemon as stopChatDaemonProcess,
   stopEmbeddingDaemon,
   type EmbeddingDaemonStartOptions,
   type EmbeddingModelDef,
@@ -964,6 +965,43 @@ export class LocalModelsOrchestrator {
           line: "local-llm: daemons stopped — hybrid recall off (embedding switch unchanged)",
         });
       }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.bus.emit({ type: "local_models_daemon_error_set", message: msg });
+      this.bus.emit({ type: "runtime_info", line: `local-llm: stop failed — ${msg}` });
+    } finally {
+      this.endActiveRefresh();
+      await this.refresh();
+    }
+  }
+
+  /**
+   * Stop only the managed *chat* daemon, leaving the embedding daemon —
+   * and therefore hybrid recall — running. Used when the chat route moves
+   * to an external llama-server: the managed chat process is the one that
+   * got replaced, and it would otherwise sit on its VRAM forever.
+   *
+   * A no-op when nothing is running, so callers can fire it
+   * unconditionally without emitting a misleading "stopped" line.
+   * `daemonSupervised` is deliberately left alone: the embedding side may
+   * still be ours to tear down at exit.
+   */
+  async stopChatDaemonOnly(): Promise<void> {
+    const cfg = getConfig();
+    const dataDir = cfg.paths.localModelsDataDir;
+    const status = await getDaemonStatus(dataDir, cfg.localModels.managed.port);
+    if (!status.running) {
+      await this.refresh();
+      return;
+    }
+    this.bus.emit({ type: "local_models_daemon_phase_set", phase: "stopping" });
+    this.beginActiveRefresh();
+    try {
+      await stopChatDaemonProcess(dataDir);
+      this.bus.emit({
+        type: "runtime_info",
+        line: "local-llm: managed chat daemon stopped — the external URL is the chat route now",
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       this.bus.emit({ type: "local_models_daemon_error_set", message: msg });

--- a/src/tui/persist-user-local-models-config.test.ts
+++ b/src/tui/persist-user-local-models-config.test.ts
@@ -12,6 +12,7 @@ import {
   persistUserLocalModelsConfig,
   persistUserLocalLlmUrl,
   persistUserRemoteLlmUrls,
+  pointsAtManagedDaemon,
 } from "./persist-user-local-models-config.js";
 
 describe("normalizeLocalLlmBaseUrl", () => {
@@ -151,5 +152,19 @@ describe("persistUserLocalLlmUrl", () => {
     expect(written.localModels.embeddings.enabled).toBe(false);
     expect(written.localModels.embeddings.modelId).toBeNull();
     expect(written.memory.embeddings.enabled).toBe(false);
+  });
+});
+
+describe("pointsAtManagedDaemon", () => {
+  it("matches the managed port on every loopback spelling", () => {
+    for (const host of ["127.0.0.1", "localhost", "[::1]"]) {
+      expect(pointsAtManagedDaemon(`http://${host}:19091`, 19091)).toBe(true);
+    }
+  });
+
+  it("rejects another port, another host, and unparseable input", () => {
+    expect(pointsAtManagedDaemon("http://127.0.0.1:8080", 19091)).toBe(false);
+    expect(pointsAtManagedDaemon("http://192.168.1.50:19091", 19091)).toBe(false);
+    expect(pointsAtManagedDaemon("not a url", 19091)).toBe(false);
   });
 });

--- a/src/tui/persist-user-local-models-config.ts
+++ b/src/tui/persist-user-local-models-config.ts
@@ -28,6 +28,27 @@ export function normalizeLocalLlmBaseUrl(raw: string): string {
 }
 
 /**
+ * True when `url` resolves to the managed daemon's own loopback address.
+ * Pointing external mode at the managed port is legal — it is how you
+ * drive a daemon you started yourself with `atomic-agent models start` —
+ * so callers that tear the managed daemon down on a switch to external
+ * must skip it here, or they would kill the server they just pointed at.
+ */
+export function pointsAtManagedDaemon(url: string, managedPort: number): boolean {
+  try {
+    const parsed = new URL(url);
+    const loopback =
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "localhost" ||
+      // `new URL` keeps IPv6 hosts bracketed.
+      parsed.hostname === "[::1]";
+    return loopback && parsed.port === String(managedPort);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Merge local-models-related user config keys, validate, write, and
  * invalidate the global config cache.
  */

--- a/src/tui/tui-app.test.tsx
+++ b/src/tui/tui-app.test.tsx
@@ -289,7 +289,7 @@ describe("TuiApp (smoke)", () => {
     expect(text).toContain("Mode:");
     expect(text).toContain("Local text models");
     expect(text).toContain("Local embeddings");
-    expect(text).toContain("Press → to switch to Cloud");
+    expect(text).toContain("Press ←/→ to switch mode");
     expect(text).not.toContain("Local runtime");
     unmount();
   });

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -10,7 +10,10 @@ import type { MetricSample, MetricSink } from "../tracing/metrics-collector.js";
 import { enterAltScreen } from "./alt-screen.js";
 import { ChatOrchestrator } from "./chat-orchestrator.js";
 import { parseTuiArgs } from "./tui-args.js";
-import { persistUserLocalLlmUrl } from "./persist-user-local-models-config.js";
+import {
+  persistUserLocalLlmUrl,
+  pointsAtManagedDaemon,
+} from "./persist-user-local-models-config.js";
 import { persistUserTuiTheme } from "./persist-user-tui-config.js";
 import {
   isManagedModeReadyOnDisk,
@@ -432,7 +435,16 @@ function persistLlamaUrl(
       if (getConfig().llm?.activeTextProvider !== "local-llama") {
         await orchestrator.providers.setActiveText("local-llama");
       }
-      await orchestrator.localModels.refresh();
+      // An external server replaces the managed chat daemon, which would
+      // otherwise keep its VRAM for a route nothing uses. Unless the new
+      // URL *is* the managed daemon — stopping it would kill the server
+      // we just pointed at. Both branches refresh the LLM tab so it stops
+      // reporting managed mode.
+      if (pointsAtManagedDaemon(nextUrl, getConfig().localModels.managed.port)) {
+        await orchestrator.localModels.refresh();
+      } else {
+        await orchestrator.localModels.stopChatDaemonOnly();
+      }
       bus.emit({
         type: "runtime_info",
         line: `local-llm URL saved (${health.latencyMs}ms)`,

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -423,6 +423,16 @@ function persistLlamaUrl(
       persistUserLocalLlmUrl(nextUrl);
       bus.emit({ type: "llama_url_changed", url: nextUrl });
       orchestrator.updateLlamaUrl(nextUrl);
+      // The URL only takes effect if the chat route points at
+      // llama-server; a cloud provider would otherwise stay active and
+      // the saved URL would look inert. Done after the probe so a dead
+      // address never steals a working route, and skipped when the route
+      // is already local so editing a URL stays quiet. `refresh()`
+      // re-reads `localModels.mode` so the LLM tab stops claiming managed.
+      if (getConfig().llm?.activeTextProvider !== "local-llama") {
+        await orchestrator.providers.setActiveText("local-llama");
+      }
+      await orchestrator.localModels.refresh();
       bus.emit({
         type: "runtime_info",
         line: `local-llm URL saved (${health.latencyMs}ms)`,


### PR DESCRIPTION
Closes #49.

## What

Adds `external` as a third pane of the LLM tab, cycled with ←/→:

```
Mode: Local | Cloud | External llama.cpp
Press ←/→ to switch mode

External llama.cpp
> base URL http://127.0.0.1:8080 [not active] · Enter: point the chat route at an external llama.cpp

  managed daemon: running pid 42 on 127.0.0.1:19091 · s start/stop
  ← Local pane: pick a managed model to switch back
```

The pane is a single row because an external llama-server *is* one base URL. Enter opens an inline editor seeded with the current URL; saving it runs the existing `/health` probe and only then persists `localModels.url` + `mode: "external"`, so an unreachable address never steals a working route. A scheme-less host gets `http://` prepended; unparseable input keeps the editor open behind an `invalid URL` hint rather than closing and silently discarding the edit.

Once the route is live the row reads `* base URL http://192.168.1.50:8080 [ok · 12ms]` and the status line switches to `mode external · <url>`.

Going back to managed is unchanged: pick a model in the Local pane, which already persists `mode: "managed"`.

## Fixes in the persist path

Both are shared with `/models <base-url>`, which had the same defects:

- Point the chat route at `local-llama` when a cloud provider is active, so the saved URL is not inert. Skipped when the route is already local, so editing a URL does not emit a spurious "Switched active text provider" line.
- Call `localModels.refresh()` so the panel stops reporting managed mode.

Both run after the probe succeeds, so a failed switch changes nothing.

## Managed daemon teardown

Switching to external now stops the managed **chat** daemon, which would otherwise hold its VRAM for a route nothing uses. `stopChatDaemonOnly()` deliberately leaves the embedding daemon and `memory.embeddings.enabled` alone — unlike the cloud path's `stopDaemon()`, which stops both and turns hybrid recall off. It no-ops when nothing is running.

Skipped when the new URL is the managed daemon's own loopback address: driving a daemon started with `atomic-agent models start` is a supported setup, and stopping it would kill the server just pointed at. `pointsAtManagedDaemon(url, port)` takes the port as an argument so it stays pure and testable.

## Implementation notes

- `LlmPanelMode` gains `external`; the two cursor fields become three behind `cursorFieldFor(mode)`, replacing the `mode === "cloud" ? … : …` branches in the reducer, selectors, and key bindings.
- `←`/`→` now carry a direction (`switchLlmMode(state, dispatch, delta)`); with three panes a plain toggle no longer works.
- The URL editor is a modal in `handleLlmModalKey`, so panel hotkeys (`s`, `n`, `c`, `/`) go into the buffer while it is open.
- `parseExternalUrl` is shared between the Enter guard and the modal renderer so the hint and the guard cannot disagree.

## Testing

- `src/tui/llm-panel/llm-panel-external.test.ts` — 10 tests: pane cycling in both directions, row active/inactive state, editor open/type/backspace/save/cancel, scheme-less normalization, the unparseable-input guard, per-pane cursors.
- `pointsAtManagedDaemon` covered in `src/tui/persist-user-local-models-config.test.ts` (loopback spellings, other ports, other hosts, garbage input).
- Verified by rendering the real panel through the real key handler end to end (throwaway harness): the frames above are actual output, and `onPersistLlamaUrl(http://192.168.1.50:8080)` fired from typing `192.168.1.50:8080`.
- `tsc --noEmit` clean, `npm run build` succeeds.
- `src/tui`: 656 passed / 6 failed, the same 6 that fail on `main` (splash-banner copy, chat-log, persist-embedding, two TuiApp smoke tests, one llm-panel selectors test). One of them, `TuiApp (smoke) > shows the two-mode LLM panel`, asserts header copy this PR changes — the assertion is updated, but the test still fails for its pre-existing reason (the test terminal is too short to render the full header, so it takes the compact path). Not fixed here.

## Not included

- A `/models external` slash subcommand.
- Making bare `/models` land on the External pane when it is the active route. `resolveModeFromActiveRoute` would need `configMode`, which is still at its default until the first refresh — managed users would land on the wrong pane at startup.