### PR TITLE
fix(providers): serve the full model catalog and stop reading API silence as no

### DIFF
--- a/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.test.ts
+++ b/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.test.ts
@@ -1,8 +1,28 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  AIMLAPI_CHAT_MODEL_ORDER,
+  AIMLAPI_MODELS_CATALOG,
+} from "./aimlapi-models-catalog.js";
+import {
   listAimlapiChatPicks,
   refreshAimlapiChatCatalogFromApi,
 } from "./fetch-aimlapi-chat-catalog.js";
+
+function staticChatIds(): readonly string[] {
+  return AIMLAPI_CHAT_MODEL_ORDER.filter(
+    (id) => AIMLAPI_MODELS_CATALOG.get(id)?.kind === "chat",
+  );
+}
+
+/**
+ * The picks cache lives at module scope, so a fallback test running after
+ * a successful refresh would happily read the previous test's cache and
+ * prove nothing. A fresh module instance starts with an empty cache.
+ */
+async function importFreshModule() {
+  vi.resetModules();
+  return import("./fetch-aimlapi-chat-catalog.js");
+}
 
 describe("refreshAimlapiChatCatalogFromApi", () => {
   afterEach(() => {
@@ -129,7 +149,7 @@ describe("refreshAimlapiChatCatalogFromApi", () => {
     expect(picks.some((p) => p.id === "openai/gpt-5-2")).toBe(true);
   });
 
-  it("returns false and leaves a static fallback when the API call fails", async () => {
+  it("returns false and serves the static catalog when the API call fails", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -137,10 +157,13 @@ describe("refreshAimlapiChatCatalogFromApi", () => {
       }),
     );
 
-    const ok = await refreshAimlapiChatCatalogFromApi();
+    const mod = await importFreshModule();
+    const ok = await mod.refreshAimlapiChatCatalogFromApi();
     expect(ok).toBe(false);
-    const picks = listAimlapiChatPicks();
-    expect(picks.length).toBeGreaterThan(0);
+    // The exact offline list, not a leftover live cache.
+    expect(mod.listAimlapiChatPicks().map((p) => p.id)).toEqual(
+      staticChatIds(),
+    );
   });
 
   it("keeps every advertised model instead of a capped head", async () => {
@@ -307,8 +330,35 @@ describe("refreshAimlapiChatCatalogFromApi", () => {
       "fetch",
       vi.fn(async () => ({ ok: true, json: async () => ({ nope: true }) })),
     );
-    const ok = await refreshAimlapiChatCatalogFromApi();
+    const mod = await importFreshModule();
+    const ok = await mod.refreshAimlapiChatCatalogFromApi();
     expect(ok).toBe(false);
-    expect(listAimlapiChatPicks().length).toBeGreaterThan(0);
+    expect(mod.listAimlapiChatPicks().map((p) => p.id)).toEqual(
+      staticChatIds(),
+    );
+  });
+
+  it("skips null rows in data instead of losing the whole live catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            null,
+            "not-an-object",
+            {
+              id: "vendor/ok",
+              type: "openai/chat-completions",
+              info: { contextLength: 8000 },
+            },
+          ],
+        }),
+      })),
+    );
+
+    const ok = await refreshAimlapiChatCatalogFromApi();
+    expect(ok).toBe(true);
+    expect(listAimlapiChatPicks().map((p) => p.id)).toEqual(["vendor/ok"]);
   });
 });

--- a/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.test.ts
+++ b/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.test.ts
@@ -142,4 +142,173 @@ describe("refreshAimlapiChatCatalogFromApi", () => {
     const picks = listAimlapiChatPicks();
     expect(picks.length).toBeGreaterThan(0);
   });
+
+  it("keeps every advertised model instead of a capped head", async () => {
+    // 50 live models: the old MAX_PICKS = 32 truncated the tail.
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      id: `vendor/model-${String(i).padStart(2, "0")}`,
+      type: "chat-completion",
+      features: ["openai.function"],
+      info: { contextLength: 128_000 },
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ data: many }) })),
+    );
+
+    const ok = await refreshAimlapiChatCatalogFromApi();
+    expect(ok).toBe(true);
+    const picks = listAimlapiChatPicks();
+    expect(picks.length).toBe(50);
+    expect(picks.some((p) => p.id === "vendor/model-49")).toBe(true);
+  });
+
+  it("orders the non-curated tail alphabetically", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: "zeta/model", type: "chat-completion", features: ["openai.function"], info: { contextLength: 8000 } },
+            { id: "alpha/model", type: "chat-completion", features: ["openai.function"], info: { contextLength: 8000 } },
+            { id: "mid/model", type: "chat-completion", features: ["openai.function"], info: { contextLength: 8000 } },
+          ],
+        }),
+      })),
+    );
+
+    await refreshAimlapiChatCatalogFromApi();
+    const ids = listAimlapiChatPicks().map((p) => p.id);
+    expect(ids).toEqual(["alpha/model", "mid/model", "zeta/model"]);
+  });
+
+  it("parses the current API shape (vendor-prefixed type, no features array)", async () => {
+    // Verbatim shape of a live row as of 2026-08: `type` gained a vendor
+    // prefix and `features` disappeared. The old parser matched neither,
+    // so every chat model was dropped and the picker silently fell back
+    // to the offline list.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "openai/gpt-4.1-mini-2025-04-14",
+              type: "openai/chat-completions",
+              aliases: ["gpt-4.1-mini-2025-04-14"],
+              tags: ["playground:chat", "tier:tier_2"],
+              info: { name: "GPT-4.1 Mini", contextLength: 1_000_000 },
+            },
+            {
+              id: "vendor/video-model",
+              type: "internal/video-generations/submit",
+              info: { name: "Video", contextLength: 8000 },
+            },
+            {
+              id: "vendor/image-model",
+              type: "openai/image-generations",
+              info: { name: "Image", contextLength: 8000 },
+            },
+            {
+              id: "anthropic/claude-x",
+              type: "anthropic/messages",
+              info: { name: "Claude", contextLength: 200_000 },
+            },
+          ],
+        }),
+      })),
+    );
+
+    const ok = await refreshAimlapiChatCatalogFromApi();
+    expect(ok).toBe(true);
+    const ids = listAimlapiChatPicks().map((p) => p.id);
+    expect(ids).toContain("openai/gpt-4.1-mini-2025-04-14");
+    // Non-chat families in the same payload stay out.
+    expect(ids).not.toContain("vendor/video-model");
+    expect(ids).not.toContain("vendor/image-model");
+    expect(ids).not.toContain("anthropic/claude-x");
+  });
+
+  it("still honours an explicit no-tools flag when the API sends one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "vendor/with-tools",
+              type: "chat-completion",
+              features: ["openai.function"],
+              info: { contextLength: 8000 },
+            },
+            {
+              id: "vendor/no-tools",
+              type: "chat-completion",
+              features: ["openai.chat"],
+              info: { contextLength: 8000 },
+            },
+          ],
+        }),
+      })),
+    );
+
+    await refreshAimlapiChatCatalogFromApi();
+    const ids = listAimlapiChatPicks().map((p) => p.id);
+    expect(ids).toContain("vendor/with-tools");
+    expect(ids).not.toContain("vendor/no-tools");
+  });
+
+  it("keeps models when the API says nothing about tool support", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "vendor/silent",
+              type: "openai/chat-completions",
+              info: { contextLength: 8000 },
+            },
+          ],
+        }),
+      })),
+    );
+
+    await refreshAimlapiChatCatalogFromApi();
+    expect(listAimlapiChatPicks().map((p) => p.id)).toContain("vendor/silent");
+  });
+
+  it("ignores rows without a usable id", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            { type: "openai/chat-completions", info: { contextLength: 8000 } },
+            { id: "", type: "openai/chat-completions", info: { contextLength: 8000 } },
+            { id: "vendor/ok", type: "openai/chat-completions", info: { contextLength: 8000 } },
+          ],
+        }),
+      })),
+    );
+
+    const ok = await refreshAimlapiChatCatalogFromApi();
+    expect(ok).toBe(true);
+    expect(listAimlapiChatPicks().map((p) => p.id)).toEqual(["vendor/ok"]);
+  });
+
+  it("falls back to the offline catalog on a malformed payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ nope: true }) })),
+    );
+    const ok = await refreshAimlapiChatCatalogFromApi();
+    expect(ok).toBe(false);
+    expect(listAimlapiChatPicks().length).toBeGreaterThan(0);
+  });
 });

--- a/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
+++ b/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
@@ -14,10 +14,14 @@ type AimlapiApiModel = {
    * Capability flags. Present in the pre-2026-08 response shape; the
    * current API dropped the field entirely, so every reader must treat
    * it as optional rather than assuming its absence means "no support".
+   *
+   * The current shape's `tags` array is deliberately NOT modelled here:
+   * as of 2026-08 it only carries playground grouping and pricing tier
+   * labels (`playground:chat`, `tier:tier_2`), never capability
+   * markers (the gpt-4o family shows up without any vision tag), so
+   * nothing can be derived from it.
    */
   features?: readonly string[];
-  /** Current shape: `playground:chat`, `tier:tier_2`, and similar. */
-  tags?: readonly string[];
   info?: {
     contextLength?: number;
     context_length?: number;
@@ -89,10 +93,24 @@ function readToolSupport(m: AimlapiApiModel): "none" | "basic" | "parallel" {
   return readAdvertisedToolSupport(m) ?? "basic";
 }
 
+/**
+ * Unlike tools, silence deliberately reads as "no vision", and the cost
+ * of that is real, not cosmetic. `supportsVision` becomes the
+ * capability bit on the synthesised {@link ModelCatalogEntry}, which is
+ * what the provider layer reads to gate image input
+ * (`ProviderCapabilities.vision`, whose `false` makes `vision.describe`
+ * raise `VisionUnsupportedError`), so a live-only id whose row stays
+ * silent loses `vision.describe` entirely, not just a "vision" badge in
+ * the picker. We still prefer underclaiming: advertising vision on a
+ * text-only route breaks at request time with a rejected image payload,
+ * while a conservative entry keeps the model usable for text and, unlike
+ * the tools case, can never empty the catalog. Curated ids are
+ * unaffected (their hand-verified static entry wins in
+ * `entryFromLiveModel`), and the current response offers no better
+ * signal to read: `features` is gone, `tags` and `info` carry no
+ * capability fields (see {@link AimlapiApiModel}).
+ */
 function readVisionSupport(m: AimlapiApiModel): boolean {
-  // Unlike tools, silence deliberately reads as "no vision": overclaiming
-  // would invite image input that the backend rejects, while underclaiming
-  // only hides a badge and never empties the catalog.
   return (m.features ?? []).some((f) => f.includes(".vision"));
 }
 
@@ -127,13 +145,20 @@ function formatCtx(tokens: number): string {
   return `${tokens}`;
 }
 
+let staticPicks: readonly AimlapiChatPick[] | null = null;
+
 function picksFromStaticCatalog(): readonly AimlapiChatPick[] {
+  // Memoized: downstream lookup caches key themselves on the array
+  // reference (see providers-model-options), so the offline fallback must
+  // return a stable array rather than a fresh one per call.
+  if (staticPicks) return staticPicks;
   const out: AimlapiChatPick[] = [];
   for (const id of AIMLAPI_CHAT_MODEL_ORDER) {
     const entry = AIMLAPI_MODELS_CATALOG.get(id);
     if (!entry || entry.kind !== "chat") continue;
     out.push({ id, label: labelForPick(id, entry), entry });
   }
+  staticPicks = out;
   return out;
 }
 

--- a/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
+++ b/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
@@ -63,7 +63,7 @@ function readContextLength(m: AimlapiApiModel): number {
  * `undefined` means "the response says nothing about it", which is the
  * case for the whole current catalog: the `features` array was removed
  * and nothing replaced it. Callers must not read that silence as "no
- * tools" — doing so filtered out all 337 chat models and silently pinned
+ * tools": doing so filtered out all 337 chat models and silently pinned
  * the picker to the offline list.
  */
 function readAdvertisedToolSupport(
@@ -90,6 +90,9 @@ function readToolSupport(m: AimlapiApiModel): "none" | "basic" | "parallel" {
 }
 
 function readVisionSupport(m: AimlapiApiModel): boolean {
+  // Unlike tools, silence deliberately reads as "no vision": overclaiming
+  // would invite image input that the backend rejects, while underclaiming
+  // only hides a badge and never empties the catalog.
   return (m.features ?? []).some((f) => f.includes(".vision"));
 }
 
@@ -147,11 +150,12 @@ export function listAimlapiChatPicks(): readonly AimlapiChatPick[] {
 /**
  * Pull the public aimlapi catalog and rebuild the TUI picker.
  *
- * Filters to rows where `type === "chat-completion"` and the model
- * advertises a `*.function` feature (the agent loop relies on tool
- * calling). Models with `type === "responses"` (e.g. `openai/o3-pro`)
- * are intentionally excluded — they live on `/v1/responses` and 404 on
- * `/v1/chat/completions`.
+ * Keeps rows whose `type` is a chat-completions variant (see
+ * {@link isChatCompletionType}) and drops a model only when the API
+ * explicitly advertises that it cannot call tools; a missing `features`
+ * array is treated as silence, not as "no". Rows on other surfaces
+ * (`responses`, `anthropic/messages`, image/video generations) are
+ * excluded because they 404 on `/v1/chat/completions`.
  *
  * For ids that exist in {@link AIMLAPI_MODELS_CATALOG}, the static
  * entry wins (we hand-curate pricing/cache flags). For new live ids,
@@ -170,6 +174,9 @@ export async function refreshAimlapiChatCatalogFromApi(): Promise<boolean> {
 
     const liveById = new Map<string, AimlapiApiModel>();
     for (const m of rows) {
+      // A single null or scalar row must not throw and drag the whole
+      // live catalog into the static fallback.
+      if (!m || typeof m !== "object") continue;
       if (typeof m.id !== "string" || m.id.length === 0) continue;
       if (!isChatCompletionType(m.type)) continue;
       // Only drop a model when the API explicitly says it cannot call

--- a/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
+++ b/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
@@ -6,18 +6,43 @@ import {
 
 const MODELS_URL = "https://api.aimlapi.com/v1/models";
 const CACHE_TTL_MS = 60 * 60 * 1000;
-const MAX_PICKS = 32;
 
 type AimlapiApiModel = {
   id?: string;
   type?: string;
+  /**
+   * Capability flags. Present in the pre-2026-08 response shape; the
+   * current API dropped the field entirely, so every reader must treat
+   * it as optional rather than assuming its absence means "no support".
+   */
   features?: readonly string[];
+  /** Current shape: `playground:chat`, `tier:tier_2`, and similar. */
+  tags?: readonly string[];
   info?: {
     contextLength?: number;
     context_length?: number;
     name?: string;
   };
 };
+
+/**
+ * Chat rows have carried two different `type` spellings: `chat-completion`
+ * (pre-2026-08) and `openai/chat-completions` (current, vendor-prefixed).
+ * Matching on the suffix keeps both working and survives the next
+ * renaming of the same idea, while still excluding the other families in
+ * the same response: video generations, image generations,
+ * `anthropic/messages`, and the `responses/submit` family.
+ */
+function isChatCompletionType(type: string | undefined): boolean {
+  if (typeof type !== "string") return false;
+  const normalized = type.toLowerCase();
+  return (
+    normalized === "chat-completion" ||
+    normalized === "chat-completions" ||
+    normalized.endsWith("/chat-completions") ||
+    normalized.endsWith("/chat-completion")
+  );
+}
 
 export type AimlapiChatPick = {
   id: string;
@@ -32,15 +57,36 @@ function readContextLength(m: AimlapiApiModel): number {
   return m.info?.contextLength ?? m.info?.context_length ?? 128_000;
 }
 
-function readToolSupport(
+/**
+ * Tool support as advertised by the API.
+ *
+ * `undefined` means "the response says nothing about it", which is the
+ * case for the whole current catalog: the `features` array was removed
+ * and nothing replaced it. Callers must not read that silence as "no
+ * tools" — doing so filtered out all 337 chat models and silently pinned
+ * the picker to the offline list.
+ */
+function readAdvertisedToolSupport(
   m: AimlapiApiModel,
-): "none" | "basic" | "parallel" {
-  const features = m.features ?? [];
+): "none" | "basic" | "parallel" | undefined {
+  const features = m.features;
+  if (features === undefined || features.length === 0) return undefined;
   const hasFn = features.some((f) => f.includes(".function"));
   const hasParallel = features.some((f) => f.includes("parallel-tool-calls"));
   if (hasParallel) return "parallel";
   if (hasFn) return "basic";
   return "none";
+}
+
+/**
+ * Effective tool support for building a catalog entry. Falls back to
+ * `basic` when the API is silent: aimlapi routes these ids to
+ * `/v1/chat/completions`, which is the tool-calling surface, and a model
+ * that turns out not to support tools fails loudly at request time
+ * rather than being invisible in the picker.
+ */
+function readToolSupport(m: AimlapiApiModel): "none" | "basic" | "parallel" {
+  return readAdvertisedToolSupport(m) ?? "basic";
 }
 
 function readVisionSupport(m: AimlapiApiModel): boolean {
@@ -124,9 +170,11 @@ export async function refreshAimlapiChatCatalogFromApi(): Promise<boolean> {
 
     const liveById = new Map<string, AimlapiApiModel>();
     for (const m of rows) {
-      if (typeof m.id !== "string") continue;
-      if (m.type !== "chat-completion") continue;
-      if (readToolSupport(m) === "none") continue;
+      if (typeof m.id !== "string" || m.id.length === 0) continue;
+      if (!isChatCompletionType(m.type)) continue;
+      // Only drop a model when the API explicitly says it cannot call
+      // tools. Silence is not a "no" (see `readAdvertisedToolSupport`).
+      if (readAdvertisedToolSupport(m) === "none") continue;
       liveById.set(m.id, m);
     }
 
@@ -142,9 +190,14 @@ export async function refreshAimlapiChatCatalogFromApi(): Promise<boolean> {
       seen.add(id);
     }
 
-    for (const [id, live] of liveById) {
+    // Everything the provider advertises, not a truncated head: the
+    // picker filters by typed text, so a long list costs nothing while a
+    // capped one silently hides most of the catalog (#62 follow-up).
+    // Curated ids above keep their hand-picked order; the rest follow
+    // alphabetically so the tail is predictable.
+    const rest = [...liveById.entries()].sort(([a], [b]) => a.localeCompare(b));
+    for (const [id, live] of rest) {
       if (seen.has(id)) continue;
-      if (picks.length >= MAX_PICKS) break;
       const entry = entryFromLiveModel(live, id);
       if (entry.kind !== "chat") continue;
       picks.push({ id, label: labelForPick(id, entry), entry });

--- a/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.test.ts
+++ b/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.test.ts
@@ -3,6 +3,26 @@ import {
   listOpenRouterChatPicks,
   refreshOpenRouterChatCatalogFromApi,
 } from "./fetch-openrouter-chat-catalog.js";
+import {
+  OPENROUTER_CHAT_MODEL_ORDER,
+  OPENROUTER_MODELS_CATALOG,
+} from "./openrouter-models-catalog.js";
+
+function staticChatIds(): readonly string[] {
+  return OPENROUTER_CHAT_MODEL_ORDER.filter(
+    (id) => OPENROUTER_MODELS_CATALOG.get(id)?.kind === "chat",
+  );
+}
+
+/**
+ * The picks cache lives at module scope, so a fallback test running after
+ * a successful refresh would happily read the previous test's cache and
+ * prove nothing. A fresh module instance starts with an empty cache.
+ */
+async function importFreshModule() {
+  vi.resetModules();
+  return import("./fetch-openrouter-chat-catalog.js");
+}
 
 describe("refreshOpenRouterChatCatalogFromApi", () => {
   afterEach(() => {
@@ -92,10 +112,39 @@ describe("refreshOpenRouterChatCatalogFromApi", () => {
         throw new Error("network down");
       }),
     );
-    const ok = await refreshOpenRouterChatCatalogFromApi();
+    const mod = await importFreshModule();
+    const ok = await mod.refreshOpenRouterChatCatalogFromApi();
     expect(ok).toBe(false);
-    // The offline list is still served, so the picker is never empty.
-    expect(listOpenRouterChatPicks().length).toBeGreaterThan(0);
+    // The exact offline list, not a leftover live cache.
+    expect(mod.listOpenRouterChatPicks().map((p) => p.id)).toEqual(
+      staticChatIds(),
+    );
+  });
+
+  it("skips null rows in data instead of losing the whole live catalog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            null,
+            "not-an-object",
+            {
+              id: "vendor/ok",
+              name: "OK",
+              context_length: 128_000,
+              pricing: { prompt: "0.000001", completion: "0.000002" },
+              supported_parameters: ["tools"],
+            },
+          ],
+        }),
+      })),
+    );
+
+    const ok = await refreshOpenRouterChatCatalogFromApi();
+    expect(ok).toBe(true);
+    expect(listOpenRouterChatPicks().map((p) => p.id)).toEqual(["vendor/ok"]);
   });
 
   it("keeps models when supported_parameters is absent", async () => {

--- a/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.test.ts
+++ b/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.test.ts
@@ -60,4 +60,98 @@ describe("refreshOpenRouterChatCatalogFromApi", () => {
     expect(picks.some((p) => p.id === "qwen/qwen3.5-35b-a3b")).toBe(false);
     expect(picks.some((p) => p.id.startsWith("anthropic/"))).toBe(false);
   });
+
+  it("keeps every advertised model instead of a capped head", async () => {
+    // 40 live models: the old MAX_PICKS = 12 cut this to a dozen, hiding
+    // most of the catalog from the picker.
+    const many = Array.from({ length: 40 }, (_, i) => ({
+      id: `vendor/model-${String(i).padStart(2, "0")}`,
+      name: `Model ${i}`,
+      context_length: 128_000,
+      pricing: { prompt: "0.000001", completion: "0.000002" },
+      supported_parameters: ["tools"],
+      architecture: { input_modalities: ["text"] },
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ data: many }) })),
+    );
+
+    const ok = await refreshOpenRouterChatCatalogFromApi();
+    expect(ok).toBe(true);
+    const picks = listOpenRouterChatPicks();
+    expect(picks.length).toBe(40);
+    // Tail models that used to be dropped are now reachable.
+    expect(picks.some((p) => p.id === "vendor/model-39")).toBe(true);
+  });
+
+  it("falls back to the static catalog when the API is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    const ok = await refreshOpenRouterChatCatalogFromApi();
+    expect(ok).toBe(false);
+    // The offline list is still served, so the picker is never empty.
+    expect(listOpenRouterChatPicks().length).toBeGreaterThan(0);
+  });
+
+  it("keeps models when supported_parameters is absent", async () => {
+    // Mirrors how aimlapi broke: if the provider stops advertising
+    // capabilities, silence must not empty the catalog.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "vendor/silent",
+              name: "Silent",
+              context_length: 128_000,
+              pricing: { prompt: "0.000001", completion: "0.000002" },
+            },
+          ],
+        }),
+      })),
+    );
+
+    const ok = await refreshOpenRouterChatCatalogFromApi();
+    expect(ok).toBe(true);
+    expect(listOpenRouterChatPicks().map((p) => p.id)).toContain("vendor/silent");
+  });
+
+  it("still drops models that explicitly lack tools", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "vendor/no-tools",
+              name: "No tools",
+              context_length: 128_000,
+              pricing: { prompt: "0.000001", completion: "0.000002" },
+              supported_parameters: ["temperature"],
+            },
+            {
+              id: "vendor/with-tools",
+              name: "With tools",
+              context_length: 128_000,
+              pricing: { prompt: "0.000001", completion: "0.000002" },
+              supported_parameters: ["tools"],
+            },
+          ],
+        }),
+      })),
+    );
+
+    await refreshOpenRouterChatCatalogFromApi();
+    const ids = listOpenRouterChatPicks().map((p) => p.id);
+    expect(ids).toContain("vendor/with-tools");
+    expect(ids).not.toContain("vendor/no-tools");
+  });
 });

--- a/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
+++ b/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
@@ -76,6 +76,9 @@ function scoreChat(m: OpenRouterApiModel): number {
 
 function apiRowToEntry(m: OpenRouterApiModel): ModelCatalogEntry {
   const id = m.id!;
+  // Unlike tools, silence deliberately reads as "no vision": overclaiming
+  // would invite image input that the route rejects, while underclaiming
+  // only hides a badge and never empties the catalog.
   const vision = (m.architecture?.input_modalities ?? []).includes("image");
   return {
     id,
@@ -139,8 +142,14 @@ export async function refreshOpenRouterChatCatalogFromApi(): Promise<boolean> {
       signal: AbortSignal.timeout(20_000),
     });
     if (!res.ok) return false;
-    const json = (await res.json()) as { data?: OpenRouterApiModel[] };
-    const rows = json.data ?? [];
+    const json = (await res.json()) as {
+      data?: (OpenRouterApiModel | null)[];
+    };
+    // A single null or scalar row must not throw and drag the whole live
+    // catalog into the static fallback.
+    const rows = (json.data ?? []).filter(
+      (m): m is OpenRouterApiModel => !!m && typeof m === "object",
+    );
     const ranked = rows
       .filter((m) => scoreChat(m) >= 0)
       .sort((a, b) => scoreChat(b) - scoreChat(a));

--- a/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
+++ b/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
@@ -76,9 +76,13 @@ function scoreChat(m: OpenRouterApiModel): number {
 
 function apiRowToEntry(m: OpenRouterApiModel): ModelCatalogEntry {
   const id = m.id!;
-  // Unlike tools, silence deliberately reads as "no vision": overclaiming
-  // would invite image input that the route rejects, while underclaiming
-  // only hides a badge and never empties the catalog.
+  // Unlike tools, silence deliberately reads as "no vision", and that is
+  // a capability decision, not a cosmetic one: `supportsVision` gates
+  // `vision.describe` through `ProviderCapabilities.vision`, so a row
+  // without `input_modalities` loses image input for that id. Still the
+  // safer default: overclaiming breaks at request time with a rejected
+  // image payload, while underclaiming keeps the model usable for text
+  // and can never empty the catalog.
   const vision = (m.architecture?.input_modalities ?? []).includes("image");
   return {
     id,
@@ -107,7 +111,13 @@ function labelForPick(id: string, entry: ModelCatalogEntry, name?: string): stri
   return `${id}${short}${price}`;
 }
 
+let staticPicks: readonly OpenRouterChatPick[] | null = null;
+
 function picksFromStaticCatalog(): readonly OpenRouterChatPick[] {
+  // Memoized: downstream lookup caches key themselves on the array
+  // reference (see providers-model-options), so the offline fallback must
+  // return a stable array rather than a fresh one per call.
+  if (staticPicks) return staticPicks;
   const out: OpenRouterChatPick[] = [];
   for (const id of OPENROUTER_CHAT_MODEL_ORDER) {
     const entry = OPENROUTER_MODELS_CATALOG.get(id);
@@ -118,6 +128,7 @@ function picksFromStaticCatalog(): readonly OpenRouterChatPick[] {
       entry,
     });
   }
+  staticPicks = out;
   return out;
 }
 

--- a/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
+++ b/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
@@ -6,7 +6,6 @@ import {
 
 const MODELS_URL = "https://openrouter.ai/api/v1/models";
 const CACHE_TTL_MS = 60 * 60 * 1000;
-const MAX_PICKS = 12;
 
 type OpenRouterApiModel = {
   id?: string;
@@ -32,8 +31,22 @@ function pricePerMillion(tokenPrice: string | undefined): number {
   return Math.round(n * 1_000_000 * 100) / 100;
 }
 
+/**
+ * Tool support as advertised by the API.
+ *
+ * A missing or empty `supported_parameters` means the response says
+ * nothing, not that the model lacks tools. Treating silence as a "no"
+ * is what emptied the aimlapi catalog when that provider dropped its
+ * capability field, so this reader keeps the two cases apart.
+ */
+function readAdvertisedTools(m: OpenRouterApiModel): boolean | undefined {
+  if (!Array.isArray(m.supported_parameters)) return undefined;
+  if (m.supported_parameters.length === 0) return undefined;
+  return m.supported_parameters.includes("tools");
+}
+
 function hasTools(m: OpenRouterApiModel): boolean {
-  return Array.isArray(m.supported_parameters) && m.supported_parameters.includes("tools");
+  return readAdvertisedTools(m) ?? true;
 }
 
 function scoreChat(m: OpenRouterApiModel): number {
@@ -146,9 +159,12 @@ export async function refreshOpenRouterChatCatalogFromApi(): Promise<boolean> {
       seen.add(auto.id);
     }
 
+    // Everything OpenRouter advertises, not a truncated head: the picker
+    // filters by typed text, so a long list costs nothing while a capped
+    // one silently hides most of the catalog (#62 follow-up). `ranked`
+    // keeps the score order, so the useful models still come first.
     for (const m of ranked) {
       if (!m.id || seen.has(m.id)) continue;
-      if (picks.length >= MAX_PICKS) break;
       const entry = apiRowToEntry(m);
       picks.push({
         id: m.id,

--- a/src/tui/components/providers-wizard.test.tsx
+++ b/src/tui/components/providers-wizard.test.tsx
@@ -1,7 +1,10 @@
 import { render } from "ink-testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { refreshAimlapiChatCatalogFromApi } from "../../llm/provider/aimlapi/fetch-aimlapi-chat-catalog.js";
+import { refreshOpenRouterChatCatalogFromApi } from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
 import { createProvidersWizardState } from "../providers/providers-wizard-state.js";
+import type { ProvidersWizardKind } from "../providers/providers-wizard-state.js";
 import { ProvidersWizard } from "./providers-wizard.js";
 
 function stripAnsi(value: string): string {
@@ -15,6 +18,19 @@ function chatModelStep(baseUrlLine: string, cursor = 0) {
     baseUrlLine,
     cursor,
   };
+}
+
+function cloudPickStep(kind: ProvidersWizardKind, cursor: number) {
+  return {
+    ...createProvidersWizardState("add", { kind }),
+    phase: "pick_chat_model" as const,
+    cursor,
+  };
+}
+
+/** Count rendered option rows by a substring every option label carries. */
+function countRows(text: string, needle: string): number {
+  return text.split("\n").filter((line) => line.includes(needle)).length;
 }
 
 async function flush(): Promise<void> {
@@ -38,7 +54,7 @@ describe("ProvidersWizard chat model step", () => {
     );
 
     const { lastFrame } = render(
-      // pasted with `/v1` — the header must show the URL actually requested
+      // pasted with `/v1`: the header must show the URL actually requested
       <ProvidersWizard wizard={chatModelStep("https://many.example/v1", 20)} />,
     );
     await flush();
@@ -49,6 +65,26 @@ describe("ProvidersWizard chat model step", () => {
     expect(text).toContain("> model-28");
     expect(text).toContain("(21/30)");
     expect(text).not.toContain("model-10");
+  });
+
+  it("keeps the compat window when the cursor sits at the tail", async () => {
+    const ids = Array.from({ length: 30 }, (_, i) => `model-${i + 1}`);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: ids.map((id) => ({ id })) }),
+      })),
+    );
+
+    const { lastFrame } = render(
+      <ProvidersWizard wizard={chatModelStep("https://many.example/v1", 29)} />,
+    );
+    await flush();
+
+    const text = stripAnsi(lastFrame() ?? "");
+    expect(text).toContain("(30/30)");
+    expect(countRows(text, "model-")).toBeLessThanOrEqual(12);
   });
 
   it("falls back to a typed id when the server refuses the list", async () => {
@@ -64,5 +100,60 @@ describe("ProvidersWizard chat model step", () => {
 
     const text = stripAnsi(lastFrame() ?? "");
     expect(text).toContain("model list unavailable (http 403)");
+  });
+});
+
+describe("ProvidersWizard cloud model pickers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("windows the OpenRouter picker when the live catalog has 300+ models", async () => {
+    const many = Array.from({ length: 305 }, (_, i) => ({
+      id: `vendor/model-${String(i).padStart(3, "0")}`,
+      name: `Model ${i}`,
+      context_length: 128_000,
+      pricing: { prompt: "0.000001", completion: "0.000002" },
+      supported_parameters: ["tools"],
+      architecture: { input_modalities: ["text"] },
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ data: many }) })),
+    );
+    await refreshOpenRouterChatCatalogFromApi();
+
+    const { lastFrame } = render(
+      <ProvidersWizard wizard={cloudPickStep("openrouter", 150)} />,
+    );
+    const text = stripAnsi(lastFrame() ?? "");
+    expect(text).toContain("> vendor/model-150");
+    expect(text).toContain("(151/305)");
+    expect(countRows(text, "vendor/model-")).toBeLessThanOrEqual(12);
+    expect(text).not.toContain("vendor/model-000");
+    expect(text).not.toContain("vendor/model-304");
+  });
+
+  it("windows the aimlapi picker when the live catalog has 300+ models", async () => {
+    const many = Array.from({ length: 337 }, (_, i) => ({
+      id: `vendor/model-${String(i).padStart(3, "0")}`,
+      type: "openai/chat-completions",
+      info: { name: `Model ${i}`, contextLength: 128_000 },
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ data: many }) })),
+    );
+    await refreshAimlapiChatCatalogFromApi();
+
+    const { lastFrame } = render(
+      <ProvidersWizard wizard={cloudPickStep("aimlapi", 336)} />,
+    );
+    const text = stripAnsi(lastFrame() ?? "");
+    // The cursor at the tail still sits inside a 12-row viewport.
+    expect(text).toContain("> vendor/model-336");
+    expect(text).toContain("(337/337)");
+    expect(countRows(text, "vendor/model-")).toBeLessThanOrEqual(12);
+    expect(text).not.toContain("vendor/model-000");
   });
 });

--- a/src/tui/components/providers-wizard.test.tsx
+++ b/src/tui/components/providers-wizard.test.tsx
@@ -63,7 +63,8 @@ describe("ProvidersWizard chat model step", () => {
     expect(text).toContain("30 from https://many.example/v1/models");
     // ids are listed sorted; cursor 20 lands on the 21st of them
     expect(text).toContain("> model-28");
-    expect(text).toContain("(21/30)");
+    // The counter opens the hint, right after the movement keys.
+    expect(text).toContain("↑/↓ move (21/30) · PgUp/PgDn jump");
     expect(text).not.toContain("model-10");
   });
 
@@ -100,6 +101,18 @@ describe("ProvidersWizard chat model step", () => {
 
     const text = stripAnsi(lastFrame() ?? "");
     expect(text).toContain("model list unavailable (http 403)");
+  });
+});
+
+describe("ProvidersWizard pick list counter", () => {
+  it("shows the position counter for short lists too", () => {
+    // 3 provider kinds, well under the viewport. The counter is not a
+    // long-list extra: hiding it below a size threshold reads as a glitch.
+    const { lastFrame } = render(
+      <ProvidersWizard wizard={createProvidersWizardState("add")} />,
+    );
+    const text = stripAnsi(lastFrame() ?? "");
+    expect(text).toContain("j/k move (1/3) · Enter pick · Esc cancel");
   });
 });
 

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -43,12 +43,26 @@ function maskedKey(buffer: string): string {
   return masked + extra;
 }
 
+/** Keep long server model lists inside a fixed viewport around the cursor. */
+const PICK_WINDOW = 12;
+
 function renderPickList(
   title: string,
   options: readonly { label: string }[],
   cursor: number,
   hint: string,
 ): ReactElement {
+  // Window every pick list, not just the openai-compatible step: the live
+  // OpenRouter/aimlapi catalogs run past 300 rows, and an unwindowed map
+  // would paint them all into the terminal at once.
+  const total = options.length;
+  const clamped = Math.min(Math.max(cursor, 0), Math.max(0, total - 1));
+  const start = Math.min(
+    Math.max(0, clamped - Math.floor(PICK_WINDOW / 2)),
+    Math.max(0, total - PICK_WINDOW),
+  );
+  const visible = options.slice(start, start + PICK_WINDOW);
+  const position = total > PICK_WINDOW ? ` (${clamped + 1}/${total})` : "";
   return (
     <Box
       flexDirection="column"
@@ -61,15 +75,22 @@ function renderPickList(
       <Text bold color={theme.colors.accentSoft}>
         {title}
       </Text>
-      {options.map((opt, i) => {
-        const mark = i === cursor ? ">" : " ";
+      {visible.map((opt, i) => {
+        const index = start + i;
+        const mark = index === clamped ? ">" : " ";
         return (
-          <Text key={`${i}-${opt.label}`} color={i === cursor ? theme.colors.accentSoft : undefined}>
+          <Text
+            key={`${index}-${opt.label}`}
+            color={index === clamped ? theme.colors.accentSoft : undefined}
+          >
             {mark} {opt.label}
           </Text>
         );
       })}
-      <Text color={theme.colors.muted}>{hint}</Text>
+      <Text color={theme.colors.muted}>
+        {hint}
+        {position}
+      </Text>
     </Box>
   );
 }
@@ -109,9 +130,6 @@ function renderLineField(props: {
   );
 }
 
-/** Keep long server model lists inside a fixed viewport around the cursor. */
-const PICK_WINDOW = 12;
-
 function CompatChatModelStep(props: {
   wizard: ProvidersWizardState;
 }): ReactElement {
@@ -150,16 +168,11 @@ function CompatChatModelStep(props: {
 
   const picks = listCompatChatModelPicks(w);
   if (picks.length > 0) {
-    const cursor = Math.min(w.cursor, picks.length - 1);
-    const start = Math.min(
-      Math.max(0, cursor - Math.floor(PICK_WINDOW / 2)),
-      Math.max(0, picks.length - PICK_WINDOW),
-    );
     return renderPickList(
       `Chat model — ${picks.length} from ${baseUrl}/v1/models`,
-      picks.slice(start, start + PICK_WINDOW).map((id) => ({ label: id })),
-      cursor - start,
-      `↑/↓ move (${cursor + 1}/${picks.length}) · Enter select · type to enter an id by hand · Esc cancel`,
+      picks.map((id) => ({ label: id })),
+      w.cursor,
+      "↑/↓ move · Enter select · type to enter an id by hand · Esc cancel",
     );
   }
 

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -16,6 +16,7 @@ import {
   OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
 } from "../providers/providers-model-options.js";
 import type { ProvidersWizardState } from "../providers/providers-wizard-state.js";
+import { renderPickList } from "./wizard-pick-list.js";
 
 const KIND_OPTIONS = [
   { id: "openrouter" as const, label: "OpenRouter (cloud chat + optional cloud embed)" },
@@ -41,58 +42,6 @@ function maskedKey(buffer: string): string {
   const masked = "•".repeat(Math.min(buffer.length, 48));
   const extra = buffer.length > 48 ? `+${buffer.length - 48}` : "";
   return masked + extra;
-}
-
-/** Keep long server model lists inside a fixed viewport around the cursor. */
-const PICK_WINDOW = 12;
-
-function renderPickList(
-  title: string,
-  options: readonly { label: string }[],
-  cursor: number,
-  hint: string,
-): ReactElement {
-  // Window every pick list, not just the openai-compatible step: the live
-  // OpenRouter/aimlapi catalogs run past 300 rows, and an unwindowed map
-  // would paint them all into the terminal at once.
-  const total = options.length;
-  const clamped = Math.min(Math.max(cursor, 0), Math.max(0, total - 1));
-  const start = Math.min(
-    Math.max(0, clamped - Math.floor(PICK_WINDOW / 2)),
-    Math.max(0, total - PICK_WINDOW),
-  );
-  const visible = options.slice(start, start + PICK_WINDOW);
-  const position = total > PICK_WINDOW ? ` (${clamped + 1}/${total})` : "";
-  return (
-    <Box
-      flexDirection="column"
-      borderStyle="round"
-      borderColor={theme.colors.accentSoft}
-      paddingX={1}
-      marginY={1}
-      width="100%"
-    >
-      <Text bold color={theme.colors.accentSoft}>
-        {title}
-      </Text>
-      {visible.map((opt, i) => {
-        const index = start + i;
-        const mark = index === clamped ? ">" : " ";
-        return (
-          <Text
-            key={`${index}-${opt.label}`}
-            color={index === clamped ? theme.colors.accentSoft : undefined}
-          >
-            {mark} {opt.label}
-          </Text>
-        );
-      })}
-      <Text color={theme.colors.muted}>
-        {hint}
-        {position}
-      </Text>
-    </Box>
-  );
 }
 
 function renderLineField(props: {
@@ -168,12 +117,14 @@ function CompatChatModelStep(props: {
 
   const picks = listCompatChatModelPicks(w);
   if (picks.length > 0) {
-    return renderPickList(
-      `Chat model — ${picks.length} from ${baseUrl}/v1/models`,
-      picks.map((id) => ({ label: id })),
-      w.cursor,
-      "↑/↓ move · Enter select · type to enter an id by hand · Esc cancel",
-    );
+    return renderPickList({
+      title: `Chat model — ${picks.length} from ${baseUrl}/v1/models`,
+      options: picks.map((id) => ({ label: id })),
+      cursor: w.cursor,
+      moveHint: "↑/↓ move",
+      actionsHint:
+        "PgUp/PgDn jump · Enter select · type to enter an id by hand · Esc cancel",
+    });
   }
 
   const hint = !isCompat
@@ -199,12 +150,13 @@ export function ProvidersWizard(props: {
   const modeLabel = w.mode === "configure" ? `configure ${w.providerId}` : "add provider";
 
   if (w.phase === "pick_kind") {
-    return renderPickList(
-      `LLM provider — ${modeLabel}`,
-      KIND_OPTIONS,
-      w.cursor,
-      "j/k move · Enter pick · Esc cancel",
-    );
+    return renderPickList({
+      title: `LLM provider — ${modeLabel}`,
+      options: KIND_OPTIONS,
+      cursor: w.cursor,
+      moveHint: "j/k move",
+      actionsHint: "Enter pick · Esc cancel",
+    });
   }
 
   if (w.phase === "api_key") {
@@ -241,43 +193,43 @@ export function ProvidersWizard(props: {
   }
 
   if (w.phase === "pick_chat_model" && w.kind === "openrouter") {
-    const models = listOpenRouterChatModels();
-    return renderPickList(
-      "Chat model (OpenRouter)",
-      models,
-      w.cursor,
-      "j/k move · Enter select · Esc cancel",
-    );
+    return renderPickList({
+      title: "Chat model (OpenRouter)",
+      options: listOpenRouterChatModels(),
+      cursor: w.cursor,
+      moveHint: "j/k move",
+      actionsHint: "PgUp/PgDn jump · Enter select · Esc cancel",
+    });
   }
 
   if (w.phase === "pick_chat_model" && w.kind === "aimlapi") {
-    const models = listAimlapiChatModels();
-    return renderPickList(
-      "Chat model (AI/ML API)",
-      models,
-      w.cursor,
-      "j/k move · Enter select · Esc cancel",
-    );
+    return renderPickList({
+      title: "Chat model (AI/ML API)",
+      options: listAimlapiChatModels(),
+      cursor: w.cursor,
+      moveHint: "j/k move",
+      actionsHint: "PgUp/PgDn jump · Enter select · Esc cancel",
+    });
   }
 
   if (w.phase === "pick_embedding" && w.kind === "openrouter") {
-    const models = listOpenRouterEmbeddingModels();
-    return renderPickList(
-      "Embedding backend",
-      models,
-      w.cursor,
-      "j/k move · Enter finish · Esc cancel",
-    );
+    return renderPickList({
+      title: "Embedding backend",
+      options: listOpenRouterEmbeddingModels(),
+      cursor: w.cursor,
+      moveHint: "j/k move",
+      actionsHint: "PgUp/PgDn jump · Enter finish · Esc cancel",
+    });
   }
 
   if (w.phase === "pick_embedding" && w.kind === "aimlapi") {
-    const models = listAimlapiEmbeddingModels();
-    return renderPickList(
-      "Embedding backend",
-      models,
-      w.cursor,
-      "j/k move · Enter finish · Esc cancel",
-    );
+    return renderPickList({
+      title: "Embedding backend",
+      options: listAimlapiEmbeddingModels(),
+      cursor: w.cursor,
+      moveHint: "j/k move",
+      actionsHint: "PgUp/PgDn jump · Enter finish · Esc cancel",
+    });
   }
 
   if (w.phase === "base_url") {

--- a/src/tui/components/wizard-pick-list.tsx
+++ b/src/tui/components/wizard-pick-list.tsx
@@ -1,0 +1,71 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import { theme } from "../theme/theme.js";
+
+/**
+ * Viewport height for every wizard pick list, and the jump distance for
+ * PgUp/PgDn in `providers-wizard-key-bindings`. Keep the two in sync by
+ * importing this constant, never by copying the number.
+ */
+export const PICK_WINDOW = 12;
+
+/**
+ * Bordered option list windowed around the cursor.
+ *
+ * Windowing lives here, not in the callers: the live OpenRouter/aimlapi
+ * catalogs run past 300 rows, and an unwindowed map would paint them all
+ * into the terminal at once.
+ *
+ * The hint line always starts with the movement keys and the position
+ * counter (`j/k move (5/30) · ...`), for short lists too, matching the
+ * original CompatChatModelStep shape. The counter is how the operator
+ * knows where they are in a list the viewport cannot show whole, and a
+ * counter that appears only past a size threshold reads as a glitch.
+ */
+export function renderPickList(props: {
+  title: string;
+  options: readonly { label: string }[];
+  cursor: number;
+  /** Movement-keys part of the hint, e.g. "j/k move". */
+  moveHint: string;
+  /** Actions part of the hint, e.g. "Enter select · Esc cancel". */
+  actionsHint: string;
+}): ReactElement {
+  const total = props.options.length;
+  const clamped = Math.min(Math.max(props.cursor, 0), Math.max(0, total - 1));
+  const start = Math.min(
+    Math.max(0, clamped - Math.floor(PICK_WINDOW / 2)),
+    Math.max(0, total - PICK_WINDOW),
+  );
+  const visible = props.options.slice(start, start + PICK_WINDOW);
+  const position = total === 0 ? "(0/0)" : `(${clamped + 1}/${total})`;
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.colors.accentSoft}
+      paddingX={1}
+      marginY={1}
+      width="100%"
+    >
+      <Text bold color={theme.colors.accentSoft}>
+        {props.title}
+      </Text>
+      {visible.map((opt, i) => {
+        const index = start + i;
+        const mark = index === clamped ? ">" : " ";
+        return (
+          <Text
+            key={`${index}-${opt.label}`}
+            color={index === clamped ? theme.colors.accentSoft : undefined}
+          >
+            {mark} {opt.label}
+          </Text>
+        );
+      })}
+      <Text color={theme.colors.muted}>
+        {props.moveHint} {position} · {props.actionsHint}
+      </Text>
+    </Box>
+  );
+}

--- a/src/tui/providers/providers-model-options.ts
+++ b/src/tui/providers/providers-model-options.ts
@@ -25,7 +25,12 @@ export { AIMLAPI_DEFAULT_CHAT_MODEL };
 export function listOpenRouterChatModels(): readonly ProviderModelOption[] {
   return listOpenRouterChatPicks().map((p) => ({
     id: p.id,
-    label: `${p.id} · ${formatOpenRouterChatModelDetails(p.id)}`,
+    // Lazy: only the rows a viewport actually paints pay the format cost.
+    // The pick lists run past 300 rows and are rebuilt per keypress, so
+    // eagerly formatting every label made each j/k press quadratic.
+    get label(): string {
+      return `${p.id} · ${formatOpenRouterChatModelDetails(p.id)}`;
+    },
   }));
 }
 
@@ -67,7 +72,10 @@ export function listOpenRouterEmbeddingModels(): readonly ProviderModelOption[] 
 export function listAimlapiChatModels(): readonly ProviderModelOption[] {
   return listAimlapiChatPicks().map((p) => ({
     id: p.id,
-    label: `${p.id} · ${formatAimlapiChatModelDetails(p.id)}`,
+    // Lazy for the same reason as the OpenRouter list above.
+    get label(): string {
+      return `${p.id} · ${formatAimlapiChatModelDetails(p.id)}`;
+    },
   }));
 }
 
@@ -106,14 +114,42 @@ export function listAimlapiEmbeddingModels(): readonly ProviderModelOption[] {
   return out;
 }
 
+/**
+ * O(1) id → entry lookup over a picks list that is itself cached at
+ * module scope in the fetcher. The map is keyed by the picks array
+ * reference: the fetchers return a stable array until a live refresh
+ * replaces it, so a reference change is exactly "the catalog changed,
+ * rebuild". Without this, every list row resolved its entry with a
+ * linear `find` over 300+ picks, which made rendering the picker
+ * quadratic on every keypress.
+ */
+function createCatalogEntryResolver(
+  listPicks: () => readonly { id: string; entry: ModelCatalogEntry }[],
+): (modelId: string) => ModelCatalogEntry | undefined {
+  let cachedSource: readonly { id: string; entry: ModelCatalogEntry }[] | null =
+    null;
+  let cachedById: Map<string, ModelCatalogEntry> = new Map();
+  return (modelId) => {
+    const picks = listPicks();
+    if (picks !== cachedSource) {
+      cachedSource = picks;
+      cachedById = new Map(picks.map((pick) => [pick.id, pick.entry]));
+    }
+    return cachedById.get(modelId);
+  };
+}
+
+const liveAimlapiEntryById = createCatalogEntryResolver(listAimlapiChatPicks);
+const liveOpenRouterEntryById = createCatalogEntryResolver(
+  listOpenRouterChatPicks,
+);
+
 function resolveAimlapiCatalogEntry(modelId: string): ModelCatalogEntry | undefined {
-  const live = listAimlapiChatPicks().find((pick) => pick.id === modelId)?.entry;
-  return live ?? AIMLAPI_MODELS_CATALOG.get(modelId);
+  return liveAimlapiEntryById(modelId) ?? AIMLAPI_MODELS_CATALOG.get(modelId);
 }
 
 function resolveOpenRouterCatalogEntry(modelId: string): ModelCatalogEntry | undefined {
-  const live = listOpenRouterChatPicks().find((pick) => pick.id === modelId)?.entry;
-  return live ?? OPENROUTER_MODELS_CATALOG.get(modelId);
+  return liveOpenRouterEntryById(modelId) ?? OPENROUTER_MODELS_CATALOG.get(modelId);
 }
 
 function formatContextWindow(tokens: number): string {

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -2,6 +2,7 @@ import type { Key } from "ink";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { PICK_WINDOW } from "../components/wizard-pick-list.js";
 import { LOCAL_EMBEDDING_CHOICE_ID } from "./providers-model-options.js";
 import { handleProvidersWizardKey } from "./providers-wizard-key-bindings.js";
 import { createProvidersWizardState } from "./providers-wizard-state.js";
@@ -15,6 +16,8 @@ function emptyKey(overrides: Partial<Key> = {}): Key {
     rightArrow: false,
     pageDown: false,
     pageUp: false,
+    home: false,
+    end: false,
     return: false,
     escape: false,
     ctrl: false,
@@ -140,6 +143,137 @@ describe("handleProvidersWizardKey", () => {
       wizard = next(wizard, "", emptyKey({ return: true }));
       expect(wizard.chatModelLine).toBe("my-own");
       expect(wizard.phase).toBe("embedding_model_line");
+    });
+
+    it("pages and jumps through a long discovered list", async () => {
+      const ids = Array.from({ length: 30 }, (_, i) => ({
+        id: `model-${String(i + 1).padStart(2, "0")}`,
+      }));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({ ok: true, json: async () => ({ data: ids }) })),
+      );
+      await fetchOpenAiCompatModels("https://paging.example", ENV_KEY);
+
+      let wizard = await wizardAtChatModelStep("https://paging.example");
+      wizard = next(wizard, "", emptyKey({ pageDown: true }));
+      expect(wizard.cursor).toBe(PICK_WINDOW);
+      wizard = next(wizard, "", emptyKey({ end: true }));
+      expect(wizard.cursor).toBe(29);
+      // PgDn at the tail clamps instead of wrapping.
+      wizard = next(wizard, "", emptyKey({ pageDown: true }));
+      expect(wizard.cursor).toBe(29);
+      wizard = next(wizard, "", emptyKey({ pageUp: true }));
+      expect(wizard.cursor).toBe(29 - PICK_WINDOW);
+      wizard = next(wizard, "", emptyKey({ home: true }));
+      expect(wizard.cursor).toBe(0);
+      // "j" stays a printable character here, not vim navigation: this
+      // list coexists with the type-an-id-by-hand editor.
+      wizard = next(wizard, "j", emptyKey());
+      expect(wizard.cursor).toBe(0);
+      expect(wizard.chatModelLine).toBe("j");
+    });
+  });
+
+  describe("cloud pick list navigation against a live catalog", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function stubOpenRouterCatalog(count: number): void {
+      // Identical scores keep the payload order (stable sort), so
+      // cursor index N is exactly `vendor/model-NNN`.
+      const data = Array.from({ length: count }, (_, i) => ({
+        id: `vendor/model-${String(i).padStart(3, "0")}`,
+        name: `Model ${i}`,
+        context_length: 128_000,
+        pricing: { prompt: "0.000001", completion: "0.000002" },
+        supported_parameters: ["tools"],
+      }));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({ ok: true, json: async () => ({ data }) })),
+      );
+    }
+
+    /**
+     * The live catalog cache lives at module scope in the fetcher; a fresh
+     * module graph per test keeps one test's refresh from leaking into the
+     * rest of this file (same pattern as the fetcher's own tests).
+     */
+    async function freshOpenRouterPickPhase(count: number) {
+      vi.resetModules();
+      const catalog = await import(
+        "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js"
+      );
+      const bindings = await import("./providers-wizard-key-bindings.js");
+      stubOpenRouterCatalog(count);
+      await catalog.refreshOpenRouterChatCatalogFromApi();
+      const wizard: ProvidersWizardState = {
+        ...createProvidersWizardState("add", { kind: "openrouter" }),
+        phase: "pick_chat_model",
+      };
+      const step = (
+        w: ProvidersWizardState,
+        input: string,
+        key: Key,
+      ): ProvidersWizardState => {
+        const result = bindings.handleProvidersWizardKey(input, key, w);
+        if (!result.handled || !("wizard" in result)) {
+          throw new Error("wizard key was not handled");
+        }
+        return result.wizard;
+      };
+      return { catalog, wizard, step };
+    }
+
+    it("jumps by one viewport with PgUp/PgDn and hits the edges with Home/End", async () => {
+      const { wizard, step } = await freshOpenRouterPickPhase(30);
+
+      let w = step(wizard, "", emptyKey({ pageDown: true }));
+      expect(w.cursor).toBe(PICK_WINDOW);
+      w = step(w, "", emptyKey({ pageDown: true }));
+      expect(w.cursor).toBe(2 * PICK_WINDOW);
+      // The jump clamps at the tail instead of wrapping.
+      w = step(w, "", emptyKey({ pageDown: true }));
+      expect(w.cursor).toBe(29);
+      w = step(w, "", emptyKey({ pageUp: true }));
+      expect(w.cursor).toBe(29 - PICK_WINDOW);
+      w = step(w, "", emptyKey({ home: true }));
+      expect(w.cursor).toBe(0);
+      w = step(w, "", emptyKey({ pageUp: true }));
+      expect(w.cursor).toBe(0);
+      w = step(w, "", emptyKey({ end: true }));
+      expect(w.cursor).toBe(29);
+    });
+
+    it("selects the highlighted row when the catalog shrank under the cursor", async () => {
+      const { catalog, wizard, step } = await freshOpenRouterPickPhase(30);
+      const deep = { ...wizard, cursor: 25 };
+
+      // A background TTL refresh replaces the module-level cache while the
+      // wizard is open; the list now has 10 rows and the cursor is stale.
+      stubOpenRouterCatalog(10);
+      await catalog.refreshOpenRouterChatCatalogFromApi();
+
+      // The render layer highlights the clamped row, the last one. Enter
+      // must select exactly that row, not silently fall back to the first.
+      const submitted = step(deep, "", emptyKey({ return: true }));
+      expect(submitted.selectedChatModelId).toBe("vendor/model-009");
+      expect(submitted.phase).toBe("pick_embedding");
+    });
+
+    it("clamps a stale cursor before arrow movement after the catalog shrank", async () => {
+      const { catalog, wizard, step } = await freshOpenRouterPickPhase(30);
+      const deep = { ...wizard, cursor: 25 };
+
+      stubOpenRouterCatalog(10);
+      await catalog.refreshOpenRouterChatCatalogFromApi();
+
+      // Highlight sits on the clamped last row (9); j wraps to the top
+      // instead of computing from the stale 25.
+      const moved = step(deep, "j", emptyKey());
+      expect(moved.cursor).toBe(0);
     });
   });
 

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -2,123 +2,19 @@ import type { Key } from "ink";
 import { resolveLlmProviderApiKey } from "../../config/resolve-llm-api-key.js";
 import { getCachedOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { normalizeOpenAiBaseUrl } from "../../llm/provider/openai/normalize-openai-base-url.js";
+import { PICK_WINDOW } from "../components/wizard-pick-list.js";
+import { OPENAI_COMPAT_DEFAULT_BASE_URL } from "./providers-model-options.js";
 import {
-  listAimlapiChatModels,
-  listAimlapiEmbeddingModels,
-  listOpenRouterChatModels,
-  listOpenRouterEmbeddingModels,
-  OPENAI_COMPAT_DEFAULT_BASE_URL,
-} from "./providers-model-options.js";
-import type {
-  ProvidersWizardKind,
-  ProvidersWizardPhase,
-  ProvidersWizardState,
-} from "./providers-wizard-state.js";
-
-const KIND_COUNT = 3;
-
-/** Maps the `pick_kind` cursor index to the actual kind. */
-const KIND_ORDER: readonly ProvidersWizardKind[] = [
-  "openrouter",
-  "aimlapi",
-  "openai-compatible",
-];
-
-function kindAtCursor(cursor: number): ProvidersWizardKind {
-  return KIND_ORDER[cursor] ?? "openrouter";
-}
-
-function isCuratedCatalogKind(
-  kind: NonNullable<ProvidersWizardState["kind"]>,
-): boolean {
-  return kind === "openrouter" || kind === "aimlapi";
-}
-
-function listChatModelsForKind(
-  kind: NonNullable<ProvidersWizardState["kind"]>,
-): ReturnType<typeof listOpenRouterChatModels> {
-  if (kind === "aimlapi") return listAimlapiChatModels();
-  return listOpenRouterChatModels();
-}
-
-function listEmbeddingModelsForKind(
-  kind: NonNullable<ProvidersWizardState["kind"]>,
-): ReturnType<typeof listOpenRouterEmbeddingModels> {
-  if (kind === "aimlapi") return listAimlapiEmbeddingModels();
-  return listOpenRouterEmbeddingModels();
-}
-
-function nextPhaseAfterApiKey(
-  kind: NonNullable<ProvidersWizardState["kind"]>,
-): ProvidersWizardPhase {
-  if (isCuratedCatalogKind(kind)) return "pick_chat_model";
-  return "base_url";
-}
-
-function advanceWizardPhase(
-  wizard: ProvidersWizardState,
-): ProvidersWizardState {
-  const { phase, kind } = wizard;
-  if (phase === "pick_kind" && kind) {
-    return { ...wizard, phase: "api_key", cursor: 0, error: null };
-  }
-  if (phase === "api_key" && kind) {
-    return {
-      ...wizard,
-      phase: nextPhaseAfterApiKey(kind),
-      cursor: 0,
-      error: null,
-    };
-  }
-  if (phase === "pick_chat_model" && kind && isCuratedCatalogKind(kind)) {
-    const models = listChatModelsForKind(kind);
-    const picked = models[wizard.cursor]?.id ?? models[0]?.id ?? null;
-    return {
-      ...wizard,
-      phase: "pick_embedding",
-      cursor: 0,
-      selectedChatModelId: picked,
-      error: null,
-    };
-  }
-  if (phase === "base_url" && kind === "openai-compatible") {
-    return { ...wizard, phase: "chat_model_line", cursor: 0, error: null };
-  }
-  if (phase === "chat_model_line" && kind === "openai-compatible") {
-    return { ...wizard, phase: "embedding_model_line", cursor: 0, error: null };
-  }
-  return wizard;
-}
-
-function listLengthForPhase(
-  phase: ProvidersWizardPhase,
-  kind: ProvidersWizardState["kind"],
-): number {
-  if (phase === "pick_kind") return KIND_COUNT;
-  if (phase === "pick_chat_model" && kind && isCuratedCatalogKind(kind)) {
-    return listChatModelsForKind(kind).length;
-  }
-  if (phase === "pick_embedding" && kind && isCuratedCatalogKind(kind)) {
-    return listEmbeddingModelsForKind(kind).length;
-  }
-  return 0;
-}
-
-function isListPhase(phase: ProvidersWizardPhase): boolean {
-  return (
-    phase === "pick_kind" ||
-    phase === "pick_chat_model" ||
-    phase === "pick_embedding"
-  );
-}
-
-function isLinePhase(phase: ProvidersWizardPhase): boolean {
-  return (
-    phase === "base_url" ||
-    phase === "chat_model_line" ||
-    phase === "embedding_model_line"
-  );
-}
+  advanceWizardPhase,
+  clampCursor,
+  isCuratedCatalogKind,
+  isLinePhase,
+  isListPhase,
+  kindAtCursor,
+  listEmbeddingModelsForKind,
+  listLengthForPhase,
+} from "./providers-wizard-phases.js";
+import type { ProvidersWizardState } from "./providers-wizard-state.js";
 
 /** Normalized so the fetch, the cache key and the displayed URL always agree. */
 export function baseUrlForWizard(wizard: ProvidersWizardState): string {
@@ -157,6 +53,37 @@ export function listCompatChatModelPicks(
       apiKeyForWizard(wizard),
     ) ?? []
   );
+}
+
+/**
+ * Cursor after one list-navigation key, or `null` when the key is not a
+ * navigation key. Every result starts from the clamped cursor so a
+ * catalog that shrank under an open wizard cannot leave the cursor
+ * pointing past the end (see `clampCursor`). Arrows wrap like before;
+ * PgUp/PgDn jump one viewport (`PICK_WINDOW`) and stop at the edges,
+ * Home/End go straight to them. Arrow-only travel to row 250 of a 300+
+ * catalog was the alternative.
+ */
+function nextListCursor(
+  input: string,
+  key: Key,
+  cursor: number,
+  length: number,
+  withVimKeys: boolean,
+): number | null {
+  const current = clampCursor(cursor, length);
+  const last = Math.max(0, length - 1);
+  if (key.downArrow || (withVimKeys && input === "j")) {
+    return (current + 1) % length;
+  }
+  if (key.upArrow || (withVimKeys && input === "k")) {
+    return (current - 1 + length) % length;
+  }
+  if (key.pageDown) return Math.min(current + PICK_WINDOW, last);
+  if (key.pageUp) return Math.max(current - PICK_WINDOW, 0);
+  if (key.home) return 0;
+  if (key.end) return last;
+  return null;
 }
 
 export type ProvidersWizardKeyResult =
@@ -210,25 +137,15 @@ export function handleProvidersWizardKey(
   if (isLinePhase(wizard.phase)) {
     const picks = listCompatChatModelPicks(wizard);
     if (picks.length > 0) {
-      // Arrows only: printable keys fall through to line editing so an id the
-      // server does not advertise can still be typed.
-      if (key.downArrow) {
-        return {
-          handled: true,
-          wizard: { ...wizard, cursor: (wizard.cursor + 1) % picks.length },
-        };
-      }
-      if (key.upArrow) {
-        return {
-          handled: true,
-          wizard: {
-            ...wizard,
-            cursor: (wizard.cursor - 1 + picks.length) % picks.length,
-          },
-        };
+      // Navigation keys only ("j"/"k" stay printable): typed characters
+      // fall through to line editing so an id the server does not
+      // advertise can still be entered by hand.
+      const moved = nextListCursor(input, key, wizard.cursor, picks.length, false);
+      if (moved !== null) {
+        return { handled: true, wizard: { ...wizard, cursor: moved } };
       }
       if (key.return) {
-        const picked = picks[wizard.cursor] ?? picks[0]!;
+        const picked = picks[clampCursor(wizard.cursor, picks.length)]!;
         return {
           handled: true,
           wizard: advanceWizardPhase({ ...wizard, chatModelLine: picked }),
@@ -284,24 +201,13 @@ export function handleProvidersWizardKey(
     return { handled: true, wizard };
   }
 
-  if (key.downArrow || input === "j") {
-    return {
-      handled: true,
-      wizard: { ...wizard, cursor: (wizard.cursor + 1) % len },
-    };
-  }
-  if (key.upArrow || input === "k") {
-    return {
-      handled: true,
-      wizard: {
-        ...wizard,
-        cursor: (wizard.cursor - 1 + len) % len,
-      },
-    };
+  const moved = nextListCursor(input, key, wizard.cursor, len, true);
+  if (moved !== null) {
+    return { handled: true, wizard: { ...wizard, cursor: moved } };
   }
   if (key.return) {
     if (wizard.phase === "pick_kind") {
-      const kind = kindAtCursor(wizard.cursor);
+      const kind = kindAtCursor(clampCursor(wizard.cursor, len));
       return {
         handled: true,
         wizard: advanceWizardPhase({
@@ -316,7 +222,8 @@ export function handleProvidersWizardKey(
       isCuratedCatalogKind(wizard.kind)
     ) {
       const models = listEmbeddingModelsForKind(wizard.kind);
-      const picked = models[wizard.cursor]?.id ?? models[0]?.id ?? null;
+      const picked =
+        models[clampCursor(wizard.cursor, models.length)]?.id ?? null;
       return {
         handled: true,
         wizard: {

--- a/src/tui/providers/providers-wizard-phases.ts
+++ b/src/tui/providers/providers-wizard-phases.ts
@@ -1,0 +1,131 @@
+import {
+  listAimlapiChatModels,
+  listAimlapiEmbeddingModels,
+  listOpenRouterChatModels,
+  listOpenRouterEmbeddingModels,
+} from "./providers-model-options.js";
+import type {
+  ProvidersWizardKind,
+  ProvidersWizardPhase,
+  ProvidersWizardState,
+} from "./providers-wizard-state.js";
+
+const KIND_COUNT = 3;
+
+/** Maps the `pick_kind` cursor index to the actual kind. */
+const KIND_ORDER: readonly ProvidersWizardKind[] = [
+  "openrouter",
+  "aimlapi",
+  "openai-compatible",
+];
+
+export function kindAtCursor(cursor: number): ProvidersWizardKind {
+  return KIND_ORDER[cursor] ?? "openrouter";
+}
+
+export function isCuratedCatalogKind(
+  kind: NonNullable<ProvidersWizardState["kind"]>,
+): boolean {
+  return kind === "openrouter" || kind === "aimlapi";
+}
+
+export function listChatModelsForKind(
+  kind: NonNullable<ProvidersWizardState["kind"]>,
+): ReturnType<typeof listOpenRouterChatModels> {
+  if (kind === "aimlapi") return listAimlapiChatModels();
+  return listOpenRouterChatModels();
+}
+
+export function listEmbeddingModelsForKind(
+  kind: NonNullable<ProvidersWizardState["kind"]>,
+): ReturnType<typeof listOpenRouterEmbeddingModels> {
+  if (kind === "aimlapi") return listAimlapiEmbeddingModels();
+  return listOpenRouterEmbeddingModels();
+}
+
+function nextPhaseAfterApiKey(
+  kind: NonNullable<ProvidersWizardState["kind"]>,
+): ProvidersWizardPhase {
+  if (isCuratedCatalogKind(kind)) return "pick_chat_model";
+  return "base_url";
+}
+
+/**
+ * Last valid index for `cursor`, `0` for an empty list. The live catalog
+ * cache can be replaced under an open wizard (TTL refresh finishing
+ * between two keypresses), so every read of `wizard.cursor` against a
+ * list must clamp first: the render layer highlights the clamped row,
+ * and selection has to pick that same row, never `models[0]`.
+ */
+export function clampCursor(cursor: number, length: number): number {
+  if (length <= 0) return 0;
+  return Math.min(Math.max(cursor, 0), length - 1);
+}
+
+export function advanceWizardPhase(
+  wizard: ProvidersWizardState,
+): ProvidersWizardState {
+  const { phase, kind } = wizard;
+  if (phase === "pick_kind" && kind) {
+    return { ...wizard, phase: "api_key", cursor: 0, error: null };
+  }
+  if (phase === "api_key" && kind) {
+    return {
+      ...wizard,
+      phase: nextPhaseAfterApiKey(kind),
+      cursor: 0,
+      error: null,
+    };
+  }
+  if (phase === "pick_chat_model" && kind && isCuratedCatalogKind(kind)) {
+    const models = listChatModelsForKind(kind);
+    // Clamped, not `?? models[0]`: when the catalog shrank under the
+    // cursor, the highlighted row is the last one, and Enter must select
+    // exactly what is highlighted.
+    const picked = models[clampCursor(wizard.cursor, models.length)]?.id ?? null;
+    return {
+      ...wizard,
+      phase: "pick_embedding",
+      cursor: 0,
+      selectedChatModelId: picked,
+      error: null,
+    };
+  }
+  if (phase === "base_url" && kind === "openai-compatible") {
+    return { ...wizard, phase: "chat_model_line", cursor: 0, error: null };
+  }
+  if (phase === "chat_model_line" && kind === "openai-compatible") {
+    return { ...wizard, phase: "embedding_model_line", cursor: 0, error: null };
+  }
+  return wizard;
+}
+
+export function listLengthForPhase(
+  phase: ProvidersWizardPhase,
+  kind: ProvidersWizardState["kind"],
+): number {
+  if (phase === "pick_kind") return KIND_COUNT;
+  if (phase === "pick_chat_model" && kind && isCuratedCatalogKind(kind)) {
+    return listChatModelsForKind(kind).length;
+  }
+  if (phase === "pick_embedding" && kind && isCuratedCatalogKind(kind)) {
+    return listEmbeddingModelsForKind(kind).length;
+  }
+  return 0;
+}
+
+export function isListPhase(phase: ProvidersWizardPhase): boolean {
+  return (
+    phase === "pick_kind" ||
+    phase === "pick_chat_model" ||
+    phase === "pick_embedding"
+  );
+}
+
+export function isLinePhase(phase: ProvidersWizardPhase): boolean {
+  return (
+    phase === "base_url" ||
+    phase === "chat_model_line" ||
+    phase === "embedding_model_line"
+  );
+}


### PR DESCRIPTION
Reported internally: the cloud model picker offers only a handful of models. Against the live APIs today the picker shows **12 of 305** usable OpenRouter models and **13 of 337** aimlapi models.

Three independent causes.

## 1. The live catalogs were capped

`MAX_PICKS` cut the list to 12 (OpenRouter) and 32 (aimlapi) after the curated ids. That cap made sense for an unfilterable list; it silently hides most of the catalog. Both caps are gone. Curated ids keep their hand-picked order, the OpenRouter tail keeps its score order, and the aimlapi tail is now sorted alphabetically instead of following map insertion order.

## 2. aimlapi changed its response shape, and the parser matched nothing

Two breaking changes on their side, neither of which failed loudly:

- rows are now typed `openai/chat-completions` instead of `chat-completion`, so the equality check matched zero rows;
- the `features` array that advertised tool support was removed entirely, so the "can this model call tools" check rejected everything that survived.

The net effect was a live refresh that always returned nothing and fell back to the 13-entry offline list, which also explains the `price unknown` labels in the picker.

Type matching is now suffix-based (`*/chat-completions`, plus the older spellings), which survives another vendor-prefix rename while still excluding the video, image, `anthropic/messages`, and `responses/submit` families that share the same payload.

## 3. Absent was read as negative

Both fetchers now distinguish "the API says this model has no tools" from "the API says nothing". Only the former drops a model. This is the generic form of the aimlapi breakage: a provider dropping a capability field can no longer empty our catalog. OpenRouter has the same guard even though its `supported_parameters` is present today.

## Review follow-up

The second commit addresses review findings. The 12-row viewport around the cursor now lives in `renderPickList` itself, so the OpenRouter and aimlapi picker phases window their rows instead of painting the full 300+ row catalog into the terminal, with a position counter once the list outgrows the window. Both fetchers skip null and scalar rows in `data`, so one bad row can no longer throw and drag the whole live catalog into the static fallback. The fallback tests now reset the module-level cache (`vi.resetModules` plus a dynamic import) and assert the exact offline list, so they test the fallback rather than a leftover cache. The stale JSDoc describing the removed type/features filter is rewritten, and a comment explains why vision silence deliberately still reads as "no vision".

## Verification

Ran the parsers against the live payloads captured from both providers: **337 aimlapi picks** (was 13) and **305 OpenRouter picks** (was 12).

Tests: 16 new across both commits. Cap removal on both providers, offline fallback on network error and on a malformed payload (against a fresh module cache), null rows skipped, the current aimlapi shape verbatim (including the non-chat families that must stay out), explicit no-tools still dropped, silent-API models kept, rows without a usable id ignored, alphabetical tail ordering, and 12-row windowing of 300+ model lists in every wizard picker phase. `tsc` clean. Full suite shows the same pre-existing failures as main.

## Scope note

Full catalog does not mean every id the providers return: `scoreChat` keeps the deliberate exclusions of `anthropic/*` and `/gemini/i`, and the catalog tests pin both. The recorded reason is the tool transport, not model preference. The cloud path drives models through the OpenAI chat-completions wire shape with native tools, and the adapter seam explicitly marks Anthropic and Gemini adapters as future work (`src/llm/provider/adapters/tool-call-adapter.ts`, since 5c7c05e). Claude additionally sits on a different surface at aimlapi: its rows are typed `anthropic/messages` and 404 on `/v1/chat/completions`. Gemini started out score-boosted and was removed in c0a73b4 together with the recovery handling for cloud models that emit tool calls as plain content, which points at tool-call reliability through the OpenAI-shape adapter. So this PR ships the full set of models the runtime can actually drive today: full minus Claude and Gemini. When dedicated adapters land, lifting the two filters should be part of that change.

## Note

Until the picker gains text filtering, these lists are long. That work is the companion branch; merging this one first is fine, since the wizard picker now windows its rows too.
