### PR TITLE
feat(tui): add known-service presets to the provider list

### DIFF
--- a/src/config/llm-config.ts
+++ b/src/config/llm-config.ts
@@ -9,6 +9,13 @@ export type UserLlmProviderEntry = {
   apiKey?: string;
   model?: string;
   baseUrl?: string;
+  /**
+   * Env var holding this entry's API key. Set for known-service presets
+   * so each service keeps its own key (`GROQ_API_KEY`, `NOUS_API_KEY`,
+   * ...). When present it is authoritative: entries without it fall
+   * back to the per-kind defaults in `resolveLlmProviderApiKey`.
+   */
+  apiKeyEnvVar?: string;
   defaultChatModel?: string;
   defaultEmbeddingModel?: string;
   headers?: Record<string, string>;
@@ -94,6 +101,7 @@ export function parseLlmProviderEntry(
     apiKey: parseOptionalString(obj.apiKey, `${field}.apiKey`),
     model: parseOptionalString(obj.model, `${field}.model`),
     baseUrl: parseOptionalString(obj.baseUrl, `${field}.baseUrl`),
+    apiKeyEnvVar: parseOptionalString(obj.apiKeyEnvVar, `${field}.apiKeyEnvVar`),
     defaultChatModel: parseOptionalString(
       obj.defaultChatModel,
       `${field}.defaultChatModel`,

--- a/src/config/resolve-llm-api-key.ts
+++ b/src/config/resolve-llm-api-key.ts
@@ -10,6 +10,16 @@ export function resolveLlmProviderApiKey(
   if (entry.apiKey && entry.apiKey.length > 0) {
     return entry.apiKey;
   }
+  // Entries created from a known-service preset carry their own env var
+  // (`GROQ_API_KEY`, `NOUS_API_KEY`, ...). It is authoritative, without
+  // a fallback to the shared per-kind variables: falling through would
+  // recreate the wrong-key-for-this-endpoint pairing presets exist to
+  // prevent (#69), and keyless local servers (LM Studio) rely on the
+  // `undefined` here to send requests without an Authorization header.
+  if (entry.apiKeyEnvVar && entry.apiKeyEnvVar.length > 0) {
+    const key = process.env[entry.apiKeyEnvVar];
+    return key && key.length > 0 ? key : undefined;
+  }
   if (entry.kind === "openrouter") {
     const key = process.env.OPENROUTER_API_KEY;
     return key && key.length > 0 ? key : undefined;

--- a/src/llm/provider/openai/openai-http.ts
+++ b/src/llm/provider/openai/openai-http.ts
@@ -13,7 +13,10 @@ export function buildOpenAiHeaders(
   return {
     "content-type": "application/json",
     accept: stream ? "text/event-stream" : "application/json",
-    authorization: `Bearer ${deps.apiKey}`,
+    // Keyless servers (a local LM Studio, an unauthenticated vLLM) get no
+    // authorization header at all: `Bearer ` with an empty token is
+    // malformed and some proxies reject it outright.
+    ...(deps.apiKey ? { authorization: `Bearer ${deps.apiKey}` } : {}),
     ...deps.extraHeaders,
   };
 }

--- a/src/tui/components/providers-wizard.test.tsx
+++ b/src/tui/components/providers-wizard.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { refreshAimlapiChatCatalogFromApi } from "../../llm/provider/aimlapi/fetch-aimlapi-chat-catalog.js";
 import { refreshOpenRouterChatCatalogFromApi } from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
+import { KIND_ROW_ORDER } from "../providers/providers-wizard-phases.js";
 import { createProvidersWizardState } from "../providers/providers-wizard-state.js";
 import type { ProvidersWizardKind } from "../providers/providers-wizard-state.js";
 import { ProvidersWizard } from "./providers-wizard.js";
@@ -105,14 +106,17 @@ describe("ProvidersWizard chat model step", () => {
 });
 
 describe("ProvidersWizard pick list counter", () => {
-  it("shows the position counter for short lists too", () => {
-    // 3 provider kinds, well under the viewport. The counter is not a
-    // long-list extra: hiding it below a size threshold reads as a glitch.
+  it("shows the position counter on the provider list", () => {
+    // 2 catalog kinds + 10 presets + manual entry. The counter is not a
+    // long-list extra: hiding it below a size threshold reads as a glitch,
+    // and with the preset rows the list now runs past the viewport anyway.
     const { lastFrame } = render(
       <ProvidersWizard wizard={createProvidersWizardState("add")} />,
     );
     const text = stripAnsi(lastFrame() ?? "");
-    expect(text).toContain("j/k move (1/3) · Enter pick · Esc cancel");
+    expect(text).toContain(
+      `j/k move (1/${KIND_ROW_ORDER.length}) · Enter pick · Esc cancel`,
+    );
   });
 });
 

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -7,7 +7,11 @@ import {
   listCompatChatModelPicks,
 } from "../providers/providers-wizard-key-bindings.js";
 import { theme } from "../theme/theme.js";
-import { PROVIDER_PRESETS } from "../providers/provider-presets.js";
+import { findProviderPreset } from "../providers/provider-presets.js";
+import {
+  KIND_ROW_ORDER,
+  type ProvidersWizardKindRow,
+} from "../providers/providers-wizard-phases.js";
 import {
   listAimlapiChatModels,
   listAimlapiEmbeddingModels,
@@ -16,35 +20,46 @@ import {
   OPENAI_COMPAT_DEFAULT_BASE_URL,
   OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
 } from "../providers/providers-model-options.js";
-import type { ProvidersWizardState } from "../providers/providers-wizard-state.js";
+import type {
+  ProvidersWizardKind,
+  ProvidersWizardState,
+} from "../providers/providers-wizard-state.js";
 import { renderPickList } from "./wizard-pick-list.js";
+
+const KIND_LABELS: Record<ProvidersWizardKind, string> = {
+  openrouter: "OpenRouter (cloud chat + optional cloud embed)",
+  aimlapi: "AI/ML API (aimlapi.com — 500+ models, OpenAI-compatible)",
+  "openai-compatible": "OpenAI-compatible API (custom base URL)",
+};
+
+function labelForKindRow(row: ProvidersWizardKindRow): string {
+  if (typeof row !== "object") return KIND_LABELS[row];
+  const preset = findProviderPreset(row.presetId);
+  if (!preset) return row.presetId;
+  return preset.note ? `${preset.label} — ${preset.note}` : preset.label;
+}
 
 /**
  * One flat provider list, matching what other agent CLIs present: the
  * two kinds with built-in catalogs, then every known service (#69), then
- * the manual entry for anything not listed.
+ * the manual entry for anything not listed. Derived from
+ * `KIND_ROW_ORDER` — the key bindings walk that same list, so a row's
+ * label and its Enter action can never drift apart.
  */
-const KIND_OPTIONS = [
-  { id: "openrouter", label: "OpenRouter (cloud chat + optional cloud embed)" },
-  {
-    id: "aimlapi",
-    label: "AI/ML API (aimlapi.com — 500+ models, OpenAI-compatible)",
-  },
-  ...PROVIDER_PRESETS.map((preset) => ({
-    id: preset.id,
-    label: preset.note ? `${preset.label} — ${preset.note}` : preset.label,
-  })),
-  {
-    id: "openai-compatible",
-    label: "OpenAI-compatible API (custom base URL)",
-  },
-];
+const KIND_OPTIONS = KIND_ROW_ORDER.map((row) => ({
+  label: labelForKindRow(row),
+}));
 
-function envHintForKind(
-  kind: ProvidersWizardState["kind"],
-): string {
-  if (kind === "openrouter") return "OPENROUTER_API_KEY";
-  if (kind === "aimlapi") return "AIMLAPI_API_KEY";
+/**
+ * Env var named on the key screen. A preset names its own variable;
+ * naming the shared compat one there would promise Groq's key a home it
+ * does not use.
+ */
+function envHintForWizard(w: ProvidersWizardState): string {
+  const preset = w.presetId ? findProviderPreset(w.presetId) : undefined;
+  if (preset) return preset.envVar;
+  if (w.kind === "openrouter") return "OPENROUTER_API_KEY";
+  if (w.kind === "aimlapi") return "AIMLAPI_API_KEY";
   return "OPENAI_COMPAT_API_KEY";
 }
 
@@ -170,7 +185,14 @@ export function ProvidersWizard(props: {
   }
 
   if (w.phase === "api_key") {
-    const envHint = envHintForKind(w.kind);
+    const envHint = envHintForWizard(w);
+    const preset = w.presetId ? findProviderPreset(w.presetId) : undefined;
+    // Local servers and keyless-listing services save with an empty key;
+    // promising ".env only" here would contradict their own list rows.
+    const emptyMeans =
+      preset && (preset.local || preset.listsModelsWithoutKey)
+        ? "Optional for this service — leave empty to connect without a key."
+        : "Leave empty only if the key is already in .env.";
     return (
       <Box
         flexDirection="column"
@@ -181,11 +203,11 @@ export function ProvidersWizard(props: {
         width="100%"
       >
         <Text bold color={theme.colors.accentSoft}>
-          API key — {w.kind ?? "provider"}
+          API key — {preset?.label ?? w.kind ?? "provider"}
         </Text>
         <Text color={theme.colors.muted}>
           Saved to <Text color={theme.colors.accentSoft}>{".env"}</Text> as{" "}
-          {envHint} (mode 0600). Leave empty only if the key is already in .env.
+          {envHint} (mode 0600). {emptyMeans}
         </Text>
         <Box>
           <Text color={theme.colors.muted}>{"> "}</Text>

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -7,6 +7,7 @@ import {
   listCompatChatModelPicks,
 } from "../providers/providers-wizard-key-bindings.js";
 import { theme } from "../theme/theme.js";
+import { PROVIDER_PRESETS } from "../providers/provider-presets.js";
 import {
   listAimlapiChatModels,
   listAimlapiEmbeddingModels,
@@ -18,14 +19,23 @@ import {
 import type { ProvidersWizardState } from "../providers/providers-wizard-state.js";
 import { renderPickList } from "./wizard-pick-list.js";
 
+/**
+ * One flat provider list, matching what other agent CLIs present: the
+ * two kinds with built-in catalogs, then every known service (#69), then
+ * the manual entry for anything not listed.
+ */
 const KIND_OPTIONS = [
-  { id: "openrouter" as const, label: "OpenRouter (cloud chat + optional cloud embed)" },
+  { id: "openrouter", label: "OpenRouter (cloud chat + optional cloud embed)" },
   {
-    id: "aimlapi" as const,
+    id: "aimlapi",
     label: "AI/ML API (aimlapi.com — 500+ models, OpenAI-compatible)",
   },
+  ...PROVIDER_PRESETS.map((preset) => ({
+    id: preset.id,
+    label: preset.note ? `${preset.label} — ${preset.note}` : preset.label,
+  })),
   {
-    id: "openai-compatible" as const,
+    id: "openai-compatible",
     label: "OpenAI-compatible API (custom base URL)",
   },
 ];

--- a/src/tui/persist-llm-provider.ts
+++ b/src/tui/persist-llm-provider.ts
@@ -102,16 +102,23 @@ export function dotenvKeyForProviderKind(
 export function writeProviderApiKeyToDotenv(
   kind: ProvidersWizardKind,
   apiKey: string,
+  /**
+   * Preset-specific variable (`GROQ_API_KEY`, `TOGETHER_API_KEY`, ...).
+   * Without it every preset would share `OPENAI_COMPAT_API_KEY` and a
+   * second service would overwrite the first one's key.
+   */
+  envVarOverride?: string,
 ): void {
   const trimmed = apiKey.trim();
   if (trimmed.length === 0) {
     throw new LlmAddProviderError("API key is empty");
   }
-  setDotenvKey(getConfig().paths.stateDir, dotenvKeyForProviderKind(kind), trimmed);
-  const envKey = dotenvKeyForProviderKind(kind);
-  if (!process.env[envKey] || process.env[envKey]!.length === 0) {
-    process.env[envKey] = trimmed;
-  }
+  const envKey = envVarOverride ?? dotenvKeyForProviderKind(kind);
+  setDotenvKey(getConfig().paths.stateDir, envKey, trimmed);
+  // Always mirror into the live environment, not only when unset: key
+  // resolution reads `process.env`, so a session that just rewrote .env
+  // must start using the new key now, not after a restart.
+  process.env[envKey] = trimmed;
 }
 
 function mergeProviderIntoBlock(

--- a/src/tui/providers/provider-presets.test.ts
+++ b/src/tui/providers/provider-presets.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findProviderPreset,
+  PROVIDER_PRESETS,
+  suggestPresetEntryId,
+} from "./provider-presets.js";
+
+describe("PROVIDER_PRESETS", () => {
+  it("has unique ids", () => {
+    const ids = PROVIDER_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("carries an absolute base URL ending in a version segment", () => {
+    for (const preset of PROVIDER_PRESETS) {
+      expect(() => new URL(preset.baseUrl)).not.toThrow();
+      // Every verified endpoint serves the OpenAI surface under /v1, so
+      // the stored base must already include it: the provider appends
+      // paths like /chat/completions, not /v1/chat/completions.
+      expect(preset.baseUrl).toMatch(/\/v1$/);
+    }
+  });
+
+  it("includes the service the request came from", () => {
+    // A user asked for presets and named Nous specifically (#69).
+    expect(findProviderPreset("nous")).toBeDefined();
+  });
+
+  it("marks LM Studio as local", () => {
+    expect(findProviderPreset("lmstudio")?.local).toBe(true);
+  });
+
+  it("only marks keyless listing where it was verified", () => {
+    const keyless = PROVIDER_PRESETS.filter((p) => p.listsModelsWithoutKey).map(
+      (p) => p.id,
+    );
+    expect(keyless).toEqual(["nous", "ollama-cloud"]);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(findProviderPreset("nope")).toBeUndefined();
+  });
+});
+
+describe("suggestPresetEntryId", () => {
+  const groq = findProviderPreset("groq")!;
+
+  it("uses the preset id when it is free", () => {
+    expect(suggestPresetEntryId(groq, [])).toBe("groq");
+  });
+
+  it("numbers a second entry for the same service", () => {
+    expect(suggestPresetEntryId(groq, ["groq"])).toBe("groq-2");
+    expect(suggestPresetEntryId(groq, ["groq", "groq-2"])).toBe("groq-3");
+  });
+
+  it("ignores unrelated ids", () => {
+    expect(suggestPresetEntryId(groq, ["nous", "openrouter"])).toBe("groq");
+  });
+});

--- a/src/tui/providers/provider-presets.test.ts
+++ b/src/tui/providers/provider-presets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   findProviderPreset,
+  presetForEntryId,
   PROVIDER_PRESETS,
   suggestPresetEntryId,
 } from "./provider-presets.js";
@@ -12,13 +13,17 @@ describe("PROVIDER_PRESETS", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("carries an absolute base URL ending in a version segment", () => {
+  it("stores API roots without the /v1 suffix, like every compat base URL", () => {
     for (const preset of PROVIDER_PRESETS) {
       expect(() => new URL(preset.baseUrl)).not.toThrow();
-      // Every verified endpoint serves the OpenAI surface under /v1, so
-      // the stored base must already include it: the provider appends
-      // paths like /chat/completions, not /v1/chat/completions.
-      expect(preset.baseUrl).toMatch(/\/v1$/);
+      // Call sites append `/v1/...` themselves (openai-provider.ts), so
+      // the repo stores compat base URLs without the version segment —
+      // `OPENAI_COMPAT_DEFAULT_BASE_URL` is `https://api.openai.com`.
+      // A stored `/v1` would only survive because normalization strips
+      // it again; presets follow the convention instead of leaning on
+      // that safety net.
+      expect(preset.baseUrl).not.toMatch(/\/v1\/?$/);
+      expect(preset.baseUrl).not.toMatch(/\/$/);
     }
   });
 
@@ -31,15 +36,40 @@ describe("PROVIDER_PRESETS", () => {
     expect(findProviderPreset("lmstudio")?.local).toBe(true);
   });
 
-  it("only marks keyless listing where it was verified", () => {
+  it("keeps the verified keyless-listing services marked", () => {
+    // Presence checks, not an exact list: a new keyless preset must not
+    // break this test, it only has to keep the verified ones flagged.
     const keyless = PROVIDER_PRESETS.filter((p) => p.listsModelsWithoutKey).map(
       (p) => p.id,
     );
-    expect(keyless).toEqual(["nous", "ollama-cloud"]);
+    expect(keyless).toContain("nous");
+    expect(keyless).toContain("ollama-cloud");
   });
 
   it("returns undefined for an unknown id", () => {
     expect(findProviderPreset("nope")).toBeUndefined();
+  });
+});
+
+describe("preset env vars", () => {
+  it("gives every preset its own variable", () => {
+    const vars = PROVIDER_PRESETS.map((p) => p.envVar);
+    expect(new Set(vars).size).toBe(vars.length);
+  });
+
+  it("never reuses the shared compat or catalog variables", () => {
+    // Sharing OPENAI_COMPAT_API_KEY meant connecting a second service
+    // silently overwrote the first one's key.
+    for (const preset of PROVIDER_PRESETS) {
+      expect(preset.envVar).not.toBe("OPENAI_COMPAT_API_KEY");
+      expect(preset.envVar).not.toBe("OPENROUTER_API_KEY");
+      expect(preset.envVar).not.toBe("AIMLAPI_API_KEY");
+    }
+  });
+
+  it("names variables after the service", () => {
+    expect(findProviderPreset("groq")?.envVar).toBe("GROQ_API_KEY");
+    expect(findProviderPreset("together")?.envVar).toBe("TOGETHER_API_KEY");
   });
 });
 
@@ -57,5 +87,21 @@ describe("suggestPresetEntryId", () => {
 
   it("ignores unrelated ids", () => {
     expect(suggestPresetEntryId(groq, ["nous", "openrouter"])).toBe("groq");
+  });
+});
+
+describe("presetForEntryId", () => {
+  it("finds the preset for a plain entry id", () => {
+    expect(presetForEntryId("groq")?.id).toBe("groq");
+  });
+
+  it("finds the preset behind a numbered suffix", () => {
+    expect(presetForEntryId("groq-2")?.id).toBe("groq");
+    expect(presetForEntryId("ollama-cloud-3")?.id).toBe("ollama-cloud");
+  });
+
+  it("returns undefined for hand-added entries", () => {
+    expect(presetForEntryId("openai-compatible")).toBeUndefined();
+    expect(presetForEntryId("my-vllm")).toBeUndefined();
   });
 });

--- a/src/tui/providers/provider-presets.ts
+++ b/src/tui/providers/provider-presets.ts
@@ -16,14 +16,29 @@ export interface ProviderPreset {
   readonly id: string;
   /** Name shown in the wizard list. */
   readonly label: string;
-  /** Base URL handed to the openai-compatible provider. */
+  /**
+   * API root handed to the openai-compatible provider, stored the way
+   * the repo stores every compat base URL: without the `/v1` suffix,
+   * because call sites append `/v1/...` themselves.
+   */
   readonly baseUrl: string;
   /**
+   * Env var holding this service's API key. Each preset gets its own so
+   * connecting a second service cannot overwrite the first one's key,
+   * which is what a shared `OPENAI_COMPAT_API_KEY` did.
+   */
+  readonly envVar: string;
+  /**
    * `true` for endpoints that serve a model list without credentials.
-   * The wizard can then show models before an API key is entered.
+   * Saving without a key is allowed for these: the operator can browse
+   * models first and paste a key later.
    */
   readonly listsModelsWithoutKey?: boolean;
-  /** `true` for servers running on the operator's own machine. */
+  /**
+   * `true` for servers running on the operator's own machine. No API
+   * key exists at all, so the wizard saves with an empty key and
+   * requests carry no Authorization header.
+   */
   readonly local?: boolean;
   /** One-line hint shown under the label. */
   readonly note?: string;
@@ -33,63 +48,73 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
   {
     id: "nous",
     label: "Nous Research",
-    baseUrl: "https://inference-api.nousresearch.com/v1",
+    baseUrl: "https://inference-api.nousresearch.com",
+    envVar: "NOUS_API_KEY",
     listsModelsWithoutKey: true,
     note: "open-weight models, 350+ ids listed without a key",
   },
   {
     id: "groq",
     label: "Groq",
-    baseUrl: "https://api.groq.com/openai/v1",
+    baseUrl: "https://api.groq.com/openai",
+    envVar: "GROQ_API_KEY",
     note: "very fast inference on open-weight models",
   },
   {
     id: "deepseek",
     label: "DeepSeek",
-    baseUrl: "https://api.deepseek.com/v1",
+    baseUrl: "https://api.deepseek.com",
+    envVar: "DEEPSEEK_API_KEY",
     note: "DeepSeek models direct from the vendor",
   },
   {
     id: "together",
     label: "Together AI",
-    baseUrl: "https://api.together.xyz/v1",
+    baseUrl: "https://api.together.xyz",
+    envVar: "TOGETHER_API_KEY",
     note: "broad open-weight catalog",
   },
   {
     id: "fireworks",
     label: "Fireworks AI",
-    baseUrl: "https://api.fireworks.ai/inference/v1",
+    baseUrl: "https://api.fireworks.ai/inference",
+    envVar: "FIREWORKS_API_KEY",
     note: "open-weight models, function calling",
   },
   {
     id: "cerebras",
     label: "Cerebras",
-    baseUrl: "https://api.cerebras.ai/v1",
+    baseUrl: "https://api.cerebras.ai",
+    envVar: "CEREBRAS_API_KEY",
     note: "high-throughput inference",
   },
   {
     id: "mistral",
     label: "Mistral",
-    baseUrl: "https://api.mistral.ai/v1",
+    baseUrl: "https://api.mistral.ai",
+    envVar: "MISTRAL_API_KEY",
     note: "Mistral models direct from the vendor",
   },
   {
     id: "xai",
     label: "xAI (Grok)",
-    baseUrl: "https://api.x.ai/v1",
+    baseUrl: "https://api.x.ai",
+    envVar: "XAI_API_KEY",
     note: "Grok models direct from the vendor",
   },
   {
     id: "ollama-cloud",
     label: "Ollama Cloud",
-    baseUrl: "https://ollama.com/v1",
+    baseUrl: "https://ollama.com",
+    envVar: "OLLAMA_CLOUD_API_KEY",
     listsModelsWithoutKey: true,
     note: "hosted Ollama, models listed without a key",
   },
   {
     id: "lmstudio",
     label: "LM Studio (local)",
-    baseUrl: "http://localhost:1234/v1",
+    baseUrl: "http://localhost:1234",
+    envVar: "LMSTUDIO_API_KEY",
     local: true,
     note: "the server LM Studio runs on your machine; no API key needed",
   },
@@ -97,6 +122,21 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
 
 export function findProviderPreset(id: string): ProviderPreset | undefined {
   return PROVIDER_PRESETS.find((p) => p.id === id);
+}
+
+/**
+ * Preset behind an existing config entry, tolerating the numbered
+ * suffixes `suggestPresetEntryId` hands out (`groq-2` is still Groq).
+ * Reconfiguring such an entry must keep its service identity: the right
+ * env var on the key screen and the same entry id on save.
+ */
+export function presetForEntryId(
+  entryId: string,
+): ProviderPreset | undefined {
+  const direct = findProviderPreset(entryId);
+  if (direct) return direct;
+  const suffixed = /^(.+)-\d+$/.exec(entryId);
+  return suffixed ? findProviderPreset(suffixed[1]!) : undefined;
 }
 
 /**

--- a/src/tui/providers/provider-presets.ts
+++ b/src/tui/providers/provider-presets.ts
@@ -1,0 +1,116 @@
+/**
+ * Known OpenAI-compatible endpoints, so the operator picks a name
+ * instead of typing a base URL from memory.
+ *
+ * These are not new provider kinds: every preset resolves to the
+ * existing `openai-compatible` kind with `baseUrl` filled in. Model
+ * lists still come from the server's own `/v1/models` (#31, #41), so
+ * nothing here needs updating when a vendor ships a new model.
+ *
+ * Every URL below was verified live: each answers `/v1/models` with an
+ * OpenAI-shaped payload (200 with a `data` array, or 401/403 asking for
+ * a key, which confirms the path exists).
+ */
+export interface ProviderPreset {
+  /** Stable id used as the provider entry id when adding. */
+  readonly id: string;
+  /** Name shown in the wizard list. */
+  readonly label: string;
+  /** Base URL handed to the openai-compatible provider. */
+  readonly baseUrl: string;
+  /**
+   * `true` for endpoints that serve a model list without credentials.
+   * The wizard can then show models before an API key is entered.
+   */
+  readonly listsModelsWithoutKey?: boolean;
+  /** `true` for servers running on the operator's own machine. */
+  readonly local?: boolean;
+  /** One-line hint shown under the label. */
+  readonly note?: string;
+}
+
+export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
+  {
+    id: "nous",
+    label: "Nous Research",
+    baseUrl: "https://inference-api.nousresearch.com/v1",
+    listsModelsWithoutKey: true,
+    note: "open-weight models, 350+ ids listed without a key",
+  },
+  {
+    id: "groq",
+    label: "Groq",
+    baseUrl: "https://api.groq.com/openai/v1",
+    note: "very fast inference on open-weight models",
+  },
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    baseUrl: "https://api.deepseek.com/v1",
+    note: "DeepSeek models direct from the vendor",
+  },
+  {
+    id: "together",
+    label: "Together AI",
+    baseUrl: "https://api.together.xyz/v1",
+    note: "broad open-weight catalog",
+  },
+  {
+    id: "fireworks",
+    label: "Fireworks AI",
+    baseUrl: "https://api.fireworks.ai/inference/v1",
+    note: "open-weight models, function calling",
+  },
+  {
+    id: "cerebras",
+    label: "Cerebras",
+    baseUrl: "https://api.cerebras.ai/v1",
+    note: "high-throughput inference",
+  },
+  {
+    id: "mistral",
+    label: "Mistral",
+    baseUrl: "https://api.mistral.ai/v1",
+    note: "Mistral models direct from the vendor",
+  },
+  {
+    id: "xai",
+    label: "xAI (Grok)",
+    baseUrl: "https://api.x.ai/v1",
+    note: "Grok models direct from the vendor",
+  },
+  {
+    id: "ollama-cloud",
+    label: "Ollama Cloud",
+    baseUrl: "https://ollama.com/v1",
+    listsModelsWithoutKey: true,
+    note: "hosted Ollama, models listed without a key",
+  },
+  {
+    id: "lmstudio",
+    label: "LM Studio (local)",
+    baseUrl: "http://localhost:1234/v1",
+    local: true,
+    note: "the server LM Studio runs on your machine; no API key needed",
+  },
+];
+
+export function findProviderPreset(id: string): ProviderPreset | undefined {
+  return PROVIDER_PRESETS.find((p) => p.id === id);
+}
+
+/**
+ * Suggested entry id when adding a preset. Falls back to numbered
+ * suffixes so a second Groq key does not collide with the first.
+ */
+export function suggestPresetEntryId(
+  preset: ProviderPreset,
+  taken: readonly string[],
+): string {
+  if (!taken.includes(preset.id)) return preset.id;
+  for (let n = 2; n < 100; n += 1) {
+    const candidate = `${preset.id}-${n}`;
+    if (!taken.includes(candidate)) return candidate;
+  }
+  return `${preset.id}-${Date.now()}`;
+}

--- a/src/tui/providers/providers-wizard-build-entry.test.ts
+++ b/src/tui/providers/providers-wizard-build-entry.test.ts
@@ -68,5 +68,71 @@ describe("buildProviderEntryFromWizard", () => {
       baseUrl: "https://api.openai.com",
       defaultChatModel: "gpt-5.4-mini",
     });
+    expect(built.entry.apiKeyEnvVar).toBeUndefined();
+  });
+
+  it("stamps a preset entry with the service's own env var", () => {
+    const built = buildProviderEntryFromWizard({
+      kind: "openai-compatible",
+      presetId: "groq",
+      chatModelId: "",
+      embeddingChoiceId: LOCAL_EMBEDDING_CHOICE_ID,
+      baseUrl: "https://api.groq.com/openai",
+      customChatModel: "llama-3.3-70b-versatile",
+    });
+
+    expect(built.entry).toMatchObject({
+      id: "groq",
+      kind: "openai-compatible",
+      apiKeyEnvVar: "GROQ_API_KEY",
+    });
+  });
+
+  it("gives a second entry for the same service a numbered id", () => {
+    const built = buildProviderEntryFromWizard({
+      kind: "openai-compatible",
+      presetId: "groq",
+      takenProviderIds: ["local-llama", "groq"],
+      chatModelId: "",
+      embeddingChoiceId: LOCAL_EMBEDDING_CHOICE_ID,
+      baseUrl: "https://api.groq.com/openai",
+      customChatModel: "llama-3.3-70b-versatile",
+    });
+
+    // Both entries stay in config: the second one gets `groq-2` instead
+    // of silently replacing the first.
+    expect(built.entry.id).toBe("groq-2");
+    expect(built.activateEmbeddingProviderId).toBe("local-llama");
+  });
+
+  it("keeps the existing id when reconfiguring", () => {
+    const built = buildProviderEntryFromWizard({
+      kind: "openai-compatible",
+      presetId: "groq",
+      existingProviderId: "groq",
+      takenProviderIds: ["local-llama", "groq"],
+      chatModelId: "",
+      embeddingChoiceId: LOCAL_EMBEDDING_CHOICE_ID,
+      baseUrl: "https://api.groq.com/openai",
+      customChatModel: "llama-3.3-70b-versatile",
+    });
+
+    // Reconfigure updates `groq` in place — no `groq-2`, and no
+    // `openai-compatible` duplicate.
+    expect(built.entry.id).toBe("groq");
+  });
+
+  it("keeps a hand-added entry id when reconfiguring without a preset", () => {
+    const built = buildProviderEntryFromWizard({
+      kind: "openai-compatible",
+      existingProviderId: "my-vllm",
+      chatModelId: "",
+      embeddingChoiceId: LOCAL_EMBEDDING_CHOICE_ID,
+      baseUrl: "http://192.168.1.50:8000",
+      customChatModel: "qwen3-30b",
+    });
+
+    expect(built.entry.id).toBe("my-vllm");
+    expect(built.entry.apiKeyEnvVar).toBeUndefined();
   });
 });

--- a/src/tui/providers/providers-wizard-build-entry.ts
+++ b/src/tui/providers/providers-wizard-build-entry.ts
@@ -1,6 +1,10 @@
 import type { UserLlmProviderEntry } from "../../config/llm-config.js";
 import { normalizeOpenAiBaseUrl } from "../../llm/provider/openai/normalize-openai-base-url.js";
 import {
+  findProviderPreset,
+  suggestPresetEntryId,
+} from "./provider-presets.js";
+import {
   LOCAL_EMBEDDING_CHOICE_ID,
   OPENAI_COMPAT_DEFAULT_BASE_URL,
   OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
@@ -15,17 +19,39 @@ export type BuiltWizardProvider = {
   activateEmbeddingProviderId: string | null;
 };
 
-export function providerIdForKind(
-  kind: ProvidersWizardKind,
-  presetId?: string | null,
-): string {
+/** The fixed entry id each wizard kind maps to when no preset is involved. */
+function baseIdForKind(kind: ProvidersWizardKind): string {
   if (kind === "openrouter") return "openrouter";
   if (kind === "aimlapi") return "aimlapi";
-  // A preset keeps its own id (`groq`, `nous`, …) so several presets can
-  // coexist instead of overwriting one shared `openai-compatible` entry
-  // (#69). Hand-typed endpoints keep the generic id as before.
-  if (presetId && presetId.length > 0) return presetId;
   return "openai-compatible";
+}
+
+/**
+ * Entry id for a wizard save.
+ *
+ * Reconfiguring keeps the existing id, whatever it is: opening `groq`
+ * (or a hand-added `my-vllm`) and changing the model must update that
+ * entry, not mint an `openai-compatible` duplicate and switch the
+ * active provider to it.
+ *
+ * Adding a preset picks the first free id for its service (`groq`,
+ * `groq-2`, ...), so a second entry for the same service coexists with
+ * the first instead of overwriting it (#69).
+ */
+function providerIdForWizardSave(input: {
+  kind: ProvidersWizardKind;
+  presetId?: string | null;
+  existingProviderId?: string | null;
+  takenProviderIds?: readonly string[];
+}): string {
+  if (input.existingProviderId && input.existingProviderId.length > 0) {
+    return input.existingProviderId;
+  }
+  const preset = input.presetId ? findProviderPreset(input.presetId) : undefined;
+  if (preset) {
+    return suggestPresetEntryId(preset, input.takenProviderIds ?? []);
+  }
+  return baseIdForKind(input.kind);
 }
 
 function isCuratedCatalogKind(kind: ProvidersWizardKind): boolean {
@@ -41,8 +67,13 @@ export function buildProviderEntryFromWizard(input: {
   customEmbeddingModel?: string;
   /** Set when the entry came from a known-service preset (#69). */
   presetId?: string | null;
+  /** Entry being reconfigured; its id is reused verbatim. */
+  existingProviderId?: string | null;
+  /** Ids already in config, so an added preset picks a free one. */
+  takenProviderIds?: readonly string[];
 }): BuiltWizardProvider {
-  const id = providerIdForKind(input.kind, input.presetId);
+  const id = providerIdForWizardSave(input);
+  const preset = input.presetId ? findProviderPreset(input.presetId) : undefined;
   const chatModel = isCuratedCatalogKind(input.kind)
     ? input.chatModelId
     : (input.customChatModel?.trim() || OPENAI_COMPAT_DEFAULT_CHAT_MODEL);
@@ -71,6 +102,11 @@ export function buildProviderEntryFromWizard(input: {
             normalizeOpenAiBaseUrl(input.baseUrl ?? "") ||
             OPENAI_COMPAT_DEFAULT_BASE_URL,
         }
+      : {}),
+    // The preset's own env var rides on the entry, so two services never
+    // resolve one shared key (see `resolveLlmProviderApiKey`).
+    ...(input.kind === "openai-compatible" && preset
+      ? { apiKeyEnvVar: preset.envVar }
       : {}),
   };
 

--- a/src/tui/providers/providers-wizard-build-entry.ts
+++ b/src/tui/providers/providers-wizard-build-entry.ts
@@ -15,9 +15,16 @@ export type BuiltWizardProvider = {
   activateEmbeddingProviderId: string | null;
 };
 
-export function providerIdForKind(kind: ProvidersWizardKind): string {
+export function providerIdForKind(
+  kind: ProvidersWizardKind,
+  presetId?: string | null,
+): string {
   if (kind === "openrouter") return "openrouter";
   if (kind === "aimlapi") return "aimlapi";
+  // A preset keeps its own id (`groq`, `nous`, …) so several presets can
+  // coexist instead of overwriting one shared `openai-compatible` entry
+  // (#69). Hand-typed endpoints keep the generic id as before.
+  if (presetId && presetId.length > 0) return presetId;
   return "openai-compatible";
 }
 
@@ -32,8 +39,10 @@ export function buildProviderEntryFromWizard(input: {
   baseUrl?: string;
   customChatModel?: string;
   customEmbeddingModel?: string;
+  /** Set when the entry came from a known-service preset (#69). */
+  presetId?: string | null;
 }): BuiltWizardProvider {
-  const id = providerIdForKind(input.kind);
+  const id = providerIdForKind(input.kind, input.presetId);
   const chatModel = isCuratedCatalogKind(input.kind)
     ? input.chatModelId
     : (input.customChatModel?.trim() || OPENAI_COMPAT_DEFAULT_CHAT_MODEL);

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -48,6 +48,36 @@ describe("createProvidersWizardState configure prefill", () => {
     });
     expect(wizard.baseUrlLine).toBe("");
   });
+
+  it("recovers the preset identity of the entry being reconfigured", () => {
+    // Reconfiguring `groq` must stay Groq: the key screen names
+    // GROQ_API_KEY and the save keeps the id instead of minting an
+    // `openai-compatible` duplicate.
+    const wizard = createProvidersWizardState("configure", {
+      providerId: "groq",
+      kind: "openai-compatible",
+      baseUrl: "https://api.groq.com/openai",
+    });
+    expect(wizard.presetId).toBe("groq");
+    expect(wizard.providerId).toBe("groq");
+  });
+
+  it("recovers the preset behind a numbered entry id", () => {
+    const wizard = createProvidersWizardState("configure", {
+      providerId: "groq-2",
+      kind: "openai-compatible",
+    });
+    expect(wizard.presetId).toBe("groq");
+    expect(wizard.providerId).toBe("groq-2");
+  });
+
+  it("leaves presetId empty for hand-added compat entries", () => {
+    const wizard = createProvidersWizardState("configure", {
+      providerId: "my-vllm",
+      kind: "openai-compatible",
+    });
+    expect(wizard.presetId).toBeNull();
+  });
 });
 
 describe("handleProvidersWizardKey", () => {
@@ -314,9 +344,7 @@ describe("handleProvidersWizardKey", () => {
     wizard = next(wizard, "", emptyKey({ return: true }));
     expect(wizard.kind).toBe("openai-compatible");
     expect(wizard.presetId).toBe("nous");
-    expect(wizard.baseUrlLine).toBe(
-      "https://inference-api.nousresearch.com/v1",
-    );
+    expect(wizard.baseUrlLine).toBe("https://inference-api.nousresearch.com");
     // The endpoint is known, so the operator lands straight on the key
     // step instead of typing a URL.
     expect(wizard.phase).toBe("api_key");
@@ -329,7 +357,7 @@ describe("handleProvidersWizardKey", () => {
     }
     wizard = next(wizard, "", emptyKey({ return: true }));
     expect(wizard.presetId).toBe("groq");
-    expect(wizard.baseUrlLine).toBe("https://api.groq.com/openai/v1");
+    expect(wizard.baseUrlLine).toBe("https://api.groq.com/openai");
   });
 });
 

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -77,10 +77,10 @@ describe("handleProvidersWizardKey", () => {
     }
   });
 
-  it("falls through to the openai-compatible flow on the third kind slot", () => {
+  it("falls through to the openai-compatible flow on the last kind slot", () => {
     let wizard = createProvidersWizardState("add");
-    wizard = next(wizard, "", emptyKey({ downArrow: true }));
-    wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    // Manual entry is the last row, after the preset rows.
+    wizard = next(wizard, "", emptyKey({ upArrow: true }));
     wizard = next(wizard, "", emptyKey({ return: true }));
     expect(wizard.kind).toBe("openai-compatible");
     expect(wizard.phase).toBe("api_key");
@@ -303,6 +303,33 @@ describe("handleProvidersWizardKey", () => {
         LOCAL_EMBEDDING_CHOICE_ID,
       );
     }
+  });
+
+  it("picks a known service straight from the provider list", () => {
+    let wizard = createProvidersWizardState("add");
+
+    // Presets follow the two catalog kinds, so Nous is the third row.
+    wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    wizard = next(wizard, "", emptyKey({ return: true }));
+    expect(wizard.kind).toBe("openai-compatible");
+    expect(wizard.presetId).toBe("nous");
+    expect(wizard.baseUrlLine).toBe(
+      "https://inference-api.nousresearch.com/v1",
+    );
+    // The endpoint is known, so the operator lands straight on the key
+    // step instead of typing a URL.
+    expect(wizard.phase).toBe("api_key");
+  });
+
+  it("reaches a later preset by moving down the same list", () => {
+    let wizard = createProvidersWizardState("add");
+    for (let i = 0; i < 3; i += 1) {
+      wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    }
+    wizard = next(wizard, "", emptyKey({ return: true }));
+    expect(wizard.presetId).toBe("groq");
+    expect(wizard.baseUrlLine).toBe("https://api.groq.com/openai/v1");
   });
 });
 

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -24,15 +24,22 @@ export function baseUrlForWizard(wizard: ProvidersWizardState): string {
   );
 }
 
-/** Typed key wins; otherwise a key already in the environment needs no retyping. */
+/**
+ * Typed key wins; otherwise a key already in the environment needs no
+ * retyping. The fallback probe resolves the preset's own variable when
+ * one is selected — reading the shared compat variable for Groq would
+ * hand the wrong service's key to the model-list fetch.
+ */
 export function apiKeyForWizard(
   wizard: ProvidersWizardState,
 ): string | undefined {
+  const preset = wizard.presetId ? findProviderPreset(wizard.presetId) : undefined;
   return (
     wizard.apiKeyBuffer.trim() ||
     resolveLlmProviderApiKey({
       id: "openai-compatible",
       kind: "openai-compatible",
+      ...(preset ? { apiKeyEnvVar: preset.envVar } : {}),
     })
   );
 }

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -3,6 +3,7 @@ import { resolveLlmProviderApiKey } from "../../config/resolve-llm-api-key.js";
 import { getCachedOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { normalizeOpenAiBaseUrl } from "../../llm/provider/openai/normalize-openai-base-url.js";
 import { PICK_WINDOW } from "../components/wizard-pick-list.js";
+import { findProviderPreset } from "./provider-presets.js";
 import { OPENAI_COMPAT_DEFAULT_BASE_URL } from "./providers-model-options.js";
 import {
   advanceWizardPhase,
@@ -10,7 +11,7 @@ import {
   isCuratedCatalogKind,
   isLinePhase,
   isListPhase,
-  kindAtCursor,
+  kindRowAtCursor,
   listEmbeddingModelsForKind,
   listLengthForPhase,
 } from "./providers-wizard-phases.js";
@@ -207,12 +208,31 @@ export function handleProvidersWizardKey(
   }
   if (key.return) {
     if (wizard.phase === "pick_kind") {
-      const kind = kindAtCursor(clampCursor(wizard.cursor, len));
+      const row = kindRowAtCursor(clampCursor(wizard.cursor, len));
+      if (typeof row === "object") {
+        const preset = findProviderPreset(row.presetId);
+        if (!preset) return { handled: true, wizard };
+        // A preset is an openai-compatible entry with the endpoint
+        // already known, so the operator goes straight to the key step
+        // and never types a base URL. Local servers (LM Studio) need no
+        // key at all, which the api_key step accepts as empty.
+        return {
+          handled: true,
+          wizard: {
+            ...wizard,
+            kind: "openai-compatible",
+            presetId: preset.id,
+            baseUrlLine: preset.baseUrl,
+            phase: "api_key",
+            cursor: 0,
+          },
+        };
+      }
       return {
         handled: true,
         wizard: advanceWizardPhase({
           ...wizard,
-          kind,
+          kind: row,
         }),
       };
     }

--- a/src/tui/providers/providers-wizard-phases.ts
+++ b/src/tui/providers/providers-wizard-phases.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_PRESETS } from "./provider-presets.js";
 import {
   listAimlapiChatModels,
   listAimlapiEmbeddingModels,
@@ -10,17 +11,34 @@ import type {
   ProvidersWizardState,
 } from "./providers-wizard-state.js";
 
-const KIND_COUNT = 3;
+/**
+ * Rows on the provider step: the two kinds with built-in catalogs, then
+ * every known service as its own row, then the manual escape hatch.
+ * Preset rows are not new provider kinds, they resolve to
+ * `openai-compatible` with a verified base URL filled in (#69), which is
+ * the same flat shape Hermes and OpenClaw present.
+ */
+export type ProvidersWizardKindRow =
+  | ProvidersWizardKind
+  | { readonly presetId: string };
 
-/** Maps the `pick_kind` cursor index to the actual kind. */
-const KIND_ORDER: readonly ProvidersWizardKind[] = [
+/**
+ * The single source of row order for `pick_kind`. The render layer
+ * derives its labels from this list, so cursor index and label can
+ * never disagree.
+ */
+export const KIND_ROW_ORDER: readonly ProvidersWizardKindRow[] = [
   "openrouter",
   "aimlapi",
+  ...PROVIDER_PRESETS.map((preset) => ({ presetId: preset.id })),
   "openai-compatible",
 ];
 
-export function kindAtCursor(cursor: number): ProvidersWizardKind {
-  return KIND_ORDER[cursor] ?? "openrouter";
+const KIND_COUNT = KIND_ROW_ORDER.length;
+
+/** Maps the `pick_kind` cursor index to the row (kind or preset). */
+export function kindRowAtCursor(cursor: number): ProvidersWizardKindRow {
+  return KIND_ROW_ORDER[cursor] ?? "openrouter";
 }
 
 export function isCuratedCatalogKind(

--- a/src/tui/providers/providers-wizard-state.ts
+++ b/src/tui/providers/providers-wizard-state.ts
@@ -1,3 +1,5 @@
+import { presetForEntryId } from "./provider-presets.js";
+
 export type ProvidersWizardKind =
   | "openrouter"
   | "aimlapi"
@@ -54,12 +56,20 @@ export function createProvidersWizardState(
 ): ProvidersWizardState {
   const configure = mode === "configure";
   const kind = opts?.kind ?? null;
+  // Reconfiguring an entry that was created from a preset must keep the
+  // preset identity: the key screen then names the service's own env
+  // var, and saving keeps the entry id instead of minting an
+  // `openai-compatible` duplicate. Suffixed ids (`groq-2`) count too.
+  const presetId =
+    configure && kind === "openai-compatible" && opts?.providerId
+      ? (presetForEntryId(opts.providerId)?.id ?? null)
+      : null;
   return {
     mode,
     phase: configure ? "api_key" : "pick_kind",
     kind,
     providerId: opts?.providerId ?? null,
-    presetId: null,
+    presetId,
     cursor: 0,
     apiKeyBuffer: "",
     baseUrlLine: opts?.baseUrl ?? "",

--- a/src/tui/providers/providers-wizard-state.ts
+++ b/src/tui/providers/providers-wizard-state.ts
@@ -20,6 +20,12 @@ export interface ProvidersWizardState {
   kind: ProvidersWizardKind | null;
   /** Set when `mode === "configure"`. */
   providerId: string | null;
+  /**
+   * Preset chosen on the `pick_preset` step. Presets are not a provider
+   * kind: they resolve to `openai-compatible` with `baseUrl` prefilled,
+   * so the operator never types an endpoint from memory (#69).
+   */
+  presetId: string | null;
   cursor: number;
   apiKeyBuffer: string;
   baseUrlLine: string;
@@ -53,6 +59,7 @@ export function createProvidersWizardState(
     phase: configure ? "api_key" : "pick_kind",
     kind,
     providerId: opts?.providerId ?? null,
+    presetId: null,
     cursor: 0,
     apiKeyBuffer: "",
     baseUrlLine: opts?.baseUrl ?? "",

--- a/src/tui/providers/save-provider-wizard.test.ts
+++ b/src/tui/providers/save-provider-wizard.test.ts
@@ -8,26 +8,30 @@ import { LOCAL_EMBEDDING_CHOICE_ID } from "./providers-model-options.js";
 import { saveProviderWizardToConfig } from "./save-provider-wizard.js";
 import { createProvidersWizardState } from "./providers-wizard-state.js";
 
+const ENV_KEYS = [
+  "OPENROUTER_API_KEY",
+  "AIMLAPI_API_KEY",
+  "OPENAI_COMPAT_API_KEY",
+  "OPENAI_API_KEY",
+  "GROQ_API_KEY",
+  "LMSTUDIO_API_KEY",
+  "NOUS_API_KEY",
+] as const;
+
 describe("saveProviderWizardToConfig", () => {
   let stateDir: string;
 
   beforeEach(() => {
     stateDir = mkdtempSync(join(tmpdir(), "provider-wizard-"));
     process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
-    delete process.env.OPENROUTER_API_KEY;
-    delete process.env.AIMLAPI_API_KEY;
-    delete process.env.OPENAI_COMPAT_API_KEY;
-    delete process.env.OPENAI_API_KEY;
+    for (const key of ENV_KEYS) delete process.env[key];
     resetConfigCache();
   });
 
   afterEach(() => {
     rmSync(stateDir, { recursive: true, force: true });
     delete process.env.ATOMIC_AGENT_STATE_DIR;
-    delete process.env.OPENROUTER_API_KEY;
-    delete process.env.AIMLAPI_API_KEY;
-    delete process.env.OPENAI_COMPAT_API_KEY;
-    delete process.env.OPENAI_API_KEY;
+    for (const key of ENV_KEYS) delete process.env[key];
     resetConfigCache();
   });
 
@@ -114,5 +118,127 @@ describe("saveProviderWizardToConfig", () => {
         baseUrl: "https://api.venice.ai/api",
         defaultChatModel: "venice-uncensored",
       });
+  });
+
+  function groqWizard(apiKey: string) {
+    return {
+      ...createProvidersWizardState("add"),
+      kind: "openai-compatible" as const,
+      presetId: "groq",
+      phase: "embedding_model_line" as const,
+      apiKeyBuffer: apiKey,
+      baseUrlLine: "https://api.groq.com/openai",
+      chatModelLine: "llama-3.3-70b-versatile",
+    };
+  }
+
+  it("stores a preset key under the service's own env var", () => {
+    const built = saveProviderWizardToConfig(groqWizard("gsk-groq"));
+
+    expect(built.entry.id).toBe("groq");
+    expect(built.entry.apiKeyEnvVar).toBe("GROQ_API_KEY");
+    expect(process.env.GROQ_API_KEY).toBe("gsk-groq");
+    // The shared compat variable stays free for hand-added endpoints.
+    expect(process.env.OPENAI_COMPAT_API_KEY).toBeUndefined();
+  });
+
+  it("keeps two services' keys apart", () => {
+    saveProviderWizardToConfig(groqWizard("gsk-groq"));
+    saveProviderWizardToConfig({
+      ...createProvidersWizardState("add"),
+      kind: "openai-compatible" as const,
+      presetId: "nous",
+      phase: "embedding_model_line" as const,
+      apiKeyBuffer: "nous-key",
+      baseUrlLine: "https://inference-api.nousresearch.com",
+      chatModelLine: "hermes-4-405b",
+    });
+
+    // Adding Nous must not overwrite the Groq key (#69's failure mode).
+    expect(process.env.GROQ_API_KEY).toBe("gsk-groq");
+    expect(process.env.NOUS_API_KEY).toBe("nous-key");
+  });
+
+  it("updates the live environment when a key is replaced mid-session", () => {
+    saveProviderWizardToConfig(groqWizard("gsk-old"));
+    saveProviderWizardToConfig({
+      ...groqWizard("gsk-new"),
+      mode: "configure" as const,
+      providerId: "groq",
+    });
+
+    // Not only .env: the running session must resolve the new key too.
+    expect(process.env.GROQ_API_KEY).toBe("gsk-new");
+  });
+
+  it("refuses an empty key for a service that requires one", () => {
+    expect(() => saveProviderWizardToConfig(groqWizard(""))).toThrow(
+      /API key is empty/,
+    );
+  });
+
+  it("saves LM Studio without any key", () => {
+    const built = saveProviderWizardToConfig({
+      ...createProvidersWizardState("add"),
+      kind: "openai-compatible" as const,
+      presetId: "lmstudio",
+      phase: "embedding_model_line" as const,
+      apiKeyBuffer: "",
+      baseUrlLine: "http://localhost:1234",
+      chatModelLine: "qwen3-30b",
+    });
+
+    expect(built.entry.id).toBe("lmstudio");
+    // Empty key is the valid state for a local server: nothing lands in
+    // the environment and the entry stores no key either.
+    expect(process.env.LMSTUDIO_API_KEY).toBeUndefined();
+    expect(built.entry.apiKey).toBeUndefined();
+    expect(getConfig().llm?.activeTextProvider).toBe("lmstudio");
+  });
+
+  it("gives a second entry for the same service a numbered id", () => {
+    saveProviderWizardToConfig(groqWizard("gsk-groq"));
+    const second = saveProviderWizardToConfig({
+      ...groqWizard(""),
+      chatModelLine: "qwen-qwq-32b",
+    });
+
+    // The service key is already in the environment, so the second
+    // entry saves without retyping it — and lands next to the first
+    // entry instead of on top of it.
+    expect(second.entry.id).toBe("groq-2");
+    const providers = getConfig().llm?.providers ?? [];
+    expect(providers.find((p) => p.id === "groq")).toMatchObject({
+      defaultChatModel: "llama-3.3-70b-versatile",
+    });
+    expect(providers.find((p) => p.id === "groq-2")).toMatchObject({
+      defaultChatModel: "qwen-qwq-32b",
+      apiKeyEnvVar: "GROQ_API_KEY",
+    });
+  });
+
+  it("reconfigure keeps the entry id instead of minting a duplicate", () => {
+    saveProviderWizardToConfig(groqWizard("gsk-groq"));
+
+    const built = saveProviderWizardToConfig({
+      ...createProvidersWizardState("configure", {
+        providerId: "groq",
+        kind: "openai-compatible",
+        baseUrl: "https://api.groq.com/openai",
+      }),
+      phase: "embedding_model_line" as const,
+      chatModelLine: "qwen-qwq-32b",
+    });
+
+    expect(built.entry.id).toBe("groq");
+    const providers = getConfig().llm?.providers ?? [];
+    expect(providers.filter((p) => p.kind === "openai-compatible")).toHaveLength(1);
+    expect(providers.find((p) => p.id === "groq")).toMatchObject({
+      defaultChatModel: "qwen-qwq-32b",
+      apiKeyEnvVar: "GROQ_API_KEY",
+    });
+    // The active provider still points at the same id — no duplicate
+    // stole the selection.
+    expect(getConfig().llm?.activeTextProvider).toBe("groq");
   });
 });

--- a/src/tui/providers/save-provider-wizard.ts
+++ b/src/tui/providers/save-provider-wizard.ts
@@ -35,6 +35,7 @@ export function saveProviderWizardToConfig(
 
   const built = buildProviderEntryFromWizard({
     kind,
+    presetId: wizard.presetId,
     chatModelId:
       wizard.selectedChatModelId ?? defaultChatModelForKind(kind),
     embeddingChoiceId:
@@ -45,7 +46,7 @@ export function saveProviderWizardToConfig(
   });
 
   const existing = getConfig().llm?.providers.find(
-    (provider) => provider.id === providerIdForKind(kind),
+    (provider) => provider.id === providerIdForKind(kind, wizard.presetId),
   );
   let entry = built.entry;
   if (wizard.apiKeyBuffer.trim().length > 0) {

--- a/src/tui/providers/save-provider-wizard.ts
+++ b/src/tui/providers/save-provider-wizard.ts
@@ -5,6 +5,7 @@ import {
   upsertLlmProvider,
   writeProviderApiKeyToDotenv,
 } from "../persist-llm-provider.js";
+import { findProviderPreset } from "./provider-presets.js";
 import {
   AIMLAPI_DEFAULT_CHAT_MODEL,
   LOCAL_EMBEDDING_CHOICE_ID,
@@ -12,7 +13,6 @@ import {
 } from "./providers-model-options.js";
 import {
   buildProviderEntryFromWizard,
-  providerIdForKind,
   type BuiltWizardProvider,
 } from "./providers-wizard-build-entry.js";
 import type {
@@ -33,9 +33,12 @@ export function saveProviderWizardToConfig(
     throw new Error("wizard kind is missing");
   }
 
+  const providers = getConfig().llm?.providers ?? [];
   const built = buildProviderEntryFromWizard({
     kind,
     presetId: wizard.presetId,
+    existingProviderId: wizard.mode === "configure" ? wizard.providerId : null,
+    takenProviderIds: providers.map((provider) => provider.id),
     chatModelId:
       wizard.selectedChatModelId ?? defaultChatModelForKind(kind),
     embeddingChoiceId:
@@ -45,19 +48,25 @@ export function saveProviderWizardToConfig(
     customEmbeddingModel: wizard.embeddingModelLine,
   });
 
-  const existing = getConfig().llm?.providers.find(
-    (provider) => provider.id === providerIdForKind(kind, wizard.presetId),
+  const existing = providers.find(
+    (provider) => provider.id === built.entry.id,
   );
   let entry = built.entry;
+  const preset = wizard.presetId ? findProviderPreset(wizard.presetId) : undefined;
+  // Local servers have no key at all, and keyless-listing services work
+  // before one is entered, so an empty key is a valid state for both:
+  // nothing is written to .env and requests go out without Authorization.
+  const keyOptional = Boolean(preset && (preset.local || preset.listsModelsWithoutKey));
   if (wizard.apiKeyBuffer.trim().length > 0) {
-    writeProviderApiKeyToDotenv(kind, wizard.apiKeyBuffer);
-  } else if (
-    !resolveLlmProviderApiKey(entry) &&
-    (!existing || !resolveLlmProviderApiKey(existing))
-  ) {
-    throw new Error("API key is empty — paste a key or set it in .env first");
+    writeProviderApiKeyToDotenv(kind, wizard.apiKeyBuffer, preset?.envVar);
   } else if (existing?.apiKey) {
     entry = { ...entry, apiKey: existing.apiKey };
+  } else if (
+    !keyOptional &&
+    !resolveLlmProviderApiKey(entry) &&
+    !(existing && resolveLlmProviderApiKey(existing))
+  ) {
+    throw new Error("API key is empty — paste a key or set it in .env first");
   }
 
   upsertLlmProvider(entry, {


### PR DESCRIPTION
Closes #69.

## Problem

Adding anything other than OpenRouter or AI/ML API meant typing a base URL from memory. That is how a user ended up with an OpenAI endpoint paired with a non-OpenAI key: the wizard offered no middle ground between the two curated catalogs and a blank URL field.

## Change

- **Ten verified services sit as their own rows** in the same flat provider list, matching how other agent CLIs present providers: Nous Research, Groq, DeepSeek, Together AI, Fireworks AI, Cerebras, Mistral, xAI, Ollama Cloud, LM Studio (local). Manual entry stays as the last row. Row order lives in one exported `KIND_ROW_ORDER`; the render layer derives its labels from it.
- **A preset is not a new provider kind.** Picking one resolves to the existing `openai-compatible` kind with the base URL filled in and goes straight to the key step. Model lists still come from each server's own `/v1/models` (#31, #41), so nothing here needs updating when a vendor ships a new model. Base URLs are stored without the `/v1` suffix, following the repo convention (call sites append `/v1/...`).
- **Each service keeps its own API key.** Every preset declares its own env var (`GROQ_API_KEY`, `NOUS_API_KEY`, ...), the entry records it as `apiKeyEnvVar`, and key resolution treats it as authoritative. Adding a second service cannot overwrite the first one's key, and the key screen names the variable that will actually be used. Replacing a key mid-session updates `process.env` unconditionally, so the running session resolves the new key without a restart.
- **Keyless services save without a key.** LM Studio (local) and the keyless-listing endpoints (Nous, Ollama Cloud) accept an empty key: nothing is written to `.env`, resolution returns `undefined`, and requests carry no `Authorization` header at all (an empty `Bearer` token is malformed).
- **Entries coexist instead of overwriting.** Each preset keeps its own entry id (`groq`, `nous`, ...), and a second entry for the same service gets a numbered suffix (`groq-2`) via `suggestPresetEntryId`, now wired into the entry builder.
- **Reconfigure keeps the entry's identity.** The configure wizard recovers the preset behind the entry id (numbered suffixes included) and reuses the existing id on save, so reconfiguring `groq` updates `groq` in place instead of minting an `openai-compatible` duplicate and switching the active provider to it. Hand-added compat entries keep their custom ids on reconfigure too.
- Every URL was verified live: each answers `/v1/models` with an OpenAI-shaped payload (200 with a `data` array, or 401/403 asking for a key, which confirms the path exists).

The provider list is 13 rows now; `renderPickList` on current `main` (#67) windows every list to `PICK_WINDOW` rows with a position counter, so the `pick_kind` step clips on short terminals instead of overflowing.

## Testing

New and updated tests across the preset layer: per-preset env vars (unique, never the shared compat or catalog names, named after the service), base URLs stored without `/v1`, keyless flags kept on the verified services (presence checks, not a pinned list), `suggestPresetEntryId` suffixing, `presetForEntryId` suffix recovery, entry-builder id selection (add, second entry, reconfigure, hand-added id), and save-path scenarios: a Groq key lands in `GROQ_API_KEY`, two services keep separate keys, a mid-session key replacement updates the live environment, an empty key is refused for Groq, LM Studio saves without a key, a second Groq becomes `groq-2`, reconfigure keeps `groq` and the active provider. Providers area plus the wizard component: 68 passing across 7 files. `tsc` clean. Full suite: 3516 passing, with the same 8 pre-existing failures as current `main`.
