### PR TITLE
fix(telegram): silence the progress bubble, stop echoing tool output, add a kill switch

### DIFF
--- a/src/channels/telegram/inbound-handler.test.ts
+++ b/src/channels/telegram/inbound-handler.test.ts
@@ -106,6 +106,8 @@ interface FakeApi extends TelegramApi {
     opts?: Record<string, unknown> | undefined;
   }>;
   typingChats: number[];
+  edits: Array<{ chatId: number; messageId: number; text: string }>;
+  deletes: Array<{ chatId: number; messageId: number }>;
 }
 
 function makeFakeApi(): FakeApi {
@@ -115,9 +117,13 @@ function makeFakeApi(): FakeApi {
     opts?: Record<string, unknown> | undefined;
   }> = [];
   const typingChats: number[] = [];
+  const edits: Array<{ chatId: number; messageId: number; text: string }> = [];
+  const deletes: Array<{ chatId: number; messageId: number }> = [];
   return {
     sent,
     typingChats,
+    edits,
+    deletes,
     sendMessage: vi.fn(
       async (
         chatId: number,
@@ -131,6 +137,16 @@ function makeFakeApi(): FakeApi {
     sendChatAction: vi.fn(async (chatId: number) => {
       typingChats.push(chatId);
       return undefined;
+    }),
+    editMessageText: vi.fn(
+      async (chatId: number, messageId: number, text: string) => {
+        edits.push({ chatId, messageId, text });
+        return true;
+      },
+    ),
+    deleteMessage: vi.fn(async (chatId: number, messageId: number) => {
+      deletes.push({ chatId, messageId });
+      return true;
     }),
   };
 }
@@ -289,6 +305,56 @@ describe("handleInboundText", () => {
     const replyMsg = api.sent.find((m) => m.text === "the sky is blue");
     expect(replyMsg).toBeDefined();
     expect(api.typingChats[0]).toBe(CHAT);
+  });
+
+  it("posts the progress bubble silently and deletes it before the reply", async () => {
+    const { runtime } = makeFakeRuntime({
+      scripts: [
+        {
+          events: [
+            {
+              type: "llm_event",
+              event: { type: "assistant_reply", text: "done" },
+            },
+          ],
+        },
+      ],
+    });
+    const api = makeFakeApi();
+    const ctx = makeContext(runtime, api, pointer, OWNER);
+    await handleInboundText(makeUpdate("do the thing"), ctx);
+
+    // First send is the bubble (silent), second is the reply (audible).
+    expect(api.sent[0]!.text).toBe("🤔 Thinking…");
+    expect(api.sent[0]!.opts).toMatchObject({ disable_notification: true });
+    expect(api.sent[1]!.text).toBe("done");
+    expect(api.sent[1]!.opts?.disable_notification).toBeUndefined();
+    // The bubble (message_id 1) is removed once the turn settles.
+    expect(api.deletes).toEqual([{ chatId: CHAT, messageId: 1 }]);
+  });
+
+  it("progressIndicator: false suppresses the bubble entirely", async () => {
+    const { runtime } = makeFakeRuntime({
+      scripts: [
+        {
+          events: [
+            {
+              type: "llm_event",
+              event: { type: "assistant_reply", text: "done" },
+            },
+          ],
+        },
+      ],
+    });
+    const api = makeFakeApi();
+    const ctx = makeContext(runtime, api, pointer, OWNER);
+    ctx.progressIndicator = false;
+    await handleInboundText(makeUpdate("do the thing"), ctx);
+
+    expect(api.sent).toHaveLength(1);
+    expect(api.sent[0]!.text).toBe("done");
+    expect(api.deletes).toHaveLength(0);
+    expect(api.edits).toHaveLength(0);
   });
 
   it("formats loop_failed events as a single error message", async () => {

--- a/src/channels/telegram/inbound-handler.ts
+++ b/src/channels/telegram/inbound-handler.ts
@@ -10,6 +10,10 @@ import {
   type TelegramLogger,
   type TelegramParseMode,
 } from "./outbound-sender.js";
+import {
+  progressLabel,
+  TelegramProgressIndicator,
+} from "./telegram-progress-indicator.js";
 import type { TelegramSessionPointer } from "./telegram-session-pointer.js";
 
 /**
@@ -92,6 +96,14 @@ export interface InboundContext {
    * Defaults to `"plain"` when omitted.
    */
   agentReplyParseMode?: TelegramParseMode;
+  /**
+   * Live progress indicator toggle (`config.telegram.progressIndicator`).
+   * Defaults to enabled when omitted; `false` suppresses the editable
+   * "Thinking…" bubble entirely (the `typing` chat action keepalive still
+   * runs). Captured by value at registration time, same as
+   * `agentReplyParseMode`.
+   */
+  progressIndicator?: boolean;
 }
 
 /** How long Telegram displays a `chatAction: "typing"` indicator. */
@@ -225,11 +237,10 @@ async function dispatchToRuntime(
   // subtle and vanish the instant a fast reply lands. Torn down before the
   // final reply is posted so the answer stands alone. Best-effort: a failed
   // post/edit/delete never affects the turn outcome.
-  const progress = new TelegramProgressIndicator(
-    ctx.api,
-    chatId,
-    toTelegramLogger(ctx.logger),
-  );
+  const progress =
+    ctx.progressIndicator !== false
+      ? new TelegramProgressIndicator(ctx.api, chatId, toTelegramLogger(ctx.logger))
+      : null;
   const eventHook = (event: AgentLoopEvent): void => {
     if (event.type === "llm_event") {
       if (event.event.type === "assistant_reply") reply = event.event.text;
@@ -237,11 +248,12 @@ async function dispatchToRuntime(
     if (event.type === "loop_failed") {
       failure = { error: event.error, category: event.category };
     }
+    if (progress === null) return;
     const label = progressLabel(event);
     if (label !== null) progress.update(label);
   };
 
-  progress.start("🤔 Thinking…");
+  progress?.start("🤔 Thinking…");
   const stopKeepalive = startTypingKeepalive(ctx, chatId);
   try {
     await ctx.runtime.runTurn(session, text, {
@@ -265,7 +277,7 @@ async function dispatchToRuntime(
   // reply (or infra message) stands alone rather than appearing above a
   // stale "Thinking…" bubble. Awaits the internal chain so a fast turn
   // whose `start()` send is still in flight is cleaned up before we send.
-  await progress.remove();
+  await progress?.remove();
 
   // Only the agent's natural-language reply gets parse-mode
   // formatting. Cancellation acks, the empty-reply marker, and
@@ -320,149 +332,6 @@ function startTypingKeepalive(
   }
   const handle = setInterval(sendTyping, TYPING_KEEPALIVE_MS);
   return () => clearInterval(handle);
-}
-
-/**
- * Maximum length of a `step_finished.summary` echoed into the live progress
- * bubble. Tool summaries can be long; clip so the indicator stays a glancable
- * status line rather than a second reply.
- */
-const PROGRESS_SUMMARY_MAX_CHARS = 80;
-
-/**
- * Minimum gap between two progress edits. Telegram rate-limits
- * `editMessageText` per chat; editing faster than this buys nothing visually
- * and risks 429 flood-waits. Combined with the "skip identical text" guard in
- * `update`, a chatty turn settles to at most ~1.4 edits/s.
- */
-const PROGRESS_MIN_EDIT_INTERVAL_MS = 700;
-
-function truncateForProgress(text: string): string {
-  const trimmed = text.trim();
-  if (trimmed.length <= PROGRESS_SUMMARY_MAX_CHARS) return trimmed;
-  return `${trimmed.slice(0, PROGRESS_SUMMARY_MAX_CHARS - 1)}…`;
-}
-
-/**
- * Map an `AgentLoopEvent` to a short, operator-facing progress label, or
- * `null` when the event carries nothing worth surfacing (token accounting,
- * streaming deltas, the terminal `assistant_reply` which the reply path
- * already handles). Tool names are shown verbatim — they are stable,
- * meaningful identifiers (`os.fs.write`, `browser.navigate`, …) and inventing
- * friendlier verbs would drift from the tool registry.
- */
-function progressLabel(event: AgentLoopEvent): string | null {
-  switch (event.type) {
-    case "turn_started":
-      return "🤔 Thinking…";
-    case "step_started":
-      return `⚙️ Working… (step ${event.stepIndex + 1})`;
-    case "step_finished": {
-      const summary = event.summary.trim();
-      return summary.length > 0 ? `✅ ${truncateForProgress(summary)}` : null;
-    }
-    case "loop_detected":
-      return `🔁 Repeating ${event.tool} (×${event.count})`;
-    case "llm_event": {
-      const step = event.event;
-      if (step.type === "tool_call_parsed") return `🔧 ${step.call.tool}`;
-      return null;
-    }
-    default:
-      return null;
-  }
-}
-
-/**
- * A single editable Telegram message that mirrors the current turn's
- * activity, giving the operator immediate visible feedback that their
- * message landed and is being worked on. Lifecycle: `start()` posts the
- * bubble, `update()` edits it (throttled + deduped), `remove()` deletes it
- * once the turn settles. Every network call is best-effort and serialised
- * through an internal promise chain so a fast turn that calls `remove()`
- * before `start()`'s `sendMessage` resolves still cleans up correctly (the
- * send handler observes `removed` and deletes the just-posted message).
- * Failures are logged (start) or swallowed (edit/delete) — the indicator is
- * pure channel infrastructure and must never affect the turn outcome.
- */
-class TelegramProgressIndicator {
-  private messageId: number | null = null;
-  private removed = false;
-  private lastText = "";
-  private lastEditAt = 0;
-  private chain: Promise<unknown> = Promise.resolve();
-
-  constructor(
-    private readonly api: TelegramApi,
-    private readonly chatId: number,
-    private readonly logger?: TelegramLogger,
-    private readonly minEditIntervalMs: number = PROGRESS_MIN_EDIT_INTERVAL_MS,
-  ) {}
-
-  /** Post the initial indicator bubble. Fire-and-forget. */
-  start(text: string): void {
-    this.lastText = text;
-    this.chain = this.chain.then(async () => {
-      if (this.removed) return;
-      try {
-        const sent = await this.api.sendMessage(this.chatId, text);
-        const messageId =
-          typeof sent === "object" && sent !== null && "message_id" in sent
-            ? (sent as { message_id?: number }).message_id
-            : undefined;
-        if (this.removed) {
-          // The turn finished while we were sending; don't leave a stale
-          // bubble behind.
-          if (typeof messageId === "number") {
-            await this.api.deleteMessage?.(this.chatId, messageId).catch(
-              () => undefined,
-            );
-          }
-          return;
-        }
-        this.messageId = typeof messageId === "number" ? messageId : null;
-        this.lastEditAt = Date.now();
-      } catch (err) {
-        this.logger?.warn("telegram: progress start failed (non-fatal)", {
-          chatId: this.chatId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    });
-  }
-
-  /** Throttled, deduped live update. Fire-and-forget. */
-  update(text: string): void {
-    if (this.removed || text === this.lastText) return;
-    const now = Date.now();
-    if (now - this.lastEditAt < this.minEditIntervalMs) return;
-    this.lastText = text;
-    this.lastEditAt = now;
-    this.chain = this.chain.then(async () => {
-      if (this.removed || this.messageId === null) return;
-      try {
-        await this.api.editMessageText?.(this.chatId, this.messageId, text);
-      } catch {
-        // "message is not modified", flood-wait, or already deleted — all
-        // non-fatal for a best-effort indicator.
-      }
-    });
-  }
-
-  /** Delete the indicator. Idempotent; resolves once the delete settles. */
-  remove(): Promise<void> {
-    this.removed = true;
-    this.chain = this.chain.then(async () => {
-      if (this.messageId === null) return;
-      try {
-        await this.api.deleteMessage?.(this.chatId, this.messageId);
-      } catch {
-        // Already gone or flood-wait — non-fatal.
-      }
-      this.messageId = null;
-    });
-    return this.chain.then(() => undefined);
-  }
 }
 
 function formatStatus(ctx: InboundContext): string {

--- a/src/channels/telegram/telegram-channel.ts
+++ b/src/channels/telegram/telegram-channel.ts
@@ -196,6 +196,10 @@ export class TelegramChannel {
           // the freshly-registered text handler — same pattern as
           // `setOwnerUserId`.
           agentReplyParseMode: this.currentParseMode,
+          // Captured by value at registration time, same as parseMode:
+          // flipping `telegram.progressIndicator` takes effect on the
+          // next channel (re)start.
+          progressIndicator: this.deps.config.telegram.progressIndicator,
           inflight: this.inflight,
           ensureApprovalSession: (sessionId, chatId) =>
             this.ensureApprovalSession(sessionId, chatId),

--- a/src/channels/telegram/telegram-progress-indicator.test.ts
+++ b/src/channels/telegram/telegram-progress-indicator.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentLoopEvent } from "../../agent/agent-loop.js";
+
+import type { TelegramApi } from "./outbound-sender.js";
+import {
+  progressLabel,
+  TelegramProgressIndicator,
+} from "./telegram-progress-indicator.js";
+
+interface Recorded {
+  sends: Array<{ text: string; opts: Record<string, unknown> | undefined }>;
+  edits: Array<{ messageId: number; text: string }>;
+  deletes: number[];
+}
+
+function makeApi(overrides: Partial<TelegramApi> = {}): {
+  api: TelegramApi;
+  recorded: Recorded;
+} {
+  const recorded: Recorded = { sends: [], edits: [], deletes: [] };
+  let nextId = 100;
+  const api: TelegramApi = {
+    sendMessage: vi.fn(async (_chatId, text, opts) => {
+      recorded.sends.push({ text, opts });
+      return { message_id: nextId++ };
+    }),
+    editMessageText: vi.fn(async (_chatId, messageId, text) => {
+      recorded.edits.push({ messageId, text });
+      return true;
+    }),
+    deleteMessage: vi.fn(async (_chatId, messageId) => {
+      recorded.deletes.push(messageId);
+      return true;
+    }),
+    ...overrides,
+  };
+  return { api, recorded };
+}
+
+/** Settle the indicator's internal promise chain. */
+async function settle(): Promise<void> {
+  // Two macrotask hops cover chain links queued from within chain links.
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("TelegramProgressIndicator", () => {
+  it("start → update → remove drives send, edit and delete in order", async () => {
+    const { api, recorded } = makeApi();
+    const progress = new TelegramProgressIndicator(api, 7, undefined, 0);
+
+    progress.start("🤔 Thinking…");
+    await settle();
+    progress.update("🔧 os.fs.read");
+    await settle();
+    await progress.remove();
+
+    expect(recorded.sends).toHaveLength(1);
+    expect(recorded.edits).toEqual([{ messageId: 100, text: "🔧 os.fs.read" }]);
+    expect(recorded.deletes).toEqual([100]);
+  });
+
+  it("sends the bubble silently (disable_notification)", async () => {
+    const { api, recorded } = makeApi();
+    const progress = new TelegramProgressIndicator(api, 7, undefined, 0);
+
+    progress.start("🤔 Thinking…");
+    await settle();
+
+    expect(recorded.sends[0]?.opts).toMatchObject({
+      disable_notification: true,
+    });
+    await progress.remove();
+  });
+
+  it("fast-turn race: remove before the send resolves still deletes the bubble", async () => {
+    const { api, recorded } = makeApi();
+    let release: (v: { message_id: number }) => void = () => undefined;
+    api.sendMessage = vi.fn(
+      () =>
+        new Promise<{ message_id: number }>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const progress = new TelegramProgressIndicator(api, 7, undefined, 0);
+
+    progress.start("🤔 Thinking…");
+    // Let the chain invoke sendMessage (which stays pending) before racing
+    // the removal against it.
+    await settle();
+    const removed = progress.remove();
+    release({ message_id: 42 });
+    await removed;
+    await settle();
+
+    expect(recorded.deletes).toEqual([42]);
+  });
+
+  it("dedupes identical text and throttles inside the edit window", async () => {
+    const { api, recorded } = makeApi();
+    // Large interval: only the first post-start edit may pass, and only
+    // when enough virtual time elapsed — with real clocks nothing passes.
+    const progress = new TelegramProgressIndicator(api, 7, undefined, 60_000);
+
+    progress.start("🤔 Thinking…");
+    await settle();
+    progress.update("🤔 Thinking…"); // identical → dropped
+    progress.update("🔧 os.fs.read"); // inside window → dropped
+    await settle();
+
+    expect(recorded.edits).toHaveLength(0);
+    await progress.remove();
+  });
+
+  it("mutes edits for retry_after seconds on a 429", async () => {
+    const { api, recorded } = makeApi();
+    api.editMessageText = vi.fn(async (_chatId, messageId, text) => {
+      recorded.edits.push({ messageId, text });
+      if (recorded.edits.length === 1) {
+        throw Object.assign(new Error("Too Many Requests"), {
+          error_code: 429,
+          parameters: { retry_after: 60 },
+        });
+      }
+      return true;
+    });
+    const progress = new TelegramProgressIndicator(api, 7, undefined, 0);
+
+    progress.start("🤔 Thinking…");
+    await settle();
+    progress.update("step 1");
+    await settle();
+    // The flood-wait from the first edit must suppress this one entirely.
+    progress.update("step 2");
+    await settle();
+
+    expect(recorded.edits).toHaveLength(1);
+    await progress.remove();
+  });
+
+  it("failure to send never throws and remove stays safe", async () => {
+    const { api } = makeApi({
+      sendMessage: vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    });
+    const warn = vi.fn();
+    const progress = new TelegramProgressIndicator(api, 7, { warn }, 0);
+
+    progress.start("🤔 Thinking…");
+    await settle();
+    await expect(progress.remove()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("progressLabel", () => {
+  it("does not echo step_finished summaries (raw tool output)", () => {
+    const event = {
+      type: "step_finished",
+      stepIndex: 2,
+      summary: "SECRET_KEY=abcdef massive raw tool output tail",
+      durationMs: 10,
+    } as AgentLoopEvent;
+    expect(progressLabel(event)).toBe("✅ Step 3 done");
+  });
+
+  it("keeps the tool-name and step labels", () => {
+    expect(
+      progressLabel({ type: "step_started", stepIndex: 0 } as AgentLoopEvent),
+    ).toBe("⚙️ Working… (step 1)");
+    expect(
+      progressLabel({
+        type: "llm_event",
+        event: { type: "tool_call_parsed", call: { tool: "browser.navigate" } },
+      } as unknown as AgentLoopEvent),
+    ).toBe("🔧 browser.navigate");
+  });
+});

--- a/src/channels/telegram/telegram-progress-indicator.ts
+++ b/src/channels/telegram/telegram-progress-indicator.ts
@@ -1,0 +1,173 @@
+import type { AgentLoopEvent } from "../../agent/agent-loop.js";
+
+import type { TelegramApi, TelegramLogger } from "./outbound-sender.js";
+
+/**
+ * Minimum gap between two progress edits. Telegram's practical per-chat
+ * ceiling is about one message per second; staying at or above it keeps a
+ * chatty turn from earning a flood-wait that would apply to the whole chat
+ * (and therefore to the final reply, not just this bubble). Combined with
+ * the "skip identical text" guard in `update`, a chatty turn settles to at
+ * most 1 edit/s.
+ */
+const PROGRESS_MIN_EDIT_INTERVAL_MS = 1000;
+
+/**
+ * Map an `AgentLoopEvent` to a short, operator-facing progress label, or
+ * `null` when the event carries nothing worth surfacing (token accounting,
+ * streaming deltas, the terminal `assistant_reply` which the reply path
+ * already handles). Tool names are shown verbatim — they are stable,
+ * meaningful identifiers (`os.fs.write`, `browser.navigate`, …) and inventing
+ * friendlier verbs would drift from the tool registry.
+ *
+ * Every label is constructed here from stable identifiers only. In
+ * particular, `step_finished.summary` is deliberately NOT echoed: it is the
+ * tail of the tool's raw output (`compressToolResult`), so a file path, a
+ * grep hit or the start of a key could otherwise end up in Telegram
+ * history, which is forwardable and outlives the session.
+ */
+export function progressLabel(event: AgentLoopEvent): string | null {
+  switch (event.type) {
+    case "turn_started":
+      return "🤔 Thinking…";
+    case "step_started":
+      return `⚙️ Working… (step ${event.stepIndex + 1})`;
+    case "step_finished":
+      return `✅ Step ${event.stepIndex + 1} done`;
+    case "loop_detected":
+      return `🔁 Repeating ${event.tool} (×${event.count})`;
+    case "llm_event": {
+      const step = event.event;
+      if (step.type === "tool_call_parsed") return `🔧 ${step.call.tool}`;
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extract `retry_after` seconds from a Telegram 429 error, or `null` when
+ * the error is anything else. Structural, so it works for grammy's
+ * `GrammyError` and for hand-rolled fakes alike.
+ */
+function retryAfterSeconds(err: unknown): number | null {
+  if (typeof err !== "object" || err === null) return null;
+  const code = (err as { error_code?: unknown }).error_code;
+  if (code !== 429) return null;
+  const params = (err as { parameters?: { retry_after?: unknown } }).parameters;
+  const after = params?.retry_after;
+  return typeof after === "number" && after > 0 ? after : 1;
+}
+
+/**
+ * A single editable Telegram message that mirrors the current turn's
+ * activity, giving the operator immediate visible feedback that their
+ * message landed and is being worked on. Lifecycle: `start()` posts the
+ * bubble, `update()` edits it (throttled + deduped), `remove()` deletes it
+ * once the turn settles. Every network call is best-effort and serialised
+ * through an internal promise chain so a fast turn that calls `remove()`
+ * before `start()`'s `sendMessage` resolves still cleans up correctly (the
+ * send handler observes `removed` and deletes the just-posted message).
+ * Failures are logged (start) or swallowed (edit/delete) — the indicator is
+ * pure channel infrastructure and must never affect the turn outcome.
+ *
+ * The bubble is sent with `disable_notification: true`: the operator
+ * already gets a push for the final reply, and a second ping for a
+ * transient status line that deletes itself would double-notify every
+ * message.
+ *
+ * A 429 on an edit mutes further edits for the server-provided
+ * `retry_after` window instead of continuing to hit the limit — a
+ * flood-wait earned here applies to the whole chat and could delay the
+ * final reply.
+ */
+export class TelegramProgressIndicator {
+  private messageId: number | null = null;
+  private removed = false;
+  private lastText = "";
+  private lastEditAt = 0;
+  private mutedUntil = 0;
+  private chain: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly api: TelegramApi,
+    private readonly chatId: number,
+    private readonly logger?: TelegramLogger,
+    private readonly minEditIntervalMs: number = PROGRESS_MIN_EDIT_INTERVAL_MS,
+  ) {}
+
+  /** Post the initial indicator bubble. Fire-and-forget. */
+  start(text: string): void {
+    this.lastText = text;
+    this.chain = this.chain.then(async () => {
+      if (this.removed) return;
+      try {
+        const sent = await this.api.sendMessage(this.chatId, text, {
+          disable_notification: true,
+        });
+        const messageId =
+          typeof sent === "object" && sent !== null && "message_id" in sent
+            ? (sent as { message_id?: number }).message_id
+            : undefined;
+        if (this.removed) {
+          // The turn finished while we were sending; don't leave a stale
+          // bubble behind.
+          if (typeof messageId === "number") {
+            await this.api.deleteMessage?.(this.chatId, messageId).catch(
+              () => undefined,
+            );
+          }
+          return;
+        }
+        this.messageId = typeof messageId === "number" ? messageId : null;
+        this.lastEditAt = Date.now();
+      } catch (err) {
+        this.logger?.warn("telegram: progress start failed (non-fatal)", {
+          chatId: this.chatId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+  }
+
+  /** Throttled, deduped live update. Fire-and-forget. */
+  update(text: string): void {
+    if (this.removed || text === this.lastText) return;
+    const now = Date.now();
+    if (now < this.mutedUntil) return;
+    if (now - this.lastEditAt < this.minEditIntervalMs) return;
+    this.lastText = text;
+    this.lastEditAt = now;
+    this.chain = this.chain.then(async () => {
+      if (this.removed || this.messageId === null) return;
+      try {
+        await this.api.editMessageText?.(this.chatId, this.messageId, text);
+      } catch (err) {
+        // "message is not modified" or already deleted — non-fatal for a
+        // best-effort indicator. A flood-wait additionally mutes edits for
+        // the window Telegram asked for, so the bubble cannot keep earning
+        // penalties that would land on the final reply.
+        const after = retryAfterSeconds(err);
+        if (after !== null) {
+          this.mutedUntil = Date.now() + after * 1000;
+        }
+      }
+    });
+  }
+
+  /** Delete the indicator. Idempotent; resolves once the delete settles. */
+  remove(): Promise<void> {
+    this.removed = true;
+    this.chain = this.chain.then(async () => {
+      if (this.messageId === null) return;
+      try {
+        await this.api.deleteMessage?.(this.chatId, this.messageId);
+      } catch {
+        // Already gone or flood-wait — non-fatal.
+      }
+      this.messageId = null;
+    });
+    return this.chain.then(() => undefined);
+  }
+}

--- a/src/channels/telegram/telegram-settings.ts
+++ b/src/channels/telegram/telegram-settings.ts
@@ -25,6 +25,7 @@ export interface PersistedTelegramSettings {
   enabled: boolean;
   ownerUserId: number | null;
   parseMode: TelegramParseMode;
+  progressIndicator: boolean;
 }
 
 /**
@@ -43,6 +44,7 @@ export function readTelegramSettings(
     enabled: block.enabled,
     ownerUserId: block.ownerUserId,
     parseMode: block.parseMode,
+    progressIndicator: block.progressIndicator,
   };
 }
 
@@ -67,6 +69,9 @@ export function writeTelegramSettings(
         ? { ownerUserId: patch.ownerUserId }
         : {}),
       ...(patch.parseMode !== undefined ? { parseMode: patch.parseMode } : {}),
+      ...(patch.progressIndicator !== undefined
+        ? { progressIndicator: patch.progressIndicator }
+        : {}),
     },
   };
   writeUserConfigFileSync(paths.userConfigPath, next);
@@ -74,6 +79,7 @@ export function writeTelegramSettings(
     enabled: next.telegram.enabled,
     ownerUserId: next.telegram.ownerUserId,
     parseMode: next.telegram.parseMode,
+    progressIndicator: next.telegram.progressIndicator,
   };
 }
 

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -552,6 +552,7 @@ describe("parseUserConfigFile", () => {
       enabled: true,
       ownerUserId: 12345678,
       parseMode: "html",
+      progressIndicator: true,
     });
   });
 
@@ -564,7 +565,30 @@ describe("parseUserConfigFile", () => {
       enabled: true,
       ownerUserId: 12345678,
       parseMode: "plain",
+      progressIndicator: true,
     });
+  });
+
+  it("accepts a v33 file and fills in telegram.progressIndicator=true transparently", () => {
+    const parsed = parseUserConfigFile({
+      version: 33,
+      telegram: { enabled: true, ownerUserId: 12345678, parseMode: "plain" },
+    });
+    expect(parsed.version).toBe(USER_CONFIG_VERSION);
+    expect(parsed.telegram.progressIndicator).toBe(true);
+  });
+
+  it("preserves an explicit telegram.progressIndicator=false", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      telegram: {
+        enabled: true,
+        ownerUserId: 12345678,
+        parseMode: "plain",
+        progressIndicator: false,
+      },
+    });
+    expect(parsed.telegram.progressIndicator).toBe(false);
   });
 
   it("rejects an unknown telegram.parseMode", () => {

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -755,6 +755,15 @@ export interface TelegramConfig {
    * `parseUserConfigFile`.
    */
   parseMode: TelegramParseMode;
+  /**
+   * Live progress indicator in the Telegram channel: a single editable
+   * "Thinking…" bubble that mirrors the turn's activity and deletes
+   * itself when the reply lands. Enabled by default; `false` is the
+   * kill switch if the always-on behavior surprises anyone in
+   * production. Added in config v34; older files transparently get
+   * `true` via the defaults-fallback in `parseUserConfigFile`.
+   */
+  progressIndicator: boolean;
 }
 
 /**
@@ -1316,7 +1325,9 @@ export interface UserConfigFile {
 // v31: skills gains `clawhub` (ClawHub registry — the primary skill
 // marketplace). Older files inherit it enabled against the public registry
 // with suspicious skills hidden.
-export const USER_CONFIG_VERSION = 33 as const;
+// v34: telegram gains `progressIndicator` (live "Thinking…" bubble toggle).
+// Older files transparently inherit `true`.
+export const USER_CONFIG_VERSION = 34 as const;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1429,6 +1440,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   30,
   31,
   32,
+  33,
   USER_CONFIG_VERSION,
 ];
 
@@ -1671,6 +1683,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
     enabled: false,
     ownerUserId: null,
     parseMode: "html",
+    progressIndicator: true,
   },
   mcp: {
     // Added in v23. Empty by default — the operator declares MCP
@@ -3283,6 +3296,11 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
       parseMode: parseTelegramParseMode(
         telegram.parseMode ?? USER_CONFIG_DEFAULTS.telegram.parseMode,
         "telegram.parseMode",
+      ),
+      progressIndicator: parseBool(
+        telegram.progressIndicator ??
+          USER_CONFIG_DEFAULTS.telegram.progressIndicator,
+        "telegram.progressIndicator",
       ),
     },
     mcp: {

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -472,6 +472,7 @@ export function loadConfig(): AtomicAgentConfig {
       enabled: user.telegram.enabled,
       ownerUserId: user.telegram.ownerUserId,
       parseMode: user.telegram.parseMode,
+      progressIndicator: user.telegram.progressIndicator,
     },
     mcp: {
       // Servers are owned by the user-config file. Deep clone the


### PR DESCRIPTION
Follow-up to #28, which merged without the changes requested in review. Closes #58. Everything below was asked for in the review thread; nothing else changed behavior.

## Changes

- **The bubble is sent with `disable_notification: true`.** Every owner message no longer produces two push notifications (one for the Thinking bubble, one for the reply).
- **`step_finished` no longer echoes the tool-output tail.** `progressLabel` now builds every label from stable identifiers only (`✅ Step N done`), so a file path, a grep hit or a key fragment can never reach forwardable Telegram history. This was the privacy concern raised in review.
- **Edit throttle raised to 1000 ms, and a 429 mutes further edits for the server-provided `retry_after` window.** Bubble edits can no longer earn a chat-wide flood-wait that would delay or drop the final reply.
- **New `telegram.progressIndicator` config flag (default `true`)** as the production kill switch, plumbed the same way `parseMode` was (schema defaults, `telegram-settings.ts`, `InboundContext`, captured at handler registration). Config v33 → v34; older files transparently inherit `true`.
- **`TelegramProgressIndicator` + `progressLabel` move to `telegram-progress-indicator.ts`** per the 300-line file guideline; `inbound-handler.ts` drops back under it.
- **The `FakeApi` in `inbound-handler.test.ts` now records `editMessageText` and `deleteMessage`**, so indicator calls stop silently no-oping under test.

## Testing

- New `telegram-progress-indicator.test.ts`: lifecycle happy path, silent send, the fast-turn race (remove before the initial send resolves deletes the just-posted message), throttle + identical-text dedup, 429 mute, failure isolation, and a regression test asserting summaries are not echoed.
- Two new handler tests: bubble is silent and deleted before the reply; `progressIndicator: false` suppresses it entirely.
- Config: default, explicit `false`, and a v33 file inheriting `true` transparently.
- `src/channels/telegram`: 139 passed. `src/config`: 136 passed. `tsc --noEmit` clean. Full suite: same pre-existing failures as `main` (six of them documented in #50; verified by running the identical file set on a clean checkout).

## Note

This PR and #52's fix both bump `USER_CONFIG_VERSION` 33 → 34 for their own field. Whichever merges second gets a trivial rebase to 35.
