### PR TITLE
fix(tui): one /model command for the LLM panel, /models and /local stay aliases

### DIFF
--- a/src/tui/commands/slash-command-handler.test.ts
+++ b/src/tui/commands/slash-command-handler.test.ts
@@ -145,8 +145,8 @@ describe("dispatchSlashCommand", () => {
     expect(result.systemMessage).toContain("debug bundle");
   });
 
-  it("opens the LLM panel on the active route and requests the picker for /models", () => {
-    const result = dispatchSlashCommand("/models");
+  it("opens the LLM panel on the active route and requests the picker for /model", () => {
+    const result = dispatchSlashCommand("/model");
     expect(result.actions).toEqual([
       { type: "ui_mode_set", mode: "debug" },
       { type: "tab_changed", tab: "llm" },
@@ -164,14 +164,14 @@ describe("dispatchSlashCommand", () => {
     ]);
   });
 
-  it("treats /model as an alias of /models (same actions)", () => {
-    expect(dispatchSlashCommand("/model").actions).toEqual(
-      dispatchSlashCommand("/models").actions,
+  it("treats /models as an alias of /model (same actions)", () => {
+    expect(dispatchSlashCommand("/models").actions).toEqual(
+      dispatchSlashCommand("/model").actions,
     );
   });
 
-  it("routes /model subcommands through the /models dispatcher", () => {
-    const result = dispatchSlashCommand("/model use qwen-3.5-4b");
+  it("routes /models subcommands through the /model dispatcher", () => {
+    const result = dispatchSlashCommand("/models use qwen-3.5-4b");
     expect(result.localModelsUseModelId).toBe("qwen-3.5-4b");
   });
 

--- a/src/tui/commands/slash-command-handler.test.ts
+++ b/src/tui/commands/slash-command-handler.test.ts
@@ -145,12 +145,13 @@ describe("dispatchSlashCommand", () => {
     expect(result.systemMessage).toContain("debug bundle");
   });
 
-  it("opens the LLM panel on the active local/cloud route for /models", () => {
+  it("opens the LLM panel on the active route and requests the picker for /models", () => {
     const result = dispatchSlashCommand("/models");
     expect(result.actions).toEqual([
       { type: "ui_mode_set", mode: "debug" },
       { type: "tab_changed", tab: "llm" },
       { type: "llm_mode_set_to_active_route" },
+      { type: "providers_chat_model_picker_requested", providerId: null },
     ]);
   });
 
@@ -163,13 +164,15 @@ describe("dispatchSlashCommand", () => {
     ]);
   });
 
-  it("opens the chat model picker for /model", () => {
-    const result = dispatchSlashCommand("/model");
-    expect(result.actions).toEqual([
-      { type: "ui_mode_set", mode: "debug" },
-      { type: "tab_changed", tab: "llm" },
-      { type: "providers_chat_model_picker_requested", providerId: null },
-    ]);
+  it("treats /model as an alias of /models (same actions)", () => {
+    expect(dispatchSlashCommand("/model").actions).toEqual(
+      dispatchSlashCommand("/models").actions,
+    );
+  });
+
+  it("routes /model subcommands through the /models dispatcher", () => {
+    const result = dispatchSlashCommand("/model use qwen-3.5-4b");
+    expect(result.localModelsUseModelId).toBe("qwen-3.5-4b");
   });
 
   it("requests persistLlamaUrl for /models with a valid URL", () => {

--- a/src/tui/commands/slash-command-handler.ts
+++ b/src/tui/commands/slash-command-handler.ts
@@ -216,7 +216,7 @@ export function dispatchSlashCommand(buffer: string): SlashDispatchResult {
       return dispatchMcpSub(parsed.args);
     case "llm":
       return dispatchLlmSub(parsed.args);
-    case "models":
+    case "model":
       return dispatchModelsSub(parsed.args, parsed.name);
     case "tasks":
       return pureActions([
@@ -317,11 +317,12 @@ function dispatchThemeSub(rawArgs: string): SlashDispatchResult {
 }
 
 /**
- * Sub-dispatcher for `/models [verb] [args]` (aliases: `/model`,
- * `/local`). `/model` used to be a separate command that only differed
- * in bare behavior (tab jump + picker request vs tab jump + route sync),
- * which read as two commands opening the same window; the two were
- * merged so either spelling lands in one place. Accepted shapes:
+ * Sub-dispatcher for `/model [verb] [args]` (aliases: `/models`,
+ * `/local`). `/model` and `/models` used to be separate commands that
+ * only differed in bare behavior (tab jump + picker request vs tab jump
+ * + route sync), which read as two commands opening the same window;
+ * the two were merged under the singular name (the industry-standard
+ * spelling) so either lands in one place. Accepted shapes:
  *   - (bare)        — open the LLM tab on the active local/cloud route
  *                     and reopen the chat model picker (#62). The picker
  *                     request no-ops for curated/local kinds, leaving
@@ -379,7 +380,7 @@ function dispatchModelsSub(rawArgs: string, commandName: string): SlashDispatchR
   } catch {
     return pureActions([], {
       systemMessage:
-        "usage: /models | /models pull <id> | /models use <id> | /models status | /models <base-url>",
+        "usage: /model | /model pull <id> | /model use <id> | /model status | /model <base-url>",
     });
   }
 }

--- a/src/tui/commands/slash-command-handler.ts
+++ b/src/tui/commands/slash-command-handler.ts
@@ -216,16 +216,6 @@ export function dispatchSlashCommand(buffer: string): SlashDispatchResult {
       return dispatchMcpSub(parsed.args);
     case "llm":
       return dispatchLlmSub(parsed.args);
-    case "model":
-      // Jump to the LLM tab and, when the active text provider is an
-      // openai-compatible entry, reopen its model picker (#62). The
-      // request no-ops for other kinds, leaving the tab switch as the
-      // whole effect, which matches the previous behavior.
-      return pureActions([
-        { type: "ui_mode_set", mode: "debug" },
-        { type: "tab_changed", tab: "llm" },
-        { type: "providers_chat_model_picker_requested", providerId: null },
-      ]);
     case "models":
       return dispatchModelsSub(parsed.args, parsed.name);
     case "tasks":
@@ -327,8 +317,16 @@ function dispatchThemeSub(rawArgs: string): SlashDispatchResult {
 }
 
 /**
- * Sub-dispatcher for `/models [verb] [args]`. Accepted shapes:
- *   - (bare)        — open the LLM tab on the active local/cloud route.
+ * Sub-dispatcher for `/models [verb] [args]` (aliases: `/model`,
+ * `/local`). `/model` used to be a separate command that only differed
+ * in bare behavior (tab jump + picker request vs tab jump + route sync),
+ * which read as two commands opening the same window; the two were
+ * merged so either spelling lands in one place. Accepted shapes:
+ *   - (bare)        — open the LLM tab on the active local/cloud route
+ *                     and reopen the chat model picker (#62). The picker
+ *                     request no-ops for curated/local kinds, leaving
+ *                     the tab switch as the whole effect there.
+ *                     `/local` pins the local pane and skips the picker.
  *   - `pull <id>`   — open the tab and kick off a pull for the given id.
  *   - `use <id>`    — open the tab and set the given id as active.
  *   - `status`      — emit the managed-runtime status line in the feed.
@@ -338,12 +336,18 @@ function dispatchModelsSub(rawArgs: string, commandName: string): SlashDispatchR
   const argPart = rawArgs.trim();
   const bits = argPart.split(/\s+/).filter(Boolean);
   if (argPart.length === 0) {
+    if (commandName === "local") {
+      return pureActions([
+        { type: "ui_mode_set", mode: "debug" },
+        { type: "tab_changed", tab: "llm" },
+        { type: "llm_mode_set", mode: "local" },
+      ]);
+    }
     return pureActions([
       { type: "ui_mode_set", mode: "debug" },
       { type: "tab_changed", tab: "llm" },
-      commandName === "local"
-        ? { type: "llm_mode_set", mode: "local" }
-        : { type: "llm_mode_set_to_active_route" },
+      { type: "llm_mode_set_to_active_route" },
+      { type: "providers_chat_model_picker_requested", providerId: null },
     ]);
   }
   if (bits[0] === "pull" && bits[1]) {

--- a/src/tui/commands/slash-commands.test.ts
+++ b/src/tui/commands/slash-commands.test.ts
@@ -51,6 +51,18 @@ describe("resolveSlashCommand", () => {
     expect(resolveSlashCommand("exit")?.name).toBe("quit");
   });
 
+  it("resolves /model and /local as aliases of /models", () => {
+    expect(resolveSlashCommand("model")?.name).toBe("models");
+    expect(resolveSlashCommand("local")?.name).toBe("models");
+  });
+
+  it("keeps a single registry entry for the model command", () => {
+    const modelish = SLASH_COMMANDS.filter(
+      (c) => c.name === "model" || c.name === "models",
+    );
+    expect(modelish.map((c) => c.name)).toEqual(["models"]);
+  });
+
   it("returns null for unknown commands", () => {
     expect(resolveSlashCommand("does-not-exist")).toBeNull();
   });

--- a/src/tui/commands/slash-commands.test.ts
+++ b/src/tui/commands/slash-commands.test.ts
@@ -51,16 +51,16 @@ describe("resolveSlashCommand", () => {
     expect(resolveSlashCommand("exit")?.name).toBe("quit");
   });
 
-  it("resolves /model and /local as aliases of /models", () => {
-    expect(resolveSlashCommand("model")?.name).toBe("models");
-    expect(resolveSlashCommand("local")?.name).toBe("models");
+  it("resolves /models and /local as aliases of /model", () => {
+    expect(resolveSlashCommand("models")?.name).toBe("model");
+    expect(resolveSlashCommand("local")?.name).toBe("model");
   });
 
   it("keeps a single registry entry for the model command", () => {
     const modelish = SLASH_COMMANDS.filter(
       (c) => c.name === "model" || c.name === "models",
     );
-    expect(modelish.map((c) => c.name)).toEqual(["models"]);
+    expect(modelish.map((c) => c.name)).toEqual(["model"]);
   });
 
   it("returns null for unknown commands", () => {

--- a/src/tui/commands/slash-commands.ts
+++ b/src/tui/commands/slash-commands.ts
@@ -77,10 +77,6 @@ export const SLASH_COMMANDS: readonly SlashCommandDef[] = [
       "open LLM Local/Cloud/External panel · `/llm provider <id>` switch text provider",
   },
   {
-    name: "model",
-    description: "open the LLM Local/Cloud/External panel",
-  },
-  {
     name: "mcp",
     description:
       "open MCP tab (configured servers + discovered tools / resources / prompts) · subcommands: `/mcp add` opens JSON-paste modal, `/mcp remove <name>` opens delete-confirm",
@@ -89,7 +85,7 @@ export const SLASH_COMMANDS: readonly SlashCommandDef[] = [
     name: "models",
     description:
       "open chat model picker · subcommands: pull <id> | use <id> | status | <base-url>",
-    aliases: ["local"],
+    aliases: ["model", "local"],
   },
   { name: "tasks", description: "jump to the Tasks tab (Option 4 cron + ingress UI)" },
   {

--- a/src/tui/commands/slash-commands.ts
+++ b/src/tui/commands/slash-commands.ts
@@ -82,10 +82,10 @@ export const SLASH_COMMANDS: readonly SlashCommandDef[] = [
       "open MCP tab (configured servers + discovered tools / resources / prompts) · subcommands: `/mcp add` opens JSON-paste modal, `/mcp remove <name>` opens delete-confirm",
   },
   {
-    name: "models",
+    name: "model",
     description:
       "open chat model picker · subcommands: pull <id> | use <id> | status | <base-url>",
-    aliases: ["model", "local"],
+    aliases: ["models", "local"],
   },
   { name: "tasks", description: "jump to the Tasks tab (Option 4 cron + ingress UI)" },
   {

--- a/src/tui/components/splash-banner.tsx
+++ b/src/tui/components/splash-banner.tsx
@@ -23,7 +23,7 @@ export function SplashBanner(): ReactElement {
         <Tip left="/help" right="list all slash commands" />
         <Tip left="/sessions" right="switch to a previous thread" />
         <Tip left="/new" right="start a fresh session" />
-        <Tip left="/models" right="change the chat model" />
+        <Tip left="/model" right="change the chat model" />
         <Tip left="/tasks" right="jump to the Tasks tab (Option 4 cron + ingress UI)" />
         <Tip left="/import" right="open the Import tab (one-shot Hermes -> atomic-agent migration)" />
         <Tip left="Ctrl+C ×2" right="quit (once aborts a running turn)" />

--- a/src/tui/providers/providers-chat-model-picker.test.ts
+++ b/src/tui/providers/providers-chat-model-picker.test.ts
@@ -5,6 +5,8 @@ import type { TuiAction } from "../tui-action.js";
 import type { TuiAppCallbacks } from "../tui-app.js";
 import { createInitialTuiState, type TuiState } from "../tui-state.js";
 import { fakeSession } from "../test-fixtures.js";
+import { reduceTuiState } from "../agent-event-reducer.js";
+import { dispatchSlashCommand } from "../commands/slash-command-handler.js";
 import { reduceProvidersPanel } from "./providers-reducer.js";
 import {
   filteredPickerModels,
@@ -371,5 +373,80 @@ describe("model picker filtering", () => {
     const picker = readyPicker({ query: " qwen " });
     expect(picker.query).toBe(" qwen ");
     expect(filteredPickerModels(picker)).toEqual(["qwen-32b"]);
+  });
+});
+
+describe("picker armed by bare /model", () => {
+  // End-to-end through the real reducer chain: the exact actions the
+  // slash handler emits for bare /model, then the orchestrator's answer
+  // to the picker request (opened + loaded). Guards the #83 promise that
+  // the filter is live from the first keystroke after /model, not only
+  // when the picker state is hand-built.
+  function stateAfterBareModel(
+    generation: number,
+    from?: TuiState,
+  ): TuiState {
+    let state = from ?? createInitialTuiState(fakeSession());
+    for (const action of dispatchSlashCommand("/model").actions) {
+      state = reduceTuiState(state, action);
+    }
+    // `providers_chat_model_picker_requested` is a state no-op; the
+    // orchestrator responds on the bus with a generation-stamped open
+    // and, once the model list fetch settles, the loaded payload.
+    state = reduceTuiState(state, {
+      type: "providers_chat_model_picker_opened",
+      providerId: "my-vllm",
+      currentModelId: "qwen-32b",
+      generation,
+    });
+    return reduceTuiState(state, {
+      type: "providers_chat_model_picker_loaded",
+      generation,
+      models: ["glm-9b", "qwen-32b", "yi-34b"],
+    });
+  }
+
+  it("bare /model lands on the LLM tab with the picker ready and an empty query", () => {
+    const state = stateAfterBareModel(1);
+    expect(state.uiMode).toBe("debug");
+    expect(state.activeTab).toBe("llm");
+    expect(state.providersPanel.chatModelPicker).toMatchObject({
+      status: "ready",
+      query: "",
+      cursor: 1,
+    });
+    expect(
+      filteredPickerModels(state.providersPanel.chatModelPicker!),
+    ).toHaveLength(3);
+  });
+
+  it("the first keystroke after /model goes straight into the filter and narrows the list", () => {
+    let state = stateAfterBareModel(1);
+    const { dispatched, handled } = pressModal("q", emptyKey(), state);
+    expect(handled).toBe(true);
+    expect(dispatched).toEqual([
+      { type: "providers_chat_model_picker_query_set", query: "q" },
+    ]);
+    for (const action of dispatched) state = reduceTuiState(state, action);
+    const picker = state.providersPanel.chatModelPicker!;
+    expect(picker.query).toBe("q");
+    expect(picker.cursor).toBe(0);
+    expect(filteredPickerModels(picker)).toEqual(["qwen-32b"]);
+  });
+
+  it("running /model again after a filtered session starts over with a fresh query", () => {
+    let state = stateAfterBareModel(1);
+    state = reduceTuiState(state, {
+      type: "providers_chat_model_picker_query_set",
+      query: "qwen",
+    });
+    state = reduceTuiState(state, {
+      type: "providers_chat_model_picker_closed",
+    });
+    state = stateAfterBareModel(2, state);
+    const picker = state.providersPanel.chatModelPicker!;
+    expect(picker.status).toBe("ready");
+    expect(picker.query).toBe("");
+    expect(filteredPickerModels(picker)).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Problem

`/model` and `/models` were two palette entries whose difference was invisible: both landed in the same LLM window. Two spellings, one window, no way to tell which one to use.

## Change

- One canonical command: `/model`. Bare `/model` does the union of both old behaviors: opens the LLM tab on the active route and reopens the filterable chat model picker for openai-compatible providers.
- `/models` and `/local` resolve as quiet aliases (parsed, never shown in the palette or `/help`), so no spelling hits "unknown command". `/local` keeps pinning the Local pane.
- `pull <id>` / `use <id>` / `status` / `<base-url>` subcommands work through any of the three names.
- The splash tip and usage string show the singular spelling.
- Singular `/model` is the industry spelling: Claude Code, Codex CLI, Gemini CLI, Hermes, and Goose all expose it (6 of the 9 agent CLIs we surveyed, atomic-agent included).

## Testing

`tsc` clean; `src/tui/commands` 79/79. The registry test pins exactly one model entry and alias resolution; handler tests cover the merged bare action, alias equivalence, and subcommand routing; a new end-to-end block asserts the first keystroke after bare `/model` lands in the picker filter and narrows the list. Full run: identical failure list to origin/main, zero new.
