### PR TITLE
fix(tui): actually run the live catalog refresh when the model picker opens

### DIFF
--- a/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
+++ b/src/llm/provider/aimlapi/fetch-aimlapi-chat-catalog.ts
@@ -187,8 +187,23 @@ export function listAimlapiChatPicks(): readonly AimlapiChatPick[] {
  * we synthesise an entry from `info.contextLength` + `features`.
  *
  * Falls back to the static catalog on network or parse errors.
+ *
+ * Concurrent callers share one request: the TUI triggers this from both
+ * the panel prefetch and the wizard's picker step, and doubling the
+ * fetch would only race two writers over the same module cache.
  */
-export async function refreshAimlapiChatCatalogFromApi(): Promise<boolean> {
+export function refreshAimlapiChatCatalogFromApi(): Promise<boolean> {
+  if (inFlight) return inFlight;
+  const request = fetchAndCacheCatalog().finally(() => {
+    inFlight = null;
+  });
+  inFlight = request;
+  return request;
+}
+
+let inFlight: Promise<boolean> | null = null;
+
+async function fetchAndCacheCatalog(): Promise<boolean> {
   try {
     const res = await fetch(MODELS_URL, {
       signal: AbortSignal.timeout(20_000),

--- a/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.test.ts
+++ b/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.test.ts
@@ -105,6 +105,43 @@ describe("refreshOpenRouterChatCatalogFromApi", () => {
     expect(picks.some((p) => p.id === "vendor/model-39")).toBe(true);
   });
 
+  it("shares one in-flight request between concurrent refresh calls", async () => {
+    let releaseFetch: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return {
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "vendor/only",
+              context_length: 128_000,
+              supported_parameters: ["tools"],
+            },
+          ],
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const mod = await importFreshModule();
+
+    const first = mod.refreshOpenRouterChatCatalogFromApi();
+    const second = mod.refreshOpenRouterChatCatalogFromApi();
+    releaseFetch();
+    expect(await first).toBe(true);
+    expect(await second).toBe(true);
+    // The TUI kicks the refresh from both the panel prefetch and the
+    // wizard picker; those must coalesce into a single network call.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // A later, non-overlapping call is a real refresh again.
+    await mod.refreshOpenRouterChatCatalogFromApi();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("falls back to the static catalog when the API is unreachable", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
+++ b/src/llm/provider/openrouter/fetch-openrouter-chat-catalog.ts
@@ -142,12 +142,27 @@ export function listOpenRouterChatPicks(): readonly OpenRouterChatPick[] {
   return getCachedOpenRouterChatPicks() ?? picksFromStaticCatalog();
 }
 
+let inFlight: Promise<boolean> | null = null;
+
 /**
  * Pull the public OpenRouter model list and rebuild the TUI picker
  * (non-Anthropic, `tools`-capable chat models). Falls back to the static
  * catalog on network/parse errors.
+ *
+ * Concurrent callers share one request: the TUI triggers this from both
+ * the panel prefetch and the wizard's picker step, and doubling the
+ * fetch would only race two writers over the same module cache.
  */
-export async function refreshOpenRouterChatCatalogFromApi(): Promise<boolean> {
+export function refreshOpenRouterChatCatalogFromApi(): Promise<boolean> {
+  if (inFlight) return inFlight;
+  const request = fetchAndCacheCatalog().finally(() => {
+    inFlight = null;
+  });
+  inFlight = request;
+  return request;
+}
+
+async function fetchAndCacheCatalog(): Promise<boolean> {
   try {
     const res = await fetch(MODELS_URL, {
       signal: AbortSignal.timeout(20_000),

--- a/src/tui/components/providers-wizard.test.tsx
+++ b/src/tui/components/providers-wizard.test.tsx
@@ -151,6 +151,89 @@ describe("ProvidersWizard cloud model pickers", () => {
     expect(text).not.toContain("vendor/model-304");
   });
 
+  it("triggers the live refresh when the picker opens cold and swaps the list in", async () => {
+    // Fresh module registry: the picker must start from the static
+    // catalog and fire the fetch itself, not inherit a cache warmed by
+    // the tests above.
+    vi.resetModules();
+    const [{ ProvidersWizard: FreshWizard }, wizardState] = await Promise.all([
+      import("./providers-wizard.js"),
+      import("../providers/providers-wizard-state.js"),
+    ]);
+
+    let releaseFetch: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const many = Array.from({ length: 305 }, (_, i) => ({
+      id: `vendor/model-${String(i).padStart(3, "0")}`,
+      name: `Model ${i}`,
+      context_length: 128_000,
+      pricing: { prompt: "0.000001", completion: "0.000002" },
+      supported_parameters: ["tools"],
+      architecture: { input_modalities: ["text"] },
+    }));
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return { ok: true, json: async () => ({ data: many }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const wizard = {
+      ...wizardState.createProvidersWizardState("add", { kind: "openrouter" }),
+      phase: "pick_chat_model" as const,
+      cursor: 0,
+    };
+    const { lastFrame } = render(<FreshWizard wizard={wizard} />);
+    await flush();
+
+    // While the fetch is in flight: static list + a visible loading note.
+    let text = stripAnsi(lastFrame() ?? "");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://openrouter.ai/api/v1/models",
+    );
+    expect(text).toContain("updating model list from API");
+    expect(text).toContain("openrouter/auto");
+    expect(text).not.toContain("/305)");
+
+    releaseFetch();
+    await flush();
+
+    text = stripAnsi(lastFrame() ?? "");
+    expect(text).toContain("(1/305)");
+    expect(text).not.toContain("updating model list from API");
+  });
+
+  it("stays on the static list without crashing when the refresh fails", async () => {
+    vi.resetModules();
+    const [{ ProvidersWizard: FreshWizard }, wizardState, aimlapiCatalog] =
+      await Promise.all([
+        import("./providers-wizard.js"),
+        import("../providers/providers-wizard-state.js"),
+        import("../../llm/provider/aimlapi/aimlapi-models-catalog.js"),
+      ]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+
+    const wizard = {
+      ...wizardState.createProvidersWizardState("add", { kind: "aimlapi" }),
+      phase: "pick_chat_model" as const,
+      cursor: 0,
+    };
+    const { lastFrame } = render(<FreshWizard wizard={wizard} />);
+    await flush();
+
+    const text = stripAnsi(lastFrame() ?? "");
+    expect(text).toContain("Chat model (AI/ML API)");
+    // The static head entry is still on screen and the loading note is gone.
+    expect(text).toContain(aimlapiCatalog.AIMLAPI_CHAT_MODEL_ORDER[0]!);
+    expect(text).not.toContain("updating model list from API");
+  });
+
   it("windows the aimlapi picker when the live catalog has 300+ models", async () => {
     const many = Array.from({ length: 337 }, (_, i) => ({
       id: `vendor/model-${String(i).padStart(3, "0")}`,

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -1,6 +1,14 @@
 import { Box, Text } from "ink";
 import { useEffect, useState, type ReactElement } from "react";
+import {
+  getCachedAimlapiChatPicks,
+  refreshAimlapiChatCatalogFromApi,
+} from "../../llm/provider/aimlapi/fetch-aimlapi-chat-catalog.js";
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import {
+  getCachedOpenRouterChatPicks,
+  refreshOpenRouterChatCatalogFromApi,
+} from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
 import {
   apiKeyForWizard,
   baseUrlForWizard,
@@ -10,12 +18,11 @@ import { theme } from "../theme/theme.js";
 import { findProviderPreset } from "../providers/provider-presets.js";
 import {
   KIND_ROW_ORDER,
+  listChatModelsForKind,
   type ProvidersWizardKindRow,
 } from "../providers/providers-wizard-phases.js";
 import {
-  listAimlapiChatModels,
   listAimlapiEmbeddingModels,
-  listOpenRouterChatModels,
   listOpenRouterEmbeddingModels,
   OPENAI_COMPAT_DEFAULT_BASE_URL,
   OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
@@ -168,6 +175,68 @@ function CompatChatModelStep(props: {
   });
 }
 
+/**
+ * Chat-model picker for the two curated cloud kinds. The static catalog
+ * renders immediately; a live refresh runs in this component the moment
+ * the step opens, because nothing else in the wizard flow is guaranteed
+ * to have fetched it (the picker used to render whatever happened to be
+ * in the module cache, which in a fresh TUI process was always the
+ * short static list). While the fetch is in flight the hint says so;
+ * when it lands, the state flip re-renders this component and the list
+ * functions re-read the now-live cache. A failed fetch resolves `false`
+ * and simply leaves the static list on screen.
+ */
+function CatalogChatModelStep(props: {
+  wizard: ProvidersWizardState;
+  kind: "openrouter" | "aimlapi";
+}): ReactElement {
+  const { wizard: w, kind } = props;
+  const getCached =
+    kind === "openrouter" ? getCachedOpenRouterChatPicks : getCachedAimlapiChatPicks;
+  const [loading, setLoading] = useState(() => getCached() === null);
+
+  useEffect(() => {
+    if (getCached() !== null) {
+      setLoading(false);
+      return;
+    }
+    let alive = true;
+    setLoading(true);
+    const refresh =
+      kind === "openrouter"
+        ? refreshOpenRouterChatCatalogFromApi
+        : refreshAimlapiChatCatalogFromApi;
+    refresh().then(
+      () => {
+        if (alive) setLoading(false);
+      },
+      () => {
+        // `refresh` swallows its own errors, but a rejection here must
+        // still clear the spinner rather than crash the wizard.
+        if (alive) setLoading(false);
+      },
+    );
+    return () => {
+      alive = false;
+    };
+    // `getCached` is derived from `kind`; re-running on kind alone is exact.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [kind]);
+
+  const title =
+    kind === "openrouter" ? "Chat model (OpenRouter)" : "Chat model (AI/ML API)";
+  const actionsHint = loading
+    ? "PgUp/PgDn jump · Enter select · Esc cancel · updating model list from API…"
+    : "PgUp/PgDn jump · Enter select · Esc cancel";
+  return renderPickList({
+    title,
+    options: listChatModelsForKind(kind),
+    cursor: w.cursor,
+    moveHint: "j/k move",
+    actionsHint,
+  });
+}
+
 export function ProvidersWizard(props: {
   wizard: ProvidersWizardState;
 }): ReactElement {
@@ -224,24 +293,11 @@ export function ProvidersWizard(props: {
     );
   }
 
-  if (w.phase === "pick_chat_model" && w.kind === "openrouter") {
-    return renderPickList({
-      title: "Chat model (OpenRouter)",
-      options: listOpenRouterChatModels(),
-      cursor: w.cursor,
-      moveHint: "j/k move",
-      actionsHint: "PgUp/PgDn jump · Enter select · Esc cancel",
-    });
-  }
-
-  if (w.phase === "pick_chat_model" && w.kind === "aimlapi") {
-    return renderPickList({
-      title: "Chat model (AI/ML API)",
-      options: listAimlapiChatModels(),
-      cursor: w.cursor,
-      moveHint: "j/k move",
-      actionsHint: "PgUp/PgDn jump · Enter select · Esc cancel",
-    });
+  if (
+    w.phase === "pick_chat_model" &&
+    (w.kind === "openrouter" || w.kind === "aimlapi")
+  ) {
+    return <CatalogChatModelStep wizard={w} kind={w.kind} />;
   }
 
   if (w.phase === "pick_embedding" && w.kind === "openrouter") {

--- a/src/tui/llm-panel/llm-panel-primary-actions.ts
+++ b/src/tui/llm-panel/llm-panel-primary-actions.ts
@@ -65,7 +65,6 @@ export function openProviderConfig(
     ) ?? state.providersPanel.rows.find((row) => isCloudProviderKind(row.kind));
   if (provider) openProviderConfigFor(provider, dispatch);
   else {
-    dispatch({ type: "providers_catalog_refresh_requested" });
     dispatch({
       type: "providers_wizard_opened",
       wizard: createProvidersWizardState("add"),
@@ -74,7 +73,6 @@ export function openProviderConfig(
 }
 
 export function openAddProvider(dispatch: (action: TuiAction) => void): void {
-  dispatch({ type: "providers_catalog_refresh_requested" });
   dispatch({
     type: "providers_wizard_opened",
     wizard: createProvidersWizardState("add"),
@@ -208,7 +206,6 @@ function openProviderConfigFor(
   dispatch: (action: TuiAction) => void,
 ): void {
   if (!isCloudProviderKind(provider.kind)) return;
-  dispatch({ type: "providers_catalog_refresh_requested" });
   dispatch({
     type: "providers_wizard_opened",
     wizard: createProvidersWizardState("configure", {

--- a/src/tui/providers/providers-actions.ts
+++ b/src/tui/providers/providers-actions.ts
@@ -17,7 +17,6 @@ export type ProvidersAction =
   | { type: "providers_status"; line: string | null }
   | { type: "providers_busy"; busy: boolean }
   | { type: "providers_wizard_opened"; wizard: ProvidersWizardState }
-  | { type: "providers_catalog_refresh_requested" }
   | {
       /**
        * Open the reopenable chat-model picker for an `openai-compatible`

--- a/src/tui/providers/providers-key-bindings.ts
+++ b/src/tui/providers/providers-key-bindings.ts
@@ -67,7 +67,6 @@ export function handleProvidersTabKey(
     return true;
   }
   if (input === "n") {
-    dispatch({ type: "providers_catalog_refresh_requested" });
     dispatch({
       type: "providers_wizard_opened",
       wizard: createProvidersWizardState("add"),
@@ -77,7 +76,6 @@ export function handleProvidersTabKey(
   if (input === "c") {
     const row = panel.rows[panel.cursor];
     if (row && isCloudProviderKind(row.kind)) {
-      dispatch({ type: "providers_catalog_refresh_requested" });
       dispatch({
         type: "providers_wizard_opened",
         wizard: createProvidersWizardState("configure", {

--- a/src/tui/providers/providers-orchestrator.test.ts
+++ b/src/tui/providers/providers-orchestrator.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentRuntime } from "../../runtime/bootstrap.js";
+
+/**
+ * The catalog caches live at module scope inside the fetch modules, so
+ * every test builds the orchestrator from a fresh module registry: a
+ * warm cache inherited from a previous test would silently skip the
+ * network path under test.
+ */
+async function importFreshOrchestrator() {
+  vi.resetModules();
+  return import("./providers-orchestrator.js");
+}
+
+function fakeBus() {
+  return {
+    subscribe: vi.fn(() => () => {}),
+    emit: vi.fn(),
+  };
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+function stubCatalogFetch() {
+  const fetchMock = vi.fn(async (url: unknown) => {
+    if (String(url).includes("openrouter")) {
+      return {
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: "vendor/live-or",
+              context_length: 128_000,
+              supported_parameters: ["tools"],
+            },
+          ],
+        }),
+      };
+    }
+    return {
+      ok: true,
+      json: async () => ({
+        data: [{ id: "vendor/live-aiml", type: "chat-completion" }],
+      }),
+    };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("ProvidersOrchestrator.prefetchCloudCatalogs", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches both catalogs when cold and reports via providers_status", async () => {
+    const fetchMock = stubCatalogFetch();
+    const { ProvidersOrchestrator } = await importFreshOrchestrator();
+    const bus = fakeBus();
+    const orchestrator = new ProvidersOrchestrator(
+      {} as AgentRuntime,
+      bus as never,
+    );
+
+    orchestrator.prefetchCloudCatalogs();
+    await flush();
+
+    const urls = fetchMock.mock.calls.map((call) => String(call[0])).sort();
+    expect(urls).toEqual([
+      "https://api.aimlapi.com/v1/models",
+      "https://openrouter.ai/api/v1/models",
+    ]);
+    // The status emits are what re-render already-mounted panels so
+    // they re-read the now-live module cache.
+    expect(bus.emit).toHaveBeenCalledWith({
+      type: "providers_status",
+      line: "OpenRouter model list updated from API",
+    });
+    expect(bus.emit).toHaveBeenCalledWith({
+      type: "providers_status",
+      line: "AI/ML API model list updated from API",
+    });
+  });
+
+  it("skips the network entirely while the caches are warm", async () => {
+    const fetchMock = stubCatalogFetch();
+    const { ProvidersOrchestrator } = await importFreshOrchestrator();
+    const bus = fakeBus();
+    const orchestrator = new ProvidersOrchestrator(
+      {} as AgentRuntime,
+      bus as never,
+    );
+
+    orchestrator.prefetchCloudCatalogs();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Wired to tab activation, this runs on every providers/LLM tab
+    // visit; within the cache TTL it must stay free.
+    orchestrator.prefetchCloudCatalogs();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the static fallback intact when both fetches fail", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { ProvidersOrchestrator } = await importFreshOrchestrator();
+    const bus = fakeBus();
+    const orchestrator = new ProvidersOrchestrator(
+      {} as AgentRuntime,
+      bus as never,
+    );
+
+    orchestrator.prefetchCloudCatalogs();
+    await flush();
+
+    // No success status lines and no crash; the pickers keep serving
+    // the static catalog.
+    expect(bus.emit).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "providers_status" }),
+    );
+
+    // A cold cache means the next visit retries instead of latching
+    // onto the failure.
+    orchestrator.prefetchCloudCatalogs();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/tui/providers/providers-orchestrator.ts
+++ b/src/tui/providers/providers-orchestrator.ts
@@ -12,8 +12,14 @@ import {
   removeLlmProvider,
   wrapLlmConfigError,
 } from "../persist-llm-provider.js";
-import { refreshAimlapiChatCatalogFromApi } from "../../llm/provider/aimlapi/fetch-aimlapi-chat-catalog.js";
-import { refreshOpenRouterChatCatalogFromApi } from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
+import {
+  getCachedAimlapiChatPicks,
+  refreshAimlapiChatCatalogFromApi,
+} from "../../llm/provider/aimlapi/fetch-aimlapi-chat-catalog.js";
+import {
+  getCachedOpenRouterChatPicks,
+  refreshOpenRouterChatCatalogFromApi,
+} from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { OPENAI_COMPAT_DEFAULT_BASE_URL } from "./providers-model-options.js";
 import { isProvidersAction } from "./providers-actions.js";
@@ -40,8 +46,6 @@ export class ProvidersOrchestrator {
       if (!isProvidersAction(action)) return;
       if (action.type === "providers_refresh_requested") {
         this.refresh();
-      } else if (action.type === "providers_catalog_refresh_requested") {
-        this.prefetchOpenRouterCatalog();
       } else if (action.type === "providers_set_active_text") {
         void this.setActiveText(action.id);
       } else if (action.type === "providers_select_chat_model") {
@@ -59,24 +63,34 @@ export class ProvidersOrchestrator {
   /**
    * Refresh chat model lists from cloud catalog endpoints (best-effort,
    * cached 1h per provider). Today: OpenRouter + aimlapi.
+   *
+   * Wired to `onProvidersTabRefresh`, so it runs on TUI start and every
+   * time the providers/LLM tab activates; the warm-cache guard keeps
+   * that to at most one network round-trip per provider per hour. The
+   * `providers_status` emit doubles as the re-render trigger that makes
+   * already-mounted panels re-read the now-live module cache.
    */
-  prefetchOpenRouterCatalog(): void {
-    void refreshOpenRouterChatCatalogFromApi().then((ok) => {
-      if (ok) {
-        this.bus.emit({
-          type: "providers_status",
-          line: "OpenRouter model list updated from API",
-        });
-      }
-    });
-    void refreshAimlapiChatCatalogFromApi().then((ok) => {
-      if (ok) {
-        this.bus.emit({
-          type: "providers_status",
-          line: "AI/ML API model list updated from API",
-        });
-      }
-    });
+  prefetchCloudCatalogs(): void {
+    if (getCachedOpenRouterChatPicks() === null) {
+      void refreshOpenRouterChatCatalogFromApi().then((ok) => {
+        if (ok) {
+          this.bus.emit({
+            type: "providers_status",
+            line: "OpenRouter model list updated from API",
+          });
+        }
+      });
+    }
+    if (getCachedAimlapiChatPicks() === null) {
+      void refreshAimlapiChatCatalogFromApi().then((ok) => {
+        if (ok) {
+          this.bus.emit({
+            type: "providers_status",
+            line: "AI/ML API model list updated from API",
+          });
+        }
+      });
+    }
   }
 
   /**

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -243,8 +243,17 @@ export async function tuiCommand(args: string[]): Promise<number> {
         onMemoryExpandNeighborsRequested: (noteId) =>
           orchestrator.memory.expandNoteNeighbors(noteId),
         onMcpAutoRefreshStart: () => orchestrator.mcp.startAutoRefresh(),
-        onProvidersTabRefresh: () =>
-          orchestrator.providers.refresh(),
+        onProvidersTabRefresh: () => {
+          orchestrator.providers.refresh();
+          // The catalog fetchers cache at module scope, so a fresh TUI
+          // process starts on the short static lists. Kick the live
+          // refresh here (TUI start + providers/LLM tab activation);
+          // the warm-cache guard inside makes repeats free. Dispatching
+          // a reducer action cannot do this: the keymap/reducer layer
+          // never reaches the bus the orchestrator listens on, which is
+          // exactly how the live lists went missing from the pickers.
+          orchestrator.providers.prefetchCloudCatalogs();
+        },
         onProvidersSetActiveText: (id) =>
           void orchestrator.providers.setActiveText(id),
         onProvidersSelectChatModel: (providerId, modelId) =>


### PR DESCRIPTION
## Problem

PR #67 shipped full live catalogs for OpenRouter and aimlapi, but the TUI never actually started the fetch. The refresh trigger was dispatched as a reducer action from the keymap layer, and the reducer never reaches the event bus that ProvidersOrchestrator subscribes to. The request died there, so the wizard pickers kept rendering the short static lists (18 OpenRouter, 13 aimlapi) instead of the full live catalogs.

## Change

- The wizard's curated pick_chat_model step now owns its refresh: the static list renders immediately, the live fetch starts the moment the step opens with an "updating model list from API" note, and the step re-renders onto the live list when the fetch lands. Rows still come from `listChatModelsForKind`, so key bindings and the render layer read the same list. A failed fetch quietly leaves the static list on screen.
- `onProvidersTabRefresh` (TUI start and providers/LLM tab activation) also calls the new `prefetchCloudCatalogs`, with a warm-cache guard so repeats within the 1h TTL cost nothing.
- The catalog fetchers dedupe concurrent refreshes into a single request.
- Removed the dead `providers_catalog_refresh_requested` action and its no-op dispatch sites.

## Testing

6 new tests, all with mocked fetch: cold-open refresh swaps the static list for the live one and clears the loading note; a failed refresh stays on the static list without crashing; `prefetchCloudCatalogs` fetches both catalogs when cold, skips the network while warm, retries after failures; concurrent refreshes share one in-flight request. `tsc` clean; targeted suites 128 tests green; full run shows no new failures beyond the known floating set.
