### PR TITLE
analytics: attach token counts and estimated spend to message_sent

### DIFF
--- a/src/analytics/analytics-events.test.ts
+++ b/src/analytics/analytics-events.test.ts
@@ -121,6 +121,79 @@ describe("captureMessageSent", () => {
     );
   });
 
+  it("attaches prompt_tokens / completion_tokens to message_sent when provided", () => {
+    const client = fakeClient();
+    const store = fakeStore({ firstMessage: true });
+    captureMessageSent(client, store, {
+      ...ctx,
+      promptTokens: 100,
+      completionTokens: 50,
+    });
+    expect(client.capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.messageSent, {
+      provider: "openrouter",
+      model: "gpt",
+      prompt_tokens: 100,
+      completion_tokens: 50,
+    });
+  });
+
+  it("attaches cost_usd to message_sent when provided", () => {
+    const client = fakeClient();
+    const store = fakeStore({ firstMessage: true });
+    captureMessageSent(client, store, {
+      ...ctx,
+      costUsd: 0.0042,
+    });
+    expect(client.capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.messageSent, {
+      provider: "openrouter",
+      model: "gpt",
+      cost_usd: 0.0042,
+    });
+  });
+
+  it("keeps prompt_tokens / completion_tokens / cost_usd off first_message_sent (only provider + model)", () => {
+    const client = fakeClient();
+    const store = fakeStore(); // first message not yet sent
+    captureMessageSent(client, store, {
+      ...ctx,
+      promptTokens: 100,
+      completionTokens: 50,
+      costUsd: 0.0042,
+    });
+    // first call is first_message_sent — must carry base props only
+    expect(client.capture).toHaveBeenNthCalledWith(
+      1,
+      ANALYTICS_EVENTS.firstMessageSent,
+      { provider: "openrouter", model: "gpt" },
+    );
+  });
+
+  it("omits prompt_tokens / completion_tokens / cost_usd keys entirely when not provided", () => {
+    const client = fakeClient();
+    const store = fakeStore({ firstMessage: true });
+    captureMessageSent(client, store, ctx);
+    const payload = client.capture.mock.calls[0][1];
+    expect(payload).not.toHaveProperty("prompt_tokens");
+    expect(payload).not.toHaveProperty("completion_tokens");
+    expect(payload).not.toHaveProperty("cost_usd");
+  });
+
+  it("emits cost_usd: 0 when explicitly provided as zero", () => {
+    const client = fakeClient();
+    const store = fakeStore({ firstMessage: true });
+    captureMessageSent(client, store, {
+      ...ctx,
+      costUsd: 0,
+    });
+    expect(client.capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.messageSent, {
+      provider: "openrouter",
+      model: "gpt",
+      cost_usd: 0,
+    });
+    const payload = client.capture.mock.calls[0][1];
+    expect(payload).toHaveProperty("cost_usd", 0);
+  });
+
   it("no-ops when analytics is disabled (null client)", () => {
     const store = fakeStore();
     expect(() => captureMessageSent(null, store, ctx)).not.toThrow();

--- a/src/analytics/analytics-events.ts
+++ b/src/analytics/analytics-events.ts
@@ -24,6 +24,15 @@ export const ANALYTICS_EVENTS = {
  *  - `outcome`     — how the turn ended: `reply` / `finish` / `max_steps`
  *                    / `cancelled` / `failed`. `max_steps` means the reply
  *                    was cut off by the step budget.
+ *  - `promptTokens` / `completionTokens`
+ *                  — tokens the turn consumed, summed across every LLM
+ *                    call it made. Reported by the provider's `usage`
+ *                    block; omitted when the provider reports none.
+ *  - `costUsd`     — estimated spend for the turn, from the same token
+ *                    counts times per-model pricing. Omitted when the
+ *                    model carries no pricing, which is the normal case
+ *                    for local runners — a free turn reports no cost
+ *                    rather than a zero one.
  */
 export interface MessageEventContext {
   provider: string;
@@ -31,6 +40,9 @@ export interface MessageEventContext {
   latencyMs?: number;
   stepCount?: number;
   outcome?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  costUsd?: number;
 }
 
 /**
@@ -52,7 +64,8 @@ export function captureAppInstalled(
  * Emit `message_sent` for every human-originated turn, plus the
  * one-time `first_message_sent` on the very first message this install
  * ever sends. Both carry `{ provider, model }`; `message_sent` also
- * carries `latency_ms` when the caller measured the turn duration.
+ * carries `latency_ms` when the caller measured the turn duration, plus
+ * token counts and estimated spend when the provider reported usage.
  * No-ops when analytics is disabled.
  */
 export function captureMessageSent(
@@ -71,5 +84,12 @@ export function captureMessageSent(
     ...(context.latencyMs !== undefined ? { latency_ms: context.latencyMs } : {}),
     ...(context.stepCount !== undefined ? { step_count: context.stepCount } : {}),
     ...(context.outcome !== undefined ? { outcome: context.outcome } : {}),
+    ...(context.promptTokens !== undefined
+      ? { prompt_tokens: context.promptTokens }
+      : {}),
+    ...(context.completionTokens !== undefined
+      ? { completion_tokens: context.completionTokens }
+      : {}),
+    ...(context.costUsd !== undefined ? { cost_usd: context.costUsd } : {}),
   });
 }

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -16,4 +16,6 @@ export {
   captureMessageSent,
 } from "./analytics-events.js";
 export type { MessageEventContext } from "./analytics-events.js";
+export { TurnUsageMeter } from "./turn-usage-meter.js";
+export type { TurnUsageSnapshot } from "./turn-usage-meter.js";
 export { sanitizeModelAlias } from "./sanitize-model-alias.js";

--- a/src/analytics/turn-usage-meter.test.ts
+++ b/src/analytics/turn-usage-meter.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import type { CompletionUsage } from "../llm/provider/completion-types.js";
+import type { ResolvedModel } from "../llm/provider/model-resolver.js";
+import { TurnUsageMeter } from "./turn-usage-meter.js";
+
+const S = "session-a";
+
+function usage(promptTokens: number, completionTokens: number): CompletionUsage {
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+  };
+}
+
+function unpricedModel(): ResolvedModel {
+  return {
+    id: "local-llama",
+    kind: "chat",
+    contextWindow: 128_000,
+    supportsVision: false,
+    supportsTools: "none",
+    supportsPromptCache: false,
+    reasoningFormat: "none",
+    source: "default",
+  };
+}
+
+function pricedModel(input: number, output: number): ResolvedModel {
+  return {
+    id: "gpt-priced",
+    kind: "chat",
+    contextWindow: 128_000,
+    supportsVision: true,
+    supportsTools: "parallel",
+    supportsPromptCache: true,
+    reasoningFormat: "none",
+    source: "catalog",
+    pricing: { input, output },
+  };
+}
+
+describe("TurnUsageMeter", () => {
+  it("record() before any begin() is a no-op — snapshot() returns {}", () => {
+    const meter = new TurnUsageMeter();
+    meter.record({ sessionId: S, usage: usage(100, 50), model: pricedModel(3, 15) });
+    expect(meter.snapshot(S)).toEqual({});
+  });
+
+  it("begin() with no record() calls yields {} (no usage reported, not zero)", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    const snap = meter.snapshot(S);
+    expect(snap).toEqual({});
+  });
+
+  it("record() with usage but no model pricing accumulates tokens and omits costUsd entirely", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    meter.record({ sessionId: S, usage: usage(100, 50), model: unpricedModel() });
+    const snap = meter.snapshot(S);
+    expect(snap.promptTokens).toBe(100);
+    expect(snap.completionTokens).toBe(50);
+    expect(snap.costUsd).toBeUndefined();
+    expect("costUsd" in snap).toBe(false);
+  });
+
+  it("record() with usage and no model at all accumulates tokens and omits costUsd", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    meter.record({ sessionId: S, usage: usage(10, 20) });
+    const snap = meter.snapshot(S);
+    expect(snap.promptTokens).toBe(10);
+    expect(snap.completionTokens).toBe(20);
+    expect("costUsd" in snap).toBe(false);
+  });
+
+  it("multiple record() calls within one turn sum prompt and completion tokens", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    meter.record({ sessionId: S, usage: usage(100, 50) });
+    meter.record({ sessionId: S, usage: usage(30, 10) });
+    meter.record({ sessionId: S, usage: usage(5, 5) });
+    const snap = meter.snapshot(S);
+    expect(snap.promptTokens).toBe(135);
+    expect(snap.completionTokens).toBe(65);
+  });
+
+  it("record() with pricing computes costUsd from prompt/completion tokens", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    meter.record({
+      sessionId: S,
+      usage: usage(1_000_000, 1_000_000),
+      model: pricedModel(3, 15),
+    });
+    const snap = meter.snapshot(S);
+    expect(snap.promptTokens).toBe(1_000_000);
+    expect(snap.completionTokens).toBe(1_000_000);
+    expect(snap.costUsd).toBeCloseTo(18, 10);
+  });
+
+  it("mixed turn: tokens sum across priced and unpriced calls, cost counts only the priced one", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    meter.record({ sessionId: S, usage: usage(1_000_000, 1_000_000), model: pricedModel(3, 15) });
+    meter.record({ sessionId: S, usage: usage(200, 100), model: unpricedModel() });
+    const snap = meter.snapshot(S);
+    expect(snap.promptTokens).toBe(1_000_200);
+    expect(snap.completionTokens).toBe(1_000_100);
+    expect(snap.costUsd).toBeCloseTo(18, 10);
+  });
+
+  it("snapshot() closes the turn — calling it twice returns {} the second time", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    meter.record({ sessionId: S, usage: usage(100, 50) });
+    const first = meter.snapshot(S);
+    expect(first.promptTokens).toBe(100);
+    const second = meter.snapshot(S);
+    expect(second).toEqual({});
+  });
+
+  it("begin() discards a previous half-finished bucket", () => {
+    const meter = new TurnUsageMeter();
+    meter.begin(S);
+    meter.record({ sessionId: S, usage: usage(999, 999) });
+    meter.begin(S);
+    const snap = meter.snapshot(S);
+    expect(snap).toEqual({});
+  });
+
+  describe("session keying", () => {
+    it("two sessions accumulate independently — neither leaks into the other", () => {
+      const meter = new TurnUsageMeter();
+      meter.begin("a");
+      meter.begin("b");
+      meter.record({ sessionId: "a", usage: usage(100, 200) });
+      meter.record({ sessionId: "b", usage: usage(7, 9) });
+
+      const snapA = meter.snapshot("a");
+      expect(snapA.promptTokens).toBe(100);
+      expect(snapA.completionTokens).toBe(200);
+
+      const snapB = meter.snapshot("b");
+      expect(snapB.promptTokens).toBe(7);
+      expect(snapB.completionTokens).toBe(9);
+    });
+
+    it("snapshot() for one session does not close another session's open turn", () => {
+      const meter = new TurnUsageMeter();
+      meter.begin("a");
+      meter.begin("b");
+      meter.record({ sessionId: "a", usage: usage(100, 200) });
+      meter.record({ sessionId: "b", usage: usage(7, 9) });
+
+      meter.snapshot("a");
+
+      const snapB = meter.snapshot("b");
+      expect(snapB.promptTokens).toBe(7);
+      expect(snapB.completionTokens).toBe(9);
+    });
+
+    it("record() for a session with no open turn is dropped even while a different session has one open", () => {
+      const meter = new TurnUsageMeter();
+      meter.begin("a");
+      meter.record({ sessionId: "b", usage: usage(50, 50) });
+
+      const snapA = meter.snapshot("a");
+      expect(snapA).toEqual({});
+
+      const snapB = meter.snapshot("b");
+      expect(snapB).toEqual({});
+    });
+
+    it("begin() on one session does not disturb another session's already-open bucket", () => {
+      const meter = new TurnUsageMeter();
+      meter.begin("a");
+      meter.record({ sessionId: "a", usage: usage(11, 22) });
+
+      meter.begin("b");
+      meter.record({ sessionId: "b", usage: usage(3, 4) });
+
+      const snapA = meter.snapshot("a");
+      expect(snapA.promptTokens).toBe(11);
+      expect(snapA.completionTokens).toBe(22);
+
+      const snapB = meter.snapshot("b");
+      expect(snapB.promptTokens).toBe(3);
+      expect(snapB.completionTokens).toBe(4);
+    });
+  });
+});

--- a/src/analytics/turn-usage-meter.ts
+++ b/src/analytics/turn-usage-meter.ts
@@ -1,0 +1,113 @@
+import type { CompletionUsage } from "../llm/provider/completion-types.js";
+import type { ResolvedModel } from "../llm/provider/model-resolver.js";
+
+/**
+ * Token + spend totals accumulated for a single turn.
+ *
+ * A turn is one human message and every LLM call it triggers — the
+ * agent loop's own steps plus any sub-runner (reflection, link-gen,
+ * vote, rewriter, distill) that ran while it was in flight. Callers
+ * read this at the end of the turn to attach non-content shape metrics
+ * to `message_sent`.
+ *
+ * `costUsd` is only meaningful when the model carries pricing. Local
+ * runners (llama.cpp) have none, so their turns accumulate tokens with
+ * a zero cost — which is why `snapshot()` reports `costUsd` as
+ * undefined rather than 0 unless at least one priced call landed.
+ */
+export interface TurnUsageSnapshot {
+  promptTokens?: number;
+  completionTokens?: number;
+  costUsd?: number;
+}
+
+interface TurnBucket {
+  promptTokens: number;
+  completionTokens: number;
+  costUsd: number;
+  sawUsage: boolean;
+  sawPricedUsage: boolean;
+}
+
+/**
+ * Accumulates completion usage across the calls that make up one turn.
+ *
+ * Providers report usage per call, but a turn is many calls, so the
+ * numbers have to be summed somewhere. This meter is that place: the
+ * provider seam records into it, the analytics seam reads from it.
+ *
+ * Buckets are keyed by session. The turn controller serializes turns
+ * *within* a session but runs different sessions concurrently — the
+ * sidecar, the Telegram channel and the task runner all drive turns
+ * independently — so a single shared bucket would bill one session's
+ * tokens to whichever session happened to finish first.
+ *
+ * Calls that arrive with no turn open for their session (background
+ * work during bootstrap, scheduler-driven turns, sub-runners firing
+ * after their turn closed) are dropped rather than misfiled.
+ */
+export class TurnUsageMeter {
+  private readonly buckets = new Map<string, TurnBucket>();
+
+  /**
+   * Open a fresh bucket for `sessionId`, discarding any half-finished
+   * one left behind by a turn that never reached `snapshot()`.
+   */
+  begin(sessionId: string): void {
+    this.buckets.set(sessionId, {
+      promptTokens: 0,
+      completionTokens: 0,
+      costUsd: 0,
+      sawUsage: false,
+      sawPricedUsage: false,
+    });
+  }
+
+  /**
+   * Fold one completion's usage into the open turn for `sessionId`.
+   * No-ops when that session has no turn open, or when the provider
+   * reported no usage block at all — absent data must stay absent
+   * rather than become a zero.
+   */
+  record(params: {
+    sessionId: string;
+    usage?: CompletionUsage;
+    model?: ResolvedModel;
+  }): void {
+    const bucket = this.buckets.get(params.sessionId);
+    if (!bucket) return;
+    const { usage } = params;
+    if (!usage) return;
+
+    bucket.sawUsage = true;
+    bucket.promptTokens += usage.promptTokens;
+    bucket.completionTokens += usage.completionTokens;
+
+    const pricing = params.model?.pricing;
+    if (!pricing) return;
+    bucket.sawPricedUsage = true;
+    bucket.costUsd +=
+      (usage.promptTokens / 1_000_000) * pricing.input +
+      (usage.completionTokens / 1_000_000) * pricing.output;
+  }
+
+  /**
+   * Close the open turn for `sessionId` and report its totals. Fields
+   * the turn could not measure are omitted entirely: a provider that
+   * never reported usage yields `{}`, and an unpriced model yields
+   * token counts with no `costUsd`.
+   *
+   * Always releases the bucket, so a turn that throws before reporting
+   * cannot leak one — callers snapshot on the failure path too.
+   */
+  snapshot(sessionId: string): TurnUsageSnapshot {
+    const bucket = this.buckets.get(sessionId);
+    this.buckets.delete(sessionId);
+    if (!bucket || !bucket.sawUsage) return {};
+    return {
+      promptTokens: bucket.promptTokens,
+      completionTokens: bucket.completionTokens,
+      ...(bucket.sawPricedUsage ? { costUsd: bucket.costUsd } : {}),
+    };
+  }
+}

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -1083,10 +1083,11 @@ export async function createAgentRuntime(
       : undefined;
 
   // Product analytics: token/spend totals for the turn currently in
-  // flight. Unlike `costAccumulator` (opt-in, drives the status bar)
-  // this is always on, because `message_sent` should carry the shape of
-  // a turn for every install — and it stays behind the same analytics
-  // opt-out, since nothing is emitted unless `captureMessageSent` fires.
+  // flight. Unlike `costAccumulator`, which is opt-in behind
+  // `costTracking.enabled`, this is always on, because `message_sent`
+  // should carry the shape of a turn for every install — and it stays
+  // behind the same analytics opt-out, since nothing is emitted unless
+  // `captureMessageSent` fires.
   const turnUsageMeter = new TurnUsageMeter();
 
   /**

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -66,6 +66,10 @@ import {
 } from "../llm/provider/index.js";
 import { resolveActiveToolTransport } from "../llm/provider/registry/resolve-tool-transport.js";
 import { CostAccumulator } from "../llm/provider/cost-accumulator.js";
+import {
+  resolveModel,
+  type ResolvedModel,
+} from "../llm/provider/model-resolver.js";
 
 import { MemoryStore } from "../memory/memory-store.js";
 import { ProfileStore } from "../memory/profile-store.js";
@@ -166,6 +170,7 @@ import {
   captureAppInstalled,
   captureMessageSent,
   sanitizeModelAlias,
+  TurnUsageMeter,
 } from "../analytics/index.js";
 import {
   createSentryClient,
@@ -1077,6 +1082,31 @@ export async function createAgentRuntime(
       ? new CostAccumulator(config.llm.costTracking.dailyResetHourUtc ?? 0)
       : undefined;
 
+  // Product analytics: token/spend totals for the turn currently in
+  // flight. Unlike `costAccumulator` (opt-in, drives the status bar)
+  // this is always on, because `message_sent` should carry the shape of
+  // a turn for every install — and it stays behind the same analytics
+  // opt-out, since nothing is emitted unless `captureMessageSent` fires.
+  const turnUsageMeter = new TurnUsageMeter();
+
+  /**
+   * Pricing for a model id on the active provider, when the operator
+   * configured any. Cloud entries carry `userModels[].pricing`; local
+   * runners have none, which is why turn cost is reported as absent
+   * rather than zero for them.
+   */
+  const resolveModelPricing = (
+    modelId: string | null,
+  ): ResolvedModel | undefined => {
+    if (!modelId) return undefined;
+    const resolved = resolveLlmConfig(getConfig());
+    const entry = resolved.providers.find(
+      (p) => p.id === resolved.activeTextProvider,
+    );
+    if (!entry) return undefined;
+    return resolveModel(entry, modelId);
+  };
+
   // Vision reuses the active text provider when it exposes describeImage.
   const visionProvider: LlmProvider | undefined = config.vision.enabled
     ? textProvider
@@ -1253,14 +1283,50 @@ export async function createAgentRuntime(
               slotId: params.slotId,
               cachePrompt: params.slotId >= 0,
             });
-      if (costAccumulator && result.usage) {
-        costAccumulator.recordTurn({
-          modelId: result.modelId,
-          usage: result.usage,
-        });
+      if (result.usage) {
+        const model = resolveModelPricing(result.modelId);
+        if (costAccumulator) {
+          costAccumulator.recordTurn({
+            modelId: result.modelId,
+            usage: result.usage,
+            ...(model ? { model } : {}),
+          });
+        }
+        if (params.sessionId) {
+          turnUsageMeter.record({
+            sessionId: params.sessionId,
+            usage: result.usage,
+            ...(model ? { model } : {}),
+          });
+        }
       }
       return result;
     });
+
+  /**
+   * Fold a streamed completion's usage into the turn meter. The stream's
+   * *return* value carries `usage` (deltas do not), so the totals only
+   * exist once the generator finishes — this passes chunks through
+   * untouched and records from the final result. A stream that is
+   * abandoned mid-flight never returns, and contributes nothing, which
+   * is correct: a cancelled turn reports the tokens it actually
+   * finished accounting for.
+   */
+  async function* meterStream(
+    sessionId: string | undefined,
+    stream: AsyncGenerator<StreamChunk, CompletionResult, void>,
+  ): AsyncGenerator<StreamChunk, CompletionResult, void> {
+    const result = yield* stream;
+    if (result.usage && sessionId) {
+      const model = resolveModelPricing(result.modelId);
+      turnUsageMeter.record({
+        sessionId,
+        usage: result.usage,
+        ...(model ? { model } : {}),
+      });
+    }
+    return result;
+  }
 
   const llmCompleteStream = options.overrides?.disableStreaming
     ? undefined
@@ -1275,23 +1341,29 @@ export async function createAgentRuntime(
               ...(params.signal ? { signal: params.signal } : {}),
             };
             if (transport === "native_tools") {
-              return provider.completeStream({
-                ...base,
-                ...(params.tools ? { tools: params.tools } : {}),
-                ...(params.toolChoice !== undefined
-                  ? { toolChoice: params.toolChoice }
-                  : {}),
-                ...(params.parallelToolCalls !== undefined
-                  ? { parallelToolCalls: params.parallelToolCalls }
-                  : {}),
-              });
+              return meterStream(
+                params.sessionId,
+                provider.completeStream({
+                  ...base,
+                  ...(params.tools ? { tools: params.tools } : {}),
+                  ...(params.toolChoice !== undefined
+                    ? { toolChoice: params.toolChoice }
+                    : {}),
+                  ...(params.parallelToolCalls !== undefined
+                    ? { parallelToolCalls: params.parallelToolCalls }
+                    : {}),
+                }),
+              );
             }
-            return provider.completeStream({
-              ...base,
-              grammar: params.grammar,
-              slotId: params.slotId,
-              cachePrompt: params.slotId >= 0,
-            });
+            return meterStream(
+              params.sessionId,
+              provider.completeStream({
+                ...base,
+                grammar: params.grammar,
+                slotId: params.slotId,
+                cachePrompt: params.slotId >= 0,
+              }),
+            );
           });
 
   const sessionStore = new SessionStore();
@@ -2019,6 +2091,7 @@ export async function createAgentRuntime(
       return turnController.enqueue(submission);
     }
     const startedAt = Date.now();
+    turnUsageMeter.begin(session.id);
     try {
       const result = await turnController.enqueue(submission);
       captureMessageSent(analytics, analyticsStateStore, {
@@ -2027,6 +2100,7 @@ export async function createAgentRuntime(
         latencyMs: Date.now() - startedAt,
         stepCount: result.stepCount,
         outcome: result.reason,
+        ...turnUsageMeter.snapshot(session.id),
       });
       return result;
     } catch (error) {
@@ -2035,6 +2109,7 @@ export async function createAgentRuntime(
         model: resolveActiveModelName(),
         latencyMs: Date.now() - startedAt,
         outcome: "failed",
+        ...turnUsageMeter.snapshot(session.id),
       });
       throw error;
     }


### PR DESCRIPTION
Follow-up to #61, which attached the *shape* of a turn to `message_sent` (`latency_ms`, `step_count`, `outcome`) and deliberately left token accounting out. This adds the size.

## The problem

`message_sent` carries no usage data, so token consumption can only be inferred by multiplying `step_count` by a hand-calibrated constant. A step that reads a long file and a step that answers "yes" count the same, so the estimate is off by multiples on exactly the turns worth looking at.

## What this adds

Providers already report per-call usage, and the pricing tables already exist in `userModels[].pricing`. Neither reached the analytics seam.

`TurnUsageMeter` sums usage across every LLM call a turn makes, the agent loop's own steps plus any sub-runner (reflection, link-gen, vote, rewriter, distill), on both the buffered and streaming paths. Three optional fields land on `message_sent`:

- `prompt_tokens`
- `completion_tokens`
- `cost_usd`

Buckets are keyed by session id. `TurnController` serializes turns within a session but runs different sessions concurrently (sidecar, Telegram, task runner), so a single shared bucket would bill one session's tokens to whichever session finished first.

## Absent stays absent

Each field is omitted rather than sent as a zero when it cannot be measured. A provider that reports no `usage` block sends no token keys; a model with no configured pricing sends no `cost_usd`. Local runners therefore report real token counts with no cost, instead of a misleading `0.00` that would read as "this turn was free" in a chart. An explicit `cost_usd: 0` is still emitted when a priced model genuinely cost nothing.

## Privacy

Numbers only. No message content, file paths, tool arguments, or user data, the same boundary #61 held to. The fields ride the existing analytics opt-out, since nothing is emitted unless `captureMessageSent` fires, and they stay off `first_message_sent`, which keeps carrying `provider` and `model` alone.

## Drive-by fix

`CostAccumulator.recordTurn` was being called without `model`, so `estimateCost` hit its `!model?.pricing` guard and returned 0 for every turn. The opt-in cost readout has been reporting a constant zero. It now receives the resolved model, which is what makes `cost_usd` meaningful, and repairs the accumulator for whenever a reader is wired up to it.

## Testing

- `tsc` clean.
- Analytics and bootstrap suites pass: 62 tests, 22 of them new (13 in `turn-usage-meter.test.ts`, including cross-session isolation; 6 added to `analytics-events.test.ts` covering key-absence and the explicit-zero case).
- Full suite shows the same pre-existing failures as `main` (TUI/sidecar/tools), none introduced here.
- Rebased onto `main` after #80, #81 and #82 landed; merged without conflicts.

## What this unlocks

Real per-user and per-model spend without the step-count multiplier, and the cost-versus-retention question that estimate could not answer. Pricing stops being hardcoded in dashboard SQL and arrives with the event.

