### PR TITLE
feat(providers): add OrcaRouter preset

### DIFF
--- a/src/tui/providers/provider-presets.test.ts
+++ b/src/tui/providers/provider-presets.test.ts
@@ -44,6 +44,14 @@ describe("PROVIDER_PRESETS", () => {
     );
     expect(keyless).toContain("nous");
     expect(keyless).toContain("ollama-cloud");
+    expect(keyless).toContain("orcarouter");
+  });
+
+  it("exposes OrcaRouter as a named preset", () => {
+    expect(findProviderPreset("orcarouter")?.baseUrl).toBe(
+      "https://api.orcarouter.ai",
+    );
+    expect(findProviderPreset("orcarouter")?.envVar).toBe("ORCAROUTER_API_KEY");
   });
 
   it("returns undefined for an unknown id", () => {

--- a/src/tui/providers/provider-presets.ts
+++ b/src/tui/providers/provider-presets.ts
@@ -111,6 +111,14 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "hosted Ollama, models listed without a key",
   },
   {
+    id: "orcarouter",
+    label: "OrcaRouter",
+    baseUrl: "https://api.orcarouter.ai",
+    envVar: "ORCAROUTER_API_KEY",
+    listsModelsWithoutKey: true,
+    note: "OpenAI-compatible gateway, 160+ models via one key",
+  },
+  {
     id: "lmstudio",
     label: "LM Studio (local)",
     baseUrl: "http://localhost:1234",


### PR DESCRIPTION
## Change

Adds OrcaRouter as a named preset in the provider wizard, mirroring the existing Groq/DeepSeek/Together presets. The operator now picks "OrcaRouter" by name instead of typing a base URL, and the API key lands in its own `ORCAROUTER_API_KEY` env var — each preset gets its own variable so connecting a second service cannot overwrite the first one's key.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway: one key routes to 160+ models across all major model families, with `orcarouter/auto` as a smart default router. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Like every other preset, this one resolves to the existing `openai-compatible` kind with `baseUrl` filled in (`https://api.orcarouter.ai`, stored without the `/v1` suffix per the repo convention — call sites append `/v1/...`). Model lists still come from the server's own `/v1/models`, so nothing here needs updating when a vendor ships a new model. OrcaRouter serves that endpoint without credentials, so `listsModelsWithoutKey` is set: the operator can browse the model catalog before pasting a key.

## Testing

- New preset resolves correctly: `findProviderPreset("orcarouter")` → `baseUrl` `https://api.orcarouter.ai`, `envVar` `ORCAROUTER_API_KEY`, `listsModelsWithoutKey` true. New test added; existing presence/uniqueness/no-`/v1`-suffix tests all still pass.
- `npm run lint` (`tsc --noEmit`) clean; `npm run build` clean.
- Live check against `https://api.orcarouter.ai` through the repo's own code path (`fetchOpenAiCompatModels` + the `openai-compatible` provider): model list returned 189 ids, 10 `orcarouter/`-namespaced including `orcarouter/auto`, and a chat completion returned normally.
- Full test suite: zero new failures — the same 8 pre-existing, environment-dependent test files fail on `main` without this change.

I'm an engineer on the OrcaRouter team.
