### PR TITLE
Fix fatal empty-content error on reasoning-only completions from OpenAI-compatible reasoning models

### DIFF
--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -272,16 +272,16 @@ describe("executeStep batch handling", () => {
     ]);
   });
 
-  it("native_tools: reasoning-only completion (empty content, no tool_calls) fails fast as ModelError", async () => {
-    // Pre-`tool_choice: "auto"` migration this case used to round-trip
-    // through a one-shot `parse_retry`. After the migration, a completion
-    // that carried `reasoningContent` but neither `content` nor
-    // `tool_calls` is treated as a model defect: replaying the same prompt
-    // would reproduce the same wall, so we fail fast with `ModelError`
-    // (category `model`) instead of burning a retry on it. The legacy
-    // "retry into a healthy tool_calls completion" path is no longer
-    // exercised because the runtime no longer rewards models that hide
-    // the answer in the reasoning channel.
+  it("native_tools: reasoning-only completion (empty content, no tool_calls) is salvaged as a reply", async () => {
+    // Reasoning models served over OpenAI-compatible APIs (Qwen3.8 with
+    // `preserve_thinking` on, DeepSeek-R1) routinely end hard turns with
+    // the entire answer in `reasoning_content`, `content` empty and no
+    // `tool_calls`. Failing fast here (the pre-Qwen3.8 contract) killed
+    // whole sessions on healthy completions. The parser now salvages the
+    // reasoning body — GBNF batch if one is embedded, otherwise a
+    // length-1 `reply` — without burning a retry: no prompt is replayed,
+    // so the original fail-fast concern (replaying the same prompt into
+    // the same wall) does not apply.
     const registry = makeRegistry();
     const session = createEmptySessionState({
       id: "s-native-reasoning-only",
@@ -289,47 +289,52 @@ describe("executeStep batch handling", () => {
     });
     let llmCalls = 0;
 
-    await expect(
-      executeStep(
-        {
-          session,
-          toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
-          capabilities: CAPS,
-          skillCatalog: SKILLS,
-          stepIndex: 0,
-          signal: new AbortController().signal,
-          userMessage: "привет",
+    const outcome = await executeStep(
+      {
+        session,
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "привет",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        async llmComplete() {
+          llmCalls += 1;
+          return {
+            content: "",
+            reasoningContent: "I should call reply.",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: 5,
+            },
+            cacheHitTokens: 0,
+            slotId: -1,
+            modelId: "openai/gpt-5.5",
+          };
         },
-        {
-          registry,
-          slotManager: new SlotManager(2),
-          async llmComplete() {
-            llmCalls += 1;
-            return {
-              content: "",
-              reasoningContent: "I should call reply.",
-              stop: true,
-              truncated: false,
-              timing: {
-                promptMs: 1,
-                predictedMs: 1,
-                promptTokens: 20,
-                predictedTokens: 5,
-              },
-              cacheHitTokens: 0,
-              slotId: -1,
-              modelId: "openai/gpt-5.5",
-            };
-          },
-          grammar: "",
-          profile: PLAIN_INSTRUCT_PROFILE,
-          toolTransport: "native_tools",
-          toolCallAdapter: null,
-          supportsSlotAffinity: false,
-        },
-      ),
-    ).rejects.toMatchObject({ name: "ModelError" });
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      },
+    );
+
     expect(llmCalls).toBe(1);
+    expect(outcome.toolResults).toHaveLength(1);
+    expect(outcome.toolResults[0]?.status).toBe("ok");
+    expect(outcome.nextSession.turns.at(-1)).toMatchObject({
+      kind: "assistant_reply",
+      text: "I should call reply.",
+    });
   });
 
   it("repairs a native-tools reply call with empty args before execution", async () => {

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -872,12 +872,22 @@ function isNativeToolsEmptyCompletionHandledByParser(
   if (deps.toolTransport !== "native_tools" || reason !== "empty") {
     return false;
   }
-  // Empty `content` is OK only when the model still emitted at least one
-  // OpenAI `tool_call` — the parser can recover those. With BOTH content
-  // and tool_calls empty there is nothing left to parse; route through
-  // ModelError so the agent loop fails fast instead of replaying the same
-  // prompt against the same wall.
-  return completion.toolCalls !== undefined && completion.toolCalls.length > 0;
+  // Empty `content` is OK when the model still emitted at least one
+  // OpenAI `tool_call` — the parser can recover those.
+  if (completion.toolCalls !== undefined && completion.toolCalls.length > 0) {
+    return true;
+  }
+  // Reasoning-only completions (Qwen3.8 with preserve_thinking,
+  // DeepSeek-R1 over OpenAI-compatible APIs): the model ends its turn
+  // with all text in `reasoning_content`, `content` empty and no
+  // tool_calls. The parser salvages these — a GBNF-shaped batch inside
+  // the reasoning, or the reasoning itself as a `reply`. Only a
+  // completion with NOTHING in any channel routes through ModelError.
+  const reasoning =
+    typeof completion.reasoningContent === "string"
+      ? completion.reasoningContent.trim()
+      : "";
+  return reasoning.length > 0;
 }
 
 /**
@@ -964,6 +974,48 @@ function tryParseToolCalls(
               },
             ],
             ...(reasoning.length > 0 ? { reasoning } : {}),
+          },
+        };
+      }
+      // Reasoning-only completion: no tool_calls, empty content, but the
+      // think channel carries text. Same two recovery paths as for plain
+      // content, applied to the reasoning body: models occasionally emit
+      // the GBNF-style call array inside the think block, and a model
+      // that reasoned its way to a final answer without ever leaving the
+      // think channel still has an answer worth delivering as `reply`.
+      const reasoningText =
+        typeof completion.reasoningContent === "string"
+          ? completion.reasoningContent.trim()
+          : "";
+      if (reasoningText.length > 0) {
+        try {
+          const grammarBatch = parseToolCalls(
+            reasoningText,
+            getReasoningTagOptions(profile),
+          );
+          if (grammarBatch.calls.length > 0) {
+            const adapter = deps.toolCallAdapter ?? openAiToolCallAdapter;
+            const calls = grammarBatch.calls.map((call) => ({
+              ...call,
+              tool: adapter.nameUnescape(call.tool),
+            }));
+            return { ok: true, batch: { ...grammarBatch, calls } };
+          }
+        } catch {
+          // Not GBNF-shaped — fall through to the reply wrap.
+        }
+        return {
+          ok: true,
+          batch: {
+            kind: "batch",
+            calls: [
+              {
+                tool: "reply",
+                args: { text: reasoningText },
+                reasoning: reasoningText,
+              },
+            ],
+            reasoning: reasoningText,
           },
         };
       }

--- a/src/llm/provider/openai/openai-describe-image.ts
+++ b/src/llm/provider/openai/openai-describe-image.ts
@@ -1,6 +1,7 @@
 import type { VisionRequest, VisionResult } from "../llm-provider.js";
 import type { OpenAiHttpDeps } from "./openai-http.js";
 import { openAiPostJson } from "./openai-http.js";
+import { normaliseMessageContent } from "./openai-normalise-response.js";
 
 export async function describeImageViaOpenAi(
   deps: OpenAiHttpDeps,
@@ -22,14 +23,27 @@ export async function describeImageViaOpenAi(
   const body = {
     model: defaultChatModel,
     messages: [{ role: "user", content: userContent }],
-    max_tokens: request.maxTokens ?? 512,
+    // Reasoning models (Qwen3.8, DeepSeek-R1) spend completion tokens on
+    // their think channel before any visible description. The old 512
+    // cap left them truncating mid-thought and returning empty or
+    // clipped descriptions, which sent the agent loop into re-crop
+    // spirals. 4096 leaves room for thinking plus a detailed answer.
+    max_tokens: request.maxTokens ?? 4096,
     temperature: request.temperature ?? 0.1,
     stream: false,
   };
   const start = Date.now();
   const json = await openAiPostJson(deps, "/v1/chat/completions", body, request);
-  const text =
-    (json.choices as Array<{ message?: { content?: string } }> | undefined)?.[0]
-      ?.message?.content ?? "";
-  return { text: String(text).trim(), durationMs: Date.now() - start };
+  const message =
+    (json.choices as Array<{ message?: Record<string, unknown> }> | undefined)?.[0]
+      ?.message ?? {};
+  let text = normaliseMessageContent(message.content).trim();
+  // Reasoning-only response: the model answered inside its think channel
+  // and left `content` empty. The reasoning body is the best available
+  // description — better than returning an empty string the tool caller
+  // treats as "saw nothing".
+  if (text.length === 0 && typeof message.reasoning_content === "string") {
+    text = message.reasoning_content.trim();
+  }
+  return { text, durationMs: Date.now() - start };
 }

--- a/src/llm/provider/openai/openai-normalise-response.ts
+++ b/src/llm/provider/openai/openai-normalise-response.ts
@@ -8,10 +8,15 @@ export function normaliseOpenAiChatResponse(
   const message = (choice.message as Record<string, unknown> | undefined) ?? {};
   const usage = (json.usage as Record<string, unknown> | undefined) ?? {};
   const toolCalls = message.tool_calls as CompletionResult["toolCalls"];
-  const content = typeof message.content === "string" ? message.content : "";
+  const content = normaliseMessageContent(message.content);
+  // Reasoning models served over OpenAI-compatible APIs (Qwen3.8 with
+  // preserve_thinking, DeepSeek-R1) return their CoT in a dedicated
+  // `reasoning_content` field alongside `content`.
+  const reasoningContent =
+    typeof message.reasoning_content === "string" ? message.reasoning_content : "";
   return {
     content,
-    reasoningContent: "",
+    reasoningContent,
     stop: true,
     truncated: choice.finish_reason === "length",
     timing: {
@@ -32,4 +37,25 @@ export function normaliseOpenAiChatResponse(
     finishReason:
       typeof choice.finish_reason === "string" ? choice.finish_reason : null,
   };
+}
+
+/**
+ * `message.content` is a plain string on most servers, but multimodal
+ * responses may carry an array of content parts. Join the text parts so
+ * the runtime never mistakes a parts-array response for an empty one.
+ */
+export function normaliseMessageContent(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw)) {
+    return raw
+      .map((part) =>
+        part !== null &&
+        typeof part === "object" &&
+        typeof (part as { text?: unknown }).text === "string"
+          ? (part as { text: string }).text
+          : "",
+      )
+      .join("");
+  }
+  return "";
 }


### PR DESCRIPTION
## Problem

Reasoning models served over OpenAI-compatible APIs (Qwen3.8 with `preserve_thinking` on, DeepSeek-R1) can end a turn with the entire answer in the `reasoning_content` field, an empty `content` and no `tool_calls`. The runtime treated this as a fatal defect: `detectModelFailure` reported `model returned empty content` and the session died mid-task. On vision-heavy steps this was reproducible on every run.

Two contributing issues in the OpenAI-compatible provider made it worse:

- the non-streaming normaliser hard-coded `reasoningContent: ""` and collapsed content-parts arrays to an empty string, so the reasoning channel was discarded before the loop could see it
- `vision.describe` capped sub-calls at `max_tokens: 512`; reasoning models spend that budget thinking and return truncated or empty descriptions, sending the loop into re-crop spirals

## Changes

- `openai-normalise-response.ts`: read `message.reasoning_content`; join content-parts arrays instead of collapsing them to `""`
- `step-executor.ts`: in `native_tools` transport, salvage reasoning-only completions — a GBNF-shaped batch embedded in the reasoning if present, otherwise the reasoning body as a length-1 `reply`. No prompt is replayed, so the original fail-fast rationale (replaying the same prompt into the same wall) is preserved. Completions with nothing in any channel still fail fast as `ModelError`.
- `openai-describe-image.ts`: default cap raised 512 → 4096; fall back to `reasoning_content` when `content` is empty

## Note on the previous contract

The old fail-fast behavior was intentional ("do not reward models that hide the answer in the reasoning channel"). With current reasoning models this policy kills healthy sessions on formats the model families now emit by design, so this PR revisits it: the salvage path recovers the answer without an extra model round-trip. The contract test is updated accordingly.

## Testing

- `npx vitest run src/agent src/llm/provider/openai src/llm/reliability src/tools/vision` — all passing (123 tests in `src/agent`, 42 across provider/vision)
- `npx tsc --noEmit` clean
- Live-verified against `alibaba/qwen3.8-max`: a receipt-photo vision task that previously failed 2/2 with `model returned empty content` completes after the patch
