### PR TITLE
docs: document the model picker filter now that #83 is on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ atomic-agent trace list --limit 10
 
 Handy slash commands: `/help` lists every command, `/tools` lists the built-in tool families, `/model` jumps to the LLM panel and reopens the model picker for the active cloud provider, `/privacy` shows what leaves the machine (`/privacy analytics off` turns analytics off). The chat log scrolls with PgUp / PgDn (fn+arrows on macOS).
 
-Cloud provider setup pulls each provider's full live model catalog, hundreds of models, instead of a short hardcoded list; OpenAI-compatible servers are asked for their own `/v1/models`, and `/model` switches models mid-session.
+Cloud provider setup pulls each provider's full live model catalog, hundreds of models, instead of a short hardcoded list; OpenAI-compatible servers are asked for their own `/v1/models`. The picker filters as you type, and `/model` switches models mid-session.
 
 </details>
 


### PR DESCRIPTION
One sentence, held back on purpose: the README refresh (#84) said the picker-filter line lands together with #83. Both merged, so this adds it: "The picker filters as you type". No other changes.