### PR TITLE
fix(tui): stop LLM panel rows garbling on a narrow terminal

### DIFF
--- a/src/tui/components/llm-mode-rows.tsx
+++ b/src/tui/components/llm-mode-rows.tsx
@@ -234,8 +234,14 @@ function Row({ row, state }: { row: LlmPanelRow; state: TuiState }): ReactElemen
     : insufficient
       ? theme.colors.muted
       : undefined;
+  // `wrap="truncate-end"` clips each row to the terminal width instead of
+  // letting Ink wrap it. A wrapped row spills a second physical line that
+  // Ink then overlaps with the following row (the whole panel already
+  // switches to a windowed view to avoid the same overflow vertically —
+  // see `LlmModeRows` — but never guarded the horizontal axis), which is
+  // what garbles adjacent rows and drags rendering on a narrow window.
   return (
-    <Text color={baseColor} bold={selected}>
+    <Text color={baseColor} bold={selected} wrap="truncate-end">
       {mark} {renderRowText(row, state)}
       {insufficient ? (
         <Text color={theme.colors.warn}> Not enough VRAM</Text>

--- a/src/tui/components/local-models-panel.tsx
+++ b/src/tui/components/local-models-panel.tsx
@@ -573,35 +573,44 @@ function renderChatRow(
       : insufficient
         ? theme.colors.muted
         : undefined;
+  // `flexWrap="nowrap"` (the Box default) clips the row at the terminal
+  // edge instead of spilling its trailing fragments onto a second
+  // physical line, which Ink then overlaps with the next row — the
+  // garble seen on a narrow window. The height-budget math elsewhere in
+  // this panel assumes one row is one line, so a wrapped row also
+  // desyncs the windowed slice. Keeping the fragments separate preserves
+  // their individual colors; the badges that fall off the edge are
+  // informational and reappear once the window is widened.
   return (
-    <Box key={r.id} flexDirection="row" flexWrap="wrap">
+    <Box key={r.id} flexDirection="row">
       <Text
         color={rowColor}
         bold={isCursor || downloading}
         dimColor={insufficient && !isCursor}
+        wrap="truncate-end"
       >
         {isCursor ? "> " : "  "}
         {r.active ? "* " : ""}
         {r.id} {r.def.sizeLabel}
       </Text>
-      <Text color={r.downloaded ? "green" : theme.colors.muted}>
+      <Text color={r.downloaded ? "green" : theme.colors.muted} wrap="truncate-end">
         {" "}
         [{renderRowAvailability(r)}]
       </Text>
       {r.def.tag ? (
-        <Text color={theme.colors.accent}> [{r.def.tag}]</Text>
+        <Text color={theme.colors.accent} wrap="truncate-end"> [{r.def.tag}]</Text>
       ) : null}
       {fit ? (
-        <Text color={ramFitColor(fit)}>
+        <Text color={ramFitColor(fit)} wrap="truncate-end">
           {" "}
           {fit === "ok" ? "✓ RAM" : fit === "tight" ? "△ RAM" : "✗ RAM"}
         </Text>
       ) : null}
       {vramFit === "insufficient" ? (
-        <Text color={theme.colors.warnStrong}> Not enough VRAM</Text>
+        <Text color={theme.colors.warnStrong} wrap="truncate-end"> Not enough VRAM</Text>
       ) : null}
       {downloading ? (
-        <Text color="yellow">
+        <Text color="yellow" wrap="truncate-end">
           {" "}
           [{mini}] {panel.pull!.percent}%
         </Text>
@@ -652,23 +661,25 @@ function renderEmbeddingRow(
     : isCursor
       ? theme.colors.accentSoft
       : undefined;
+  // See renderChatRow: nowrap + per-fragment truncate-end so a narrow
+  // window clips the row instead of wrapping and overlapping the next.
   return (
-    <Box key={r.id} flexDirection="row" flexWrap="wrap">
-      <Text color={rowColor} bold={isCursor || downloading}>
+    <Box key={r.id} flexDirection="row">
+      <Text color={rowColor} bold={isCursor || downloading} wrap="truncate-end">
         {isCursor ? "> " : "  "}
         {r.active ? "* " : ""}
         {r.id} {r.def.sizeLabel}
       </Text>
-      <Text color={r.downloaded ? "green" : theme.colors.muted}>
+      <Text color={r.downloaded ? "green" : theme.colors.muted} wrap="truncate-end">
         {" "}
         [{r.downloaded ? "gguf" : "remote"}]
       </Text>
-      <Text color={theme.colors.muted}>
+      <Text color={theme.colors.muted} wrap="truncate-end">
         {" "}
         dim {r.def.dim}
       </Text>
       {downloading ? (
-        <Text color="yellow">
+        <Text color="yellow" wrap="truncate-end">
           {" "}
           [{mini}] {panel.embeddingPull!.percent}%
         </Text>

--- a/src/tui/components/wizard-pick-list.test.tsx
+++ b/src/tui/components/wizard-pick-list.test.tsx
@@ -1,0 +1,66 @@
+import { Box } from "ink";
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+
+import { renderPickList } from "./wizard-pick-list.js";
+
+/**
+ * Constrain the list to a fixed inner width so the truncation guard is
+ * deterministic regardless of the test host's real terminal size —
+ * `wrap="truncate-end"` clips to the parent Box, so a 40-column Box is
+ * a stand-in for a 40-column terminal.
+ */
+function narrow(node: ReturnType<typeof renderPickList>, columns: number) {
+  return render(<Box width={columns}>{node}</Box>);
+}
+
+/**
+ * Longest line any rendered frame row reaches, in physical columns.
+ * A wrapped row would split one option across two lines and desync the
+ * windowed height math, so the guard is: no visible line exceeds the
+ * viewport width, and no option's text bleeds onto a second line.
+ */
+function widestLine(frame: string): number {
+  return Math.max(0, ...frame.split("\n").map((line) => line.length));
+}
+
+describe("renderPickList narrow-width rendering", () => {
+  const longLabel =
+    "Together AI — broad open-weight catalog vendored without a key, long enough to overflow";
+
+  it("truncates a long option instead of wrapping it onto a second line", () => {
+    const { lastFrame } = narrow(
+      renderPickList({
+        title: "Provider",
+        options: [{ label: longLabel }, { label: "Short one" }],
+        cursor: 0,
+        moveHint: "j/k move",
+        actionsHint: "Enter pick · Esc cancel",
+      }),
+      40,
+    );
+    const frame = lastFrame() ?? "";
+    // The whole frame stays within the viewport — no wrapped overflow.
+    expect(widestLine(frame)).toBeLessThanOrEqual(40);
+    // The long label is present but clipped: its head shows, its tail does not.
+    expect(frame).toContain("Together AI");
+    expect(frame).not.toContain("overflow");
+    // The following option is never fused into the truncated row: it
+    // still appears on its own line intact.
+    expect(frame).toContain("Short one");
+  });
+
+  it("leaves a short option intact", () => {
+    const { lastFrame } = narrow(
+      renderPickList({
+        title: "Provider",
+        options: [{ label: "OpenRouter" }],
+        cursor: 0,
+        moveHint: "j/k move",
+        actionsHint: "Enter pick · Esc cancel",
+      }),
+      80,
+    );
+    expect(lastFrame() ?? "").toContain("OpenRouter");
+  });
+});

--- a/src/tui/components/wizard-pick-list.tsx
+++ b/src/tui/components/wizard-pick-list.tsx
@@ -58,6 +58,7 @@ export function renderPickList(props: {
           <Text
             key={`${index}-${opt.label}`}
             color={index === clamped ? theme.colors.accentSoft : undefined}
+            wrap="truncate-end"
           >
             {mark} {opt.label}
           </Text>


### PR DESCRIPTION
In a window narrower than a row's text, Ink wrapped the row onto a second physical line and then overlapped it with the next row, fusing adjacent rows into unreadable text (`broad open-weight catalogthe vendored...`). The panel already switches to a windowed view to avoid the same overflow vertically, but nothing guarded the horizontal axis — and every height-budget calculation assumes one row is one line, so a wrapped row also desynced the windowed slice, which is what made the panel feel laggy (not any compute cost).

## Three render paths built rows with no width awareness

- `wizard-pick-list.tsx` — the shared list behind every provider/model picker
- `llm-mode-rows.tsx` — the LLM tab's Local/Cloud/External rows
- `local-models-panel.tsx` — chat + embedding rows, a multi-fragment `flexWrap="wrap"` row that spilled its trailing badges onto the next line

## Fix

Each row is now clipped to the terminal width: bare `<Text>` rows get `wrap="truncate-end"`; the local-models rows drop `flexWrap="wrap"` (Box rows default to `nowrap`) and truncate each fragment — keeping per-fragment colors while letting off-screen badges fall off the edge until the window is widened.

Pre-existing on `main` since v0.1.46, independent of the recent provider-catalog PRs — the longer preset labels they added just made it visible.

## Testing

- New render test: a long option truncates instead of wrapping and never fuses with the next row; a short option stays intact.
- `tsc` clean; TUI suite shows the same pre-existing failures as `main`, none introduced here.
