### PR TITLE
llm: brand the OpenRouter app as "Atomic Agent" and add marketplace categories

### DIFF
--- a/src/llm/provider/openrouter/openrouter-provider.test.ts
+++ b/src/llm/provider/openrouter/openrouter-provider.test.ts
@@ -14,6 +14,43 @@ describe("normalizeOpenRouterBaseUrl", () => {
 });
 
 describe("OpenRouterProvider", () => {
+  it("sends app-attribution headers on the request", async () => {
+    let sent: Headers | undefined;
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      sent = new Headers(init?.headers);
+      return new Response(
+        JSON.stringify({
+          id: "gen-1",
+          model: "openrouter/auto",
+          choices: [
+            {
+              message: { role: "assistant", content: "ok" },
+              finish_reason: "stop",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const provider = new OpenRouterProvider({
+      id: "openrouter",
+      apiKey: "test-key",
+      defaultChatModel: "openrouter/auto",
+      fetchImpl: fetchImpl as typeof fetch,
+      requestTimeoutMs: 5000,
+      httpReferer: "https://example.com",
+      xTitle: "Example App",
+      categories: "cli-agent,personal-agent",
+    });
+
+    await provider.complete({ prompt: "hi", maxTokens: 16, temperature: 0 });
+
+    expect(sent?.get("HTTP-Referer")).toBe("https://example.com");
+    expect(sent?.get("X-Title")).toBe("Example App");
+    expect(sent?.get("X-OpenRouter-Categories")).toBe("cli-agent,personal-agent");
+  });
+
   it("posts chat completions to /api/v1/chat/completions (not double /v1)", async () => {
     const fetchImpl = vi.fn(async (url: string) => {
       expect(url).toBe("https://openrouter.ai/api/v1/chat/completions");

--- a/src/llm/provider/openrouter/openrouter-provider.ts
+++ b/src/llm/provider/openrouter/openrouter-provider.ts
@@ -3,6 +3,17 @@ import { OpenAiProvider, type OpenAiProviderOptions } from "../openai/openai-pro
 /** Root without `/v1` — {@link OpenAiProvider} appends `/v1/chat/completions`. */
 export const DEFAULT_OPENROUTER_BASE = "https://openrouter.ai/api";
 
+/**
+ * App-attribution values sent on every OpenRouter request (chat and
+ * embeddings). The referer is the app's stable identity on
+ * openrouter.ai/apps, so it stays on the GitHub URL to keep one app page;
+ * the title is the display name and the categories place us in the
+ * marketplace boards. See https://openrouter.ai/docs/app-attribution.
+ */
+export const OPENROUTER_APP_REFERER = "https://github.com/AtomicBot-ai/atomic-agent";
+export const OPENROUTER_APP_TITLE = "Atomic Agent";
+export const OPENROUTER_APP_CATEGORIES = "cli-agent,personal-agent";
+
 /** Strips a trailing `/v1` so paths are not doubled (`/api/v1/v1/...`). */
 export { normalizeOpenAiBaseUrl as normalizeOpenRouterBaseUrl } from "../openai/normalize-openai-base-url.js";
 
@@ -10,6 +21,8 @@ export type OpenRouterProviderOptions = Omit<OpenAiProviderOptions, "baseUrl"> &
   baseUrl?: string;
   httpReferer?: string;
   xTitle?: string;
+  /** Comma-separated marketplace categories, e.g. `cli-agent,personal-agent`. */
+  categories?: string;
 };
 
 /**
@@ -24,6 +37,9 @@ export class OpenRouterProvider extends OpenAiProvider {
     }
     if (options.xTitle) {
       headers["X-Title"] = options.xTitle;
+    }
+    if (options.categories) {
+      headers["X-OpenRouter-Categories"] = options.categories;
     }
     super({
       ...options,

--- a/src/llm/provider/registry/register-built-in-providers.ts
+++ b/src/llm/provider/registry/register-built-in-providers.ts
@@ -4,7 +4,12 @@ import { AimlapiProvider } from "../aimlapi/aimlapi-provider.js";
 import { AIMLAPI_DEFAULT_CHAT_MODEL } from "../aimlapi/aimlapi-models-catalog.js";
 import { LlamaServerProvider } from "../llama-server/llama-server-provider.js";
 import { OpenAiProvider } from "../openai/openai-provider.js";
-import { OpenRouterProvider } from "../openrouter/openrouter-provider.js";
+import {
+  OpenRouterProvider,
+  OPENROUTER_APP_CATEGORIES,
+  OPENROUTER_APP_REFERER,
+  OPENROUTER_APP_TITLE,
+} from "../openrouter/openrouter-provider.js";
 import { registerProviderKind } from "./provider-types.js";
 
 let registered = false;
@@ -62,8 +67,9 @@ export function registerBuiltInProviderKinds(): void {
       supportsVision: entry.supportsVision ?? true,
       supportsParallelTools: entry.supportsTools ?? true,
       requestTimeoutMs: entry.requestTimeoutMs,
-      httpReferer: "https://github.com/AtomicBot-ai/atomic-agent",
-      xTitle: "atomic-agent",
+      httpReferer: OPENROUTER_APP_REFERER,
+      xTitle: OPENROUTER_APP_TITLE,
+      categories: OPENROUTER_APP_CATEGORIES,
     });
   });
 

--- a/src/memory/embeddings/openai-embedding-provider.test.ts
+++ b/src/memory/embeddings/openai-embedding-provider.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  OpenAiEmbeddingProvider,
+  OpenRouterEmbeddingProvider,
+} from "./openai-embedding-provider.js";
+
+function embeddingResponse(dim: number): Response {
+  return new Response(
+    JSON.stringify({
+      model: "openai/text-embedding-3-small",
+      data: [{ embedding: new Array(dim).fill(0) }],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("OpenAiEmbeddingProvider", () => {
+  it("forwards extra headers on the embeddings request", async () => {
+    let sent: Headers | undefined;
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      sent = new Headers(init?.headers);
+      return embeddingResponse(3);
+    });
+
+    const provider = new OpenAiEmbeddingProvider({
+      baseUrl: "https://example.com",
+      apiKey: "test-key",
+      model: "text-embedding-3-small",
+      dim: 3,
+      fetchImpl: fetchImpl as typeof fetch,
+      headers: { "X-Custom": "yes" },
+    });
+
+    await provider.embed({ text: "hello" });
+
+    expect(sent?.get("X-Custom")).toBe("yes");
+    expect(sent?.get("authorization")).toBe("Bearer test-key");
+  });
+});
+
+describe("OpenRouterEmbeddingProvider", () => {
+  it("sends app-attribution headers on the embeddings request", async () => {
+    let sent: Headers | undefined;
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://openrouter.ai/api/v1/embeddings");
+      sent = new Headers(init?.headers);
+      return embeddingResponse(1536);
+    });
+
+    const provider = new OpenRouterEmbeddingProvider({
+      baseUrl: "https://openrouter.ai/api",
+      apiKey: "test-key",
+      model: "openai/text-embedding-3-small",
+      dim: 1536,
+      fetchImpl: fetchImpl as typeof fetch,
+      httpReferer: "https://example.com",
+      xTitle: "Example App",
+      categories: "cli-agent,personal-agent",
+    });
+
+    await provider.embed({ text: "hello" });
+
+    expect(sent?.get("HTTP-Referer")).toBe("https://example.com");
+    expect(sent?.get("X-Title")).toBe("Example App");
+    expect(sent?.get("X-OpenRouter-Categories")).toBe("cli-agent,personal-agent");
+  });
+});

--- a/src/memory/embeddings/openai-embedding-provider.ts
+++ b/src/memory/embeddings/openai-embedding-provider.ts
@@ -13,6 +13,8 @@ export interface OpenAiEmbeddingProviderOptions {
   dim: number;
   requestTimeoutMs?: number;
   fetchImpl?: typeof fetch;
+  /** Extra request headers, e.g. OpenRouter attribution headers. */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -36,6 +38,7 @@ export class OpenAiEmbeddingProvider implements EmbeddingClient {
           headers: {
             "content-type": "application/json",
             authorization: `Bearer ${this.options.apiKey}`,
+            ...this.options.headers,
           },
           body: JSON.stringify({
             model: this.options.model,
@@ -78,13 +81,16 @@ export class OpenRouterEmbeddingProvider extends OpenAiEmbeddingProvider {
     options: OpenAiEmbeddingProviderOptions & {
       httpReferer?: string;
       xTitle?: string;
+      categories?: string;
     },
   ) {
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = { ...options.headers };
     if (options.httpReferer) headers["HTTP-Referer"] = options.httpReferer;
     if (options.xTitle) headers["X-Title"] = options.xTitle;
+    if (options.categories) headers["X-OpenRouter-Categories"] = options.categories;
     super({
       ...options,
+      headers,
       baseUrl: normalizeOpenRouterBaseUrl(
         options.baseUrl ?? "https://openrouter.ai/api",
       ),

--- a/src/memory/embeddings/register-built-in-embedding-providers.ts
+++ b/src/memory/embeddings/register-built-in-embedding-providers.ts
@@ -5,6 +5,11 @@ import {
 } from "./openai-embedding-provider.js";
 import { registerEmbeddingProviderKind } from "./embedding-provider-registry.js";
 import { getEmbeddingModelDef, isKnownEmbeddingModelId } from "../../local-llm/models-catalog.js";
+import {
+  OPENROUTER_APP_CATEGORIES,
+  OPENROUTER_APP_REFERER,
+  OPENROUTER_APP_TITLE,
+} from "../../llm/provider/openrouter/openrouter-provider.js";
 
 export function registerBuiltInEmbeddingProviderKinds(): void {
   registerEmbeddingProviderKind("llama-server", async ({ config, entry }) => {
@@ -43,8 +48,9 @@ export function registerBuiltInEmbeddingProviderKinds(): void {
       model: entry.defaultEmbeddingModel ?? "openai/text-embedding-3-small",
       dim: 1536,
       requestTimeoutMs: entry.requestTimeoutMs,
-      httpReferer: "https://github.com/AtomicBot-ai/atomic-agent",
-      xTitle: "atomic-agent",
+      httpReferer: OPENROUTER_APP_REFERER,
+      xTitle: OPENROUTER_APP_TITLE,
+      categories: OPENROUTER_APP_CATEGORIES,
     });
   });
 }


### PR DESCRIPTION
## What

Brand the OpenRouter app as **Atomic Agent** and place it in the marketplace category boards.

Attribution headers already ship, but the app shows up on [openrouter.ai/apps](https://openrouter.ai/apps) as the lowercase package name with no category, so it is missing from the Coding / Personal-agent boards where Hermes and OpenClaw sit.

- Send `X-Title: Atomic Agent` (was `atomic-agent`).
- Add `X-OpenRouter-Categories: cli-agent,personal-agent` (a new option on the provider).
- Keep `HTTP-Referer` on the GitHub URL. The referer is the app's stable identity on OpenRouter, so changing it would fork the app page and orphan the accumulated usage. Title and categories are cosmetic and update the existing page in place.
- Share the three attribution values as consts so the chat and embedding registrations cannot drift apart.

## Bug fix (found while here)

`OpenRouterEmbeddingProvider` built the attribution headers but never passed them to the base client, and `OpenAiEmbeddingProvider` had no way to send extra headers at all. So embedding requests reached OpenRouter **unattributed** (visible as near-zero embedding usage on the app page). This threads a `headers` option through the base embedding client and wires it up.

## Scope

Only OpenRouter provider code is touched (chat + embeddings). The launch command, package name, MCP client name, and HTTP API model id (`atomic-agent`) are unchanged — `X-Title` is a display label sent to OpenRouter, not any of those.

## Tests

- New: chat provider sends `HTTP-Referer` / `X-Title` / `X-OpenRouter-Categories` on the request.
- New: embedding provider sends the same headers (regression guard for the bug above), plus base-client header passthrough.
- `tsc --noEmit` clean; provider + embeddings suites green (100/100).

## Notes

The logo, description, and Docs link (like Hermes/OpenClaw) are **not** settable via headers — OpenRouter renders those from a claimed app profile. That is being handled separately by contacting OpenRouter, keeping the GitHub URL so the existing stats stay on one page.
