### PR TITLE
fix(local-llm): stop the managed daemon when the last session exits

### DIFF
--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -442,6 +442,29 @@ describe("parseUserConfigFile", () => {
     expect(parsed.localModels.managed.device).toBe("auto");
   });
 
+  it("defaults localModels.managed.stopOnExit to true", () => {
+    const parsed = parseUserConfigFile({ version: USER_CONFIG_VERSION });
+    expect(parsed.localModels.managed.stopOnExit).toBe(true);
+  });
+
+  it("preserves an explicit localModels.managed.stopOnExit=false", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      localModels: { managed: { stopOnExit: false } },
+    });
+    expect(parsed.localModels.managed.stopOnExit).toBe(false);
+  });
+
+  it("accepts a v33 file and fills in stopOnExit=true transparently", () => {
+    const parsed = parseUserConfigFile({
+      version: 33,
+      localModels: { managed: { autoUpdate: true } },
+    });
+    expect(parsed.version).toBe(USER_CONFIG_VERSION);
+    expect(parsed.localModels.managed.stopOnExit).toBe(true);
+    expect(parsed.localModels.managed.autoUpdate).toBe(true);
+  });
+
   it("preserves an explicit localModels.managed.device override", () => {
     const parsed = parseUserConfigFile({
       version: USER_CONFIG_VERSION,

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -791,6 +791,16 @@ export interface UserManagedLocalLlmConfig {
    *     model's trained context ceiling.
    */
   contextSize: number;
+  /**
+   * Stop the managed chat daemon when the last CLI session exits.
+   * `true` (default) — closing the terminal frees the RAM/VRAM the
+   * model was holding; a second live session keeps the daemon up (see
+   * `session-registry.ts`). `false` — keep the model warm between
+   * sessions; the operator stops it via `atomic-agent models stop`.
+   * Standalone daemons started with `models start` are never touched.
+   * Added in config v34; older files transparently get `true`.
+   */
+  stopOnExit: boolean;
 }
 
 /**
@@ -1316,7 +1326,9 @@ export interface UserConfigFile {
 // v31: skills gains `clawhub` (ClawHub registry — the primary skill
 // marketplace). Older files inherit it enabled against the public registry
 // with suspicious skills hidden.
-export const USER_CONFIG_VERSION = 33 as const;
+// v34: localModels.managed gains `stopOnExit` (stop the managed daemon when
+// the last CLI session exits). Older files transparently inherit `true`.
+export const USER_CONFIG_VERSION = 34 as const;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1429,6 +1441,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   30,
   31,
   32,
+  33,
   USER_CONFIG_VERSION,
 ];
 
@@ -1443,6 +1456,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       port: 19091,
       dataDirOverride: null,
       autoUpdate: false,
+      stopOnExit: true,
       device: "auto",
       contextSize: 0,
     },
@@ -2611,6 +2625,11 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
     autoUpdate: parseBool(
       rawManaged.autoUpdate ?? USER_CONFIG_DEFAULTS.localModels.managed.autoUpdate,
       "localModels.managed.autoUpdate",
+    ),
+    stopOnExit: parseBool(
+      rawManaged.stopOnExit ??
+        USER_CONFIG_DEFAULTS.localModels.managed.stopOnExit,
+      "localModels.managed.stopOnExit",
     ),
     device: parseNonEmptyString(
       rawManaged.device ?? USER_CONFIG_DEFAULTS.localModels.managed.device,

--- a/src/local-llm/session-registry.test.ts
+++ b/src/local-llm/session-registry.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, readdirSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  hasOtherLiveSessions,
+  registerSession,
+} from "./session-registry.js";
+
+describe("session-registry", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "aa-sessions-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("registerSession writes a marker for this pid and release removes it", () => {
+    const release = registerSession(dataDir);
+    expect(readdirSync(join(dataDir, "sessions"))).toEqual([
+      String(process.pid),
+    ]);
+    release();
+    expect(readdirSync(join(dataDir, "sessions"))).toEqual([]);
+    // Releasing twice is safe.
+    release();
+  });
+
+  it("reports no other sessions when only this process is registered", () => {
+    const release = registerSession(dataDir);
+    expect(hasOtherLiveSessions(dataDir)).toBe(false);
+    release();
+  });
+
+  it("reports no other sessions when the directory does not exist", () => {
+    expect(hasOtherLiveSessions(dataDir)).toBe(false);
+  });
+
+  it("sees another live process (the test runner's parent)", () => {
+    const dir = join(dataDir, "sessions");
+    mkdirSync(dir, { recursive: true });
+    // `process.ppid` is a live pid that is not us.
+    writeFileSync(join(dir, String(process.ppid)), String(process.ppid));
+    expect(hasOtherLiveSessions(dataDir)).toBe(true);
+  });
+
+  it("reclaims stale markers from dead pids and garbage names", () => {
+    const dir = join(dataDir, "sessions");
+    mkdirSync(dir, { recursive: true });
+    // Max pid on Linux defaults to ~4M; anything above is guaranteed dead
+    // on every platform we ship.
+    writeFileSync(join(dir, "99999999"), "99999999");
+    writeFileSync(join(dir, "not-a-pid"), "junk");
+    expect(hasOtherLiveSessions(dataDir)).toBe(false);
+    expect(readdirSync(dir)).toEqual([]);
+  });
+});

--- a/src/local-llm/session-registry.ts
+++ b/src/local-llm/session-registry.ts
@@ -1,0 +1,108 @@
+import {
+  mkdirSync,
+  readdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Live-session registry for the managed llama-server daemon.
+ *
+ * The daemon is spawned detached so it survives the CLI process on
+ * purpose (a warm model between sessions). The flip side is teardown:
+ * when the last TUI session exits, `stopOnExit` wants to stop the
+ * daemon — but only the *last* one may do it, or the first session to
+ * exit kills the model out from under a second one still chatting
+ * (a real bug before this module existed).
+ *
+ * Each TUI session drops a marker file `<dataDir>/sessions/<pid>` on
+ * startup and removes it on clean exit. `hasOtherLiveSessions` scans
+ * the directory, ignores the calling process and any marker whose pid
+ * is dead (crashed sessions leave stale files behind; they are
+ * reclaimed here, same pattern as `telegram-lockfile.ts`), and reports
+ * whether anyone else is still running.
+ *
+ * Marker files are advisory, not locks: a race between "session A
+ * exits" and "session B starts" at worst leaves the daemon running one
+ * session longer or stops it a moment before B adopts it — B's
+ * `autoStartIfReady` restarts it either way.
+ */
+
+const SESSIONS_DIR = "sessions";
+
+function sessionsDir(dataDir: string): string {
+  return join(dataDir, SESSIONS_DIR);
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // `EPERM` (POSIX) / `EACCES` (Windows) both mean the process exists
+    // but is owned by someone else — i.e. still alive. Only `ESRCH`
+    // means dead.
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === "EPERM" || code === "EACCES";
+  }
+}
+
+/**
+ * Record this process as a live session. Returns a release function
+ * for the clean-exit path; releasing twice is safe. A session that
+ * dies without releasing is reclaimed by the next
+ * `hasOtherLiveSessions` scan via the pid liveness check.
+ */
+export function registerSession(dataDir: string): () => void {
+  const dir = sessionsDir(dataDir);
+  const file = join(dir, String(process.pid));
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, String(process.pid));
+  } catch {
+    // Best-effort: a session that could not register behaves like the
+    // only session, which at worst stops the daemon while another
+    // (equally unregistered) session is live — no worse than the
+    // pre-registry behavior.
+  }
+  return () => {
+    try {
+      unlinkSync(file);
+    } catch {
+      // Already gone — release is idempotent.
+    }
+  };
+}
+
+/**
+ * True when at least one *other* process holds a live session marker.
+ * Stale markers (dead pid, unparsable name) are deleted as they are
+ * encountered so the directory cannot accumulate garbage.
+ */
+export function hasOtherLiveSessions(dataDir: string): boolean {
+  const dir = sessionsDir(dataDir);
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return false;
+  }
+  let others = false;
+  for (const entry of entries) {
+    const pid = Number.parseInt(entry, 10);
+    const valid =
+      Number.isFinite(pid) && pid > 0 && String(pid) === entry;
+    if (valid && pid === process.pid) continue;
+    if (valid && isAlive(pid)) {
+      others = true;
+      continue;
+    }
+    try {
+      unlinkSync(join(dir, entry));
+    } catch {
+      // Someone else cleaned it first — fine.
+    }
+  }
+  return others;
+}

--- a/src/tui/local-models/local-models-orchestrator.test.ts
+++ b/src/tui/local-models/local-models-orchestrator.test.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getConfig, resetConfigCache } from "../../config/index.js";
+import {
+  getConfig,
+  resetConfigCache,
+  USER_CONFIG_VERSION,
+} from "../../config/index.js";
 import {
   getEmbeddingModelDef,
   getLocalModelDef,
@@ -51,6 +55,69 @@ describe("LocalModelsOrchestrator", () => {
     resetConfigCache();
     vi.restoreAllMocks();
     rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function writeUserConfig(overrides: Record<string, unknown>): void {
+    writeFileSync(
+      join(stateDir, "config.json"),
+      JSON.stringify({ version: USER_CONFIG_VERSION, ...overrides }),
+    );
+    resetConfigCache();
+  }
+
+  function makeSupervisedOrchestrator(): {
+    orchestrator: LocalModelsOrchestrator;
+    stopped: () => number;
+  } {
+    const orchestrator = new LocalModelsOrchestrator({ emit() {} });
+    (orchestrator as unknown as { daemonSupervised: boolean }).daemonSupervised =
+      true;
+    const spy = vi
+      .spyOn(
+        orchestrator as unknown as {
+          stopDaemonSilent: () => Promise<void>;
+        },
+        "stopDaemonSilent",
+      )
+      .mockResolvedValue();
+    return { orchestrator, stopped: () => spy.mock.calls.length };
+  }
+
+  describe("shutdown daemon teardown (stopOnExit)", () => {
+    it("stops the supervised daemon by default (last session)", async () => {
+      writeUserConfig({});
+      const { orchestrator, stopped } = makeSupervisedOrchestrator();
+      await orchestrator.shutdown();
+      expect(stopped()).toBe(1);
+    });
+
+    it("leaves the daemon running when stopOnExit=false", async () => {
+      writeUserConfig({ localModels: { managed: { stopOnExit: false } } });
+      const { orchestrator, stopped } = makeSupervisedOrchestrator();
+      await orchestrator.shutdown();
+      expect(stopped()).toBe(0);
+    });
+
+    it("leaves the daemon running while another live session exists", async () => {
+      writeUserConfig({});
+      const dataDir = getConfig().paths.localModelsDataDir;
+      const sessionsDir = join(dataDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      // `process.ppid` is a live pid that is not this process.
+      writeFileSync(join(sessionsDir, String(process.ppid)), "");
+      const { orchestrator, stopped } = makeSupervisedOrchestrator();
+      await orchestrator.shutdown();
+      expect(stopped()).toBe(0);
+    });
+
+    it("never stops a daemon it does not supervise", async () => {
+      writeUserConfig({});
+      const { orchestrator, stopped } = makeSupervisedOrchestrator();
+      (orchestrator as unknown as { daemonSupervised: boolean }).daemonSupervised =
+        false;
+      await orchestrator.shutdown();
+      expect(stopped()).toBe(0);
+    });
   });
 
   it("cancels the previous model pull when another model is selected", async () => {

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -1,6 +1,7 @@
 import { totalmem } from "node:os";
 
 import { getConfig, resetConfigCache } from "../../config/index.js";
+import { hasOtherLiveSessions } from "../../local-llm/session-registry.js";
 import {
   checkForBackendUpdate,
   DEFAULT_EMBEDDING_MODEL_ID,
@@ -180,7 +181,17 @@ export class LocalModelsOrchestrator {
     // llama-server is orphaned in the background.
     if (this.daemonSupervised) {
       this.daemonSupervised = false;
-      await this.stopDaemonSilent();
+      const cfg = getConfig();
+      // `stopOnExit: false` keeps the model warm between sessions (the
+      // operator owns teardown via `models stop`). With it on, only the
+      // LAST live session stops the daemon — a second TUI window still
+      // chatting must not lose its model because this one closed first.
+      if (
+        cfg.localModels.managed.stopOnExit &&
+        !hasOtherLiveSessions(cfg.paths.localModelsDataDir)
+      ) {
+        await this.stopDaemonSilent();
+      }
     }
   }
 

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -7,6 +7,7 @@ import { checkLlamaServer } from "../llm/llama-server-health.js";
 import { createAgentRuntime } from "../runtime/bootstrap.js";
 import type { LogRecord, LogSink } from "../tracing/structured-logger.js";
 import type { MetricSample, MetricSink } from "../tracing/metrics-collector.js";
+import { registerSession } from "../local-llm/session-registry.js";
 import { enterAltScreen } from "./alt-screen.js";
 import { ChatOrchestrator } from "./chat-orchestrator.js";
 import { parseTuiArgs } from "./tui-args.js";
@@ -143,6 +144,16 @@ export async function tuiCommand(args: string[]): Promise<number> {
   const onSignal = (): void => orchestrator.quit();
   process.once("SIGINT", onSignal);
   process.once("SIGTERM", onSignal);
+  // SIGHUP fires when the terminal window is closed. Without a handler
+  // the default action kills the process before `orchestrator.shutdown()`
+  // runs, orphaning the managed llama-server with the model still in
+  // RAM/VRAM — the exact complaint in #52.
+  process.once("SIGHUP", onSignal);
+
+  // Mark this process as a live TUI session so `stopOnExit` teardown can
+  // tell "last session exits, stop the daemon" from "another window is
+  // still chatting, leave it running".
+  const releaseSession = registerSession(config.paths.localModelsDataDir);
 
   const altScreen = enterAltScreen({ stdout: process.stdout, hideCursor: false });
 
@@ -360,9 +371,16 @@ export async function tuiCommand(args: string[]): Promise<number> {
   } finally {
     process.off("SIGINT", onSignal);
     process.off("SIGTERM", onSignal);
-    altScreen.restore();
-    ink.clear();
+    process.off("SIGHUP", onSignal);
+    try {
+      altScreen.restore();
+      ink.clear();
+    } catch {
+      // After SIGHUP the tty is gone and these writes raise EIO; the
+      // daemon teardown below must still run.
+    }
     await orchestrator.shutdown();
+    releaseSession();
   }
 
   // Self-update restart handoff. The runtime is fully shut down and the


### PR DESCRIPTION
Closes #52.

The managed llama-server is spawned detached so it survives the CLI on purpose, and the clean-exit path (q, Ctrl+C, SIGTERM) already stops it. The complaint in #52 turned out to be the terminal-close path: closing the window sends SIGHUP, which had no handler, so the process died before `orchestrator.shutdown()` ran and the daemon kept holding RAM/VRAM until a manual `models stop`.

## Changes

- **SIGHUP is handled in the TUI entry** alongside SIGINT/SIGTERM, and the alt-screen restore is EIO-safe so teardown still runs when the tty is already gone.
- **New `localModels.managed.stopOnExit` flag, default `true`.** Closing the last session frees the memory; `false` keeps the model warm between sessions for operators who prefer the old behavior. Config v33 → v34; older files transparently inherit `true`. Standalone daemons started with `atomic-agent models start` are never touched, same as before.
- **New session registry** (`<dataDir>/sessions/<pid>` marker files, same liveness pattern as `telegram-lockfile.ts`): only the last live session stops the daemon. This also fixes a pre-existing bug: with two parallel TUI windows, the first one to exit killed the model out from under the second. Stale markers from crashed sessions are reclaimed on scan.

## Testing

- `session-registry.test.ts`: register/release, own-pid exclusion, live-other detection (via `process.ppid`), stale-marker reclamation.
- Orchestrator shutdown: stops by default as the last session, honors `stopOnExit: false`, leaves the daemon alone while another live session exists, never touches an unsupervised daemon.
- Config: default, explicit `false`, v33 file inheriting `true`.
- `tsc --noEmit` clean; full suite has the same pre-existing failures as `main` (verified against a clean checkout).

## Manual verification checklist (needs a machine with a downloaded model)

1. Close the terminal window mid-session: `ps` shows llama-server gone.
2. Two parallel TUI sessions: first exit leaves the daemon up, second exit stops it.
3. Windows: closing the console window (CTRL_CLOSE_EVENT allows ~5 s; teardown uses a 2 s timeout).
4. `stopOnExit: false`: daemon survives exit and the next TUI start adopts the warm model.

## Note

This PR and the telegram follow-up both bump `USER_CONFIG_VERSION` 33 → 34 for their own field. Whichever merges second gets a trivial rebase to 35.
