### PR TITLE
feat(tui): land the model picker filter that merged into an already-merged base

### DIFF
--- a/src/tui/components/llm-panel-modals.tsx
+++ b/src/tui/components/llm-panel-modals.tsx
@@ -6,7 +6,43 @@ import { ProvidersWizard } from "./providers-wizard.js";
 import { parseExternalUrl } from "../llm-panel/llm-panel-modal-key-bindings.js";
 import { filteredPickerModels } from "../providers/providers-panel-state.js";
 
-export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | null {
+/** Upper bound for the picker's list window (roomy terminals). */
+const PICKER_MAX_WINDOW = 12;
+/** Never shrink the list window below this many rows. */
+const PICKER_MIN_WINDOW = 3;
+/**
+ * Picker box rows that are not list rows: two border lines, the title,
+ * the filter/status line, the footer, and the box's bottom margin.
+ */
+const PICKER_CHROME_ROWS = 6;
+
+/**
+ * List rows the picker shows. Sized from the tab's row budget so short
+ * terminals get a smaller (but still fixed) window instead of a frame
+ * that outgrows the screen.
+ */
+function pickerWindowRows(maxRows: number | undefined): number {
+  if (maxRows === undefined) return PICKER_MAX_WINDOW;
+  return Math.max(
+    PICKER_MIN_WINDOW,
+    Math.min(PICKER_MAX_WINDOW, maxRows - PICKER_CHROME_ROWS),
+  );
+}
+
+/** `count` blank lines that hold a box at its fixed height. */
+function blankRows(count: number): ReactElement[] {
+  return Array.from({ length: count }, (_unused, i) => (
+    <Text key={`pad-${i}`}> </Text>
+  ));
+}
+
+export function LlmPanelModals({
+  state,
+  maxRows,
+}: {
+  state: TuiState;
+  maxRows?: number;
+}): ReactElement | null {
   if (state.providersPanel.wizard) {
     return <ProvidersWizard wizard={state.providersPanel.wizard} />;
   }
@@ -47,40 +83,49 @@ export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | n
   }
   if (state.providersPanel.chatModelPicker !== null) {
     const picker = state.providersPanel.chatModelPicker;
+    // Fixed-height picker: every status branch (loading, ready, error)
+    // renders the same number of lines, and the ready branch pads its
+    // list area with blanks up to a constant window. Rationale: Ink 7
+    // repaints by erasing the previous frame's line count and rewriting
+    // it (log-update), and once a frame outgrows the terminal it stops
+    // erasing in place and falls back to clearing and rewriting the
+    // whole screen (shouldClearTerminalForFrame in ink). The stray-glyph
+    // artifact this PR chased (`toolss`, text bleeding into the header)
+    // was observed while the unwindowed 337-row catalog pushed frames
+    // past the terminal height, i.e. into that non-erasing regime (see
+    // the review discussion on #68). Holding the modal at one constant
+    // height, sized down on short terminals, keeps repaints in place.
+    const window = pickerWindowRows(maxRows);
     if (picker.status === "loading") {
       return (
         <PromptBox tone="accent" title={`Models — ${picker.providerId}`}>
-          <Text color={theme.colors.muted}>fetching model list… · Esc cancel</Text>
+          <Text color={theme.colors.muted}>fetching model list…</Text>
+          {blankRows(window)}
+          <Text color={theme.colors.muted}>Esc cancel</Text>
         </PromptBox>
       );
     }
     if (picker.status === "error") {
       return (
         <PromptBox tone="danger" title={`Models — ${picker.providerId}`}>
-          <Text color={theme.colors.error}>
+          <Text color={theme.colors.error} wrap="truncate-end">
             model list unavailable ({picker.error ?? "unknown error"})
           </Text>
+          {blankRows(window)}
           <Text color={theme.colors.muted}>Enter/Esc close</Text>
         </PromptBox>
       );
     }
     const rows = filteredPickerModels(picker);
-    // Fixed-height window: the box always renders WINDOW rows, padding
-    // with blanks when the result set is shorter. Ink repaints a frame
-    // by overwriting the previous one line for line, so a box that
-    // changes height between renders leaves the tail of the taller frame
-    // on screen: that is the source of the stray characters (`toolss`,
-    // `toolsls`) and the text bleeding into the header.
-    const WINDOW = 12;
     const start = Math.max(
       0,
       Math.min(
-        picker.cursor - Math.floor(WINDOW / 2),
-        Math.max(0, rows.length - WINDOW),
+        picker.cursor - Math.floor(window / 2),
+        Math.max(0, rows.length - window),
       ),
     );
-    const visible = rows.slice(start, start + WINDOW);
-    const blanks = Math.max(0, WINDOW - visible.length);
+    const visible = rows.slice(start, start + window);
+    const blanks = Math.max(0, window - visible.length);
     const queryLine = picker.query;
     const counter =
       rows.length === 0
@@ -90,7 +135,7 @@ export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | n
           }`;
     return (
       <PromptBox tone="accent" title={`Models — ${picker.providerId}`}>
-        <Text color={theme.colors.muted}>
+        <Text color={theme.colors.muted} wrap="truncate-end">
           {"filter: "}
           <Text color={theme.colors.accent}>{queryLine}</Text>
           <Text color={theme.colors.muted}>▏</Text>
@@ -99,21 +144,26 @@ export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | n
           const idx = start + i;
           const selected = idx === picker.cursor;
           const isCurrent = id === picker.currentModelId;
-          // Key on the row slot, not the id: ids can repeat across a
-          // re-filter, and a duplicate key makes Ink reuse the previous
-          // row's text, which is what left half-erased model names behind.
+          // Slot keys keep the row elements stable across refilters.
+          // They are not what fixed the stray-glyph artifact: ids are
+          // unique within a single render, so key={id} never collided
+          // (see the review of #68); that traced to frame height, per
+          // the fixed-height note above. truncate-end keeps a long id
+          // from wrapping into a second line and changing the height.
           return (
-            <Text key={`row-${i}`} color={selected ? theme.colors.accent : undefined}>
+            <Text
+              key={`row-${i}`}
+              color={selected ? theme.colors.accent : undefined}
+              wrap="truncate-end"
+            >
               {selected ? "› " : "  "}
               {id}
               {isCurrent ? <Text color={theme.colors.success}> current</Text> : null}
             </Text>
           );
         })}
-        {Array.from({ length: blanks }, (_unused, i) => (
-          <Text key={`pad-${i}`}> </Text>
-        ))}
-        <Text color={theme.colors.muted}>
+        {blankRows(blanks)}
+        <Text color={theme.colors.muted} wrap="truncate-end">
           {`↑/↓ move (${counter}) · type to filter · Enter select · Esc cancel`}
         </Text>
       </PromptBox>

--- a/src/tui/components/llm-panel-modals.tsx
+++ b/src/tui/components/llm-panel-modals.tsx
@@ -81,7 +81,7 @@ export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | n
     );
     const visible = rows.slice(start, start + WINDOW);
     const blanks = Math.max(0, WINDOW - visible.length);
-    const queryLine = picker.query.length > 0 ? picker.query : "";
+    const queryLine = picker.query;
     const counter =
       rows.length === 0
         ? "no match"

--- a/src/tui/components/llm-panel-modals.tsx
+++ b/src/tui/components/llm-panel-modals.tsx
@@ -4,6 +4,7 @@ import { theme } from "../theme/theme.js";
 import type { TuiState } from "../tui-state.js";
 import { ProvidersWizard } from "./providers-wizard.js";
 import { parseExternalUrl } from "../llm-panel/llm-panel-modal-key-bindings.js";
+import { filteredPickerModels } from "../providers/providers-panel-state.js";
 
 export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | null {
   if (state.providersPanel.wizard) {
@@ -63,29 +64,57 @@ export function LlmPanelModals({ state }: { state: TuiState }): ReactElement | n
         </PromptBox>
       );
     }
-    // 12-row window around the cursor, same shape as the wizard picker.
+    const rows = filteredPickerModels(picker);
+    // Fixed-height window: the box always renders WINDOW rows, padding
+    // with blanks when the result set is shorter. Ink repaints a frame
+    // by overwriting the previous one line for line, so a box that
+    // changes height between renders leaves the tail of the taller frame
+    // on screen: that is the source of the stray characters (`toolss`,
+    // `toolsls`) and the text bleeding into the header.
     const WINDOW = 12;
     const start = Math.max(
       0,
-      Math.min(picker.cursor - Math.floor(WINDOW / 2), picker.models.length - WINDOW),
+      Math.min(
+        picker.cursor - Math.floor(WINDOW / 2),
+        Math.max(0, rows.length - WINDOW),
+      ),
     );
-    const visible = picker.models.slice(start, start + WINDOW);
+    const visible = rows.slice(start, start + WINDOW);
+    const blanks = Math.max(0, WINDOW - visible.length);
+    const queryLine = picker.query.length > 0 ? picker.query : "";
+    const counter =
+      rows.length === 0
+        ? "no match"
+        : `${picker.cursor + 1}/${rows.length}${
+            rows.length !== picker.models.length ? ` of ${picker.models.length}` : ""
+          }`;
     return (
       <PromptBox tone="accent" title={`Models — ${picker.providerId}`}>
+        <Text color={theme.colors.muted}>
+          {"filter: "}
+          <Text color={theme.colors.accent}>{queryLine}</Text>
+          <Text color={theme.colors.muted}>▏</Text>
+        </Text>
         {visible.map((id: string, i: number) => {
           const idx = start + i;
           const selected = idx === picker.cursor;
           const isCurrent = id === picker.currentModelId;
+          // Key on the row slot, not the id: ids can repeat across a
+          // re-filter, and a duplicate key makes Ink reuse the previous
+          // row's text, which is what left half-erased model names behind.
           return (
-            <Text key={id} color={selected ? theme.colors.accent : undefined}>
+            <Text key={`row-${i}`} color={selected ? theme.colors.accent : undefined}>
               {selected ? "› " : "  "}
               {id}
               {isCurrent ? <Text color={theme.colors.success}> current</Text> : null}
             </Text>
           );
         })}
+        {Array.from({ length: blanks }, (_unused, i) => (
+          <Text key={`pad-${i}`}> </Text>
+        ))}
         <Text color={theme.colors.muted}>
-          {`↑/↓ move (${picker.cursor + 1}/${picker.models.length}) · Enter select · Esc cancel`}
+          {`↑/↓ move (${counter}) · type to filter · Enter select · Esc cancel`}
         </Text>
       </PromptBox>
     );

--- a/src/tui/components/llm-panel.test.tsx
+++ b/src/tui/components/llm-panel.test.tsx
@@ -1,9 +1,42 @@
 import { render } from "ink-testing-library";
 import { describe, expect, it } from "vitest";
 
-import { createInitialTuiState } from "../tui-state.js";
+import { createInitialTuiState, type TuiState } from "../tui-state.js";
 import { fakeSession } from "../test-fixtures.js";
+import type { ProvidersChatModelPickerState } from "../providers/providers-panel-state.js";
 import { LlmPanel } from "./llm-panel.js";
+
+function stateWithPicker(
+  overrides: Partial<ProvidersChatModelPickerState>,
+): TuiState {
+  const base = createInitialTuiState(fakeSession());
+  return {
+    ...base,
+    uiMode: "debug" as const,
+    activeTab: "llm" as const,
+    llmPanel: { ...base.llmPanel, mode: "cloud" as const },
+    providersPanel: {
+      ...base.providersPanel,
+      chatModelPickerGeneration: 1,
+      chatModelPicker: {
+        providerId: "my-vllm",
+        currentModelId: "qwen-32b",
+        status: "ready",
+        models: ["glm-9b", "qwen-32b", "yi-34b"],
+        query: "",
+        cursor: 0,
+        error: null,
+        generation: 1,
+        ...overrides,
+      },
+    },
+  };
+}
+
+function frameHeight(state: TuiState, maxRows: number): number {
+  const { lastFrame } = render(<LlmPanel state={state} maxRows={maxRows} />);
+  return (lastFrame() ?? "").split("\n").length;
+}
 
 function stripAnsi(value: string): string {
   return value.replace(/\u001b\[[0-9;]*m/g, "");
@@ -79,5 +112,45 @@ describe("LlmPanel", () => {
     expect(text).toContain("downloading — Nomic embedding");
     expect(text).toContain("model: nomic-embed-text-v1.5");
     expect(text).toContain("60%");
+  });
+});
+
+describe("model picker fixed height", () => {
+  const MAX_ROWS = 20;
+
+  it("loading, ready and error branches all render the same frame height", () => {
+    const heights = [
+      frameHeight(stateWithPicker({ status: "loading", models: [] }), MAX_ROWS),
+      frameHeight(stateWithPicker({}), MAX_ROWS),
+      frameHeight(
+        stateWithPicker({ status: "error", error: "http 500" }),
+        MAX_ROWS,
+      ),
+    ];
+    expect(new Set(heights).size).toBe(1);
+  });
+
+  it("a narrowing filter keeps the frame height constant", () => {
+    const full = frameHeight(stateWithPicker({ query: "" }), MAX_ROWS);
+    const narrowed = frameHeight(stateWithPicker({ query: "qwen" }), MAX_ROWS);
+    const empty = frameHeight(stateWithPicker({ query: "no-such" }), MAX_ROWS);
+    expect(narrowed).toBe(full);
+    expect(empty).toBe(full);
+  });
+
+  it("short terminals get a smaller window, still equal across branches", () => {
+    const SHORT = 10;
+    const heights = [
+      frameHeight(stateWithPicker({ status: "loading", models: [] }), SHORT),
+      frameHeight(stateWithPicker({}), SHORT),
+      frameHeight(
+        stateWithPicker({ status: "error", error: "http 500" }),
+        SHORT,
+      ),
+    ];
+    expect(new Set(heights).size).toBe(1);
+    expect(heights[0]!).toBeLessThan(
+      frameHeight(stateWithPicker({}), MAX_ROWS),
+    );
   });
 });

--- a/src/tui/components/llm-panel.tsx
+++ b/src/tui/components/llm-panel.tsx
@@ -49,7 +49,7 @@ export function LlmPanel({
   const listBudget = Math.max(1, maxRows - headerRows);
   return (
     <Box flexDirection="column" width="100%">
-      <LlmPanelModals state={state} />
+      <LlmPanelModals state={state} maxRows={maxRows} />
       {/* The starting banner and active-download banners are important
           feedback — keep them visible regardless of the compact/full
           header decision. */}

--- a/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
@@ -4,6 +4,7 @@ import type { TuiAppCallbacks } from "../tui-app.js";
 import type { TuiState } from "../tui-state.js";
 import { handleProvidersWizardKey } from "../providers/providers-wizard-key-bindings.js";
 import { normalizeLocalLlmBaseUrl } from "../persist-user-local-models-config.js";
+import { filteredPickerModels } from "../providers/providers-panel-state.js";
 import { stopLocalDaemonsForCloudSelection } from "./llm-panel-primary-actions.js";
 
 export function handleLlmModalKey(
@@ -96,20 +97,37 @@ export function handleLlmModalKey(
       dispatch({ type: "providers_chat_model_picker_closed" });
       return true;
     }
-    if (picker.status === "ready" && picker.models.length > 0) {
+    if (picker.status === "ready") {
+      const rows = filteredPickerModels(picker);
       if (key.upArrow || key.downArrow) {
+        if (rows.length === 0) return true;
         const delta = key.downArrow ? 1 : -1;
-        const next =
-          (picker.cursor + delta + picker.models.length) % picker.models.length;
+        const next = (picker.cursor + delta + rows.length) % rows.length;
         dispatch({ type: "providers_chat_model_picker_cursor_set", cursor: next });
         return true;
       }
       if (key.return) {
-        const modelId = picker.models[picker.cursor];
+        const modelId = rows[picker.cursor];
         if (modelId === undefined) return true;
         dispatch({ type: "providers_chat_model_picker_closed" });
         callbacks.onProvidersSelectChatModel?.(picker.providerId, modelId);
         stopLocalDaemonsForCloudSelection(state, callbacks);
+        return true;
+      }
+      if (key.backspace || key.delete) {
+        dispatch({
+          type: "providers_chat_model_picker_query_set",
+          query: picker.query.slice(0, -1),
+        });
+        return true;
+      }
+      // Printable keys type into the filter. Modifier combos are left
+      // alone so global hotkeys keep working while the modal is open.
+      if (input && input.length > 0 && !key.ctrl && !key.meta) {
+        dispatch({
+          type: "providers_chat_model_picker_query_set",
+          query: picker.query + input,
+        });
         return true;
       }
     }

--- a/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
@@ -124,11 +124,34 @@ export function handleLlmModalKey(
         });
         return true;
       }
-      // Printable keys type into the filter. Ctrl/meta combos are not
-      // typed into it, but they are still swallowed by the modal below.
-      // Ctrl+C keeps working only because handleAppKey (tui-app.tsx) runs
-      // before this handler ever sees the key.
-      if (input && input.length > 0 && !key.ctrl && !key.meta) {
+      // Printable keys type into the filter. The guard is explicit
+      // rather than "anything with input": Ink 7's parse-keypress
+      // reports input === "" for Tab, arrows and PgUp/PgDn, but that is
+      // an implementation detail, so navigation keys are excluded by
+      // flag and control characters by code point before anything is
+      // appended to the query. Ctrl/meta combos are not typed into it,
+      // but they are still swallowed by the modal below. Ctrl+C keeps
+      // working only because handleAppKey (tui-app.tsx) runs before
+      // this handler ever sees the key.
+      const isNavigationKey =
+        key.tab ||
+        key.return ||
+        key.escape ||
+        key.backspace ||
+        key.delete ||
+        key.upArrow ||
+        key.downArrow ||
+        key.leftArrow ||
+        key.rightArrow ||
+        key.pageUp ||
+        key.pageDown;
+      if (
+        input.length > 0 &&
+        !key.ctrl &&
+        !key.meta &&
+        !isNavigationKey &&
+        isPrintableFilterInput(input)
+      ) {
         dispatch({
           type: "providers_chat_model_picker_query_set",
           query: picker.query + input,
@@ -188,6 +211,21 @@ export function handleLlmModalKey(
   }
 
   return null;
+}
+
+/**
+ * True when every code point of the reported input is printable text.
+ * Rejects C0 controls (below 0x20) and DEL (0x7f) so escape-sequence
+ * fragments and raw control bytes can never land in the picker filter.
+ */
+function isPrintableFilterInput(input: string): boolean {
+  for (const char of input) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined || codePoint < 0x20 || codePoint === 0x7f) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
@@ -115,14 +115,19 @@ export function handleLlmModalKey(
         return true;
       }
       if (key.backspace || key.delete) {
+        // Nothing to erase: dispatching would reset the cursor to the top
+        // of the list for no reason, so swallow the key instead.
+        if (picker.query.length === 0) return true;
         dispatch({
           type: "providers_chat_model_picker_query_set",
           query: picker.query.slice(0, -1),
         });
         return true;
       }
-      // Printable keys type into the filter. Modifier combos are left
-      // alone so global hotkeys keep working while the modal is open.
+      // Printable keys type into the filter. Ctrl/meta combos are not
+      // typed into it, but they are still swallowed by the modal below.
+      // Ctrl+C keeps working only because handleAppKey (tui-app.tsx) runs
+      // before this handler ever sees the key.
       if (input && input.length > 0 && !key.ctrl && !key.meta) {
         dispatch({
           type: "providers_chat_model_picker_query_set",

--- a/src/tui/providers/providers-actions.ts
+++ b/src/tui/providers/providers-actions.ts
@@ -41,6 +41,7 @@ export type ProvidersAction =
     }
   | { type: "providers_chat_model_picker_failed"; generation: number; error: string }
   | { type: "providers_chat_model_picker_cursor_set"; cursor: number }
+  | { type: "providers_chat_model_picker_query_set"; query: string }
   | { type: "providers_chat_model_picker_closed" }
   | { type: "providers_wizard_updated"; wizard: ProvidersWizardState }
   | { type: "providers_wizard_closed" }

--- a/src/tui/providers/providers-chat-model-picker.test.ts
+++ b/src/tui/providers/providers-chat-model-picker.test.ts
@@ -6,7 +6,10 @@ import type { TuiAppCallbacks } from "../tui-app.js";
 import { createInitialTuiState, type TuiState } from "../tui-state.js";
 import { fakeSession } from "../test-fixtures.js";
 import { reduceProvidersPanel } from "./providers-reducer.js";
-import type { ProvidersChatModelPickerState } from "./providers-panel-state.js";
+import {
+  filteredPickerModels,
+  type ProvidersChatModelPickerState,
+} from "./providers-panel-state.js";
 import { handleLlmModalKey } from "../llm-panel/llm-panel-modal-key-bindings.js";
 
 function emptyKey(overrides: Partial<Key> = {}): Key {
@@ -64,6 +67,7 @@ function readyPicker(
     currentModelId: "qwen-32b",
     status: "ready",
     models: ["glm-9b", "qwen-32b", "yi-34b"],
+    query: "",
     cursor: 1,
     error: null,
     generation: 1,
@@ -207,5 +211,107 @@ describe("model picker modal keys", () => {
       stateWithPicker(readyPicker({ status: "error", error: "http 500" })),
     );
     expect(dispatched).toEqual([{ type: "providers_chat_model_picker_closed" }]);
+  });
+});
+
+describe("model picker filtering", () => {
+  it("typing narrows the visible rows and resets the cursor", () => {
+    const state = stateWithPicker(readyPicker({ cursor: 2 }));
+    const next = reduceProvidersPanel(state, {
+      type: "providers_chat_model_picker_query_set",
+      query: "qwen",
+    });
+    const picker = next.providersPanel.chatModelPicker!;
+    expect(picker.query).toBe("qwen");
+    expect(picker.cursor).toBe(0);
+    expect(filteredPickerModels(picker)).toEqual(["qwen-32b"]);
+  });
+
+  it("filtering is case-insensitive and matches anywhere in the id", () => {
+    const picker = readyPicker({ query: "34B" });
+    expect(filteredPickerModels(picker)).toEqual(["yi-34b"]);
+  });
+
+  it("an empty query shows the whole catalog", () => {
+    expect(filteredPickerModels(readyPicker({ query: "" }))).toHaveLength(3);
+  });
+
+  it("a query matching nothing yields an empty list without crashing", () => {
+    expect(filteredPickerModels(readyPicker({ query: "nope" }))).toEqual([]);
+  });
+
+  it("typing a printable character dispatches a query update", () => {
+    const { dispatched } = pressModal(
+      "q",
+      emptyKey(),
+      stateWithPicker(readyPicker({ query: "" })),
+    );
+    expect(dispatched).toEqual([
+      { type: "providers_chat_model_picker_query_set", query: "q" },
+    ]);
+  });
+
+  it("backspace trims the query", () => {
+    const { dispatched } = pressModal(
+      "",
+      emptyKey({ backspace: true }),
+      stateWithPicker(readyPicker({ query: "qwen" })),
+    );
+    expect(dispatched).toEqual([
+      { type: "providers_chat_model_picker_query_set", query: "qwe" },
+    ]);
+  });
+
+  it("arrows walk the filtered list, not the full one", () => {
+    // "qwen" leaves a single row, so moving down wraps to itself.
+    const { dispatched } = pressModal(
+      "",
+      emptyKey({ downArrow: true }),
+      stateWithPicker(readyPicker({ query: "qwen", cursor: 0 })),
+    );
+    expect(dispatched).toEqual([
+      { type: "providers_chat_model_picker_cursor_set", cursor: 0 },
+    ]);
+  });
+
+  it("Enter selects from the filtered list", () => {
+    const onProvidersSelectChatModel = vi.fn();
+    pressModal(
+      "",
+      emptyKey({ return: true }),
+      stateWithPicker(readyPicker({ query: "yi", cursor: 0 })),
+      callbacks({ onProvidersSelectChatModel }),
+    );
+    expect(onProvidersSelectChatModel).toHaveBeenCalledWith("my-vllm", "yi-34b");
+  });
+
+  it("Enter on an empty result set does nothing", () => {
+    const onProvidersSelectChatModel = vi.fn();
+    const { dispatched } = pressModal(
+      "",
+      emptyKey({ return: true }),
+      stateWithPicker(readyPicker({ query: "nope", cursor: 0 })),
+      callbacks({ onProvidersSelectChatModel }),
+    );
+    expect(onProvidersSelectChatModel).not.toHaveBeenCalled();
+    expect(dispatched).toEqual([]);
+  });
+
+  it("Esc still closes while a query is active", () => {
+    const { dispatched } = pressModal(
+      "",
+      emptyKey({ escape: true }),
+      stateWithPicker(readyPicker({ query: "qwen" })),
+    );
+    expect(dispatched).toEqual([{ type: "providers_chat_model_picker_closed" }]);
+  });
+
+  it("ctrl and meta combos are not typed into the filter", () => {
+    const { dispatched } = pressModal(
+      "c",
+      emptyKey({ ctrl: true }),
+      stateWithPicker(readyPicker({ query: "" })),
+    );
+    expect(dispatched).toEqual([]);
   });
 });

--- a/src/tui/providers/providers-chat-model-picker.test.ts
+++ b/src/tui/providers/providers-chat-model-picker.test.ts
@@ -324,4 +324,52 @@ describe("model picker filtering", () => {
     );
     expect(dispatched).toEqual([]);
   });
+
+  it("Tab is not typed into the filter", () => {
+    const { dispatched, handled } = pressModal(
+      "\t",
+      emptyKey({ tab: true }),
+      stateWithPicker(readyPicker({ query: "" })),
+    );
+    expect(handled).toBe(true);
+    expect(dispatched).toEqual([]);
+  });
+
+  it("PageDown is not typed into the filter, even with a raw sequence as input", () => {
+    const { dispatched, handled } = pressModal(
+      "[6~",
+      emptyKey({ pageDown: true }),
+      stateWithPicker(readyPicker({ query: "" })),
+    );
+    expect(handled).toBe(true);
+    expect(dispatched).toEqual([]);
+  });
+
+  it("left/right arrows are not typed into the filter", () => {
+    for (const overrides of [{ leftArrow: true }, { rightArrow: true }] as const) {
+      const { dispatched } = pressModal(
+        "",
+        emptyKey(overrides),
+        stateWithPicker(readyPicker({ query: "" })),
+      );
+      expect(dispatched).toEqual([]);
+    }
+  });
+
+  it("control characters never reach the filter", () => {
+    for (const raw of ["\u0007", "\u001b", "\u001b[A", "\u007f"]) {
+      const { dispatched } = pressModal(
+        raw,
+        emptyKey(),
+        stateWithPicker(readyPicker({ query: "" })),
+      );
+      expect(dispatched).toEqual([]);
+    }
+  });
+
+  it("surrounding whitespace stays visible in the query but is ignored when filtering", () => {
+    const picker = readyPicker({ query: " qwen " });
+    expect(picker.query).toBe(" qwen ");
+    expect(filteredPickerModels(picker)).toEqual(["qwen-32b"]);
+  });
 });

--- a/src/tui/providers/providers-chat-model-picker.test.ts
+++ b/src/tui/providers/providers-chat-model-picker.test.ts
@@ -262,6 +262,16 @@ describe("model picker filtering", () => {
     ]);
   });
 
+  it("backspace on an empty query is a no-op and keeps the cursor put", () => {
+    const { dispatched, handled } = pressModal(
+      "",
+      emptyKey({ backspace: true }),
+      stateWithPicker(readyPicker({ query: "", cursor: 2 })),
+    );
+    expect(handled).toBe(true);
+    expect(dispatched).toEqual([]);
+  });
+
   it("arrows walk the filtered list, not the full one", () => {
     // "qwen" leaves a single row, so moving down wraps to itself.
     const { dispatched } = pressModal(

--- a/src/tui/providers/providers-panel-state.ts
+++ b/src/tui/providers/providers-panel-state.ts
@@ -39,10 +39,30 @@ export interface ProvidersChatModelPickerState {
   providerId: string;
   currentModelId: string | null;
   status: "loading" | "ready" | "error";
+  /** Everything the provider offers, unfiltered. */
   models: readonly string[];
+  /**
+   * Typed filter. Empty string means "no filter"; the picker always
+   * renders `filteredModels(picker)` rather than `models` so the cursor
+   * and the visible rows agree on one list.
+   */
+  query: string;
   cursor: number;
   error: string | null;
   generation: number;
+}
+
+/**
+ * Rows the picker actually shows: every model whose id contains the
+ * typed query, case-insensitively. Kept as a helper rather than stored
+ * state so the filter can never drift out of sync with `models`.
+ */
+export function filteredPickerModels(
+  picker: ProvidersChatModelPickerState,
+): readonly string[] {
+  const q = picker.query.trim().toLowerCase();
+  if (q.length === 0) return picker.models;
+  return picker.models.filter((id) => id.toLowerCase().includes(q));
 }
 
 export interface ProvidersPanelState {

--- a/src/tui/providers/providers-reducer.ts
+++ b/src/tui/providers/providers-reducer.ts
@@ -120,6 +120,7 @@ export function reduceProvidersPanel(
             currentModelId: action.currentModelId,
             status: "loading",
             models: [],
+            query: "",
             cursor: 0,
             error: null,
             generation: action.generation,
@@ -179,6 +180,23 @@ export function reduceProvidersPanel(
         providersPanel: {
           ...panel,
           chatModelPicker: { ...panel.chatModelPicker, cursor: action.cursor },
+        },
+      };
+    }
+    case "providers_chat_model_picker_query_set": {
+      if (!panel.chatModelPicker) return state;
+      // Every keystroke re-filters, so the cursor is reset to the top of
+      // the new result set rather than pointing at a row that may no
+      // longer exist.
+      return {
+        ...state,
+        providersPanel: {
+          ...panel,
+          chatModelPicker: {
+            ...panel.chatModelPicker,
+            query: action.query,
+            cursor: 0,
+          },
         },
       };
     }


### PR DESCRIPTION
#68 was reviewed and merged, but its base was `feat/full-provider-catalogs`, and the merge landed 8 seconds after that base itself merged into main. The result: GitHub shows #68 as merged while none of its commits are ancestors of main (`d9bad8c` merged into the branch, not into main).

This PR carries exactly those commits with no new changes: typing filters the model picker, the backspace guard for an empty filter, and the review fixes from #68 (fixed-height loading and error branches, the window sized from the tab's row budget, the explicit printable-key guard, and the corrected rendering-cause comment). The diff is identical to what was already approved in #68.
