### PR TITLE
fix(tui): make /model work more than once per session (picker wiring + editor cursor)

### DIFF
--- a/src/tui/components/multi-line-editor.tsx
+++ b/src/tui/components/multi-line-editor.tsx
@@ -1,5 +1,5 @@
 import { Box, useInput, type Key } from "ink";
-import { useCallback, useEffect, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { theme } from "../theme/theme.js";
 import { EditorBody } from "./multi-line-editor-body.js";
 import {
@@ -81,14 +81,25 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
     bare = false,
   } = props;
   const [cursorPos, setCursorPos] = useState<number>(value.length);
-  // Clamp cursor whenever the controlled value shrinks (e.g. slash
-  // command cleared the buffer or history recall shortened it).
+  // Distinguish our own edits (keystrokes routed through `setBuffer`)
+  // from external buffer replacements: slash-seeding from panel hotkeys
+  // (the LLM tab dispatches `input_changed "/"` on `/`), history recall,
+  // or a command clearing the buffer. External writers cannot know the
+  // editor's private cursor, so the cursor jumps to the end of the new
+  // value — otherwise typing after a seeded "/" inserted BEFORE it
+  // ("model/" instead of "/model"), which is why /model only ever
+  // worked once per session.
+  const lastInternalValue = useRef(value);
+
   useEffect(() => {
-    setCursorPos((c) => Math.min(c, value.length));
+    if (value === lastInternalValue.current) return;
+    lastInternalValue.current = value;
+    setCursorPos(value.length);
   }, [value]);
 
   const setBuffer = useCallback(
     (next: string, nextCursor: number) => {
+      lastInternalValue.current = next;
       setCursorPos(Math.max(0, Math.min(nextCursor, next.length)));
       onChange(next);
     },

--- a/src/tui/llm-panel/llm-panel-key-bindings.test.ts
+++ b/src/tui/llm-panel/llm-panel-key-bindings.test.ts
@@ -93,6 +93,37 @@ describe("handleLlmPanelKey", () => {
     expect(onStop).toHaveBeenCalledTimes(1);
   });
 
+  it("asks for the model picker on an openai-compatible model row via the callback", () => {
+    // A dispatched `providers_chat_model_picker_requested` is a reducer
+    // no-op the orchestrator never sees; the request must travel as a
+    // callback, so Enter on the row must not dispatch anything.
+    const base = seededState();
+    const state = {
+      ...base,
+      providersPanel: {
+        ...base.providersPanel,
+        rows: base.providersPanel.rows.map((row) =>
+          row.id === "openrouter" ? { ...row, kind: "openai-compatible" } : row,
+        ),
+      },
+      llmPanel: { ...base.llmPanel, mode: "cloud" as const, cloudCursor: 1 },
+    };
+    const dispatched: TuiAction[] = [];
+    const onPickerRequested = vi.fn();
+    const onSelectChatModel = vi.fn();
+    handleLlmPanelKey("", emptyKey({ return: true }), {
+      state,
+      dispatch: (action) => dispatched.push(action),
+      callbacks: callbacks({
+        onProvidersChatModelPickerRequested: onPickerRequested,
+        onProvidersSelectChatModel: onSelectChatModel,
+      }),
+    });
+    expect(dispatched).toEqual([]);
+    expect(onPickerRequested).toHaveBeenCalledWith("openrouter");
+    expect(onSelectChatModel).not.toHaveBeenCalled();
+  });
+
   it("selects an exact cloud embedding model", () => {
     const base = seededState();
     const state = {

--- a/src/tui/llm-panel/llm-panel-primary-actions.ts
+++ b/src/tui/llm-panel/llm-panel-primary-actions.ts
@@ -179,11 +179,10 @@ function triggerCloudChatModel(
   if (row.provider.kind === "openai-compatible") {
     // The picker owns selection for server-listed providers: Enter on the
     // current-model row reopens the `/v1/models` list instead of
-    // re-selecting the same model (#62).
-    dispatch({
-      type: "providers_chat_model_picker_requested",
-      providerId: row.providerId,
-    });
+    // re-selecting the same model (#62). Routed as a callback into
+    // `ProvidersOrchestrator.openChatModelPicker`: dispatch feeds the
+    // reducer only and never reaches the bus the orchestrator listens on.
+    callbacks.onProvidersChatModelPickerRequested?.(row.providerId);
     return;
   }
   callbacks.onProvidersSelectChatModel?.(row.providerId, row.modelId);

--- a/src/tui/providers/picker-reopen-app.test.tsx
+++ b/src/tui/providers/picker-reopen-app.test.tsx
@@ -1,0 +1,106 @@
+import { render } from "ink-testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentRuntime } from "../../runtime/bootstrap.js";
+import type { AtomicAgentConfig } from "../../config/index.js";
+import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "../tui-app.js";
+import { fakeSession } from "../test-fixtures.js";
+import { ProvidersOrchestrator } from "./providers-orchestrator.js";
+
+vi.mock("../../config/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../config/index.js")>();
+  return {
+    ...original,
+    getConfig: () => currentConfig,
+  };
+});
+
+let currentConfig: AtomicAgentConfig;
+
+function configWithNous(baseUrl: string): AtomicAgentConfig {
+  return {
+    llm: {
+      activeTextProvider: "nous",
+      activeEmbeddingProvider: "local-llama-embed",
+      toolTransport: "auto",
+      providers: [
+        {
+          id: "nous",
+          kind: "openai-compatible",
+          baseUrl,
+          apiKey: "sk-nous-test",
+          model: "nous/bytedance",
+          defaultChatModel: "nous/bytedance",
+        },
+      ],
+    },
+  } as AtomicAgentConfig;
+}
+
+const SESSION = fakeSession({ workingDir: "/tmp/smoke" });
+
+function strip(value: string): string {
+  return value
+    .replace(/\[[0-9;]*m/g, "")
+    .replace(/\]8;;[^]*/g, "");
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 25));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("full-app picker reopen (ink render, real orchestrator)", () => {
+  it("/model opens, Esc closes, /model opens again", async () => {
+    currentConfig = configWithNous("https://app.nous.example");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "alpha" }, { id: "beta" }] }),
+      })),
+    );
+
+    const bus = makeTuiEventBus();
+    const orchestrator = new ProvidersOrchestrator({} as AgentRuntime, bus);
+    const callbacks: TuiAppCallbacks = {
+      onApprovalDecision: () => {},
+      onAbort: () => {},
+      onQuit: () => {},
+      onMessageSubmitted: () => {},
+      onProvidersTabRefresh: () => orchestrator.refresh(),
+      onProvidersChatModelPickerRequested: (providerId) =>
+        void orchestrator.openChatModelPicker(providerId),
+    };
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={callbacks} />,
+    );
+    await tick();
+
+    // First /model from the chat editor.
+    stdin.write("/model");
+    await tick();
+    stdin.write("\r");
+    await tick();
+    await tick();
+    expect(strip(lastFrame() ?? "")).toContain("Models — nous");
+
+    // Esc closes the picker.
+    stdin.write("");
+    await tick();
+    expect(strip(lastFrame() ?? "")).not.toContain("Models — nous");
+
+    // Second /model, typed from the LLM tab.
+    stdin.write("/");
+    await tick();
+    stdin.write("model");
+    await tick();
+    stdin.write("\r");
+    await tick();
+    await tick();
+    expect(strip(lastFrame() ?? "")).toContain("Models — nous");
+
+    unmount();
+  });
+});

--- a/src/tui/submit-handler.test.ts
+++ b/src/tui/submit-handler.test.ts
@@ -44,6 +44,29 @@ describe("handleEditorSubmit", () => {
     expect(systemMessages.some((t) => t.includes("chat cleared"))).toBe(true);
   });
 
+  it("routes the /model picker request through the callback, not dispatch", () => {
+    // The orchestrator that owns the /v1/models fetch listens on the
+    // event bus; a dispatched request action is a reducer no-op it
+    // never sees, which is why /model looked dead in the app.
+    const state = createInitialTuiState(fakeSession());
+    const dispatched: Array<{ type: string }> = [];
+    const onPickerRequested = vi.fn();
+    handleEditorSubmit(
+      "/model",
+      state,
+      ((a: { type: string }) => dispatched.push(a)) as never,
+      stubCallbacks({ onProvidersChatModelPickerRequested: onPickerRequested }),
+    );
+    expect(onPickerRequested).toHaveBeenCalledWith(null);
+    expect(
+      dispatched.some(
+        (a) => a.type === "providers_chat_model_picker_requested",
+      ),
+    ).toBe(false);
+    // The jump to the LLM tab still travels through the reducer.
+    expect(dispatched.some((a) => a.type === "tab_changed")).toBe(true);
+  });
+
   it("with palette open, runs the buffer when it is a full registered command (stale slashQuery)", () => {
     const base = createInitialTuiState(fakeSession());
     const state: TuiState = {

--- a/src/tui/submit-handler.ts
+++ b/src/tui/submit-handler.ts
@@ -137,7 +137,18 @@ export function runSlashCommand(
     setActiveTheme(THEMES[result.setThemeName]);
     callbacks.onThemePersistRequested?.(result.setThemeName);
   }
-  for (const action of result.actions) dispatch(action);
+  for (const action of result.actions) {
+    if (action.type === "providers_chat_model_picker_requested") {
+      // A state no-op as a reducer action: the orchestrator that owns
+      // the `/v1/models` fetch listens on the event bus, and dispatch
+      // never reaches it. Route the request through the callback that
+      // `tui-command` binds to `ProvidersOrchestrator.openChatModelPicker`,
+      // like every other provider operation.
+      callbacks.onProvidersChatModelPickerRequested?.(action.providerId);
+      continue;
+    }
+    dispatch(action);
+  }
   if (result.systemMessage) {
     dispatch({ type: "runtime_info", line: result.systemMessage });
     dispatch({ type: "system_message", text: result.systemMessage });

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -216,6 +216,16 @@ export interface TuiAppCallbacks {
   onProvidersSetActiveText?(id: string): void;
   /** Providers tab / LLM panel: select an exact chat model for a provider. */
   onProvidersSelectChatModel?(providerId: string, modelId: string): void;
+  /**
+   * LLM panel / bare `/model`: open the reopenable chat-model picker.
+   * `providerId: null` targets the active text provider. This must be a
+   * callback into `ProvidersOrchestrator.openChatModelPicker`, not a
+   * dispatched reducer action: dispatch feeds the React reducer only,
+   * and the event bus the orchestrator listens on is bridged into the
+   * reducer one way (`bus.subscribe(dispatch)`), so a dispatched
+   * request never reaches the orchestrator and the picker never opens.
+   */
+  onProvidersChatModelPickerRequested?(providerId: string | null): void;
   /** Providers tab / LLM panel: switch the active embedding provider. */
   onProvidersSetActiveEmbedding?(id: string): void;
   /** Providers tab / LLM panel: select an exact embedding model. */

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -249,6 +249,8 @@ export async function tuiCommand(args: string[]): Promise<number> {
           void orchestrator.providers.setActiveText(id),
         onProvidersSelectChatModel: (providerId, modelId) =>
           void orchestrator.providers.selectChatModel(providerId, modelId),
+        onProvidersChatModelPickerRequested: (providerId) =>
+          void orchestrator.providers.openChatModelPicker(providerId),
         onProvidersSetActiveEmbedding: (id) =>
           void orchestrator.providers.setActiveEmbedding(id),
         onProvidersSelectEmbeddingModel: (providerId, modelId) =>


### PR DESCRIPTION
Stacked on the catalog-refresh and model-command PRs; merge those first and this retargets.

## Problem

Two independent breaks stacked on the same flow.

1. Dead picker request. Bare `/model` and Enter on an openai-compatible model row dispatch `providers_chat_model_picker_requested` as a reducer action. Dispatch feeds the reducer only, and the event bus the orchestrator subscribes to is bridged one way, so the request never reaches the orchestrator: the `/v1/models` fetch never runs and the picker never opens. On current main the only visible effect of `/model` is the jump to the LLM tab.
2. Editor cursor stuck at 0 after external seeds. `MultiLineEditor` kept a private cursor and only clamped it when the value shrank. The LLM tab seeds the editor with `/` on the slash hotkey; after the previous command cleared the buffer the cursor sat at 0, so the next letters landed before the seeded slash and produced `model/`. The string never resolved as a slash command, which is why the picker appeared to open only once per session.

## Change

Commit 1 routes the picker request through a new callback `onProvidersChatModelPickerRequested`, bound in tui-command to `ProvidersOrchestrator.openChatModelPicker`, the same wiring every other provider operation uses. The action stays in the union and the orchestrator keeps its bus branch, so bus-based tests still exercise the orchestrator path.

Commit 2 makes the editor track its own values: any external replacement (slash seed, history recall, clear) moves the cursor to the end.

## Testing

New full-app regression drives `/model` -> Esc -> `/` + `model` through real stdin keystrokes; red without either commit, green with both. Handler and key-binding tests cover the callback path. `tsc` clean; full run has the same pre-existing failures as origin/main, zero new.
