### PR TITLE
fix(local-llm): read the CUDA version from driver 610+ nvidia-smi headers

### DIFF
--- a/src/local-llm/windows-backend-variant.test.ts
+++ b/src/local-llm/windows-backend-variant.test.ts
@@ -33,6 +33,18 @@ describe("parseDriverCudaVersion", () => {
     });
   });
 
+  it("reads the `CUDA UMD Version` field used by driver 610+", () => {
+    // Driver 610.x reworked the header: `Driver Version` became `KMD
+    // Version` and `CUDA Version` became `CUDA UMD Version`. Matching
+    // `CUDA Version:` literally returned null on those boxes, which sent
+    // an RTX 5070 Ti to the Vulkan build.
+    expect(
+      parseDriverCudaVersion(
+        "| NVIDIA-SMI 610.47                 KMD Version: 610.47        CUDA UMD Version: 13.3     |",
+      ),
+    ).toEqual({ major: 13, minor: 3 });
+  });
+
   it("returns null when the field is absent", () => {
     expect(parseDriverCudaVersion("no gpu here")).toBeNull();
   });

--- a/src/local-llm/windows-backend-variant.ts
+++ b/src/local-llm/windows-backend-variant.ts
@@ -21,14 +21,23 @@ export interface CudaVersion {
 }
 
 /**
- * Parse the `CUDA Version: X.Y` field from `nvidia-smi` header output.
- * This value is the **maximum** CUDA runtime version the installed
- * driver supports (not the CUDA toolkit version), which is exactly what
- * we need to decide which prebuilt CUDA backend will load. Returns null
- * when the field is absent.
+ * Parse the CUDA version field from `nvidia-smi` header output. This
+ * value is the **maximum** CUDA runtime version the installed driver
+ * supports (not the CUDA toolkit version), which is exactly what we need
+ * to decide which prebuilt CUDA backend will load. Returns null when the
+ * field is absent.
+ *
+ * The field name is not stable across drivers. Up to 5xx/6xx-early the
+ * header reads `Driver Version: X  CUDA Version: Y`; driver 610 renamed
+ * the pair to `KMD Version: X  CUDA UMD Version: Y`. Matching
+ * `CUDA Version:` literally returned null on 610 boxes, so every machine
+ * on a current driver silently fell back to the Vulkan build — which is
+ * the only configuration that enumerates an AMD APU alongside the
+ * NVIDIA card. The optional word tolerates that rename (and any future
+ * qualifier) without loosening the match to bare "CUDA".
  */
 export function parseDriverCudaVersion(output: string): CudaVersion | null {
-  const match = output.match(/CUDA Version:\s*(\d+)\.(\d+)/i);
+  const match = output.match(/CUDA(?:\s+\w+)?\s+Version:\s*(\d+)\.(\d+)/i);
   if (!match) return null;
   const major = Number(match[1]);
   const minor = Number(match[2]);


### PR DESCRIPTION
Closes #54.

NVIDIA driver 610 renamed the `nvidia-smi` header fields — `Driver Version` became `KMD Version`, and `CUDA Version` became `CUDA UMD Version`:

```
# driver 5xx
| NVIDIA-SMI 552.22   Driver Version: 552.22   CUDA Version: 12.6 |

# driver 610+
| NVIDIA-SMI 610.47   KMD Version: 610.47      CUDA UMD Version: 13.3 |
```

`parseDriverCudaVersion` matched `CUDA Version:` literally, so on any 610+ machine it returned `null` and `selectWindowsBackendAsset(null)` fell back to Vulkan by design.

The consequence is worse than losing CUDA throughput. The CUDA builds enumerate NVIDIA devices only; the Vulkan build enumerates everything, so an AMD APU lands back in `--list-devices` and in the `auto` selection pool — the condition 0a10bf2 removed. Reported on an RTX 5070 Ti + Ryzen 9900X box on driver 610.47, where the backend dir held `ggml-vulkan.dll` and no `ggml-cuda.dll` despite `nvidia-smi` answering in 53 ms with CUDA 13.3.

The gating logic from 0a10bf2 was correct; it was never handed a version to gate on.

## Change

One regex, allowing an optional qualifier between "CUDA" and "Version" so both header generations parse:

```diff
-  const match = output.match(/CUDA Version:\s*(\d+)\.(\d+)/i);
+  const match = output.match(/CUDA(?:\s+\w+)?\s+Version:\s*(\d+)\.(\d+)/i);
```

Deliberately not loosened to bare `CUDA`, so an unrelated line carrying a version number can't be mistaken for the driver's CUDA runtime ceiling.

`nvidia-smi-vram.ts` is unaffected — it uses `--query-gpu` machine-readable output, not the header.

## Verification

- New test covers the 610.47 header; it fails on the old regex and passes on the new one.
- Existing coverage for the 5xx header and the `cuda version:13.3` spacing case still passes.
- `src/local-llm` suite: 116/116 pass. `tsc --noEmit` clean.
- Confirmed on the reporting machine: after this change plus a forced backend re-download, `ggml-cuda.dll` is installed and generation runs on the 5070 Ti.

## Note for already-affected installs

The parser fix alone does not repair a machine that already has the Vulkan backend on disk — `isBackendDownloaded` only checks that `llama-server.exe` exists, and every Windows zip ships that same filename. Deleting the backend directory before `models update` forces a clean re-download.

Adjacent gap left alone here: `checkForBackendUpdate` guards variant staleness behind `current?.asset !== undefined` (`src/local-llm/backend-installer.ts:137`), so an install whose `backend-version.json` predates the `asset` field can never be flagged as running the wrong compute backend while its tag matches latest. Happy to fix in a follow-up if you want it in the same release.
