### PR TITLE
fix(tui): prefill the stored base URL in the configure-mode provider wizard

### DIFF
--- a/src/tui/llm-panel/llm-panel-primary-actions.ts
+++ b/src/tui/llm-panel/llm-panel-primary-actions.ts
@@ -194,7 +194,7 @@ function triggerCloudEmbeddingModel(
 }
 
 function openProviderConfigFor(
-  provider: { id: string; kind: string },
+  provider: { id: string; kind: string; baseUrl?: string | null },
   dispatch: (action: TuiAction) => void,
 ): void {
   if (!isCloudProviderKind(provider.kind)) return;
@@ -204,6 +204,7 @@ function openProviderConfigFor(
     wizard: createProvidersWizardState("configure", {
       providerId: provider.id,
       kind: provider.kind,
+      ...(provider.baseUrl ? { baseUrl: provider.baseUrl } : {}),
     }),
   });
 }

--- a/src/tui/providers/providers-key-bindings.ts
+++ b/src/tui/providers/providers-key-bindings.ts
@@ -83,6 +83,7 @@ export function handleProvidersTabKey(
         wizard: createProvidersWizardState("configure", {
           providerId: row.id,
           kind: row.kind,
+          ...(row.baseUrl ? { baseUrl: row.baseUrl } : {}),
         }),
       });
     }

--- a/src/tui/providers/providers-orchestrator.ts
+++ b/src/tui/providers/providers-orchestrator.ts
@@ -83,6 +83,7 @@ export class ProvidersOrchestrator {
         isActiveText: p.id === resolved.activeTextProvider,
         isActiveEmbedding: p.id === resolved.activeEmbeddingProvider,
         hasApiKey: Boolean(resolveLlmProviderApiKey(p)?.length),
+        baseUrl: fileEntry?.baseUrl ?? null,
         chatModel: fileEntry?.defaultChatModel ?? fileEntry?.model ?? null,
         chatModelOptions: listChatModelOptionsForEntry(fileEntry),
         embeddingModel: fileEntry?.defaultEmbeddingModel ?? null,

--- a/src/tui/providers/providers-panel-state.ts
+++ b/src/tui/providers/providers-panel-state.ts
@@ -8,6 +8,13 @@ export type ProviderRow = {
   isActiveText: boolean;
   isActiveEmbedding: boolean;
   hasApiKey: boolean;
+  /**
+   * Stored base URL for `openai-compatible` entries (`null` for curated
+   * kinds and when unset). Carried on the row so configure-mode wizards
+   * can prefill the URL step instead of opening on an empty field that
+   * silently resets a custom endpoint to the OpenAI default.
+   */
+  baseUrl: string | null;
   chatModel: string | null;
   chatModelOptions?: readonly string[];
   embeddingModel: string | null;

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -27,6 +27,26 @@ function emptyKey(overrides: Partial<Key> = {}): Key {
   };
 }
 
+describe("createProvidersWizardState configure prefill", () => {
+  it("prefills baseUrlLine from the stored base URL", () => {
+    const wizard = createProvidersWizardState("configure", {
+      providerId: "my-vllm",
+      kind: "openai-compatible",
+      baseUrl: "http://192.168.1.50:8000",
+    });
+    expect(wizard.baseUrlLine).toBe("http://192.168.1.50:8000");
+    expect(wizard.phase).toBe("api_key");
+  });
+
+  it("keeps baseUrlLine empty when no stored URL is passed", () => {
+    const wizard = createProvidersWizardState("configure", {
+      providerId: "my-vllm",
+      kind: "openai-compatible",
+    });
+    expect(wizard.baseUrlLine).toBe("");
+  });
+});
+
 describe("handleProvidersWizardKey", () => {
   it("walks the aimlapi onboarding flow when the cursor lands on it", () => {
     let wizard = createProvidersWizardState("add");

--- a/src/tui/providers/providers-wizard-state.ts
+++ b/src/tui/providers/providers-wizard-state.ts
@@ -35,7 +35,16 @@ export interface ProvidersWizardState {
 
 export function createProvidersWizardState(
   mode: ProvidersWizardMode,
-  opts?: { providerId?: string; kind?: ProvidersWizardKind },
+  opts?: {
+    providerId?: string;
+    kind?: ProvidersWizardKind;
+    /**
+     * Stored base URL of the entry being reconfigured. Prefills the
+     * `base_url` step so pressing Enter through it keeps the custom
+     * endpoint instead of silently resetting it to the OpenAI default.
+     */
+    baseUrl?: string;
+  },
 ): ProvidersWizardState {
   const configure = mode === "configure";
   const kind = opts?.kind ?? null;
@@ -46,7 +55,7 @@ export function createProvidersWizardState(
     providerId: opts?.providerId ?? null,
     cursor: 0,
     apiKeyBuffer: "",
-    baseUrlLine: "",
+    baseUrlLine: opts?.baseUrl ?? "",
     chatModelLine: "",
     embeddingModelLine: "",
     selectedChatModelId: null,


### PR DESCRIPTION
Part of #62 (the Related item).

## Problem

Re-running the provider wizard for an existing openai-compatible entry opens the base_url step on an empty field. Pressing Enter through it falls back to `https://api.openai.com` and silently clobbers a custom endpoint (vLLM, LM Studio). A user re-running the wizard just to change the model can break their setup without noticing.

## Change

`ProviderRow` now carries the stored `baseUrl`, and both configure-mode entry points (the providers panel `c` binding and the LLM panel row action) pass it into `createProvidersWizardState`, which prefills `baseUrlLine`. Enter through the step now keeps the custom URL; clearing the field still applies the default.

## Testing

Two new tests on the wizard state prefill. `src/tui/providers` and `src/tui/llm-panel`: all passing except the one `llm-panel-selectors` failure that is pre-existing on main (documented in #50). `tsc --noEmit` clean.