### PR TITLE
llm: type cloud provider errors and give the cloud path a retry budget

### DIFF
--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -31,6 +31,7 @@ import {
   TransportError,
   classifyFailure,
   detectModelFailure,
+  humanizeOpenAiHttpError,
 } from "../llm/index.js";
 import { getConfig } from "../config/index.js";
 import {
@@ -1440,8 +1441,12 @@ function toLlmFailure(err: unknown, ctx: StepContext): LlmFailure {
   // problems, not tool bugs. A 429 or a dead key must never read as
   // `Turn failed [tool]`. The HTTP client has already spent its bounded
   // retry budget on the transient subset by the time this propagates.
+  // The chat message gets the human wording; the raw technical string
+  // stays on the cause for logs.
   if (err instanceof OpenAiHttpError) {
-    return new TransportError(err.message, err.status, err.url, { cause: err });
+    return new TransportError(humanizeOpenAiHttpError(err), err.status, err.url, {
+      cause: err,
+    });
   }
   if (err instanceof ToolCallParseError) {
     return new GrammarError(err.message, "", { cause: err });

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -26,6 +26,7 @@ import {
   LlmFailure,
   LlamaServerError,
   ModelError,
+  OpenAiHttpError,
   ToolExecutionError,
   TransportError,
   classifyFailure,
@@ -1434,6 +1435,13 @@ function toLlmFailure(err: unknown, ctx: StepContext): LlmFailure {
       return new TransportError(err.message, err.status, err.url, { cause: err });
     }
     return new GrammarError(err.message, "", { cause: err });
+  }
+  // Cloud provider failures — any status — are provider-boundary
+  // problems, not tool bugs. A 429 or a dead key must never read as
+  // `Turn failed [tool]`. The HTTP client has already spent its bounded
+  // retry budget on the transient subset by the time this propagates.
+  if (err instanceof OpenAiHttpError) {
+    return new TransportError(err.message, err.status, err.url, { cause: err });
   }
   if (err instanceof ToolCallParseError) {
     return new GrammarError(err.message, "", { cause: err });

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,5 +1,8 @@
 export { LlamaServerClient, LlamaServerError } from "./llama-server-client.js";
-export { OpenAiHttpError } from "./provider/openai/openai-http.js";
+export {
+  OpenAiHttpError,
+  humanizeOpenAiHttpError,
+} from "./provider/openai/openai-http.js";
 export type {
   CompletionRequest,
   CompletionResult,

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,4 +1,5 @@
 export { LlamaServerClient, LlamaServerError } from "./llama-server-client.js";
+export { OpenAiHttpError } from "./provider/openai/openai-http.js";
 export type {
   CompletionRequest,
   CompletionResult,

--- a/src/llm/provider/openai/openai-http.test.ts
+++ b/src/llm/provider/openai/openai-http.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  OpenAiHttpError,
+  openAiPostJson,
+  openAiStartStream,
+  type OpenAiHttpDeps,
+} from "./openai-http.js";
+import { classifyFailure } from "../../reliability/classify-failure.js";
+
+function depsWith(fetchImpl: typeof fetch, requestTimeoutMs = 60_000): OpenAiHttpDeps {
+  return {
+    baseUrl: "https://api.example.com",
+    apiKey: "key",
+    extraHeaders: {},
+    requestTimeoutMs,
+    fetchImpl,
+  };
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function errorResponse(
+  status: number,
+  body = "boom",
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(body, { status, headers });
+}
+
+describe("openAiPostJson", () => {
+  it("returns parsed JSON on success without retrying", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ ok: true }));
+    const result = await openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/v1/chat/completions",
+      {},
+      {},
+    );
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws OpenAiHttpError carrying the status and body preview", async () => {
+    const fetchImpl = vi.fn(async () => errorResponse(401, "bad key"));
+    const err = await openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/v1/chat/completions",
+      {},
+      {},
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(OpenAiHttpError);
+    expect((err as OpenAiHttpError).status).toBe(401);
+    expect((err as OpenAiHttpError).message).toContain("openai provider 401");
+    expect((err as OpenAiHttpError).message).toContain("bad key");
+  });
+
+  it("does not retry deterministic 4xx failures", async () => {
+    const fetchImpl = vi.fn(async () => errorResponse(401));
+    await expect(
+      openAiPostJson(depsWith(fetchImpl as unknown as typeof fetch), "/x", {}, {}),
+    ).rejects.toBeInstanceOf(OpenAiHttpError);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient 5xx and succeeds", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(500))
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const result = await openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/x",
+      {},
+      {},
+    );
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up after the retry budget and throws the last error", async () => {
+    const fetchImpl = vi.fn(async () => errorResponse(500, "still down"));
+    const err = await openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/x",
+      {},
+      {},
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(OpenAiHttpError);
+    expect((err as OpenAiHttpError).status).toBe(500);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries 429 and reads retry-after into the error", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(429, "slow down", { "retry-after": "0" }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const result = await openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/x",
+      {},
+      {},
+    );
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("wraps network failures as status null and retries them", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const result = await openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/x",
+      {},
+      {},
+    );
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks our own timeout as timedOut and does not retry it", async () => {
+    // fetch honors the abort signal armed by the 0ms request timeout.
+    const fetchImpl = vi.fn(
+      (_url: unknown, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          });
+        }),
+    );
+    const err = await openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch, 1),
+      "/x",
+      {},
+      {},
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(OpenAiHttpError);
+    expect((err as OpenAiHttpError).timedOut).toBe(true);
+    expect((err as OpenAiHttpError).status).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows caller aborts untouched so they stay cancellations", async () => {
+    const controller = new AbortController();
+    const fetchImpl = vi.fn(
+      (_url: unknown, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          });
+        }),
+    );
+    const pending = openAiPostJson(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/x",
+      {},
+      { signal: controller.signal },
+    ).catch((e: unknown) => e);
+    controller.abort();
+    const err = await pending;
+    expect(err).not.toBeInstanceOf(OpenAiHttpError);
+    expect((err as Error).name).toBe("AbortError");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("openAiStartStream", () => {
+  it("retries a failed stream open before any chunk exists", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(503))
+      .mockResolvedValueOnce(
+        new Response(new Blob(["data: {}\n\n"]).stream(), { status: 200 }),
+      );
+    const res = await openAiStartStream(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/x",
+      {},
+      {},
+    );
+    expect(res.ok).toBe(true);
+    expect(res.body).not.toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a 2xx without a body as a provider failure", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const err = await openAiStartStream(
+      depsWith(fetchImpl as unknown as typeof fetch),
+      "/x",
+      {},
+      {},
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(OpenAiHttpError);
+  });
+});
+
+describe("classification", () => {
+  it("classifies every cloud HTTP status as transport, never tool", () => {
+    for (const status of [400, 401, 403, 404, 429, 500, 502, 503]) {
+      const err = new OpenAiHttpError(`openai provider ${status}: x`, status, "u");
+      expect(classifyFailure(err)).toBe("transport");
+    }
+  });
+
+  it("classifies cloud network failures and timeouts as transport", () => {
+    expect(classifyFailure(new OpenAiHttpError("net", null, "u"))).toBe("transport");
+    expect(classifyFailure(new OpenAiHttpError("timeout", null, "u", true))).toBe(
+      "transport",
+    );
+  });
+});

--- a/src/llm/provider/openai/openai-http.test.ts
+++ b/src/llm/provider/openai/openai-http.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   OpenAiHttpError,
+  humanizeOpenAiHttpError,
   openAiPostJson,
   openAiStartStream,
   type OpenAiHttpDeps,
@@ -15,6 +16,7 @@ function depsWith(fetchImpl: typeof fetch, requestTimeoutMs = 60_000): OpenAiHtt
     extraHeaders: {},
     requestTimeoutMs,
     fetchImpl,
+    label: "testprov",
   };
 }
 
@@ -201,6 +203,40 @@ describe("openAiStartStream", () => {
       {},
     ).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(OpenAiHttpError);
+  });
+});
+
+describe("humanizeOpenAiHttpError", () => {
+  const mk = (
+    status: number | null,
+    timedOut = false,
+  ): OpenAiHttpError =>
+    new OpenAiHttpError("raw", status, "https://api.x.ai/v1/y", timedOut, null, "openrouter");
+
+  it("names the provider and the remedy per failure class", () => {
+    expect(humanizeOpenAiHttpError(mk(null))).toContain('Can\'t reach "openrouter"');
+    expect(humanizeOpenAiHttpError(mk(null))).toContain("Check the provider URL");
+    expect(humanizeOpenAiHttpError(mk(401))).toContain("rejected the API key (401)");
+    expect(humanizeOpenAiHttpError(mk(403))).toContain("rejected the API key (403)");
+    expect(humanizeOpenAiHttpError(mk(404))).toContain("model id or the base URL");
+    expect(humanizeOpenAiHttpError(mk(429))).toContain("rate-limiting this key (429)");
+    expect(humanizeOpenAiHttpError(mk(500))).toContain("server trouble (500)");
+    expect(humanizeOpenAiHttpError(mk(500))).toContain("not your setup");
+    expect(humanizeOpenAiHttpError(mk(null, true))).toContain("took too long to answer");
+  });
+
+  it("claims a retry count only for classes the client retries", () => {
+    expect(humanizeOpenAiHttpError(mk(401))).not.toContain("Tried");
+    expect(humanizeOpenAiHttpError(mk(404))).not.toContain("Tried");
+    expect(humanizeOpenAiHttpError(mk(null, true))).not.toContain("Tried");
+    expect(humanizeOpenAiHttpError(mk(429))).toContain("Tried 3 times");
+    expect(humanizeOpenAiHttpError(mk(500))).toContain("Tried 3 times");
+    expect(humanizeOpenAiHttpError(mk(null))).toContain("Tried 3 times");
+  });
+
+  it("falls back to the host when no provider label is set", () => {
+    const err = new OpenAiHttpError("raw", 500, "https://api.x.ai/v1/y");
+    expect(humanizeOpenAiHttpError(err)).toContain('"api.x.ai"');
   });
 });
 

--- a/src/llm/provider/openai/openai-http.ts
+++ b/src/llm/provider/openai/openai-http.ts
@@ -4,6 +4,8 @@ export type OpenAiHttpDeps = {
   extraHeaders: Record<string, string>;
   requestTimeoutMs: number;
   fetchImpl: typeof fetch;
+  /** Provider id shown in user-facing failure messages ("openrouter"). */
+  label: string;
 };
 
 /**
@@ -28,9 +30,52 @@ export class OpenAiHttpError extends Error {
     public readonly url: string,
     public readonly timedOut = false,
     public readonly retryAfterMs: number | null = null,
+    /** Provider id for user-facing wording; falls back to the host. */
+    public readonly providerLabel = "",
   ) {
     super(message);
     this.name = "OpenAiHttpError";
+  }
+}
+
+/**
+ * Turn a typed cloud failure into the sentence a user should read in
+ * chat: who failed, what happened, what to do about it. The raw
+ * technical message stays on the error itself for logs. Wording follows
+ * "provider + condition + remedy"; the retry count is only claimed for
+ * classes the client actually retries.
+ */
+export function humanizeOpenAiHttpError(err: OpenAiHttpError): string {
+  const who = `"${err.providerLabel || hostOf(err.url)}"`;
+  if (err.timedOut) {
+    return `${who} took too long to answer and the request was stopped.`;
+  }
+  if (err.status === null) {
+    return (
+      `Can't reach ${who} — no response from ${hostOf(err.url)}. ` +
+      `Tried ${OPENAI_MAX_ATTEMPTS} times. Check the provider URL or your connection.`
+    );
+  }
+  if (err.status === 401 || err.status === 403) {
+    return `${who} rejected the API key (${err.status}). Check the key in the Providers panel.`;
+  }
+  if (err.status === 404) {
+    return `${who} answered 404 (not found). The model id or the base URL is likely wrong.`;
+  }
+  if (err.status === 429) {
+    return `${who} is rate-limiting this key (429). Tried ${OPENAI_MAX_ATTEMPTS} times — wait a minute and retry.`;
+  }
+  if (err.status >= 500) {
+    return `${who} is having server trouble (${err.status}). Tried ${OPENAI_MAX_ATTEMPTS} times — this is on the provider, not your setup.`;
+  }
+  return `${who} rejected the request (${err.status}).`;
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
   }
 }
 
@@ -160,6 +205,8 @@ export async function openAiFetch(
         null,
         `${deps.baseUrl}${path}`,
         true,
+        null,
+        deps.label,
       );
     }
     // fetch threw without an HTTP response: DNS failure, refused
@@ -169,6 +216,9 @@ export async function openAiFetch(
       `openai provider network error: ${detail}`,
       null,
       `${deps.baseUrl}${path}`,
+      false,
+      null,
+      deps.label,
     );
   } finally {
     clearTimeout(timer);
@@ -188,6 +238,7 @@ async function httpErrorFromResponse(
     `${deps.baseUrl}${path}`,
     false,
     parseRetryAfterMs(res.headers.get("retry-after")),
+    deps.label,
   );
 }
 

--- a/src/llm/provider/openai/openai-http.ts
+++ b/src/llm/provider/openai/openai-http.ts
@@ -6,6 +6,53 @@ export type OpenAiHttpDeps = {
   fetchImpl: typeof fetch;
 };
 
+/**
+ * Typed failure for the OpenAI-compatible HTTP path, mirroring
+ * `LlamaServerError` so the reliability classifier can tell provider
+ * failures apart from our own tool bugs (which is where untyped cloud
+ * errors used to land).
+ *
+ *  - HTTP error responses carry `status` plus a bounded body preview.
+ *  - Network-level failures (fetch threw) carry `status === null`.
+ *  - `timedOut` marks our *own* `requestTimeoutMs` controller firing, as
+ *    opposed to the transport failing or the caller cancelling. Both
+ *    surface as aborts, but a timeout is "the provider is slower than
+ *    the budget" — replaying it just burns another full timeout.
+ *  - `retryAfterMs` is populated from a `retry-after` header when the
+ *    provider sent one (429/503), so the retry loop can honor it.
+ */
+export class OpenAiHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number | null,
+    public readonly url: string,
+    public readonly timedOut = false,
+    public readonly retryAfterMs: number | null = null,
+  ) {
+    super(message);
+    this.name = "OpenAiHttpError";
+  }
+}
+
+/** Cap on how much of an error body we fold into the message. */
+const OPENAI_ERROR_DETAIL_MAX_LEN = 300;
+
+/**
+ * Bounded retry budget for transient failures, mirroring the llama
+ * client's defaults (`localModels.completionRetries` = 3, 150ms base).
+ * Deliberately not config-driven yet: the knob can follow once the
+ * fallback work settles where such settings live for cloud providers.
+ */
+const OPENAI_MAX_ATTEMPTS = 3;
+const OPENAI_BACKOFF_BASE_MS = 150;
+/**
+ * Ceiling on how long a provider's `retry-after` can stall one attempt.
+ * Interactive turns cannot absorb a "come back in 60s" wait; a provider
+ * asking for more than this gets the capped wait and then the next
+ * attempt (or the typed error, which the caller can act on).
+ */
+const OPENAI_RETRY_AFTER_CAP_MS = 5_000;
+
 export function buildOpenAiHeaders(
   deps: OpenAiHttpDeps,
   stream: boolean,
@@ -25,12 +72,13 @@ export async function openAiGetJson(
   deps: OpenAiHttpDeps,
   path: string,
 ): Promise<Record<string, unknown>> {
-  const res = await openAiFetch(deps, path, null, {}, false, "GET");
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`openai provider ${res.status}: ${text.slice(0, 300)}`);
-  }
-  return (await res.json()) as Record<string, unknown>;
+  return runOpenAiWithRetry(deps, path, undefined, async () => {
+    const res = await openAiFetch(deps, path, null, {}, false, "GET");
+    if (!res.ok) {
+      throw await httpErrorFromResponse(deps, path, res);
+    }
+    return (await res.json()) as Record<string, unknown>;
+  });
 }
 
 export async function openAiPostJson(
@@ -39,12 +87,36 @@ export async function openAiPostJson(
   body: Record<string, unknown>,
   request: { signal?: AbortSignal },
 ): Promise<Record<string, unknown>> {
-  const res = await openAiFetch(deps, path, body, request, false, "POST");
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`openai provider ${res.status}: ${text.slice(0, 300)}`);
-  }
-  return (await res.json()) as Record<string, unknown>;
+  return runOpenAiWithRetry(deps, path, request.signal, async () => {
+    const res = await openAiFetch(deps, path, body, request, false, "POST");
+    if (!res.ok) {
+      throw await httpErrorFromResponse(deps, path, res);
+    }
+    return (await res.json()) as Record<string, unknown>;
+  });
+}
+
+/**
+ * Open a streaming completion and return the raw `Response` once the
+ * server has answered 2xx with a body. Failures to *open* the stream —
+ * connection errors, 429s, 5xxs — happen entirely inside the retry
+ * loop, before the caller has consumed a single chunk, so retrying here
+ * can never duplicate output. Once this resolves, the stream is live
+ * and failures downstream are not retryable at this layer.
+ */
+export async function openAiStartStream(
+  deps: OpenAiHttpDeps,
+  path: string,
+  body: Record<string, unknown>,
+  request: { signal?: AbortSignal },
+): Promise<Response & { body: NonNullable<Response["body"]> }> {
+  return runOpenAiWithRetry(deps, path, request.signal, async () => {
+    const res = await openAiFetch(deps, path, body, request, true, "POST");
+    if (!res.ok || !res.body) {
+      throw await httpErrorFromResponse(deps, path, res);
+    }
+    return res as Response & { body: NonNullable<Response["body"]> };
+  });
 }
 
 export async function openAiFetch(
@@ -56,7 +128,11 @@ export async function openAiFetch(
   method: "GET" | "POST" = "POST",
 ): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), deps.requestTimeoutMs);
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, deps.requestTimeoutMs);
   const externalSignal = request.signal;
   const onAbort = (): void => controller.abort();
   if (externalSignal) {
@@ -73,8 +149,131 @@ export async function openAiFetch(
       ...(body && method === "POST" ? { body: JSON.stringify(body) } : {}),
       signal: controller.signal,
     });
+  } catch (err) {
+    // Caller cancellation must stay a cancellation — rethrow untouched
+    // so the classifier keeps reporting it as `cancelled`, not as a
+    // provider failure.
+    if (externalSignal?.aborted) throw err;
+    if (timedOut) {
+      throw new OpenAiHttpError(
+        `openai provider timed out after ${deps.requestTimeoutMs}ms: ${deps.baseUrl}${path}`,
+        null,
+        `${deps.baseUrl}${path}`,
+        true,
+      );
+    }
+    // fetch threw without an HTTP response: DNS failure, refused
+    // connection, TLS error, socket reset.
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new OpenAiHttpError(
+      `openai provider network error: ${detail}`,
+      null,
+      `${deps.baseUrl}${path}`,
+    );
   } finally {
     clearTimeout(timer);
     externalSignal?.removeEventListener("abort", onAbort);
   }
+}
+
+async function httpErrorFromResponse(
+  deps: OpenAiHttpDeps,
+  path: string,
+  res: Response,
+): Promise<OpenAiHttpError> {
+  const text = await res.text().catch(() => "");
+  return new OpenAiHttpError(
+    `openai provider ${res.status}: ${text.slice(0, OPENAI_ERROR_DETAIL_MAX_LEN)}`,
+    res.status,
+    `${deps.baseUrl}${path}`,
+    false,
+    parseRetryAfterMs(res.headers.get("retry-after")),
+  );
+}
+
+/**
+ * Transient failures worth another attempt: network blips (status null,
+ * but never our own timeout — replaying one burns another full budget),
+ * server errors, throttling, and request timeouts the *server* reported.
+ * Auth and request-shape errors (401/403/404/400) are deterministic;
+ * retrying them only delays the real message to the user.
+ */
+function isRetryableOpenAiError(err: unknown): boolean {
+  if (!(err instanceof OpenAiHttpError)) return false;
+  if (err.timedOut) return false;
+  if (err.status === null) return true;
+  return err.status >= 500 || err.status === 429 || err.status === 408;
+}
+
+async function runOpenAiWithRetry<T>(
+  deps: OpenAiHttpDeps,
+  path: string,
+  signal: AbortSignal | undefined,
+  attempt: () => Promise<T>,
+): Promise<T> {
+  let lastError: unknown;
+  for (let i = 1; i <= OPENAI_MAX_ATTEMPTS; i += 1) {
+    if (signal?.aborted) {
+      throw new OpenAiHttpError(
+        "completion aborted by caller",
+        null,
+        `${deps.baseUrl}${path}`,
+      );
+    }
+    try {
+      return await attempt();
+    } catch (err) {
+      lastError = err;
+      // A caller-triggered abort is never retryable, whatever shape it
+      // surfaced as.
+      if (signal?.aborted) throw err;
+      if (!isRetryableOpenAiError(err) || i >= OPENAI_MAX_ATTEMPTS) throw err;
+      await sleep(resolveWaitMs(err, i), signal);
+    }
+  }
+  // Unreachable: the loop either returns or throws.
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * Wait between attempts: exponential backoff with ±20% jitter (matching
+ * the llama client), stretched to a provider-requested `retry-after`
+ * when one was sent — capped so a long server-side cooldown cannot
+ * stall an interactive turn.
+ */
+function resolveWaitMs(err: unknown, attemptNumber: number): number {
+  const exp = OPENAI_BACKOFF_BASE_MS * Math.pow(2, attemptNumber - 1);
+  const jitter = exp * (Math.random() * 0.4 - 0.2);
+  const backoff = Math.max(0, Math.round(exp + jitter));
+  const retryAfter =
+    err instanceof OpenAiHttpError && err.retryAfterMs !== null
+      ? Math.min(err.retryAfterMs, OPENAI_RETRY_AFTER_CAP_MS)
+      : 0;
+  return Math.max(backoff, retryAfter);
+}
+
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) {
+    return Math.max(0, date - Date.now());
+  }
+  return null;
+}
+
+async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(done, ms);
+    function done(): void {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", done);
+      resolve();
+    }
+    signal?.addEventListener("abort", done, { once: true });
+  });
 }

--- a/src/llm/provider/openai/openai-provider.ts
+++ b/src/llm/provider/openai/openai-provider.ts
@@ -20,9 +20,9 @@ import { createOpenAiStreamConsumer } from "./openai-stream-consumer.js";
 import { buildOpenAiChatBody } from "./openai-build-body.js";
 import {
   buildOpenAiHeaders,
-  openAiFetch,
   openAiGetJson,
   openAiPostJson,
+  openAiStartStream,
   type OpenAiHttpDeps,
 } from "./openai-http.js";
 import { normaliseOpenAiChatResponse } from "./openai-normalise-response.js";
@@ -91,11 +91,15 @@ export class OpenAiProvider implements LlmProvider {
     request: CompletionRequest,
   ): AsyncGenerator<StreamChunk, CompletionResult, void> {
     const body = buildOpenAiChatBody(request, this.defaultChatModel, true);
-    const res = await openAiFetch(this.http, "/v1/chat/completions", body, request, true);
-    if (!res.ok || !res.body) {
-      const text = await res.text().catch(() => "");
-      throw new Error(`chat completion stream failed: ${res.status} ${text}`);
-    }
+    // Opening the stream (connect + status check) happens inside the
+    // client's bounded retry, strictly before the first chunk exists.
+    // From here on the stream is live and failures are terminal.
+    const res = await openAiStartStream(
+      this.http,
+      "/v1/chat/completions",
+      body,
+      request,
+    );
     let accumulated = "";
     let accumulatedReasoning = "";
     let streamFinal: StreamFinalResult | void;

--- a/src/llm/provider/openai/openai-provider.ts
+++ b/src/llm/provider/openai/openai-provider.ts
@@ -78,6 +78,7 @@ export class OpenAiProvider implements LlmProvider {
       extraHeaders: options.headers ?? {},
       requestTimeoutMs: options.requestTimeoutMs ?? 600_000,
       fetchImpl: options.fetchImpl ?? fetch,
+      label: options.id,
     };
   }
 

--- a/src/llm/reliability/classify-failure.ts
+++ b/src/llm/reliability/classify-failure.ts
@@ -1,4 +1,5 @@
 import { LlamaServerError } from "../llama-server-client.js";
+import { OpenAiHttpError } from "../provider/openai/openai-http.js";
 import { ToolCallParseError } from "../grammar/tool-call-grammar.js";
 import type { LlmFailureCategory } from "./failure-category.js";
 import { LlmFailure } from "./llm-failures.js";
@@ -21,6 +22,11 @@ export function classifyFailure(err: unknown): LlmFailureCategory {
     if (err.status >= 500) return "transport";
     return "grammar";
   }
+  // Cloud provider failures are provider-boundary problems whatever the
+  // status — a 429 or 401 is no more "our tool broke" than a 503. The
+  // retry budget was already spent inside the HTTP client, matching the
+  // TransportError contract.
+  if (err instanceof OpenAiHttpError) return "transport";
   if (isAbortError(err)) return "cancelled";
   return "tool";
 }


### PR DESCRIPTION
Cloud failures were thrown as plain `Error`, so the classifier filed every one of them under category `tool`: a provider 429 read as `Turn failed [tool]`, indistinguishable from a bug in our tool layer, and the client's own timeout surfaced as `cancelled`, as if the user had pressed Esc. The llama path retries transient failures three times; the cloud path retried nothing.

## What this adds

`OpenAiHttpError` mirrors `LlamaServerError`: `status` (null for network failures), `url`, a `timedOut` flag for our own timeout controller, and `retryAfterMs` parsed from a `retry-after` header. Caller aborts are rethrown untouched, so cancellation stays cancellation.

The classifier maps it to `TransportError` for every status: a provider-boundary failure is transport, not our tool, whatever the code. Retry policy is decoupled from the category and lives in the client, matching the llama split:

- three attempts on the transient subset only: network blips, 5xx, 429, 408
- same 150ms exponential backoff with jitter as the llama client
- `retry-after` honored up to a 5s cap, so a server-side cooldown cannot stall an interactive turn
- deterministic failures (401/403/404/400) and our own timeouts fail fast
- streams retry only the open: connect and status check run inside the loop, strictly before the first chunk exists, so a retry can never duplicate output

## User-facing messages

The typed fields also feed a human sentence in chat instead of the raw transport line. Wording is provider + condition + remedy:

- `Can't reach "openrouter" — no response from api.example.com. Tried 3 times. Check the provider URL or your connection.`
- `"openrouter" rejected the API key (401). Check the key in the Providers panel.`
- `"openrouter" is rate-limiting this key (429). Tried 3 times — wait a minute and retry.`
- `"openrouter" answered 404 (not found). The model id or the base URL is likely wrong.`
- `"openrouter" is having server trouble (500). Tried 3 times — this is on the provider, not your setup.`

A retry count is only claimed for classes the client actually retries. The raw technical string stays on the error's cause chain for logs.

## Scope notes

No new failure categories and no new config keys. Whether auth deserves its own signal is an open design question, and the retry constants can grow knobs once it settles where cloud provider settings live. Both are deliberate: this PR fixes the misclassification and honors the existing `TransportError` contract ("by the time it propagates, the bounded budget is exhausted") with the smallest surface.

## Testing

- 16 tests in `openai-http.test.ts`: typed fields, retry-vs-fail-fast per status, `retry-after`, network wrap, own-timeout flag, caller-abort passthrough, stream-open retry, humanized wording per class, classification table (every cloud status maps to `transport`, never `tool`).
- `tsc` clean; `src/llm/` + `src/agent/` suites pass (399 tests).
- Verified end to end against a dead provider: the turn fails in ~0.5s with `Turn failed [transport]` after three fast attempts.

Foundation for the fallback-chain design in #70; worth shipping on its own for the classification fix.
