### PR TITLE
analytics: attach turn latency + shape metrics to message_sent

### DIFF
--- a/src/analytics/analytics-events.test.ts
+++ b/src/analytics/analytics-events.test.ts
@@ -76,7 +76,7 @@ describe("captureMessageSent", () => {
     expect(store.markFirstMessageSent).toHaveBeenCalledTimes(1);
   });
 
-  it("attaches only provider + model", () => {
+  it("attaches only provider + model when no shape metrics given", () => {
     const client = fakeClient();
     const store = fakeStore({ firstMessage: true });
     captureMessageSent(client, store, ctx);
@@ -84,6 +84,41 @@ describe("captureMessageSent", () => {
       provider: "openrouter",
       model: "gpt",
     });
+  });
+
+  it("attaches latency_ms / step_count / outcome to message_sent when provided", () => {
+    const client = fakeClient();
+    const store = fakeStore({ firstMessage: true });
+    captureMessageSent(client, store, {
+      ...ctx,
+      latencyMs: 1234,
+      stepCount: 5,
+      outcome: "reply",
+    });
+    expect(client.capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.messageSent, {
+      provider: "openrouter",
+      model: "gpt",
+      latency_ms: 1234,
+      step_count: 5,
+      outcome: "reply",
+    });
+  });
+
+  it("keeps shape metrics off first_message_sent (only provider + model)", () => {
+    const client = fakeClient();
+    const store = fakeStore(); // first message not yet sent
+    captureMessageSent(client, store, {
+      ...ctx,
+      latencyMs: 1234,
+      stepCount: 5,
+      outcome: "reply",
+    });
+    // first call is first_message_sent — must carry base props only
+    expect(client.capture).toHaveBeenNthCalledWith(
+      1,
+      ANALYTICS_EVENTS.firstMessageSent,
+      { provider: "openrouter", model: "gpt" },
+    );
   });
 
   it("no-ops when analytics is disabled (null client)", () => {

--- a/src/analytics/analytics-events.ts
+++ b/src/analytics/analytics-events.ts
@@ -12,10 +12,25 @@ export const ANALYTICS_EVENTS = {
  * Non-sensitive context attached to message events. Only the active LLM
  * provider name and model identifier — never message content, file
  * paths, tool arguments, or any user data.
+ *
+ * The optional shape metrics below describe the *cost/shape* of the turn,
+ * never its content. All are attached to `message_sent` only, never to
+ * `first_message_sent`, and each is omitted when the caller cannot
+ * measure it:
+ *  - `latencyMs`   — wall-clock duration of the turn (submit -> final
+ *                    assistant response) in milliseconds.
+ *  - `stepCount`   — number of agent steps taken (0..N tool steps + reply).
+ *                    A proxy for "how much work the turn required".
+ *  - `outcome`     — how the turn ended: `reply` / `finish` / `max_steps`
+ *                    / `cancelled` / `failed`. `max_steps` means the reply
+ *                    was cut off by the step budget.
  */
 export interface MessageEventContext {
   provider: string;
   model: string;
+  latencyMs?: number;
+  stepCount?: number;
+  outcome?: string;
 }
 
 /**
@@ -36,8 +51,9 @@ export function captureAppInstalled(
 /**
  * Emit `message_sent` for every human-originated turn, plus the
  * one-time `first_message_sent` on the very first message this install
- * ever sends. Both carry only `{ provider, model }`. No-ops when
- * analytics is disabled.
+ * ever sends. Both carry `{ provider, model }`; `message_sent` also
+ * carries `latency_ms` when the caller measured the turn duration.
+ * No-ops when analytics is disabled.
  */
 export function captureMessageSent(
   client: AnalyticsClient | null,
@@ -45,10 +61,15 @@ export function captureMessageSent(
   context: MessageEventContext,
 ): void {
   if (!client) return;
-  const properties = { provider: context.provider, model: context.model };
+  const base = { provider: context.provider, model: context.model };
   if (!store.isFirstMessageSent()) {
-    client.capture(ANALYTICS_EVENTS.firstMessageSent, properties);
+    client.capture(ANALYTICS_EVENTS.firstMessageSent, base);
     store.markFirstMessageSent();
   }
-  client.capture(ANALYTICS_EVENTS.messageSent, properties);
+  client.capture(ANALYTICS_EVENTS.messageSent, {
+    ...base,
+    ...(context.latencyMs !== undefined ? { latency_ms: context.latencyMs } : {}),
+    ...(context.stepCount !== undefined ? { step_count: context.stepCount } : {}),
+    ...(context.outcome !== undefined ? { outcome: context.outcome } : {}),
+  });
 }

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -1940,17 +1940,6 @@ export async function createAgentRuntime(
     } = {},
   ): Promise<RunTurnResult> => {
     const origin = runOptions.origin ?? "cli";
-    // Product analytics: count only human-originated turns. Scheduler-
-    // driven turns (durable tasks, cron, webhook ingress) are excluded
-    // — they are not "a person sending a message". `captureMessageSent`
-    // no-ops when analytics is disabled and also fires the one-time
-    // `first_message_sent`.
-    if (origin !== "scheduler") {
-      captureMessageSent(analytics, analyticsStateStore, {
-        provider: providerRegistry.activeText.name,
-        model: resolveActiveModelName(),
-      });
-    }
     const submission = {
       sessionId: session.id,
       origin,
@@ -1958,7 +1947,39 @@ export async function createAgentRuntime(
       ...(runOptions.eventHook ? { eventHook: runOptions.eventHook } : {}),
       ...(runOptions.signal ? { signal: runOptions.signal } : {}),
     } as const;
-    return turnController.enqueue(submission);
+
+    // Product analytics: count only human-originated turns. Scheduler-
+    // driven turns (durable tasks, cron, webhook ingress) are excluded
+    // — they are not "a person sending a message". We measure the turn's
+    // wall-clock duration (`latency_ms`) plus non-content shape metrics
+    // (`step_count`, `outcome`), and emit whether the turn resolves or
+    // throws — a failed/aborted turn is still a real "message sent"
+    // attempt. On throw we have no result, so only `outcome: "failed"`
+    // is known. `captureMessageSent` no-ops when analytics is disabled
+    // and also fires the one-time `first_message_sent`.
+    if (origin === "scheduler") {
+      return turnController.enqueue(submission);
+    }
+    const startedAt = Date.now();
+    try {
+      const result = await turnController.enqueue(submission);
+      captureMessageSent(analytics, analyticsStateStore, {
+        provider: providerRegistry.activeText.name,
+        model: resolveActiveModelName(),
+        latencyMs: Date.now() - startedAt,
+        stepCount: result.stepCount,
+        outcome: result.reason,
+      });
+      return result;
+    } catch (error) {
+      captureMessageSent(analytics, analyticsStateStore, {
+        provider: providerRegistry.activeText.name,
+        model: resolveActiveModelName(),
+        latencyMs: Date.now() - startedAt,
+        outcome: "failed",
+      });
+      throw error;
+    }
   };
 
   const taskRunner = new TaskRunner({


### PR DESCRIPTION
## Why

We have no visibility into response cost in product analytics — neither how *slow* nor how *heavy* turns are — so we can't tell whether slow or complex turns drive drop-off. This adds three content-free "shape" metrics to the existing `message_sent` event.

## What

New optional fields on `message_sent` (each omitted when unmeasurable; **none ever attached to `first_message_sent`**):

| Field | Meaning |
|---|---|
| `latency_ms` | Wall-clock turn duration (submit -> final assistant response). |
| `step_count` | Number of agent steps taken — a proxy for how much work the turn required. From `RunTurnResult.stepCount`. |
| `outcome` | How the turn ended: `reply` / `finish` / `max_steps` / `cancelled` / `failed`. `max_steps` means the reply was cut off by the step budget. |

## How

- Extend `MessageEventContext` with optional `latencyMs` / `stepCount` / `outcome`; `captureMessageSent` spreads each in only when present.
- In `runTurn`, time the turn around `turnController.enqueue`. On success, emit latency + `result.stepCount` + `result.reason`; on throw, emit latency + `outcome: "failed"` (no result to read), then rethrow. The emit moved from *before* the turn to *after* it, so duration and outcome are observable — the same "fires on success or failure" guarantee as before.
- Scheduler-origin turns remain excluded, exactly as before.

## Privacy

Unchanged in spirit: the event still carries only `provider` / `model` plus these numeric/enum shape fields — **no message content, file paths, tool arguments, or any user data**. The event doc comment is updated to match. Respects the analytics opt-out (no-ops when disabled).

## Notes for review

- Metric is **whole-turn wall clock** (including tool steps), not time-to-first-token. Sufficient for the "are we slow?" question; TTFT would need streaming hooks.
- The post-turn emit means that for the very first message, `first_message_sent` now also fires after the turn — believe this is fine (arguably more correct), flagging since it's a semantic shift.
- Deliberately **not** sending token counts or tool-call counts yet — those live inside the loop and aren't on `RunTurnResult`. Happy to surface them as a small follow-up in `agent-loop.ts` if wanted.

## Verified locally

- `tsc --noEmit` clean.
- `src/analytics/` tests: 26/26 pass (added 2 asserting the metrics land on `message_sent` and stay off `first_message_sent`).

⚛️ Generated with [Atomic Agent](https://atomicagent.io/)