### PR TITLE
feat(tui): inline filterable model list in the Cloud pane

### DIFF
--- a/src/llm/provider/openai/fetch-openai-compat-models.test.ts
+++ b/src/llm/provider/openai/fetch-openai-compat-models.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchOpenAiCompatModels,
   getCachedOpenAiCompatModels,
+  getCachedOpenAiCompatModelsForBaseUrl,
 } from "./fetch-openai-compat-models.js";
 
 describe("fetchOpenAiCompatModels", () => {
@@ -60,6 +61,26 @@ describe("fetchOpenAiCompatModels", () => {
 
     await fetchOpenAiCompatModels("https://stale.example", "key");
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves the URL-only lookup from a keyed fetch, but never past the TTL", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: [{ id: "grok-4" }] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchOpenAiCompatModels("https://panel.example", "secret");
+    // The panel knows the base URL but not the key that fetched the list.
+    expect(getCachedOpenAiCompatModelsForBaseUrl("https://panel.example/")).toEqual([
+      "grok-4",
+    ]);
+
+    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+    expect(
+      getCachedOpenAiCompatModelsForBaseUrl("https://panel.example"),
+    ).toBeUndefined();
   });
 
   it("throws on a rejected request so callers can fall back to typing", async () => {

--- a/src/llm/provider/openai/fetch-openai-compat-models.ts
+++ b/src/llm/provider/openai/fetch-openai-compat-models.ts
@@ -24,6 +24,27 @@ export function getCachedOpenAiCompatModels(
   return hit.ids;
 }
 
+/**
+ * Cache lookup by base URL alone, for read-only UI surfaces (the LLM
+ * panel's inline model list) that know a provider's URL but not which
+ * API key fetched the list. The strict keyed lookup above exists so an
+ * anonymous *fetch* never reuses an authenticated response; a panel that
+ * merely renders ids already stored on this machine leaks nothing, so
+ * here the freshest entry for the URL wins regardless of key.
+ */
+export function getCachedOpenAiCompatModelsForBaseUrl(
+  baseUrl: string,
+): readonly string[] | undefined {
+  const prefix = `${normalizeOpenAiBaseUrl(baseUrl)}\n`;
+  let best: { fetchedAt: number; ids: readonly string[] } | undefined;
+  for (const [key, hit] of cache) {
+    if (!key.startsWith(prefix)) continue;
+    if (Date.now() - hit.fetchedAt > CACHE_TTL_MS) continue;
+    if (!best || hit.fetchedAt > best.fetchedAt) best = hit;
+  }
+  return best?.ids;
+}
+
 /** Throws on unreachable/unauthorized servers so the caller can fall back to typing. */
 export async function fetchOpenAiCompatModels(
   baseUrl: string,

--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -184,7 +184,11 @@ export function handleAppKey(
       state.localModelsPanel.embeddingOnboardingPrompt !== null ||
       state.providersPanel.chatModelPicker !== null ||
       state.llmPanel.externalUrlDraft !== null ||
-      state.llmPanel.stopLocalDaemonsPrompt !== null);
+      state.llmPanel.stopLocalDaemonsPrompt !== null ||
+      // Focused inline model filter is a text-entry surface: Tab/Ctrl+B
+      // must not cycle the nav away mid-typing.
+      (state.llmPanel.mode === "cloud" &&
+        state.llmPanel.cloudModelFilterFocused));
   const debugTabBusy =
     tasksTabBusy ||
     skillsTabBusy ||

--- a/src/tui/commands/slash-command-handler.test.ts
+++ b/src/tui/commands/slash-command-handler.test.ts
@@ -145,13 +145,16 @@ describe("dispatchSlashCommand", () => {
     expect(result.systemMessage).toContain("debug bundle");
   });
 
-  it("opens the LLM panel on the active route and requests the picker for /model", () => {
+  it("opens the LLM panel on the active route and focuses the inline model filter for /model", () => {
     const result = dispatchSlashCommand("/model");
     expect(result.actions).toEqual([
       { type: "ui_mode_set", mode: "debug" },
       { type: "tab_changed", tab: "llm" },
       { type: "llm_mode_set_to_active_route" },
-      { type: "providers_chat_model_picker_requested", providerId: null },
+      { type: "llm_cloud_filter_focus_set", focused: true },
+      // Intercepted by submit-handler and routed through the
+      // orchestrator callback; it must never reach the reducer.
+      { type: "providers_inline_models_ensure_requested", providerId: null },
     ]);
   });
 

--- a/src/tui/commands/slash-command-handler.ts
+++ b/src/tui/commands/slash-command-handler.ts
@@ -323,11 +323,13 @@ function dispatchThemeSub(rawArgs: string): SlashDispatchResult {
  * + route sync), which read as two commands opening the same window;
  * the two were merged under the singular name (the industry-standard
  * spelling) so either lands in one place. Accepted shapes:
- *   - (bare)        — open the LLM tab on the active local/cloud route
- *                     and reopen the chat model picker (#62). The picker
- *                     request no-ops for curated/local kinds, leaving
+ *   - (bare)        — open the LLM tab on the active local/cloud route,
+ *                     focus the inline model list's `filter:` row and
+ *                     ensure the catalog is loaded (#62). On a local
+ *                     route the focus action no-ops (the reducer flips
+ *                     the pane to cloud only for explicit `f`), leaving
  *                     the tab switch as the whole effect there.
- *                     `/local` pins the local pane and skips the picker.
+ *                     `/local` pins the local pane and skips the list.
  *   - `pull <id>`   — open the tab and kick off a pull for the given id.
  *   - `use <id>`    — open the tab and set the given id as active.
  *   - `status`      — emit the managed-runtime status line in the feed.
@@ -344,11 +346,18 @@ function dispatchModelsSub(rawArgs: string, commandName: string): SlashDispatchR
         { type: "llm_mode_set", mode: "local" },
       ]);
     }
+    // The inline model list replaces the modal picker in the Cloud pane:
+    // jump to the active route, focus the `filter:` row and ensure the
+    // catalog is loaded. The ensure request is intercepted by
+    // submit-handler and routed through the orchestrator callback — a
+    // dispatched reducer action never reaches the bus the orchestrator
+    // listens on.
     return pureActions([
       { type: "ui_mode_set", mode: "debug" },
       { type: "tab_changed", tab: "llm" },
       { type: "llm_mode_set_to_active_route" },
-      { type: "providers_chat_model_picker_requested", providerId: null },
+      { type: "llm_cloud_filter_focus_set", focused: true },
+      { type: "providers_inline_models_ensure_requested", providerId: null },
     ]);
   }
   if (bits[0] === "pull" && bits[1]) {

--- a/src/tui/components/llm-mode-rows-cloud.test.tsx
+++ b/src/tui/components/llm-mode-rows-cloud.test.tsx
@@ -1,0 +1,162 @@
+import { render } from "ink-testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { selectLlmPanelRows } from "../llm-panel/llm-panel-selectors.js";
+import type { ProviderRow } from "../providers/providers-panel-state.js";
+import { fakeSession } from "../test-fixtures.js";
+import { createInitialTuiState, type TuiState } from "../tui-state.js";
+import { LlmModeRows } from "./llm-mode-rows.js";
+
+/** Prime the module-level `/v1/models` cache exactly like the picker does. */
+async function seedCompatCache(
+  baseUrl: string,
+  ids: readonly string[],
+): Promise<void> {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: ids.map((id) => ({ id })) }),
+    })),
+  );
+  await fetchOpenAiCompatModels(baseUrl, "key");
+  vi.unstubAllGlobals();
+}
+
+function compatProvider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  return {
+    id: "nous",
+    kind: "openai-compatible",
+    isActiveText: true,
+    isActiveEmbedding: false,
+    hasApiKey: true,
+    baseUrl: "https://render.nous.example",
+    chatModel: "m-000",
+    chatModelOptions: ["m-000"],
+    embeddingModel: null,
+    ...overrides,
+  };
+}
+
+function cloudState(
+  rows: readonly ProviderRow[],
+  patch: Partial<TuiState["llmPanel"]> = {},
+  inlineModels: TuiState["providersPanel"]["inlineModels"] = null,
+): TuiState {
+  const base = createInitialTuiState(fakeSession());
+  return {
+    ...base,
+    providersPanel: { ...base.providersPanel, rows, inlineModels },
+    llmPanel: { ...base.llmPanel, mode: "cloud", ...patch },
+  };
+}
+
+function strip(value: string): string {
+  return value.replace(/\[[0-9;]*m/g, "");
+}
+
+function renderRows(state: TuiState, maxRows: number): string {
+  const rows = selectLlmPanelRows(state);
+  const { lastFrame, unmount } = render(
+    <LlmModeRows rows={rows} state={state} maxRows={maxRows} />,
+  );
+  const frame = strip(lastFrame() ?? "");
+  unmount();
+  return frame;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("CloudRows inline model section", () => {
+  it("renders the two-line header (provider:/filter:) between providers and embeddings", async () => {
+    await seedCompatCache("https://render.nous.example", ["m-000", "m-001"]);
+    const frame = renderRows(cloudState([compatProvider()]), 30);
+    const lines = frame.split("\n").map((line) => line.trimEnd());
+    const providersIdx = lines.findIndex((l) => l.includes("Cloud providers"));
+    const headerIdx = lines.findIndex((l) => l.includes("Cloud text models"));
+    const providerLineIdx = lines.findIndex((l) => l.startsWith("provider: nous"));
+    const filterLineIdx = lines.findIndex((l) => l.startsWith("filter:"));
+    const embeddingsIdx = lines.findIndex((l) => l.includes("Cloud embeddings"));
+    expect(providersIdx).toBeGreaterThanOrEqual(0);
+    expect(headerIdx).toBeGreaterThan(providersIdx);
+    expect(providerLineIdx).toBe(headerIdx + 1);
+    expect(filterLineIdx).toBe(headerIdx + 2);
+    expect(embeddingsIdx).toBeGreaterThan(filterLineIdx);
+  });
+
+  it("windows 354 models to exactly 12 visible rows with the (n/N) counter", async () => {
+    const models = Array.from({ length: 354 }, (_, i) =>
+      `m-${String(i).padStart(3, "0")}`,
+    );
+    await seedCompatCache("https://render354.nous.example", models);
+    const state = cloudState([
+      compatProvider({ baseUrl: "https://render354.nous.example" }),
+    ]);
+    const frame = renderRows(state, 40);
+    const modelLines = frame
+      .split("\n")
+      .filter((line) => line.includes("nous/m-") && line.includes("[text]"));
+    expect(modelLines).toHaveLength(12);
+    expect(frame).toContain("(1/354)");
+  });
+
+  it("marks the current model and shows the filtered counter", async () => {
+    await seedCompatCache("https://renderfilter.nous.example", [
+      "m-000",
+      "m-001",
+      "x-002",
+    ]);
+    const state = cloudState(
+      [compatProvider({ baseUrl: "https://renderfilter.nous.example" })],
+      { cloudModelFilter: "m-0", cloudModelFilterFocused: true, cloudCursor: 1 },
+    );
+    const frame = renderRows(state, 30);
+    expect(frame).toContain("filter: m-0");
+    expect(frame).toContain("type to filter");
+    // Current model row keeps its active mark and Current wording.
+    expect(frame).toContain("* nous/m-000 [text]");
+    expect(frame).toContain("Current: nous/m-000");
+    // x-002 is filtered out; counter reports filtered of total.
+    expect(frame).not.toContain("x-002");
+    expect(frame).toContain("(1/2 of 3)");
+  });
+
+  it("shows the loading line while the catalog fetch is in flight", () => {
+    const state = cloudState(
+      [compatProvider({ baseUrl: "https://renderload.nous.example" })],
+      {},
+      {
+        providerId: "nous",
+        status: "loading",
+        models: [],
+        error: null,
+        generation: 1,
+      },
+    );
+    const frame = renderRows(state, 30);
+    expect(frame).toContain("fetching model list…");
+    // Fallback current-model row stays selectable under the loading line.
+    expect(frame).toContain("nous/m-000 [text]");
+  });
+
+  it("shows the error line and the one-row current-model fallback on fetch failure", () => {
+    const state = cloudState(
+      [compatProvider({ baseUrl: "https://rendererr.nous.example" })],
+      {},
+      {
+        providerId: "nous",
+        status: "error",
+        models: [],
+        error: "getaddrinfo ENOTFOUND rendererr.nous.example",
+        generation: 1,
+      },
+    );
+    const frame = renderRows(state, 30);
+    expect(frame).toContain("model list unavailable");
+    expect(frame).toContain("ENOTFOUND");
+    expect(frame).toContain("showing current model only");
+    expect(frame).toContain("nous/m-000 [text]");
+  });
+});

--- a/src/tui/components/llm-mode-rows.tsx
+++ b/src/tui/components/llm-mode-rows.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
+import { selectCloudModelSection } from "../llm-panel/llm-panel-row-builders.js";
 import { activeCursor, selectLlmPanelRows, type LlmPanelRow } from "../llm-panel/llm-panel-selectors.js";
 import { classifyRamFit, classifyVramFit } from "../local-models/local-models-panel-state.js";
 import { computeRowWindow } from "../row-window.js";
@@ -15,6 +16,11 @@ export function LlmModeRows({
   state: TuiState;
   maxRows?: number;
 }): ReactElement {
+  // The Cloud pane windows its own model list (the catalog can be 350+
+  // rows), so it never goes through the generic overflow fallback.
+  if (state.llmPanel.mode === "cloud") {
+    return <CloudRows rows={rows} state={state} maxRows={maxRows} />;
+  }
   // When the catalog overflows the available height, switch to a
   // cursor-windowed flat view so the rendered frame never exceeds the
   // terminal (Ink overlaps/garbles lines when it does — it does NOT
@@ -28,10 +34,7 @@ export function LlmModeRows({
     return <WindowedRows rows={rows} state={state} maxRows={maxRows} />;
   }
   if (state.llmPanel.mode === "local") return <LocalRows rows={rows} state={state} />;
-  if (state.llmPanel.mode === "external") {
-    return <ExternalRows rows={rows} state={state} />;
-  }
-  return <CloudRows rows={rows} state={state} />;
+  return <ExternalRows rows={rows} state={state} />;
 }
 
 /** Human-readable section title for a row, used by the windowed view. */
@@ -134,16 +137,64 @@ function LocalRows({
   );
 }
 
+/**
+ * Preferred number of visible model rows in the inline list — matches
+ * the window the modal picker used. Shrinks when the terminal budget
+ * cannot afford it next to the provider/embedding sections.
+ */
+const MODEL_WINDOW = 12;
+
+/**
+ * Cloud pane: providers, then the inline filterable model list (full
+ * catalog of the active provider, windowed around the cursor), then
+ * embeddings. Replaces both the single static model row and the modal
+ * picker this pane used to open.
+ */
 function CloudRows({
   rows,
   state,
+  maxRows,
 }: {
   rows: readonly LlmPanelRow[];
   state: TuiState;
+  maxRows: number;
 }): ReactElement {
   const providerRows = rows.filter((row) => row.kind === "cloudProvider");
   const textRows = rows.filter((row) => row.kind === "cloudChatModel");
   const embeddingRows = rows.filter((row) => row.kind === "cloudEmbeddingModel");
+  const section = selectCloudModelSection(state);
+  const filter = state.llmPanel.cloudModelFilter;
+  const filterFocused = state.llmPanel.cloudModelFilterFocused;
+  const statusLine = section.status !== "ready";
+  // Everything around the model window costs lines: section headers (3),
+  // their bottom margins (3), provider:/filter: (2), the counter (1),
+  // provider/embedding rows, plus a loading/error line when shown.
+  const overhead =
+    9 +
+    Math.max(1, providerRows.length) +
+    Math.max(1, embeddingRows.length) +
+    (statusLine ? 1 : 0);
+  const windowSize = Math.max(3, Math.min(MODEL_WINDOW, maxRows - overhead));
+  const cursorInSection = Math.max(
+    0,
+    Math.min(activeCursor(state) - section.sectionStart, textRows.length - 1),
+  );
+  const start = Math.max(
+    0,
+    Math.min(
+      cursorInSection - Math.floor(windowSize / 2),
+      textRows.length - windowSize,
+    ),
+  );
+  const visible = textRows.slice(start, start + windowSize);
+  const counter =
+    textRows.length === 0
+      ? "no match"
+      : `${cursorInSection + 1}/${textRows.length}${
+          textRows.length !== section.models.length
+            ? ` of ${section.models.length}`
+            : ""
+        }`;
   return (
     <Box flexDirection="column">
       <RowsSection
@@ -152,7 +203,43 @@ function CloudRows({
         state={state}
         empty="No cloud providers configured. Press n to add one."
       />
-      <RowsSection title="Cloud text models" rows={textRows} state={state} />
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold color={theme.colors.accentSoft}>
+          Cloud text models
+        </Text>
+        <Text color={theme.colors.muted}>
+          {"provider: "}
+          <Text bold color={theme.colors.accentSoft}>
+            {section.provider?.id ?? "none"}
+          </Text>
+        </Text>
+        <Text color={theme.colors.muted}>
+          {"filter: "}
+          <Text color={filterFocused ? theme.colors.accent : undefined}>
+            {filter}
+          </Text>
+          {filterFocused ? <Text color={theme.colors.muted}>▏</Text> : null}
+          {!filterFocused && filter.length === 0 ? (
+            <Text color={theme.colors.muted}>f to filter</Text>
+          ) : null}
+        </Text>
+        {section.status === "loading" ? (
+          <Text color={theme.colors.muted}>  fetching model list…</Text>
+        ) : null}
+        {section.status === "error" ? (
+          <Text color={theme.colors.error}>
+            {"  "}model list unavailable ({section.error ?? "unknown error"}) -
+            showing current model only
+          </Text>
+        ) : null}
+        {visible.map((row) => (
+          <Row key={row.id} row={row} state={state} />
+        ))}
+        <Text color={theme.colors.muted}>
+          {"  "}↑/↓ move ({counter})
+          {filterFocused ? " · type to filter · Enter select · Esc done" : ""}
+        </Text>
+      </Box>
       <RowsSection title="Cloud embeddings" rows={embeddingRows} state={state} />
     </Box>
   );

--- a/src/tui/components/llm-panel.tsx
+++ b/src/tui/components/llm-panel.tsx
@@ -72,8 +72,8 @@ export function LlmPanel({
       <Box marginTop={useFull ? 1 : 0} flexDirection="column">
         <Text color={theme.colors.muted}>
           {useFull
-            ? "j/k move · Enter selected action · ←/→ switch Local/Cloud/External · n add provider · c configure · r refresh"
-            : "j/k · Enter · ←/→ mode · r"}
+            ? "j/k move · Enter selected action · ←/→ switch Local/Cloud/External · f filter · n add provider · c configure · r refresh"
+            : "j/k · Enter · ←/→ mode · f filter · r"}
         </Text>
       </Box>
     </Box>

--- a/src/tui/llm-panel/llm-panel-actions.ts
+++ b/src/tui/llm-panel/llm-panel-actions.ts
@@ -9,7 +9,11 @@ export type LlmPanelAction =
   | { type: "llm_stop_local_daemons_prompt_opened"; providerId: string }
   | { type: "llm_stop_local_daemons_prompt_closed" }
   /** Opens (string), edits (string) or closes (`null`) the external URL editor. */
-  | { type: "llm_external_url_draft_set"; value: string | null };
+  | { type: "llm_external_url_draft_set"; value: string | null }
+  /** Focus/unfocus the Cloud pane's inline `filter:` row. */
+  | { type: "llm_cloud_filter_focus_set"; focused: boolean }
+  /** Replace the inline filter text (cursor snaps to the top of the result set). */
+  | { type: "llm_cloud_filter_set"; value: string };
 
 export function isLlmPanelAction(
   action: { type: string },
@@ -22,6 +26,8 @@ export function isLlmPanelAction(
     action.type === "llm_focus_set" ||
     action.type === "llm_stop_local_daemons_prompt_opened" ||
     action.type === "llm_stop_local_daemons_prompt_closed" ||
-    action.type === "llm_external_url_draft_set"
+    action.type === "llm_external_url_draft_set" ||
+    action.type === "llm_cloud_filter_focus_set" ||
+    action.type === "llm_cloud_filter_set"
   );
 }

--- a/src/tui/llm-panel/llm-panel-key-bindings.test.ts
+++ b/src/tui/llm-panel/llm-panel-key-bindings.test.ts
@@ -93,10 +93,11 @@ describe("handleLlmPanelKey", () => {
     expect(onStop).toHaveBeenCalledTimes(1);
   });
 
-  it("asks for the model picker on an openai-compatible model row via the callback", () => {
-    // A dispatched `providers_chat_model_picker_requested` is a reducer
-    // no-op the orchestrator never sees; the request must travel as a
-    // callback, so Enter on the row must not dispatch anything.
+  it("selects directly on an openai-compatible model row, no modal detour", () => {
+    // The inline Cloud-pane list renders `/v1/models` entries as
+    // first-class rows, so Enter switches the model through the same
+    // callback as curated kinds; the picker modal stays closed and no
+    // dead reducer action is dispatched.
     const base = seededState();
     const state = {
       ...base,
@@ -120,8 +121,44 @@ describe("handleLlmPanelKey", () => {
       }),
     });
     expect(dispatched).toEqual([]);
-    expect(onPickerRequested).toHaveBeenCalledWith("openrouter");
-    expect(onSelectChatModel).not.toHaveBeenCalled();
+    expect(onSelectChatModel).toHaveBeenCalledWith(
+      "openrouter",
+      "openai/gpt-4o-mini",
+    );
+    expect(onPickerRequested).not.toHaveBeenCalled();
+  });
+
+  it("f focuses the inline model filter and typed letters land in it", () => {
+    const base = seededState();
+    const state = {
+      ...base,
+      llmPanel: { ...base.llmPanel, mode: "cloud" as const },
+    };
+    const dispatched: TuiAction[] = [];
+    const handled = handleLlmPanelKey("f", emptyKey(), {
+      state,
+      dispatch: (action) => dispatched.push(action),
+      callbacks: callbacks(),
+    });
+    expect(handled).toBe(true);
+    expect(dispatched).toEqual([
+      { type: "llm_mode_set", mode: "cloud" },
+      { type: "llm_cloud_filter_focus_set", focused: true },
+    ]);
+
+    // With the filter focused, a letter that doubles as a hotkey ("c")
+    // edits the filter instead of opening the provider config.
+    const focused = {
+      ...state,
+      llmPanel: { ...state.llmPanel, cloudModelFilterFocused: true },
+    };
+    const typed: TuiAction[] = [];
+    handleLlmPanelKey("c", emptyKey(), {
+      state: focused,
+      dispatch: (action) => typed.push(action),
+      callbacks: callbacks(),
+    });
+    expect(typed).toEqual([{ type: "llm_cloud_filter_set", value: "c" }]);
   });
 
   it("selects an exact cloud embedding model", () => {

--- a/src/tui/llm-panel/llm-panel-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-key-bindings.ts
@@ -2,7 +2,11 @@ import type { Key } from "ink";
 import type { TuiAction } from "../tui-action.js";
 import type { TuiAppCallbacks } from "../tui-app.js";
 import type { TuiState } from "../tui-state.js";
-import { handleLlmModalKey } from "./llm-panel-modal-key-bindings.js";
+import {
+  handleLlmModalKey,
+  isPrintableFilterInput,
+} from "./llm-panel-modal-key-bindings.js";
+import { selectCloudModelSection } from "./llm-panel-row-builders.js";
 import { clampLlmCursor, selectLlmRowAt } from "./llm-panel-selectors.js";
 import { cursorFieldFor } from "./llm-panel-state.js";
 import {
@@ -30,6 +34,22 @@ export function handleLlmPanelKey(
 
   const modalHandled = handleLlmModalKey(input, key, ctx);
   if (modalHandled !== null) return modalHandled;
+
+  // Focused `filter:` row of the inline Cloud model list: printable keys
+  // edit the filter, ↑/↓ walk the filtered models, Enter selects, Esc
+  // unfocuses (the text stays). Letters are text here, so this branch
+  // must run before every letter hotkey below.
+  if (state.llmPanel.mode === "cloud" && state.llmPanel.cloudModelFilterFocused) {
+    return handleCloudFilterKey(input, key, ctx);
+  }
+
+  // `f` drops into the inline model filter. From the Local/External
+  // panes it first flips to Cloud, same pattern as `n`/`c`.
+  if (input === "f") {
+    dispatch({ type: "llm_mode_set", mode: "cloud" });
+    dispatch({ type: "llm_cloud_filter_focus_set", focused: true });
+    return true;
+  }
 
   // `/` bootstraps the global slash-command palette. The LLM tab keeps
   // the editor unfocused so single letters act as panel hotkeys, which
@@ -103,5 +123,68 @@ export function handleLlmPanelKey(
 
 function activeCursor(state: TuiState): number {
   return state.llmPanel[cursorFieldFor(state.llmPanel.mode)];
+}
+
+/**
+ * Key handling while the inline `filter:` row is focused. The list
+ * cursor stays live the whole time — filtering and walking the results
+ * never require leaving the filter row. Printable input follows the
+ * same discipline as the modal picker's filter: navigation keys are
+ * excluded by flag and control characters by code point, so escape
+ * sequences can never land in the query.
+ */
+function handleCloudFilterKey(
+  input: string,
+  key: Key,
+  ctx: LlmPanelKeyContext,
+): boolean {
+  const { state, dispatch, callbacks } = ctx;
+  const filter = state.llmPanel.cloudModelFilter;
+  if (key.escape) {
+    dispatch({ type: "llm_cloud_filter_focus_set", focused: false });
+    return true;
+  }
+  if (key.upArrow || key.downArrow) {
+    const section = selectCloudModelSection(state);
+    if (section.filtered.length === 0) return true;
+    const first = section.sectionStart;
+    const last = section.sectionStart + section.filtered.length - 1;
+    const delta = key.downArrow ? 1 : -1;
+    const cursor = Math.min(last, Math.max(first, activeCursor(state) + delta));
+    dispatch({ type: "llm_cursor_set", cursor });
+    return true;
+  }
+  if (key.return) {
+    const row = selectLlmRowAt(state);
+    if (row?.kind !== "cloudChatModel") return true;
+    // Selection ends the filtering session; the hotkey layer takes over.
+    dispatch({ type: "llm_cloud_filter_focus_set", focused: false });
+    triggerLlmPrimary(row, state, dispatch, callbacks);
+    return true;
+  }
+  if (key.backspace || key.delete) {
+    // Nothing to erase: dispatching would snap the cursor to the top of
+    // the list for no reason, so swallow the key instead.
+    if (filter.length === 0) return true;
+    dispatch({ type: "llm_cloud_filter_set", value: filter.slice(0, -1) });
+    return true;
+  }
+  const isNavigationKey =
+    key.tab ||
+    key.leftArrow ||
+    key.rightArrow ||
+    key.pageUp ||
+    key.pageDown;
+  if (
+    input.length > 0 &&
+    !key.ctrl &&
+    !key.meta &&
+    !isNavigationKey &&
+    isPrintableFilterInput(input)
+  ) {
+    dispatch({ type: "llm_cloud_filter_set", value: filter + input });
+    return true;
+  }
+  return true;
 }
 

--- a/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
@@ -216,9 +216,11 @@ export function handleLlmModalKey(
 /**
  * True when every code point of the reported input is printable text.
  * Rejects C0 controls (below 0x20) and DEL (0x7f) so escape-sequence
- * fragments and raw control bytes can never land in the picker filter.
+ * fragments and raw control bytes can never land in a filter. Shared
+ * with the Cloud pane's inline model filter so both text surfaces apply
+ * the same discipline.
  */
-function isPrintableFilterInput(input: string): boolean {
+export function isPrintableFilterInput(input: string): boolean {
   for (const char of input) {
     const codePoint = char.codePointAt(0);
     if (codePoint === undefined || codePoint < 0x20 || codePoint === 0x7f) {

--- a/src/tui/llm-panel/llm-panel-primary-actions.ts
+++ b/src/tui/llm-panel/llm-panel-primary-actions.ts
@@ -174,15 +174,10 @@ function triggerCloudChatModel(
     openProviderConfigFor(row.provider, dispatch);
     return;
   }
-  if (row.provider.kind === "openai-compatible") {
-    // The picker owns selection for server-listed providers: Enter on the
-    // current-model row reopens the `/v1/models` list instead of
-    // re-selecting the same model (#62). Routed as a callback into
-    // `ProvidersOrchestrator.openChatModelPicker`: dispatch feeds the
-    // reducer only and never reaches the bus the orchestrator listens on.
-    callbacks.onProvidersChatModelPickerRequested?.(row.providerId);
-    return;
-  }
+  // Every model row selects directly now, openai-compatible included:
+  // the inline Cloud-pane list renders the full `/v1/models` catalog as
+  // first-class rows (with a live fetch behind `ensureInlineModels`), so
+  // Enter no longer needs to detour through the picker modal (#62).
   callbacks.onProvidersSelectChatModel?.(row.providerId, row.modelId);
   stopLocalDaemonsForCloudSelection(state, callbacks);
 }

--- a/src/tui/llm-panel/llm-panel-reducer.ts
+++ b/src/tui/llm-panel/llm-panel-reducer.ts
@@ -1,6 +1,7 @@
 import type { TuiAction } from "../tui-action.js";
 import type { TuiState } from "../tui-state.js";
 import { isLlmPanelAction } from "./llm-panel-actions.js";
+import { selectCloudModelSection } from "./llm-panel-row-builders.js";
 import { cursorFieldFor, LLM_PANEL_MODES, type LlmPanelMode } from "./llm-panel-state.js";
 
 export function reduceLlmPanelAction(
@@ -70,6 +71,52 @@ export function reduceLlmPanelAction(
         ...state,
         llmPanel: { ...panel, externalUrlDraft: action.value },
       };
+    case "llm_cloud_filter_focus_set": {
+      if (!action.focused) {
+        return {
+          ...state,
+          llmPanel: { ...panel, cloudModelFilterFocused: false },
+        };
+      }
+      // Focus only applies to the Cloud pane: /model on a local route
+      // dispatches this right after `llm_mode_set_to_active_route`
+      // resolved to `local`, and there the tab switch is the whole
+      // effect. (`f` flips the pane to cloud explicitly before this.)
+      if (panel.mode !== "cloud") return state;
+      // Focusing the filter drops the cursor into the model section so
+      // ↑/↓ and Enter act on models immediately. The section lists the
+      // current model first; when the cursor is already inside the
+      // section, leave it where the operator put it.
+      const section = selectCloudModelSection(state);
+      const sectionEnd = section.sectionStart + section.filtered.length - 1;
+      const cursorInSection =
+        panel.cloudCursor >= section.sectionStart &&
+        panel.cloudCursor <= sectionEnd;
+      return {
+        ...state,
+        llmPanel: {
+          ...panel,
+          cloudModelFilterFocused: true,
+          cloudCursor: cursorInSection ? panel.cloudCursor : section.sectionStart,
+        },
+      };
+    }
+    case "llm_cloud_filter_set": {
+      // Every edit re-filters, so the cursor snaps to the top of the new
+      // result set — same rule the modal picker used.
+      const next: TuiState = {
+        ...state,
+        llmPanel: { ...panel, cloudModelFilter: action.value },
+      };
+      const section = selectCloudModelSection(next);
+      return {
+        ...next,
+        llmPanel: {
+          ...next.llmPanel,
+          cloudCursor: section.sectionStart,
+        },
+      };
+    }
     default:
       return state;
   }

--- a/src/tui/llm-panel/llm-panel-row-builders.test.ts
+++ b/src/tui/llm-panel/llm-panel-row-builders.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import type { ProviderRow } from "../providers/providers-panel-state.js";
+import { createInitialTuiState, type TuiState } from "../tui-state.js";
+import { fakeSession } from "../test-fixtures.js";
+import type { TuiAction } from "../tui-action.js";
+import type { TuiAppCallbacks } from "../tui-app.js";
+import { selectCloudModelSection, selectCloudRows } from "./llm-panel-row-builders.js";
+import type { LlmPanelRow } from "./llm-panel-selectors.js";
+import { triggerLlmPrimary } from "./llm-panel-primary-actions.js";
+
+/** Prime the module-level `/v1/models` cache exactly like the picker does. */
+async function seedCompatCache(
+  baseUrl: string,
+  ids: readonly string[],
+): Promise<void> {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: ids.map((id) => ({ id })) }),
+    })),
+  );
+  await fetchOpenAiCompatModels(baseUrl, "key");
+  vi.unstubAllGlobals();
+}
+
+function compatProvider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  return {
+    id: "xai",
+    kind: "openai-compatible",
+    isActiveText: true,
+    isActiveEmbedding: false,
+    hasApiKey: true,
+    baseUrl: "https://api.x.ai",
+    chatModel: "grok-4",
+    chatModelOptions: ["grok-4"],
+    embeddingModel: null,
+    ...overrides,
+  };
+}
+
+function stateWith(
+  rows: readonly ProviderRow[],
+  patch: {
+    filter?: string;
+    inlineModels?: TuiState["providersPanel"]["inlineModels"];
+  } = {},
+): TuiState {
+  const base = createInitialTuiState(fakeSession());
+  return {
+    ...base,
+    providersPanel: {
+      ...base.providersPanel,
+      rows,
+      inlineModels: patch.inlineModels ?? null,
+    },
+    llmPanel: {
+      ...base.llmPanel,
+      mode: "cloud",
+      cloudModelFilter: patch.filter ?? "",
+    },
+  };
+}
+
+function chatRows(state: TuiState) {
+  return selectCloudRows(state).filter(
+    (row): row is Extract<LlmPanelRow, { kind: "cloudChatModel" }> =>
+      row.kind === "cloudChatModel",
+  );
+}
+
+function callbacks(overrides: Partial<TuiAppCallbacks> = {}): TuiAppCallbacks {
+  return {
+    onApprovalDecision: vi.fn(),
+    onAbort: vi.fn(),
+    onQuit: vi.fn(),
+    onMessageSubmitted: vi.fn(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("inline cloud model section from the openai-compat cache", () => {
+  it("lists every cached model as its own row, current first", async () => {
+    const models = [
+      "grok-2",
+      "grok-3",
+      "grok-3-mini",
+      "grok-4",
+      "grok-4-fast",
+      "grok-code",
+    ];
+    await seedCompatCache("https://api.x.ai", models);
+    const state = stateWith([compatProvider()]);
+
+    const rows = chatRows(state);
+    expect(rows).toHaveLength(6);
+    // Current model first, marked as such; the rest select directly.
+    expect(rows[0]).toMatchObject({
+      modelId: "grok-4",
+      active: true,
+      primaryAction: "current",
+      enterEffect: "Current: xai/grok-4",
+    });
+    expect(rows.map((row) => row.modelId).sort()).toEqual(models.sort());
+    expect(
+      rows.find((row) => row.modelId === "grok-2"),
+    ).toMatchObject({ primaryAction: "use", enterEffect: "Enter: use xai/grok-2" });
+    expect(selectCloudModelSection(state).status).toBe("ready");
+  });
+
+  it("keeps all 354 models as rows: the renderer windows, the list does not cap", async () => {
+    const models = Array.from({ length: 354 }, (_, i) =>
+      `m-${String(i).padStart(3, "0")}`,
+    );
+    await seedCompatCache("https://inference.nous.example", models);
+    const state = stateWith([
+      compatProvider({
+        id: "nous",
+        baseUrl: "https://inference.nous.example",
+        chatModel: "m-200",
+        chatModelOptions: ["m-200"],
+      }),
+    ]);
+
+    const rows = chatRows(state);
+    expect(rows).toHaveLength(354);
+    expect(rows[0]).toMatchObject({
+      modelId: "m-200",
+      active: true,
+      primaryAction: "current",
+    });
+    const section = selectCloudModelSection(state);
+    expect(section.models).toHaveLength(354);
+    expect(section.filtered).toHaveLength(354);
+    // Model rows start right after the single provider row.
+    expect(section.sectionStart).toBe(1);
+  });
+
+  it("filters the rows with the typed query, case-insensitively", async () => {
+    await seedCompatCache("https://filter.example", [
+      "grok-4.3",
+      "grok-4.20-0309-non-reasoning",
+      "grok-4.20-0309-reasoning",
+      "other-model",
+    ]);
+    const state = stateWith(
+      [
+        compatProvider({
+          baseUrl: "https://filter.example",
+          chatModel: "grok-4.3",
+          chatModelOptions: ["grok-4.3"],
+        }),
+      ],
+      { filter: "REASONING" },
+    );
+
+    const rows = chatRows(state);
+    expect(rows.map((row) => row.modelId)).toEqual([
+      "grok-4.20-0309-non-reasoning",
+      "grok-4.20-0309-reasoning",
+    ]);
+    const section = selectCloudModelSection(state);
+    expect(section.models).toHaveLength(4);
+    expect(section.filtered).toHaveLength(2);
+  });
+
+  it("reports loading with a single current-model fallback row while the cache is cold", () => {
+    const state = stateWith([
+      compatProvider({ baseUrl: "https://cold.example", chatModel: "grok-4" }),
+    ]);
+
+    const rows = chatRows(state);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ modelId: "grok-4", primaryAction: "current" });
+    expect(selectCloudModelSection(state).status).toBe("loading");
+  });
+
+  it("prefers the live inline catalog state over the module cache", () => {
+    const state = stateWith(
+      [compatProvider({ baseUrl: "https://live.example" })],
+      {
+        inlineModels: {
+          providerId: "xai",
+          status: "ready",
+          models: ["live-a", "live-b"],
+          error: null,
+          generation: 1,
+        },
+      },
+    );
+    const rows = chatRows(state);
+    expect(rows.map((row) => row.modelId)).toEqual(["grok-4", "live-a", "live-b"]);
+  });
+
+  it("falls back to one current-model row and surfaces the message on fetch error", () => {
+    const state = stateWith(
+      [compatProvider({ baseUrl: "https://down.example" })],
+      {
+        inlineModels: {
+          providerId: "xai",
+          status: "error",
+          models: [],
+          error: "getaddrinfo ENOTFOUND down.example",
+          generation: 1,
+        },
+      },
+    );
+    const rows = chatRows(state);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ modelId: "grok-4", primaryAction: "current" });
+    const section = selectCloudModelSection(state);
+    expect(section.status).toBe("error");
+    expect(section.error).toContain("ENOTFOUND");
+  });
+});
+
+describe("inline cloud model section for curated providers", () => {
+  it("lists the full OpenRouter catalog inline, current model first", () => {
+    const state = stateWith([
+      {
+        id: "openrouter",
+        kind: "openrouter",
+        isActiveText: true,
+        isActiveEmbedding: false,
+        hasApiKey: true,
+        baseUrl: null,
+        chatModel: "qwen/qwen3.7-max",
+        chatModelOptions: ["qwen/qwen3.7-max"],
+        embeddingModel: null,
+      },
+    ]);
+
+    const rows = chatRows(state);
+    // The static catalog alone lists 18 chat models; all become rows.
+    expect(rows.length).toBeGreaterThan(12);
+    expect(rows[0]).toMatchObject({
+      modelId: "qwen/qwen3.7-max",
+      active: true,
+    });
+    expect(selectCloudModelSection(state).status).toBe("ready");
+  });
+});
+
+describe("Enter on a model row", () => {
+  it("selects the model directly through onProvidersSelectChatModel", async () => {
+    await seedCompatCache("https://select.example", ["alpha", "beta", "gamma"]);
+    const state = stateWith([
+      compatProvider({
+        id: "xai",
+        baseUrl: "https://select.example",
+        chatModel: "alpha",
+        chatModelOptions: ["alpha"],
+      }),
+    ]);
+    const row = chatRows(state).find((r) => r.modelId === "beta");
+    expect(row).toBeDefined();
+
+    const dispatched: TuiAction[] = [];
+    const onProvidersSelectChatModel = vi.fn();
+    triggerLlmPrimary(
+      row!,
+      state,
+      (action) => dispatched.push(action),
+      callbacks({ onProvidersSelectChatModel }),
+    );
+    expect(onProvidersSelectChatModel).toHaveBeenCalledWith("xai", "beta");
+    expect(dispatched).toEqual([]);
+  });
+});

--- a/src/tui/llm-panel/llm-panel-row-builders.ts
+++ b/src/tui/llm-panel/llm-panel-row-builders.ts
@@ -2,7 +2,8 @@ import type {
   EmbeddingModelRow,
   LocalModelRow,
 } from "../local-models/local-models-panel-state.js";
-import type { ProviderRow } from "../providers/providers-panel-state.js";
+import { getCachedOpenAiCompatModelsForBaseUrl } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { filterModelIds, type ProviderRow } from "../providers/providers-panel-state.js";
 import {
   formatAimlapiChatModelDetails,
   formatAimlapiEmbeddingModelDetails,
@@ -54,19 +55,65 @@ export function selectExternalRows(state: TuiState): readonly LlmPanelRow[] {
   ];
 }
 
+/**
+ * The inline "Cloud text models" section: the full filterable model
+ * catalog of the active provider, rendered in place inside the Cloud
+ * pane (between Cloud providers and Cloud embeddings). Replaces the
+ * single current-model row + modal picker that pane used to open: the
+ * list is complete, the `filter:` row narrows it, and the renderer
+ * windows it to a dozen visible rows.
+ */
+export interface CloudModelSection {
+  /** Provider whose models are listed (active text provider, or first cloud). */
+  provider: ProviderRow | null;
+  status: "loading" | "ready" | "error";
+  /** Human-readable fetch error when `status === "error"`. */
+  error: string | null;
+  /** Full unfiltered catalog, current model first. */
+  models: readonly string[];
+  /** `models` narrowed by `llmPanel.cloudModelFilter`. */
+  filtered: readonly string[];
+  /** Flat-row index of the first model row (= cloud provider row count). */
+  sectionStart: number;
+}
+
+export function selectCloudModelSection(state: TuiState): CloudModelSection {
+  const providers = state.providersPanel.rows.filter(
+    (row) => row.kind !== "llama-server",
+  );
+  const provider =
+    providers.find((row) => row.isActiveText) ?? providers[0] ?? null;
+  const sectionStart = providers.length;
+  if (!provider) {
+    return {
+      provider: null,
+      status: "ready",
+      error: null,
+      models: [],
+      filtered: [],
+      sectionStart,
+    };
+  }
+  const catalog = inlineModelsForProvider(state, provider);
+  const filtered = filterModelIds(
+    catalog.models,
+    state.llmPanel.cloudModelFilter,
+  );
+  return { provider, ...catalog, filtered, sectionStart };
+}
+
 export function selectCloudRows(state: TuiState): readonly LlmPanelRow[] {
   const providers = state.providersPanel.rows.filter(
     (row) => row.kind !== "llama-server",
   );
-  const activeProvider =
-    providers.find((row) => row.isActiveText) ?? providers[0] ?? null;
   const rows: LlmPanelRow[] = providers.map((provider) => cloudProviderRow(provider));
-  if (activeProvider) {
-    for (const modelId of chatModelsForProvider(activeProvider)) {
-      rows.push(cloudChatRow(activeProvider, modelId));
+  const section = selectCloudModelSection(state);
+  if (section.provider) {
+    for (const modelId of section.filtered) {
+      rows.push(cloudChatRow(section.provider, modelId));
     }
-    for (const modelId of embeddingModelsForProvider(activeProvider)) {
-      rows.push(cloudEmbeddingRow(activeProvider, modelId));
+    for (const modelId of embeddingModelsForProvider(section.provider)) {
+      rows.push(cloudEmbeddingRow(section.provider, modelId));
     }
   }
   return rows;
@@ -283,18 +330,50 @@ function cloudEmbeddingEnterEffect(
     : `Enter: use embedding ${provider.id}/${modelId}`;
 }
 
-function chatModelsForProvider(provider: ProviderRow): readonly string[] {
+/**
+ * Full chat-model list for a provider, current model first. Curated
+ * kinds read their catalog synchronously. `openai-compatible` prefers
+ * the orchestrator-owned inline catalog state (which carries live
+ * loading/error transitions), then the 1h `/v1/models` module cache.
+ * When neither has data yet the section reports `loading` — the fetch is
+ * kicked by `ensureInlineModels` on tab activation and provider switch —
+ * and only the current model shows as a fallback row. On `error` the
+ * same single current-model row keeps the route selectable.
+ */
+function inlineModelsForProvider(
+  state: TuiState,
+  provider: ProviderRow,
+): { models: readonly string[]; status: "loading" | "ready" | "error"; error: string | null } {
   const out = new Set<string>();
   for (const option of provider.chatModelOptions ?? []) out.add(option);
   if (provider.chatModel) out.add(provider.chatModel);
   if (provider.kind === "openrouter") {
     for (const option of listOpenRouterChatModels()) out.add(option.id);
-  } else if (provider.kind === "aimlapi") {
-    for (const option of listAimlapiChatModels()) out.add(option.id);
-  } else if (provider.kind === "openai-compatible" && out.size === 0) {
-    out.add(OPENAI_COMPAT_DEFAULT_CHAT_MODEL);
+    return { models: [...out], status: "ready", error: null };
   }
-  return [...out];
+  if (provider.kind === "aimlapi") {
+    for (const option of listAimlapiChatModels()) out.add(option.id);
+    return { models: [...out], status: "ready", error: null };
+  }
+  // openai-compatible: live catalog state first, module cache second.
+  const inline = state.providersPanel.inlineModels;
+  if (inline && inline.providerId === provider.id) {
+    if (inline.status === "ready") {
+      for (const id of inline.models) out.add(id);
+      return { models: [...out], status: "ready", error: null };
+    }
+    if (out.size === 0) out.add(OPENAI_COMPAT_DEFAULT_CHAT_MODEL);
+    return { models: [...out], status: inline.status, error: inline.error };
+  }
+  const cached = provider.baseUrl
+    ? getCachedOpenAiCompatModelsForBaseUrl(provider.baseUrl)
+    : undefined;
+  if (cached && cached.length > 0) {
+    for (const id of cached) out.add(id);
+    return { models: [...out], status: "ready", error: null };
+  }
+  if (out.size === 0) out.add(OPENAI_COMPAT_DEFAULT_CHAT_MODEL);
+  return { models: [...out], status: "loading", error: null };
 }
 
 function embeddingModelsForProvider(provider: ProviderRow): readonly string[] {

--- a/src/tui/llm-panel/llm-panel-selectors.test.ts
+++ b/src/tui/llm-panel/llm-panel-selectors.test.ts
@@ -77,7 +77,7 @@ describe("llm-panel selectors", () => {
         providerId: "openrouter",
         modelId: "qwen/qwen3.7-max",
         active: true,
-        enterEffect: expect.stringContaining("$2.5/$7.5"),
+        enterEffect: expect.stringContaining("$1.25/$3.75"),
       }),
     );
     const activeCloud = cloudRows.find(

--- a/src/tui/llm-panel/llm-panel-state.ts
+++ b/src/tui/llm-panel/llm-panel-state.ts
@@ -28,6 +28,17 @@ export interface LlmPanelState {
    * keyboard.
    */
   externalUrlDraft: string | null;
+  /**
+   * Typed filter of the Cloud pane's inline model list. Persists when
+   * the filter row loses focus (Esc keeps the text, like the modal did).
+   */
+  cloudModelFilter: string;
+  /**
+   * True while the `filter:` row owns printable keys: typing edits the
+   * filter, ↑/↓ still walk the filtered list, Esc unfocuses. Entered via
+   * `f` or `/model`.
+   */
+  cloudModelFilterFocused: boolean;
 }
 
 export function createInitialLlmPanelState(): LlmPanelState {
@@ -39,6 +50,8 @@ export function createInitialLlmPanelState(): LlmPanelState {
     syncModeToActiveRoute: false,
     stopLocalDaemonsPrompt: null,
     externalUrlDraft: null,
+    cloudModelFilter: "",
+    cloudModelFilterFocused: false,
   };
 }
 

--- a/src/tui/providers/picker-reopen-app.test.tsx
+++ b/src/tui/providers/picker-reopen-app.test.tsx
@@ -7,6 +7,16 @@ import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "../tui-app.js";
 import { fakeSession } from "../test-fixtures.js";
 import { ProvidersOrchestrator } from "./providers-orchestrator.js";
 
+/**
+ * Full-app regression tests rendered through real Ink: real stdin
+ * keystrokes, real bus, real orchestrator, real reducer. This is the
+ * layer where the "/model works only once" bug lived: the LLM panel
+ * seeds the editor buffer with "/" from a hotkey, and the editor's
+ * private cursor used to stay at 0, turning the second "/model" into
+ * "model/" which never ran. No harness below the app shell can catch
+ * that class of bug.
+ */
+
 vi.mock("../../config/index.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../../config/index.js")>();
   return {
@@ -41,41 +51,53 @@ const SESSION = fakeSession({ workingDir: "/tmp/smoke" });
 
 function strip(value: string): string {
   return value
-    .replace(/\[[0-9;]*m/g, "")
-    .replace(/\]8;;[^]*/g, "");
+    .replace(/\[[0-9;]*m/g, "")
+    .replace(/\]8;;[^]*/g, "");
 }
 
 const tick = () => new Promise((r) => setTimeout(r, 25));
+
+function makeApp() {
+  const bus = makeTuiEventBus();
+  const orchestrator = new ProvidersOrchestrator({} as AgentRuntime, bus);
+  const onProvidersSelectChatModel = vi.fn();
+  const callbacks: TuiAppCallbacks = {
+    onApprovalDecision: () => {},
+    onAbort: () => {},
+    onQuit: () => {},
+    onMessageSubmitted: () => {},
+    onProvidersTabRefresh: () => {
+      orchestrator.refresh();
+      void orchestrator.ensureInlineModels(null);
+    },
+    onProvidersSelectChatModel,
+    onProvidersInlineModelsEnsureRequested: (providerId) =>
+      void orchestrator.ensureInlineModels(providerId),
+  };
+  const rendered = render(
+    <TuiApp session={SESSION} bus={bus} callbacks={callbacks} />,
+  );
+  return { ...rendered, onProvidersSelectChatModel };
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("full-app picker reopen (ink render, real orchestrator)", () => {
-  it("/model opens, Esc closes, /model opens again", async () => {
-    currentConfig = configWithNous("https://app.nous.example");
+describe("full-app inline model list (ink render, real orchestrator)", () => {
+  it("/model focuses the filter, Esc exits, /model works again (editor cursor regression)", async () => {
+    currentConfig = configWithNous("https://app-inline.nous.example");
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
         ok: true,
-        json: async () => ({ data: [{ id: "alpha" }, { id: "beta" }] }),
+        json: async () => ({
+          data: [{ id: "qwen/qwen-3.5" }, { id: "meta/llama-4" }],
+        }),
       })),
     );
 
-    const bus = makeTuiEventBus();
-    const orchestrator = new ProvidersOrchestrator({} as AgentRuntime, bus);
-    const callbacks: TuiAppCallbacks = {
-      onApprovalDecision: () => {},
-      onAbort: () => {},
-      onQuit: () => {},
-      onMessageSubmitted: () => {},
-      onProvidersTabRefresh: () => orchestrator.refresh(),
-      onProvidersChatModelPickerRequested: (providerId) =>
-        void orchestrator.openChatModelPicker(providerId),
-    };
-    const { lastFrame, stdin, unmount } = render(
-      <TuiApp session={SESSION} bus={bus} callbacks={callbacks} />,
-    );
+    const { lastFrame, stdin, unmount, onProvidersSelectChatModel } = makeApp();
     await tick();
 
     // First /model from the chat editor.
@@ -84,14 +106,31 @@ describe("full-app picker reopen (ink render, real orchestrator)", () => {
     stdin.write("\r");
     await tick();
     await tick();
-    expect(strip(lastFrame() ?? "")).toContain("Models — nous");
+    let frame = strip(lastFrame() ?? "");
+    expect(frame).toContain("Cloud text models");
+    expect(frame).toContain("provider: nous");
+    expect(frame).toContain("filter:");
+    // Focused filter advertises its keys.
+    expect(frame).toContain("type to filter");
+    expect(frame).toContain("qwen/qwen-3.5");
 
-    // Esc closes the picker.
+    // Typing goes into the filter, not the chat editor.
+    stdin.write("qwen");
+    await tick();
+    frame = strip(lastFrame() ?? "");
+    expect(frame).toContain("filter: qwen");
+    expect(frame).toContain("qwen/qwen-3.5");
+    expect(frame).not.toContain("meta/llama-4");
+
+    // Esc exits filter mode; the list and text stay.
     stdin.write("");
     await tick();
-    expect(strip(lastFrame() ?? "")).not.toContain("Models — nous");
+    frame = strip(lastFrame() ?? "");
+    expect(frame).not.toContain("type to filter");
+    expect(frame).toContain("filter: qwen");
 
-    // Second /model, typed from the LLM tab.
+    // Second /model, typed from the LLM tab: the "/" hotkey seeds the
+    // editor buffer, the typed letters must land AFTER the seeded slash.
     stdin.write("/");
     await tick();
     stdin.write("model");
@@ -99,7 +138,56 @@ describe("full-app picker reopen (ink render, real orchestrator)", () => {
     stdin.write("\r");
     await tick();
     await tick();
-    expect(strip(lastFrame() ?? "")).toContain("Models — nous");
+    frame = strip(lastFrame() ?? "");
+    expect(frame).toContain("type to filter");
+    expect(frame).toContain("provider: nous");
+
+    // Enter selects the model under the cursor via the real callback.
+    stdin.write("\r");
+    await tick();
+    expect(onProvidersSelectChatModel).toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("windows 354 models to a dozen visible rows with an (n/N) counter", async () => {
+    currentConfig = configWithNous("https://app-354.nous.example");
+    const models = Array.from({ length: 354 }, (_, i) =>
+      `vendor/model-${String(i).padStart(3, "0")}`,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: models.map((id) => ({ id })) }),
+      })),
+    );
+
+    const { lastFrame, stdin, unmount } = makeApp();
+    await tick();
+    stdin.write("/model");
+    await tick();
+    stdin.write("\r");
+    await tick();
+    await tick();
+
+    const frame = strip(lastFrame() ?? "");
+    // 354 catalog models + the current (typoed) model = 355 rows total.
+    expect(frame).toContain("(1/355)");
+    // The window adapts to the test terminal's height; the exact
+    // 12-row window is pinned by the LlmModeRows component test.
+    const visibleModels = frame
+      .split("\n")
+      .filter((line) => line.includes("vendor/model-"));
+    expect(visibleModels.length).toBeGreaterThanOrEqual(2);
+    expect(visibleModels.length).toBeLessThanOrEqual(12);
+
+    // Filtering narrows the counter to the filtered/total form.
+    stdin.write("353");
+    await tick();
+    const filtered = strip(lastFrame() ?? "");
+    expect(filtered).toContain("vendor/model-353");
+    expect(filtered).toContain("(1/1 of 355)");
 
     unmount();
   });

--- a/src/tui/providers/providers-actions.ts
+++ b/src/tui/providers/providers-actions.ts
@@ -42,6 +42,41 @@ export type ProvidersAction =
   | { type: "providers_chat_model_picker_cursor_set"; cursor: number }
   | { type: "providers_chat_model_picker_query_set"; query: string }
   | { type: "providers_chat_model_picker_closed" }
+  | {
+      /**
+       * Make sure the Cloud pane's inline model list has (or is
+       * fetching) the catalog of `providerId` (`null` = active text
+       * provider). Dispatched by `/model`; `submit-handler` intercepts
+       * it and routes it through the
+       * `onProvidersInlineModelsEnsureRequested` callback into
+       * `ProvidersOrchestrator.ensureInlineModels`, because a dispatched
+       * reducer action never reaches the event bus the orchestrator
+       * listens on (same rule as the picker request above).
+       */
+      type: "providers_inline_models_ensure_requested";
+      providerId: string | null;
+    }
+  | {
+      /**
+       * Inline Cloud-pane model list transitions, emitted by
+       * `ProvidersOrchestrator.ensureInlineModels` on the event bus.
+       */
+      type: "providers_inline_models_loading";
+      providerId: string;
+      generation: number;
+    }
+  | {
+      type: "providers_inline_models_loaded";
+      providerId: string;
+      generation: number;
+      models: readonly string[];
+    }
+  | {
+      type: "providers_inline_models_failed";
+      providerId: string;
+      generation: number;
+      error: string;
+    }
   | { type: "providers_wizard_updated"; wizard: ProvidersWizardState }
   | { type: "providers_wizard_closed" }
   | { type: "providers_wizard_submit_started" }

--- a/src/tui/providers/providers-inline-models-flow.test.ts
+++ b/src/tui/providers/providers-inline-models-flow.test.ts
@@ -1,0 +1,488 @@
+import type { Key } from "ink";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentRuntime } from "../../runtime/bootstrap.js";
+import type { AtomicAgentConfig } from "../../config/index.js";
+import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { reduceTuiState } from "../agent-event-reducer.js";
+import { handleLlmPanelKey } from "../llm-panel/llm-panel-key-bindings.js";
+import { selectCloudModelSection } from "../llm-panel/llm-panel-row-builders.js";
+import { selectLlmPanelRows } from "../llm-panel/llm-panel-selectors.js";
+import { makeTuiEventBus } from "../make-event-bus.js";
+import { runSlashCommand } from "../submit-handler.js";
+import { fakeSession } from "../test-fixtures.js";
+import type { TuiAppCallbacks } from "../tui-app.js";
+import { createInitialTuiState, type TuiState } from "../tui-state.js";
+import { ProvidersOrchestrator } from "./providers-orchestrator.js";
+
+/**
+ * Integration tests for the LIVE inline-model-list chain:
+ *
+ *   keypress / slash command -> keymap handler or submit pipeline
+ *   -> `onProvidersInlineModelsEnsureRequested` callback
+ *   -> `ProvidersOrchestrator.ensureInlineModels` -> event bus
+ *   -> real reducer -> inline section state -> row builder.
+ *
+ * The TUI has two channels: `dispatch` feeds the React reducer only, and
+ * the event bus (which the orchestrator subscribes to and emits on) is
+ * bridged into the reducer one way via `bus.subscribe(dispatch)`. These
+ * tests wire the same pieces `tui-command.ts` wires and only ever press
+ * keys / run slash commands, then assert on the resulting reducer state
+ * — the discipline that caught the dead-reducer-action bug (e5ef04a).
+ */
+
+vi.mock("../../config/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../config/index.js")>();
+  return {
+    ...original,
+    getConfig: () => currentConfig,
+  };
+});
+
+// Provider switching persists the choice; tests must not write the real
+// user config, so the persistence layer mutates the mocked config only.
+vi.mock("../persist-llm-provider.js", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../persist-llm-provider.js")>();
+  return {
+    ...original,
+    setActiveTextProviderInConfig: (id: string) => {
+      currentConfig = {
+        ...currentConfig,
+        llm: { ...currentConfig.llm!, activeTextProvider: id },
+      } as AtomicAgentConfig;
+    },
+  };
+});
+
+let currentConfig: AtomicAgentConfig;
+
+function configWithNous(baseUrl: string): AtomicAgentConfig {
+  return {
+    llm: {
+      activeTextProvider: "nous",
+      activeEmbeddingProvider: "local-llama-embed",
+      toolTransport: "auto",
+      providers: [
+        {
+          id: "nous",
+          kind: "openai-compatible",
+          baseUrl,
+          apiKey: "sk-nous-test",
+          model: "nous/bytedance",
+          defaultChatModel: "nous/bytedance",
+        },
+      ],
+    },
+  } as AtomicAgentConfig;
+}
+
+function configWithTwoProviders(
+  nousBaseUrl: string,
+  xaiBaseUrl: string,
+): AtomicAgentConfig {
+  return {
+    llm: {
+      activeTextProvider: "nous",
+      activeEmbeddingProvider: "local-llama-embed",
+      toolTransport: "auto",
+      providers: [
+        {
+          id: "nous",
+          kind: "openai-compatible",
+          baseUrl: nousBaseUrl,
+          apiKey: "sk-nous-test",
+          model: "nous/bytedance",
+          defaultChatModel: "nous/bytedance",
+        },
+        {
+          id: "xai",
+          kind: "openai-compatible",
+          baseUrl: xaiBaseUrl,
+          apiKey: "sk-xai-test",
+          model: "grok-4",
+          defaultChatModel: "grok-4",
+        },
+      ],
+    },
+  } as AtomicAgentConfig;
+}
+
+function emptyKey(overrides: Partial<Key> = {}): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageDown: false,
+    pageUp: false,
+    return: false,
+    escape: false,
+    ctrl: false,
+    shift: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    meta: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Assemble the production wiring in miniature: a real bus, a real
+ * orchestrator subscribed to it, the real reducer as the only state
+ * writer, and callbacks bound the same way `tui-command.ts` binds them.
+ */
+function makeHarness() {
+  const bus = makeTuiEventBus();
+  const runtime = {
+    providerRegistry: {
+      setActive: vi.fn(async () => {}),
+      listIds: () => [],
+    },
+    reloadLlmProvider: vi.fn(async () => {}),
+    reloadLlmProviders: vi.fn(async () => {}),
+  } as unknown as AgentRuntime;
+  const orchestrator = new ProvidersOrchestrator(runtime, bus);
+  const store = { state: createInitialTuiState(fakeSession()) };
+  const applyToReducer = (action: unknown) => {
+    store.state = reduceTuiState(store.state, action as never);
+  };
+  // One-way bridge, exactly like `useEffect(() => bus.subscribe(dispatch))`.
+  bus.subscribe(applyToReducer);
+  const onProvidersSelectChatModel = vi.fn();
+  const callbacks: TuiAppCallbacks = {
+    onApprovalDecision: vi.fn(),
+    onAbort: vi.fn(),
+    onQuit: vi.fn(),
+    onMessageSubmitted: vi.fn(),
+    onProvidersSelectChatModel,
+    // The wiring under test, verbatim from tui-command.ts.
+    onProvidersChatModelPickerRequested: (providerId) =>
+      void orchestrator.openChatModelPicker(providerId),
+    onProvidersInlineModelsEnsureRequested: (providerId) =>
+      void orchestrator.ensureInlineModels(providerId),
+    onProvidersSetActiveText: (id) => void orchestrator.setActiveText(id),
+  };
+  const press = (input: string, key: Partial<Key> = {}) =>
+    handleLlmPanelKey(input, emptyKey(key), {
+      state: store.state,
+      dispatch: applyToReducer,
+      callbacks,
+    });
+  return { bus, orchestrator, store, callbacks, press, applyToReducer, onProvidersSelectChatModel };
+}
+
+function openLlmCloudTab(h: ReturnType<typeof makeHarness>, cursor: number): void {
+  h.applyToReducer({ type: "ui_mode_set", mode: "debug" });
+  h.applyToReducer({ type: "tab_changed", tab: "llm" });
+  h.applyToReducer({ type: "llm_mode_set", mode: "cloud" });
+  h.applyToReducer({ type: "llm_cursor_set", cursor });
+}
+
+function section(state: TuiState) {
+  return selectCloudModelSection(state);
+}
+
+function modelRowIds(state: TuiState): readonly string[] {
+  return selectLlmPanelRows(state, "cloud")
+    .filter((row) => row.kind === "cloudChatModel")
+    .map((row) => (row.kind === "cloudChatModel" ? row.modelId : ""));
+}
+
+function picker(state: TuiState) {
+  return state.providersPanel.chatModelPicker;
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("inline list open flow: /model (cold /v1/models cache)", () => {
+  it("focuses the filter, shows loading, loads the list, filters by typing, and selects", async () => {
+    // Unique base URL per test: the /v1/models cache is module-global.
+    currentConfig = configWithNous("https://cold-inline.nous.example");
+    let releaseFetch: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const fetchMock = vi.fn(async () => {
+      await gate;
+      return {
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: "qwen/qwen-3.5" },
+            { id: "bytedance/seed-1.6" },
+            { id: "meta/llama-4" },
+          ],
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const h = makeHarness();
+    h.orchestrator.refresh();
+
+    runSlashCommand("/model", h.store.state, h.applyToReducer, h.callbacks);
+
+    // Landed on the LLM tab, Cloud pane, filter focused, section loading
+    // while /v1/models is in flight.
+    expect(h.store.state.uiMode).toBe("debug");
+    expect(h.store.state.activeTab).toBe("llm");
+    expect(h.store.state.llmPanel.mode).toBe("cloud");
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(true);
+    expect(section(h.store.state)).toMatchObject({ status: "loading" });
+    // The loading fallback keeps the current model selectable.
+    expect(modelRowIds(h.store.state)).toEqual(["nous/bytedance"]);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://cold-inline.nous.example/v1/models",
+    );
+    // The provider's key must ride along on the fetch.
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: { Authorization: "Bearer sk-nous-test" },
+    });
+
+    releaseFetch();
+    await flush();
+    expect(section(h.store.state)).toMatchObject({ status: "ready" });
+    expect(modelRowIds(h.store.state)).toEqual([
+      "nous/bytedance",
+      "bytedance/seed-1.6",
+      "meta/llama-4",
+      "qwen/qwen-3.5",
+    ]);
+
+    // Typing filters the list in place through the panel key handler.
+    for (const ch of "qwen") h.press(ch);
+    expect(h.store.state.llmPanel.cloudModelFilter).toBe("qwen");
+    expect(modelRowIds(h.store.state)).toEqual(["qwen/qwen-3.5"]);
+    // The cursor snapped to the top of the filtered result set.
+    expect(h.store.state.llmPanel.cloudCursor).toBe(
+      section(h.store.state).sectionStart,
+    );
+
+    // Enter selects the filtered model through the existing mechanism.
+    h.press("", { return: true });
+    expect(h.onProvidersSelectChatModel).toHaveBeenCalledWith(
+      "nous",
+      "qwen/qwen-3.5",
+    );
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(false);
+  });
+
+  it("shows the fetch error inline with a one-line current-model fallback", async () => {
+    currentConfig = configWithNous("https://down-inline.nous.example");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("getaddrinfo ENOTFOUND down-inline.nous.example");
+      }),
+    );
+
+    const h = makeHarness();
+    h.orchestrator.refresh();
+
+    runSlashCommand("/model", h.store.state, h.applyToReducer, h.callbacks);
+    await flush();
+
+    expect(section(h.store.state)).toMatchObject({
+      status: "error",
+      error: expect.stringContaining("ENOTFOUND"),
+    });
+    // Fallback: the current model stays as the single selectable row.
+    expect(modelRowIds(h.store.state)).toEqual(["nous/bytedance"]);
+  });
+});
+
+describe("inline list reopen cycle: /model, Esc, /model again (live repro)", () => {
+  it("keeps working on every invocation, not just the first", async () => {
+    currentConfig = configWithNous("https://reopen-inline.nous.example");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "alpha" }, { id: "beta" }] }),
+      })),
+    );
+
+    const h = makeHarness();
+    h.orchestrator.refresh();
+
+    runSlashCommand("/model", h.store.state, h.applyToReducer, h.callbacks);
+    await flush();
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(true);
+    expect(section(h.store.state)).toMatchObject({ status: "ready" });
+
+    // Esc leaves filter mode through the real key route; typed text stays.
+    for (const ch of "al") h.press(ch);
+    h.press("", { escape: true });
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(false);
+    expect(h.store.state.llmPanel.cloudModelFilter).toBe("al");
+
+    runSlashCommand("/model", h.store.state, h.applyToReducer, h.callbacks);
+    await flush();
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(true);
+    expect(section(h.store.state)).toMatchObject({ status: "ready" });
+    expect(modelRowIds(h.store.state)).toEqual(["alpha"]);
+  });
+});
+
+describe("f key: focus the inline filter from the panel", () => {
+  it("focuses the filter row and drops the cursor into the model section", async () => {
+    const baseUrl = "https://fkey.nous.example";
+    currentConfig = configWithNous(baseUrl);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "alpha" }, { id: "beta" }] }),
+      })),
+    );
+    await fetchOpenAiCompatModels(baseUrl, "sk-nous-test");
+
+    const h = makeHarness();
+    h.orchestrator.refresh();
+    openLlmCloudTab(h, 0); // cursor on the provider row
+
+    expect(h.press("f")).toBe(true);
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(true);
+    // Cursor moved into the model section (first model row).
+    expect(h.store.state.llmPanel.cloudCursor).toBe(
+      section(h.store.state).sectionStart,
+    );
+
+    // Arrow keys keep walking the filtered list while typing.
+    h.press("", { downArrow: true });
+    expect(h.store.state.llmPanel.cloudCursor).toBe(
+      section(h.store.state).sectionStart + 1,
+    );
+
+    // Backspace edits, Esc exits and the letters become hotkeys again.
+    h.press("a");
+    h.press("", { backspace: true });
+    expect(h.store.state.llmPanel.cloudModelFilter).toBe("");
+    h.press("", { escape: true });
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(false);
+  });
+});
+
+describe("provider switch repopulates the inline section", () => {
+  it("Enter on another provider row fetches its catalog live and resets the filter", async () => {
+    currentConfig = configWithTwoProviders(
+      "https://switch-nous.example",
+      "https://switch-xai.example",
+    );
+    let releaseXai: () => void = () => {};
+    const xaiGate = new Promise<void>((resolve) => {
+      releaseXai = resolve;
+    });
+    const fetchMock = vi.fn(async (url: unknown) => {
+      if (String(url).includes("switch-xai")) {
+        await xaiGate;
+        return {
+          ok: true,
+          json: async () => ({ data: [{ id: "grok-4" }, { id: "grok-5" }] }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ data: [{ id: "nous-a" }, { id: "nous-b" }] }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const h = makeHarness();
+    h.orchestrator.refresh();
+    void h.orchestrator.ensureInlineModels(null);
+    await flush();
+    expect(section(h.store.state).provider?.id).toBe("nous");
+    expect(section(h.store.state).status).toBe("ready");
+
+    // Leftover filter from browsing nous.
+    h.applyToReducer({ type: "llm_cloud_filter_set", value: "nous" });
+
+    // Enter on the second provider row (rows: [nous, xai, models...]).
+    openLlmCloudTab(h, 1);
+    h.press("", { return: true });
+    await flush();
+
+    // Switch landed: section now belongs to xai and is visibly loading
+    // (its /v1/models is still in flight), the old filter is gone.
+    expect(section(h.store.state).provider?.id).toBe("xai");
+    expect(section(h.store.state).status).toBe("loading");
+    expect(h.store.state.llmPanel.cloudModelFilter).toBe("");
+
+    releaseXai();
+    await flush();
+    expect(section(h.store.state).status).toBe("ready");
+    expect(modelRowIds(h.store.state)).toEqual(["grok-4", "grok-5"]);
+  });
+});
+
+describe("modal picker (still used outside the Cloud pane) reopens cleanly", () => {
+  it("open -> Esc -> open again through the real modal key route", async () => {
+    const baseUrl = "https://modal-cycle.nous.example";
+    currentConfig = configWithNous(baseUrl);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "alpha" }, { id: "beta" }] }),
+      })),
+    );
+
+    const h = makeHarness();
+    h.orchestrator.refresh();
+    openLlmCloudTab(h, 0);
+
+    h.callbacks.onProvidersChatModelPickerRequested?.("nous");
+    await flush();
+    expect(picker(h.store.state)).toMatchObject({ status: "ready" });
+
+    h.press("", { escape: true });
+    expect(picker(h.store.state)).toBeNull();
+
+    h.callbacks.onProvidersChatModelPickerRequested?.("nous");
+    await flush();
+    expect(picker(h.store.state)).toMatchObject({
+      status: "ready",
+      models: ["alpha", "beta"],
+    });
+  });
+});
+
+describe("inline list flow: bare /model end to end", () => {
+  it("/model lands in the focused inline filter with the catalog loaded", async () => {
+    currentConfig = configWithNous("https://slash-inline.nous.example");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ data: [{ id: "delta" }, { id: "gamma" }] }),
+      })),
+    );
+
+    const h = makeHarness();
+    h.orchestrator.refresh();
+
+    runSlashCommand("/model", h.store.state, h.applyToReducer, h.callbacks);
+    await flush();
+
+    expect(h.store.state.uiMode).toBe("debug");
+    expect(h.store.state.activeTab).toBe("llm");
+    expect(h.store.state.llmPanel.cloudModelFilterFocused).toBe(true);
+    expect(section(h.store.state)).toMatchObject({ status: "ready" });
+    expect(modelRowIds(h.store.state)).toEqual([
+      "nous/bytedance",
+      "delta",
+      "gamma",
+    ]);
+  });
+});

--- a/src/tui/providers/providers-orchestrator.ts
+++ b/src/tui/providers/providers-orchestrator.ts
@@ -38,6 +38,9 @@ export class ProvidersOrchestrator {
   /** Backs the picker's stale-response guard; see `openChatModelPicker`. */
   private chatModelPickerGeneration = 0;
 
+  /** Backs the inline model list's stale-response guard; see `ensureInlineModels`. */
+  private inlineModelsGeneration = 0;
+
   constructor(
     private readonly runtime: AgentRuntime,
     private readonly bus: TuiEventBus & { emit(action: unknown): void },
@@ -94,10 +97,16 @@ export class ProvidersOrchestrator {
   }
 
   /**
-   * Open the reopenable model picker for an `openai-compatible` provider
-   * and drive its async list fetch. `providerId: null` resolves to the
-   * active text provider. No-ops for curated kinds (their models are
-   * already first-class rows) and for unknown ids.
+   * Open the reopenable model picker MODAL for an `openai-compatible`
+   * provider and drive its async list fetch. `providerId: null` resolves
+   * to the active text provider. No-ops for curated kinds (their models
+   * are already first-class rows) and for unknown ids.
+   *
+   * The Cloud pane and `/model` moved to the inline model list
+   * (`ensureInlineModels`); this modal stays for flows outside that
+   * pane. Reached via the `onProvidersChatModelPickerRequested`
+   * callback, not via a dispatched reducer action, which never reaches
+   * this bus.
    */
   async openChatModelPicker(providerId: string | null): Promise<void> {
     const config = getConfig();
@@ -129,6 +138,58 @@ export class ProvidersOrchestrator {
     } catch (err) {
       this.bus.emit({
         type: "providers_chat_model_picker_failed",
+        generation,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Make sure the Cloud pane's inline model list has (or is fetching)
+   * the catalog of `providerId` (`null` = active text provider).
+   * Curated kinds (OpenRouter, aimlapi) resolve synchronously from
+   * their catalog module and need no inline state, so they no-op here —
+   * the row builder reads them directly. `openai-compatible` providers:
+   * warm `/v1/models` cache loads immediately; a cold cache emits a
+   * visible `loading` state, then `loaded` or `failed`.
+   *
+   * Reached via the `onProvidersInlineModelsEnsureRequested` callback
+   * (tab activation, `/model`) and internally after a provider switch —
+   * never via a dispatched reducer action, which cannot reach this bus.
+   */
+  async ensureInlineModels(providerId: string | null): Promise<void> {
+    const config = getConfig();
+    const resolved = resolveLlmConfig(config);
+    const id = providerId ?? resolved.activeTextProvider;
+    if (!id) return;
+    const provider = resolved.providers.find((p) => p.id === id);
+    const fileEntry = config.llm?.providers.find((e) => e.id === id);
+    if (!provider || !isCloudProviderKind(provider.kind)) return;
+    if (provider.kind !== "openai-compatible") return;
+    const generation = ++this.inlineModelsGeneration;
+    this.bus.emit({
+      type: "providers_inline_models_loading",
+      providerId: id,
+      generation,
+    });
+    const baseUrl = fileEntry?.baseUrl ?? OPENAI_COMPAT_DEFAULT_BASE_URL;
+    try {
+      const apiKey = resolveLlmProviderApiKey(provider) ?? undefined;
+      // Warm 1h cache resolves without a network round-trip, so the
+      // loading state is only ever visible on a genuinely cold fetch.
+      const models = await fetchOpenAiCompatModels(baseUrl, apiKey);
+      this.bus.emit({
+        type: "providers_inline_models_loaded",
+        providerId: id,
+        generation,
+        models,
+      });
+      // Model ids became rows: nudge mounted panels to re-read state.
+      this.refresh();
+    } catch (err) {
+      this.bus.emit({
+        type: "providers_inline_models_failed",
+        providerId: id,
         generation,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -174,6 +235,11 @@ export class ProvidersOrchestrator {
         line: `Switched active text provider to "${id}". New messages use ${transport}.`,
       });
       this.refresh();
+      // The inline Cloud-pane list now shows this provider's models:
+      // repopulate it (live fetch with visible loading when the cache
+      // is cold). Fire-and-forget so a slow /v1/models cannot delay the
+      // switch feedback above.
+      void this.ensureInlineModels(id);
     } catch (err) {
       this.bus.emit({
         type: "providers_status",

--- a/src/tui/providers/providers-panel-state.ts
+++ b/src/tui/providers/providers-panel-state.ts
@@ -25,8 +25,10 @@ export interface ProvidersRemoveConfirmState {
 }
 
 /**
- * Reopenable chat-model picker for `openai-compatible` providers, opened
- * from the LLM panel's model row or `/model`. Lives here rather than on
+ * Reopenable chat-model picker modal. The Cloud pane replaced it with
+ * the inline filterable model list (`InlineModelCatalogState` below), so
+ * the modal no longer has an entry point there; it stays for non-panel
+ * flows that need a standalone picker. Lives here rather than on
  * `llmPanel` because the async `/v1/models` fetch and the resulting
  * selection are owned by `ProvidersOrchestrator`, matching `wizard` and
  * `removeConfirm`. A non-null value means the modal owns the keyboard.
@@ -60,9 +62,42 @@ export interface ProvidersChatModelPickerState {
 export function filteredPickerModels(
   picker: ProvidersChatModelPickerState,
 ): readonly string[] {
-  const q = picker.query.trim().toLowerCase();
-  if (q.length === 0) return picker.models;
-  return picker.models.filter((id) => id.toLowerCase().includes(q));
+  return filterModelIds(picker.models, picker.query);
+}
+
+/**
+ * Case-insensitive substring filter over model ids. Shared by the modal
+ * picker and the inline Cloud-pane model list so both surfaces match the
+ * same rows for the same query.
+ */
+export function filterModelIds(
+  models: readonly string[],
+  query: string,
+): readonly string[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return models;
+  return models.filter((id) => id.toLowerCase().includes(q));
+}
+
+/**
+ * Live model catalog behind the Cloud pane's inline "Cloud text models"
+ * section. Owned by `ProvidersOrchestrator.ensureInlineModels`, which is
+ * the only writer: curated kinds (OpenRouter, aimlapi) load synchronously
+ * from their catalog module and never populate this state, while
+ * `openai-compatible` drives the async `/v1/models` fetch with a visible
+ * `loading` state and an `error` state that falls back to a single
+ * current-model row.
+ *
+ * `generation` mirrors the modal picker's stale-response guard: a fetch
+ * that settles after the operator already switched providers must not
+ * repopulate the section with the previous provider's models.
+ */
+export interface InlineModelCatalogState {
+  providerId: string;
+  status: "loading" | "ready" | "error";
+  models: readonly string[];
+  error: string | null;
+  generation: number;
 }
 
 export interface ProvidersPanelState {
@@ -76,6 +111,8 @@ export interface ProvidersPanelState {
   chatModelPicker: ProvidersChatModelPickerState | null;
   /** Monotonic counter backing `ProvidersChatModelPickerState.generation`. */
   chatModelPickerGeneration: number;
+  /** Inline Cloud-pane model catalog; `null` until first ensured. */
+  inlineModels: InlineModelCatalogState | null;
 }
 
 export function createInitialProvidersPanelState(): ProvidersPanelState {
@@ -89,5 +126,6 @@ export function createInitialProvidersPanelState(): ProvidersPanelState {
     removeConfirm: null,
     chatModelPicker: null,
     chatModelPickerGeneration: 0,
+    inlineModels: null,
   };
 }

--- a/src/tui/providers/providers-reducer.ts
+++ b/src/tui/providers/providers-reducer.ts
@@ -205,6 +205,75 @@ export function reduceProvidersPanel(
         ...state,
         providersPanel: { ...panel, chatModelPicker: null },
       };
+    case "providers_inline_models_loading": {
+      // Newest ensure wins unconditionally: the loading emit is the
+      // authoritative "the section now belongs to this provider" signal.
+      // A provider switch also resets the filter — the typed query was
+      // about the previous provider's catalog.
+      const providerChanged =
+        panel.inlineModels?.providerId !== action.providerId;
+      return {
+        ...state,
+        providersPanel: {
+          ...panel,
+          inlineModels: {
+            providerId: action.providerId,
+            status: "loading",
+            models:
+              panel.inlineModels?.providerId === action.providerId
+                ? panel.inlineModels.models
+                : [],
+            error: null,
+            generation: action.generation,
+          },
+        },
+        llmPanel: providerChanged
+          ? { ...state.llmPanel, cloudModelFilter: "" }
+          : state.llmPanel,
+      };
+    }
+    case "providers_inline_models_loaded": {
+      // Generation-keyed like the modal picker: a fetch that settled
+      // after the operator switched providers must not repopulate the
+      // section with the previous provider's models.
+      if (
+        !panel.inlineModels ||
+        panel.inlineModels.generation !== action.generation
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        providersPanel: {
+          ...panel,
+          inlineModels: {
+            ...panel.inlineModels,
+            status: "ready",
+            models: action.models,
+            error: null,
+          },
+        },
+      };
+    }
+    case "providers_inline_models_failed": {
+      if (
+        !panel.inlineModels ||
+        panel.inlineModels.generation !== action.generation
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        providersPanel: {
+          ...panel,
+          inlineModels: {
+            ...panel.inlineModels,
+            status: "error",
+            error: action.error,
+          },
+        },
+      };
+    }
     case "providers_remove_opened":
       return {
         ...state,

--- a/src/tui/submit-handler.test.ts
+++ b/src/tui/submit-handler.test.ts
@@ -44,27 +44,37 @@ describe("handleEditorSubmit", () => {
     expect(systemMessages.some((t) => t.includes("chat cleared"))).toBe(true);
   });
 
-  it("routes the /model picker request through the callback, not dispatch", () => {
+  it("routes the /model catalog ensure through the callback, not dispatch", () => {
     // The orchestrator that owns the /v1/models fetch listens on the
     // event bus; a dispatched request action is a reducer no-op it
     // never sees, which is why /model looked dead in the app.
     const state = createInitialTuiState(fakeSession());
     const dispatched: Array<{ type: string }> = [];
+    const onEnsureRequested = vi.fn();
     const onPickerRequested = vi.fn();
     handleEditorSubmit(
       "/model",
       state,
       ((a: { type: string }) => dispatched.push(a)) as never,
-      stubCallbacks({ onProvidersChatModelPickerRequested: onPickerRequested }),
+      stubCallbacks({
+        onProvidersInlineModelsEnsureRequested: onEnsureRequested,
+        onProvidersChatModelPickerRequested: onPickerRequested,
+      }),
     );
-    expect(onPickerRequested).toHaveBeenCalledWith(null);
+    expect(onEnsureRequested).toHaveBeenCalledWith(null);
+    // The Cloud pane no longer opens the modal picker.
+    expect(onPickerRequested).not.toHaveBeenCalled();
     expect(
       dispatched.some(
-        (a) => a.type === "providers_chat_model_picker_requested",
+        (a) => a.type === "providers_inline_models_ensure_requested",
       ),
     ).toBe(false);
-    // The jump to the LLM tab still travels through the reducer.
+    // The jump to the LLM tab and the filter focus still travel
+    // through the reducer.
     expect(dispatched.some((a) => a.type === "tab_changed")).toBe(true);
+    expect(
+      dispatched.some((a) => a.type === "llm_cloud_filter_focus_set"),
+    ).toBe(true);
   });
 
   it("with palette open, runs the buffer when it is a full registered command (stale slashQuery)", () => {

--- a/src/tui/submit-handler.ts
+++ b/src/tui/submit-handler.ts
@@ -147,6 +147,13 @@ export function runSlashCommand(
       callbacks.onProvidersChatModelPickerRequested?.(action.providerId);
       continue;
     }
+    if (action.type === "providers_inline_models_ensure_requested") {
+      // Same wiring rule for the inline Cloud-pane model list (`/model`):
+      // the catalog ensure must reach
+      // `ProvidersOrchestrator.ensureInlineModels` through the callback.
+      callbacks.onProvidersInlineModelsEnsureRequested?.(action.providerId);
+      continue;
+    }
     dispatch(action);
   }
   if (result.systemMessage) {

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -226,6 +226,13 @@ export interface TuiAppCallbacks {
    * request never reaches the orchestrator and the picker never opens.
    */
   onProvidersChatModelPickerRequested?(providerId: string | null): void;
+  /**
+   * Cloud pane / `/model`: make sure the inline model list has (or is
+   * fetching) the catalog of `providerId` (`null` = active text
+   * provider). Callback for the same reason as the picker request
+   * above: only the callback layer reaches the orchestrator's bus.
+   */
+  onProvidersInlineModelsEnsureRequested?(providerId: string | null): void;
   /** Providers tab / LLM panel: switch the active embedding provider. */
   onProvidersSetActiveEmbedding?(id: string): void;
   /** Providers tab / LLM panel: select an exact embedding model. */

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -257,6 +257,11 @@ export async function tuiCommand(args: string[]): Promise<number> {
           // never reaches the bus the orchestrator listens on, which is
           // exactly how the live lists went missing from the pickers.
           orchestrator.providers.prefetchCloudCatalogs();
+          // Same for the inline Cloud-pane model list: the /v1/models
+          // fetch for openai-compatible providers starts here so the
+          // section is populated (or visibly loading) by the time the
+          // pane renders.
+          void orchestrator.providers.ensureInlineModels(null);
         },
         onProvidersSetActiveText: (id) =>
           void orchestrator.providers.setActiveText(id),
@@ -264,6 +269,8 @@ export async function tuiCommand(args: string[]): Promise<number> {
           void orchestrator.providers.selectChatModel(providerId, modelId),
         onProvidersChatModelPickerRequested: (providerId) =>
           void orchestrator.providers.openChatModelPicker(providerId),
+        onProvidersInlineModelsEnsureRequested: (providerId) =>
+          void orchestrator.providers.ensureInlineModels(providerId),
         onProvidersSetActiveEmbedding: (id) =>
           void orchestrator.providers.setActiveEmbedding(id),
         onProvidersSelectEmbeddingModel: (providerId, modelId) =>


### PR DESCRIPTION
## Problem

For openai-compatible providers (xai, nous, groq, custom vLLM) the Cloud pane showed one current-model row and pushed the real catalog behind a modal picker on Enter: an extra hop for every switch, no visibility into what the server offers, and the modal hid the pane while open.

## Change

The "Cloud text models" section now renders the active provider's full catalog inline, per the owner's redesign: `provider:` and `filter:` header rows ("f to filter" placeholder); the list windows to 12 rows around the cursor with an `(n/N)` counter (`(n/N of M)` while filtered), current model first and marked; Enter switches directly; `f` focuses the filter (Local/External flip to Cloud first), typing filters live, Esc keeps the text; `/model` lands in the focused filter. openai-compatible catalogs load live through `ensureInlineModels`: "fetching model list..." on a cold cache, a generation guard against stale responses, and a one-row current-model fallback with "model list unavailable ... showing current model only" on errors; provider switches repopulate and reset the filter. The picker modal loses its Cloud-pane entry points but stays intact for other flows.

The single `/model` command lands directly in the inline filter (the reducer no longer opens the modal picker in the Cloud pane), routed through `dispatchModelsSub` so the `/models` and `/local` aliases keep working.

## Testing

`tsc` clean. New suites: row builders (8), CloudRows render (5), an integration suite (7) driving /model, f, Esc, provider switch and the error fallback through the real bus + reducer + orchestrator; a full-app ink test runs `/model` end to end twice and pins the 354-model window. Every inline model row renders through the shared `Row` component, which keeps the narrow-terminal `wrap="truncate-end"` clip so the new list does not garble on a small window. Full run: no net regressions versus origin/main, and one long-standing OpenRouter pricing test failure (`llm-panel-selectors`) is fixed here.
