### PR TITLE
fix(tui): sort provider presets alphabetically in the add-provider wizard

### DIFF
--- a/src/tui/providers/provider-presets.test.ts
+++ b/src/tui/providers/provider-presets.test.ts
@@ -27,6 +27,14 @@ describe("PROVIDER_PRESETS", () => {
     }
   });
 
+  it("is sorted alphabetically by label", () => {
+    // Array order is what the wizard renders, so keep it readable:
+    // plain code-unit comparison, no locale involved.
+    const labels = PROVIDER_PRESETS.map((p) => p.label);
+    const sorted = [...labels].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    expect(labels).toEqual(sorted);
+  });
+
   it("includes the service the request came from", () => {
     // A user asked for presets and named Nous specifically (#69).
     expect(findProviderPreset("nous")).toBeDefined();

--- a/src/tui/providers/provider-presets.ts
+++ b/src/tui/providers/provider-presets.ts
@@ -44,21 +44,21 @@ export interface ProviderPreset {
   readonly note?: string;
 }
 
+/**
+ * Array order is display order: `KIND_ROW_ORDER` in
+ * `providers-wizard-phases.ts` renders preset rows exactly as listed
+ * here, between the two catalog kinds (OpenRouter, AI/ML API) and the
+ * manual openai-compatible entry. Keep the entries sorted
+ * alphabetically by `label` (plain code-unit order, no locale) so the
+ * list reads predictably; a test enforces this.
+ */
 export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
   {
-    id: "nous",
-    label: "Nous Research",
-    baseUrl: "https://inference-api.nousresearch.com",
-    envVar: "NOUS_API_KEY",
-    listsModelsWithoutKey: true,
-    note: "open-weight models, 350+ ids listed without a key",
-  },
-  {
-    id: "groq",
-    label: "Groq",
-    baseUrl: "https://api.groq.com/openai",
-    envVar: "GROQ_API_KEY",
-    note: "very fast inference on open-weight models",
+    id: "cerebras",
+    label: "Cerebras",
+    baseUrl: "https://api.cerebras.ai",
+    envVar: "CEREBRAS_API_KEY",
+    note: "high-throughput inference",
   },
   {
     id: "deepseek",
@@ -68,13 +68,6 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "DeepSeek models direct from the vendor",
   },
   {
-    id: "together",
-    label: "Together AI",
-    baseUrl: "https://api.together.xyz",
-    envVar: "TOGETHER_API_KEY",
-    note: "broad open-weight catalog",
-  },
-  {
     id: "fireworks",
     label: "Fireworks AI",
     baseUrl: "https://api.fireworks.ai/inference",
@@ -82,11 +75,19 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "open-weight models, function calling",
   },
   {
-    id: "cerebras",
-    label: "Cerebras",
-    baseUrl: "https://api.cerebras.ai",
-    envVar: "CEREBRAS_API_KEY",
-    note: "high-throughput inference",
+    id: "groq",
+    label: "Groq",
+    baseUrl: "https://api.groq.com/openai",
+    envVar: "GROQ_API_KEY",
+    note: "very fast inference on open-weight models",
+  },
+  {
+    id: "lmstudio",
+    label: "LM Studio (local)",
+    baseUrl: "http://localhost:1234",
+    envVar: "LMSTUDIO_API_KEY",
+    local: true,
+    note: "the server LM Studio runs on your machine; no API key needed",
   },
   {
     id: "mistral",
@@ -96,11 +97,12 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "Mistral models direct from the vendor",
   },
   {
-    id: "xai",
-    label: "xAI (Grok)",
-    baseUrl: "https://api.x.ai",
-    envVar: "XAI_API_KEY",
-    note: "Grok models direct from the vendor",
+    id: "nous",
+    label: "Nous Research",
+    baseUrl: "https://inference-api.nousresearch.com",
+    envVar: "NOUS_API_KEY",
+    listsModelsWithoutKey: true,
+    note: "open-weight models, 350+ ids listed without a key",
   },
   {
     id: "ollama-cloud",
@@ -111,12 +113,18 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "hosted Ollama, models listed without a key",
   },
   {
-    id: "lmstudio",
-    label: "LM Studio (local)",
-    baseUrl: "http://localhost:1234",
-    envVar: "LMSTUDIO_API_KEY",
-    local: true,
-    note: "the server LM Studio runs on your machine; no API key needed",
+    id: "together",
+    label: "Together AI",
+    baseUrl: "https://api.together.xyz",
+    envVar: "TOGETHER_API_KEY",
+    note: "broad open-weight catalog",
+  },
+  {
+    id: "xai",
+    label: "xAI (Grok)",
+    baseUrl: "https://api.x.ai",
+    envVar: "XAI_API_KEY",
+    note: "Grok models direct from the vendor",
   },
 ];
 

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -3,8 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { PICK_WINDOW } from "../components/wizard-pick-list.js";
+import { PROVIDER_PRESETS } from "./provider-presets.js";
 import { LOCAL_EMBEDDING_CHOICE_ID } from "./providers-model-options.js";
 import { handleProvidersWizardKey } from "./providers-wizard-key-bindings.js";
+import { KIND_ROW_ORDER } from "./providers-wizard-phases.js";
 import { createProvidersWizardState } from "./providers-wizard-state.js";
 import type { ProvidersWizardState } from "./providers-wizard-state.js";
 
@@ -77,6 +79,22 @@ describe("createProvidersWizardState configure prefill", () => {
       kind: "openai-compatible",
     });
     expect(wizard.presetId).toBeNull();
+  });
+});
+
+describe("KIND_ROW_ORDER", () => {
+  it("lists catalogs first, presets alphabetically by label, manual last", () => {
+    expect(KIND_ROW_ORDER[0]).toBe("openrouter");
+    expect(KIND_ROW_ORDER[1]).toBe("aimlapi");
+    expect(KIND_ROW_ORDER[KIND_ROW_ORDER.length - 1]).toBe("openai-compatible");
+
+    const presetRows = KIND_ROW_ORDER.slice(2, -1);
+    expect(presetRows).toEqual(
+      PROVIDER_PRESETS.map((preset) => ({ presetId: preset.id })),
+    );
+    const labels = PROVIDER_PRESETS.map((p) => p.label);
+    const sorted = [...labels].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    expect(labels).toEqual(sorted);
   });
 });
 
@@ -338,9 +356,12 @@ describe("handleProvidersWizardKey", () => {
   it("picks a known service straight from the provider list", () => {
     let wizard = createProvidersWizardState("add");
 
-    // Presets follow the two catalog kinds, so Nous is the third row.
-    wizard = next(wizard, "", emptyKey({ downArrow: true }));
-    wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    // Presets follow the two catalog kinds, alphabetically by label,
+    // so the row index is computed instead of hardcoded.
+    const nousIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "nous");
+    for (let i = 0; i < nousIdx; i += 1) {
+      wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    }
     wizard = next(wizard, "", emptyKey({ return: true }));
     expect(wizard.kind).toBe("openai-compatible");
     expect(wizard.presetId).toBe("nous");
@@ -352,12 +373,13 @@ describe("handleProvidersWizardKey", () => {
 
   it("reaches a later preset by moving down the same list", () => {
     let wizard = createProvidersWizardState("add");
+    // Fourth row is the second preset (DeepSeek, alphabetical order).
     for (let i = 0; i < 3; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }
     wizard = next(wizard, "", emptyKey({ return: true }));
-    expect(wizard.presetId).toBe("groq");
-    expect(wizard.baseUrlLine).toBe("https://api.groq.com/openai");
+    expect(wizard.presetId).toBe("deepseek");
+    expect(wizard.baseUrlLine).toBe("https://api.deepseek.com");
   });
 });
 


### PR DESCRIPTION
## What

The add-provider wizard listed the ten service presets in code-insertion order (Nous, Groq, DeepSeek, ...). This sorts `PROVIDER_PRESETS` by label (plain code-unit order), so the list reads: Cerebras, DeepSeek, Fireworks AI, Groq, LM Studio, Mistral, Nous Research, Ollama Cloud, Together AI, xAI. Catalogs stay first, manual entry stays last.

## Why it is safe

`KIND_ROW_ORDER` derives the rows from the array and the render layer derives labels from it, so cursor position, labels and key bindings stay consistent by construction. The LLM panel is untouched: connected providers still show in the order they were added. The order is stable as new presets land (for example the OrcaRouter preset in #89): a row's position comes from its label through the sort, not a hand-written order.

## Testing

New invariants lock the alphabetical preset order and the catalogs-first / presets-alphabetical / manual-last row order; the two key-binding tests that hardcoded row indexes now compute them. `tsc` clean; full run identical to origin/main baseline, zero new failures.
