### PR TITLE
feat(llm): add first-class Gemini provider

### DIFF
--- a/src/config/llm-config.test.ts
+++ b/src/config/llm-config.test.ts
@@ -56,6 +56,34 @@ describe("llm-config", () => {
     );
   });
 
+  it("accepts gemini as a first-class provider kind", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      llm: {
+        activeTextProvider: "gemini",
+        activeEmbeddingProvider: "local-llama",
+        toolTransport: "auto",
+        providers: [
+          {
+            id: "local-llama",
+            kind: "llama-server",
+            url: "http://127.0.0.1:19091",
+          },
+          {
+            id: "gemini",
+            kind: "gemini",
+            defaultChatModel: "gemini-2.5-flash",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.llm?.providers.find((p) => p.id === "gemini")).toMatchObject({
+      kind: "gemini",
+      defaultChatModel: "gemini-2.5-flash",
+    });
+  });
+
   const baseLlm = (fallback: unknown) => ({
     version: USER_CONFIG_VERSION,
     llm: {

--- a/src/config/llm-config.ts
+++ b/src/config/llm-config.ts
@@ -47,6 +47,7 @@ const PROVIDER_KINDS = new Set([
   "openai-compatible",
   "openrouter",
   "aimlapi",
+  "gemini",
 ]);
 
 function parseProviderId(raw: unknown, field: string): string {

--- a/src/config/resolve-llm-api-key.test.ts
+++ b/src/config/resolve-llm-api-key.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveLlmProviderApiKey } from "./resolve-llm-api-key.js";
+
+describe("resolveLlmProviderApiKey", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("resolves Gemini keys from GEMINI_API_KEY", () => {
+    vi.stubEnv("GEMINI_API_KEY", "gemini-test-key");
+
+    expect(resolveLlmProviderApiKey({ id: "gemini", kind: "gemini" })).toBe(
+      "gemini-test-key",
+    );
+  });
+});

--- a/src/config/resolve-llm-api-key.ts
+++ b/src/config/resolve-llm-api-key.ts
@@ -28,6 +28,10 @@ export function resolveLlmProviderApiKey(
     const key = process.env.AIMLAPI_API_KEY;
     return key && key.length > 0 ? key : undefined;
   }
+  if (entry.kind === "gemini") {
+    const key = process.env.GEMINI_API_KEY;
+    return key && key.length > 0 ? key : undefined;
+  }
   if (entry.kind === "openai-compatible") {
     const key =
       process.env.OPENAI_COMPAT_API_KEY ??

--- a/src/llm/provider/gemini/fetch-gemini-models.ts
+++ b/src/llm/provider/gemini/fetch-gemini-models.ts
@@ -28,6 +28,25 @@ export function getCachedGeminiModels(
   return hit.ids;
 }
 
+/**
+ * Cache lookup for read-only UI surfaces (the LLM panel's inline model
+ * list) that render whatever ids are already stored on this machine but do
+ * not know which API key fetched them. Mirrors
+ * `getCachedOpenAiCompatModelsForBaseUrl`: the strict keyed lookup above
+ * guards the *fetch* path so an anonymous request never reuses an
+ * authenticated response; here the freshest entry wins regardless of key.
+ */
+export function getCachedGeminiModelsForPanel():
+  | readonly string[]
+  | undefined {
+  let best: { fetchedAt: number; ids: readonly string[] } | undefined;
+  for (const hit of cache.values()) {
+    if (Date.now() - hit.fetchedAt > CACHE_TTL_MS) continue;
+    if (!best || hit.fetchedAt > best.fetchedAt) best = hit;
+  }
+  return best?.ids;
+}
+
 /** Throws on unreachable/unauthorized servers so the caller can surface failure. */
 export async function fetchGeminiModels(
   apiKey?: string,

--- a/src/llm/provider/gemini/fetch-gemini-models.ts
+++ b/src/llm/provider/gemini/fetch-gemini-models.ts
@@ -1,0 +1,55 @@
+/**
+ * Model discovery for Gemini's OpenAI-compatible surface:
+ * `GET {DEFAULT_GEMINI_BASE}{GEMINI_API_PATH_PREFIX}/models`.
+ * Mirrors the openai-compatible module cache so repeated Cloud-pane
+ * visits stay free within the TTL and a cold fetch surfaces a visible
+ * loading state before `loaded`/`failed`.
+ */
+
+import {
+  DEFAULT_GEMINI_BASE,
+  GEMINI_API_PATH_PREFIX,
+} from "./gemini-provider.js";
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+const cache = new Map<string, { fetchedAt: number; ids: readonly string[] }>();
+
+/** The key is part of the identity: an anonymous list must not serve an authenticated request. */
+function cacheKey(apiKey?: string): string {
+  return apiKey ?? "";
+}
+
+export function getCachedGeminiModels(
+  apiKey?: string,
+): readonly string[] | undefined {
+  const hit = cache.get(cacheKey(apiKey));
+  if (!hit || Date.now() - hit.fetchedAt > CACHE_TTL_MS) return undefined;
+  return hit.ids;
+}
+
+/** Throws on unreachable/unauthorized servers so the caller can surface failure. */
+export async function fetchGeminiModels(
+  apiKey?: string,
+): Promise<readonly string[]> {
+  const cached = getCachedGeminiModels(apiKey);
+  if (cached) return cached;
+
+  const res = await fetch(
+    `${DEFAULT_GEMINI_BASE}${GEMINI_API_PATH_PREFIX}/models`,
+    {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  if (!res.ok) throw new Error(`http ${res.status}`);
+  const json = (await res.json()) as { data?: readonly { id?: unknown }[] };
+  const ids = (json.data ?? [])
+    .map((row) => row?.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  if (ids.length === 0) throw new Error("server listed no models");
+
+  cache.set(cacheKey(apiKey), { fetchedAt: Date.now(), ids });
+  return ids;
+}

--- a/src/llm/provider/gemini/gemini-provider.test.ts
+++ b/src/llm/provider/gemini/gemini-provider.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AtomicAgentConfig } from "../../../config/index.js";
+import { GeminiProvider } from "./gemini-provider.js";
+import { registerBuiltInProviderKinds } from "../registry/register-built-in-providers.js";
+import { getProviderFactory } from "../registry/provider-types.js";
+
+const GEMINI_CHAT_URL =
+  "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+const GEMINI_MODELS_URL =
+  "https://generativelanguage.googleapis.com/v1beta/openai/models";
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function buildGeminiProvider(fetchImpl: typeof fetch) {
+  registerBuiltInProviderKinds();
+  const factory = getProviderFactory("gemini");
+  expect(factory).toBeTypeOf("function");
+  if (!factory) throw new Error("gemini provider kind is not registered");
+  vi.stubGlobal("fetch", fetchImpl);
+  return factory({
+    config: {} as AtomicAgentConfig,
+    entry: {
+      id: "gemini",
+      kind: "gemini",
+      apiKey: "test-gemini-key",
+      defaultChatModel: "gemini-2.5-flash",
+    },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  });
+}
+
+describe("GeminiProvider", () => {
+  it("posts chat requests to Google's OpenAI-compatible path", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe(GEMINI_CHAT_URL);
+      return jsonResponse({
+        id: "gen-1",
+        model: "gemini-2.5-flash",
+        choices: [
+          {
+            message: { role: "assistant", content: "ok" },
+            finish_reason: "stop",
+          },
+        ],
+      });
+    });
+    const provider = await buildGeminiProvider(fetchImpl as unknown as typeof fetch);
+
+    const result = await provider.complete({
+      prompt: "hi",
+      maxTokens: 16,
+      temperature: 0,
+    });
+
+    expect(result.content).toBe("ok");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("accepts Google's full documented OpenAI-compatible root without duplicating it", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe(GEMINI_CHAT_URL);
+      return jsonResponse({
+        model: "gemini-2.5-flash",
+        choices: [{ message: { role: "assistant", content: "ok" } }],
+      });
+    });
+    const provider = new GeminiProvider({
+      id: "gemini",
+      baseUrl:
+        "https://generativelanguage.googleapis.com/v1beta/openai/",
+      apiKey: "test-...ey",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await provider.complete({ prompt: "hi" });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("opens streams at Google's OpenAI-compatible path", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe(GEMINI_CHAT_URL);
+      return new Response(
+        'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    });
+    const provider = await buildGeminiProvider(fetchImpl as unknown as typeof fetch);
+
+    const stream = provider.completeStream({ prompt: "hello" });
+    await stream.next();
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("posts vision requests to Google's OpenAI-compatible path", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe(GEMINI_CHAT_URL);
+      return jsonResponse({ choices: [{ message: { content: "image" } }] });
+    });
+    const provider = await buildGeminiProvider(fetchImpl as unknown as typeof fetch);
+
+    await provider.describeImage({
+      prompt: "describe",
+      images: [{ bytes: new Uint8Array([1]), mimeType: "image/png" }],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("lists models from Google's OpenAI-compatible path", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe(GEMINI_MODELS_URL);
+      return jsonResponse({ data: [{ id: "gemini-2.5-flash" }] });
+    });
+    const provider = await buildGeminiProvider(fetchImpl as unknown as typeof fetch);
+
+    await expect(provider.listModels?.()).resolves.toEqual(["gemini-2.5-flash"]);
+  });
+
+  it("checks health at Google's OpenAI-compatible models path", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe(GEMINI_MODELS_URL);
+      return jsonResponse({ data: [] });
+    });
+    const provider = await buildGeminiProvider(fetchImpl as unknown as typeof fetch);
+
+    await expect(provider.health()).resolves.toMatchObject({ reachable: true, status: 200 });
+  });
+
+  it("does not expose the API key in provider errors", async () => {
+    const key = "gemini-secret-marker";
+    registerBuiltInProviderKinds();
+    const factory = getProviderFactory("gemini");
+    expect(factory).toBeTypeOf("function");
+    if (!factory) throw new Error("gemini provider kind is not registered");
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("unauthorized", { status: 401 })));
+    const provider = await factory({
+      config: {} as AtomicAgentConfig,
+      entry: { id: "gemini", kind: "gemini", apiKey: key },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    const error = await provider
+      .complete({ prompt: "hi", maxTokens: 16, temperature: 0 })
+      .catch((caught: unknown) => caught);
+
+    expect(String(error)).not.toContain(key);
+  });
+});

--- a/src/llm/provider/gemini/gemini-provider.ts
+++ b/src/llm/provider/gemini/gemini-provider.ts
@@ -1,0 +1,35 @@
+import {
+  OpenAiProvider,
+  type OpenAiProviderOptions,
+} from "../openai/openai-provider.js";
+
+export const DEFAULT_GEMINI_BASE = "https://generativelanguage.googleapis.com";
+export const GEMINI_API_PATH_PREFIX = "/v1beta/openai";
+export const GEMINI_DEFAULT_CHAT_MODEL = "gemini-2.5-flash";
+
+export type GeminiProviderOptions = Omit<
+  OpenAiProviderOptions,
+  "baseUrl" | "apiPathPrefix" | "defaultChatModel"
+> & {
+  baseUrl?: string;
+  defaultChatModel?: string;
+};
+
+/** Gemini's OpenAI-compatible API uses `/v1beta/openai`, not `/v1`. */
+export class GeminiProvider extends OpenAiProvider {
+  constructor(options: GeminiProviderOptions) {
+    super({
+      ...options,
+      baseUrl: normalizeGeminiBaseUrl(options.baseUrl ?? DEFAULT_GEMINI_BASE),
+      apiPathPrefix: GEMINI_API_PATH_PREFIX,
+      defaultChatModel: options.defaultChatModel ?? GEMINI_DEFAULT_CHAT_MODEL,
+    });
+  }
+}
+
+function normalizeGeminiBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, "");
+  return trimmed.endsWith(GEMINI_API_PATH_PREFIX)
+    ? trimmed.slice(0, -GEMINI_API_PATH_PREFIX.length)
+    : trimmed;
+}

--- a/src/llm/provider/gemini/index.test.ts
+++ b/src/llm/provider/gemini/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { GeminiProvider as PublicGeminiProvider } from "../index.js";
+import { GeminiProvider as LocalGeminiProvider } from "./index.js";
+
+describe("Gemini provider exports", () => {
+  it("is available from the feature and public provider barrels", () => {
+    expect(LocalGeminiProvider).toBe(PublicGeminiProvider);
+  });
+});

--- a/src/llm/provider/gemini/index.ts
+++ b/src/llm/provider/gemini/index.ts
@@ -1,0 +1,7 @@
+export {
+  GeminiProvider,
+  type GeminiProviderOptions,
+  DEFAULT_GEMINI_BASE,
+  GEMINI_API_PATH_PREFIX,
+  GEMINI_DEFAULT_CHAT_MODEL,
+} from "./gemini-provider.js";

--- a/src/llm/provider/index.ts
+++ b/src/llm/provider/index.ts
@@ -30,6 +30,13 @@ export { CostAccumulator, type CostAccumulatorSnapshot } from "./cost-accumulato
 export { OpenAiProvider, type OpenAiProviderOptions } from "./openai/index.js";
 export { OpenRouterProvider } from "./openrouter/index.js";
 export {
+  GeminiProvider,
+  type GeminiProviderOptions,
+  DEFAULT_GEMINI_BASE,
+  GEMINI_API_PATH_PREFIX,
+  GEMINI_DEFAULT_CHAT_MODEL,
+} from "./gemini/index.js";
+export {
   AimlapiProvider,
   type AimlapiProviderOptions,
   AIMLAPI_CHAT_MODEL_ORDER,

--- a/src/llm/provider/openai/openai-describe-image.ts
+++ b/src/llm/provider/openai/openai-describe-image.ts
@@ -7,6 +7,7 @@ export async function describeImageViaOpenAi(
   deps: OpenAiHttpDeps,
   defaultChatModel: string,
   request: VisionRequest,
+  apiPathPrefix = "/v1",
 ): Promise<VisionResult> {
   const userContent: Array<
     | { type: "image_url"; image_url: { url: string } }
@@ -33,7 +34,12 @@ export async function describeImageViaOpenAi(
     stream: false,
   };
   const start = Date.now();
-  const json = await openAiPostJson(deps, "/v1/chat/completions", body, request);
+  const json = await openAiPostJson(
+    deps,
+    `${apiPathPrefix}/chat/completions`,
+    body,
+    request,
+  );
   const message =
     (json.choices as Array<{ message?: Record<string, unknown> }> | undefined)?.[0]
       ?.message ?? {};

--- a/src/llm/provider/openai/openai-provider.ts
+++ b/src/llm/provider/openai/openai-provider.ts
@@ -43,6 +43,7 @@ export interface OpenAiProviderOptions {
   fetchImpl?: typeof fetch;
   toolCallAdapter?: ToolCallAdapter;
   streamConsumer?: StreamConsumer;
+  apiPathPrefix?: string;
 }
 
 export class OpenAiProvider implements LlmProvider {
@@ -54,6 +55,7 @@ export class OpenAiProvider implements LlmProvider {
 
   private readonly http: OpenAiHttpDeps;
   private readonly defaultChatModel: string;
+  private readonly apiPathPrefix: string;
 
   constructor(options: OpenAiProviderOptions) {
     this.id = options.id;
@@ -72,6 +74,7 @@ export class OpenAiProvider implements LlmProvider {
       reasoningFormat: options.reasoningFormat ?? "delta_reasoning",
     };
     this.defaultChatModel = options.defaultChatModel;
+    this.apiPathPrefix = normalizeApiPathPrefix(options.apiPathPrefix ?? "/v1");
     this.http = {
       baseUrl: normalizeOpenAiBaseUrl(options.baseUrl),
       apiKey: options.apiKey,
@@ -84,7 +87,12 @@ export class OpenAiProvider implements LlmProvider {
 
   async complete(request: CompletionRequest): Promise<CompletionResult> {
     const body = buildOpenAiChatBody(request, this.defaultChatModel, false);
-    const json = await openAiPostJson(this.http, "/v1/chat/completions", body, request);
+    const json = await openAiPostJson(
+      this.http,
+      `${this.apiPathPrefix}/chat/completions`,
+      body,
+      request,
+    );
     return normaliseOpenAiChatResponse(json, this.defaultChatModel);
   }
 
@@ -97,7 +105,7 @@ export class OpenAiProvider implements LlmProvider {
     // From here on the stream is live and failures are terminal.
     const res = await openAiStartStream(
       this.http,
-      "/v1/chat/completions",
+      `${this.apiPathPrefix}/chat/completions`,
       body,
       request,
     );
@@ -136,7 +144,7 @@ export class OpenAiProvider implements LlmProvider {
   async health(): Promise<ProviderHealthResult> {
     const start = Date.now();
     try {
-      const res = await this.http.fetchImpl(`${this.http.baseUrl}/v1/models`, {
+      const res = await this.http.fetchImpl(`${this.http.baseUrl}${this.apiPathPrefix}/models`, {
         method: "GET",
         headers: buildOpenAiHeaders(this.http, false),
       });
@@ -164,14 +172,24 @@ export class OpenAiProvider implements LlmProvider {
     if (!this.capabilities.vision) {
       throw new VisionUnsupportedError(this.name);
     }
-    return describeImageViaOpenAi(this.http, this.defaultChatModel, request);
+    return describeImageViaOpenAi(
+      this.http,
+      this.defaultChatModel,
+      request,
+      this.apiPathPrefix,
+    );
   }
 
   async listModels(): Promise<readonly string[]> {
-    const json = await openAiGetJson(this.http, "/v1/models");
+    const json = await openAiGetJson(this.http, `${this.apiPathPrefix}/models`);
     const data = (json.data as Array<{ id?: string }> | undefined) ?? [];
     return data.map((row) => row.id).filter((id): id is string => typeof id === "string");
   }
+}
+
+function normalizeApiPathPrefix(prefix: string): string {
+  const trimmed = prefix.trim().replace(/\/+$/, "");
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }
 
 function completionFromStreamFinal(

--- a/src/llm/provider/registry/provider-registry.test.ts
+++ b/src/llm/provider/registry/provider-registry.test.ts
@@ -8,6 +8,7 @@ import {
 import { registerBuiltInProviderKinds } from "./register-built-in-providers.js";
 import type { AtomicAgentConfig } from "../../../config/index.js";
 import { getConfig } from "../../../config/index.js";
+import { GeminiProvider } from "../gemini/gemini-provider.js";
 
 describe("ProviderRegistry", () => {
   it("registers built-in kinds", () => {
@@ -16,6 +17,7 @@ describe("ProviderRegistry", () => {
     expect(kinds).toContain("llama-server");
     expect(kinds).toContain("openai-compatible");
     expect(kinds).toContain("openrouter");
+    expect(kinds).toContain("gemini");
   });
 
   it("resolveLlmConfig synthesizes local-llama when llm block absent", () => {
@@ -24,6 +26,38 @@ describe("ProviderRegistry", () => {
     expect(resolved.activeTextProvider).toBe("local-llama");
     expect(resolved.providers[0]?.kind).toBe("llama-server");
     expect(resolved.toolTransport).toBe("auto");
+  });
+
+  it("constructs Gemini through the built-in registry factory", async () => {
+    const fakeConfig = {
+      ...getConfig(),
+      llm: {
+        activeTextProvider: "gemini",
+        activeEmbeddingProvider: "local-llama-embed",
+        toolTransport: "auto" as const,
+        providers: [
+          {
+            id: "gemini",
+            kind: "gemini",
+            apiKey: "test-key",
+          },
+        ],
+      },
+    } as AtomicAgentConfig;
+
+    const registry = await ProviderRegistry.fromConfig(fakeConfig, {
+      config: fakeConfig,
+      llamaClient: {} as never,
+      getProfile: () => ({}) as never,
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      } as never,
+    });
+
+    expect(registry.activeText).toBeInstanceOf(GeminiProvider);
   });
 
   it("rejects unknown provider kind at fromConfig", async () => {
@@ -42,7 +76,12 @@ describe("ProviderRegistry", () => {
         config: fakeConfig,
         llamaClient: {} as never,
         getProfile: () => ({}) as never,
-        logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+        logger: {
+          debug: () => {},
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        } as never,
       }),
     ).rejects.toThrow(/unknown llm provider kind/);
   });

--- a/src/llm/provider/registry/register-built-in-providers.ts
+++ b/src/llm/provider/registry/register-built-in-providers.ts
@@ -2,6 +2,10 @@ import { getConfig } from "../../../config/index.js";
 import { LlamaServerClient } from "../../llama-server-client.js";
 import { AimlapiProvider } from "../aimlapi/aimlapi-provider.js";
 import { AIMLAPI_DEFAULT_CHAT_MODEL } from "../aimlapi/aimlapi-models-catalog.js";
+import {
+  GeminiProvider,
+  GEMINI_DEFAULT_CHAT_MODEL,
+} from "../gemini/gemini-provider.js";
 import { LlamaServerProvider } from "../llama-server/llama-server-provider.js";
 import { OpenAiProvider } from "../openai/openai-provider.js";
 import {
@@ -80,6 +84,20 @@ export function registerBuiltInProviderKinds(): void {
       baseUrl: entry.baseUrl,
       apiKey: entry.apiKey ?? "",
       defaultChatModel: entry.defaultChatModel ?? AIMLAPI_DEFAULT_CHAT_MODEL,
+      headers: entry.headers,
+      supportsVision: entry.supportsVision ?? true,
+      supportsParallelTools: entry.supportsTools ?? true,
+      requestTimeoutMs: entry.requestTimeoutMs,
+    });
+  });
+
+  registerProviderKind("gemini", (ctx) => {
+    const entry = ctx.entry;
+    return new GeminiProvider({
+      id: entry.id,
+      baseUrl: entry.baseUrl,
+      apiKey: entry.apiKey ?? "",
+      defaultChatModel: entry.defaultChatModel ?? GEMINI_DEFAULT_CHAT_MODEL,
       headers: entry.headers,
       supportsVision: entry.supportsVision ?? true,
       supportsParallelTools: entry.supportsTools ?? true,

--- a/src/tui/components/providers-wizard.test.tsx
+++ b/src/tui/components/providers-wizard.test.tsx
@@ -128,6 +128,14 @@ describe("ProvidersWizard chat model step", () => {
 });
 
 describe("ProvidersWizard pick list counter", () => {
+  it("shows a clear Gemini provider row", () => {
+    const { lastFrame } = render(
+      <ProvidersWizard wizard={createProvidersWizardState("add")} />,
+    );
+
+    expect(stripAnsi(lastFrame() ?? "")).toContain("Gemini (Google AI)");
+  });
+
   it("shows the position counter on the provider list", () => {
     // 2 catalog kinds + 10 presets + manual entry. The counter is not a
     // long-list extra: hiding it below a size threshold reads as a glitch,

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -5,6 +5,7 @@ import {
   refreshAimlapiChatCatalogFromApi,
 } from "../../llm/provider/aimlapi/fetch-aimlapi-chat-catalog.js";
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { fetchGeminiModels } from "../../llm/provider/gemini/fetch-gemini-models.js";
 import {
   getCachedOpenRouterChatPicks,
   refreshOpenRouterChatCatalogFromApi,
@@ -142,17 +143,24 @@ function CompatChatModelStep(props: {
   const w = props.wizard;
   const baseUrl = baseUrlForWizard(w);
   const isCompat = w.kind === "openai-compatible";
+  const isGemini = w.kind === "gemini";
+  const canList = isCompat || isGemini;
   const [status, setStatus] = useState<{ loading: boolean; error: string | null }>(
-    { loading: isCompat, error: null },
+    { loading: canList, error: null },
   );
 
   useEffect(() => {
-    // Only the openai-compatible kind carries an operator-supplied base URL;
-    // any other kind would fire this at the default host with a stray key.
-    if (!isCompat) return;
+    // Only these kinds have a live model surface worth listing: openai-compatible
+    // carries an operator-supplied base URL, gemini has a fixed host keyed by its
+    // own key. Any other kind would fire at the default host with a stray key.
+    if (!canList) return;
     let alive = true;
     setStatus({ loading: true, error: null });
-    fetchOpenAiCompatModels(baseUrl, apiKeyForWizard(w)).then(
+    const apiKey = apiKeyForWizard(w);
+    const fetchModels = isGemini
+      ? fetchGeminiModels(apiKey)
+      : fetchOpenAiCompatModels(baseUrl, apiKey);
+    fetchModels.then(
       () => {
         if (alive) setStatus({ loading: false, error: null });
       },
@@ -170,12 +178,15 @@ function CompatChatModelStep(props: {
     };
     // Re-fetch only when the server changes; the key is fixed for this wizard run.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [baseUrl, isCompat]);
+  }, [baseUrl, isCompat, isGemini]);
 
   const picks = listCompatChatModelPicks(w);
   if (picks.length > 0) {
+    const source = isGemini
+      ? "from Gemini /v1beta/openai/models"
+      : `from ${baseUrl}/v1/models`;
     return renderPickList({
-      title: `Chat model — ${picks.length} from ${baseUrl}/v1/models`,
+      title: `Chat model — ${picks.length} ${source}`,
       options: picks.map((id) => ({ label: id })),
       cursor: w.cursor,
       moveHint: "↑/↓ move",
@@ -184,10 +195,12 @@ function CompatChatModelStep(props: {
     });
   }
 
-  const hint = !isCompat
+  const hint = !canList
     ? "Enter to save · Esc back"
     : status.loading
-      ? `listing models from ${baseUrl}/v1/models…`
+      ? isGemini
+        ? "listing models from Gemini…"
+        : `listing models from ${baseUrl}/v1/models…`
       : status.error
       ? `${explainModelListError(status.error, w)} · type the id · Enter to save`
       : "Enter to save · Backspace to empty for the model list · Esc back";

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -22,6 +22,7 @@ import {
   type ProvidersWizardKindRow,
 } from "../providers/providers-wizard-phases.js";
 import {
+  GEMINI_DEFAULT_CHAT_MODEL,
   listAimlapiEmbeddingModels,
   listOpenRouterEmbeddingModels,
   OPENAI_COMPAT_DEFAULT_BASE_URL,
@@ -36,6 +37,7 @@ import { renderPickList } from "./wizard-pick-list.js";
 const KIND_LABELS: Record<ProvidersWizardKind, string> = {
   openrouter: "OpenRouter (cloud chat + optional cloud embed)",
   aimlapi: "AI/ML API (aimlapi.com — 500+ models, OpenAI-compatible)",
+  gemini: "Gemini (Google AI)",
   "openai-compatible": "OpenAI-compatible API (custom base URL)",
 };
 
@@ -67,6 +69,7 @@ function envHintForWizard(w: ProvidersWizardState): string {
   if (preset) return preset.envVar;
   if (w.kind === "openrouter") return "OPENROUTER_API_KEY";
   if (w.kind === "aimlapi") return "AIMLAPI_API_KEY";
+  if (w.kind === "gemini") return "GEMINI_API_KEY";
   return "OPENAI_COMPAT_API_KEY";
 }
 
@@ -191,7 +194,10 @@ function CompatChatModelStep(props: {
   return renderLineField({
     title: "Chat model id",
     value: w.chatModelLine,
-    placeholder: OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
+    placeholder:
+      w.kind === "gemini"
+        ? GEMINI_DEFAULT_CHAT_MODEL
+        : OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
     hint,
     error: w.error,
   });

--- a/src/tui/llm-panel/llm-panel-row-builders.test.ts
+++ b/src/tui/llm-panel/llm-panel-row-builders.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { fetchGeminiModels } from "../../llm/provider/gemini/fetch-gemini-models.js";
 import type { ProviderRow } from "../providers/providers-panel-state.js";
 import { createInitialTuiState, type TuiState } from "../tui-state.js";
 import { fakeSession } from "../test-fixtures.js";
@@ -35,6 +36,34 @@ function compatProvider(overrides: Partial<ProviderRow> = {}): ProviderRow {
     baseUrl: "https://api.x.ai",
     chatModel: "grok-4",
     chatModelOptions: ["grok-4"],
+    embeddingModel: null,
+    ...overrides,
+  };
+}
+
+/** Prime the gemini module cache exactly like the orchestrator warm does. */
+async function seedGeminiCache(ids: readonly string[]): Promise<void> {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: ids.map((id) => ({ id })) }),
+    })),
+  );
+  await fetchGeminiModels("key");
+  vi.unstubAllGlobals();
+}
+
+function geminiProvider(overrides: Partial<ProviderRow> = {}): ProviderRow {
+  return {
+    id: "gemini",
+    kind: "gemini",
+    isActiveText: true,
+    isActiveEmbedding: false,
+    hasApiKey: true,
+    baseUrl: null,
+    chatModel: "gemini-2.5-pro",
+    chatModelOptions: ["gemini-2.5-pro"],
     embeddingModel: null,
     ...overrides,
   };
@@ -242,6 +271,57 @@ describe("inline cloud model section for curated providers", () => {
       modelId: "qwen/qwen3.7-max",
       active: true,
     });
+    expect(selectCloudModelSection(state).status).toBe("ready");
+  });
+});
+
+describe("inline cloud model section for gemini", () => {
+  it("reads the gemini-keyed cache (no baseUrl), current model first", async () => {
+    await seedGeminiCache(["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"]);
+    const state = stateWith([geminiProvider()]);
+
+    const rows = chatRows(state);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      modelId: "gemini-2.5-pro",
+      active: true,
+      primaryAction: "current",
+    });
+    expect(rows.map((row) => row.modelId).sort()).toEqual(
+      ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"].sort(),
+    );
+    expect(selectCloudModelSection(state).status).toBe("ready");
+  });
+
+  it("never surfaces the openai-compat placeholder (gpt-5.4-mini)", () => {
+    // The degrade the reviewer flagged: with an empty chatModel the gemini
+    // branch must not fall through to OPENAI_COMPAT_DEFAULT_CHAT_MODEL. The
+    // module cache may already be warm from an earlier test in this file, so
+    // assert the invariant — every surfaced id is a gemini model — rather
+    // than a specific cold-cache list.
+    const state = stateWith([
+      geminiProvider({ chatModel: null, chatModelOptions: [] }),
+    ]);
+    const section = selectCloudModelSection(state);
+    expect(section.models).not.toContain("gpt-5.4-mini");
+    for (const id of section.models) expect(id).toMatch(/^gemini-/);
+  });
+
+  it("serves live inlineModels state when it belongs to this gemini provider", () => {
+    const state = stateWith([geminiProvider()], {
+      inlineModels: {
+        providerId: "gemini",
+        status: "ready",
+        models: ["gemini-2.5-pro", "gemini-2.5-flash"],
+        error: null,
+        generation: 1,
+      },
+    });
+    const rows = chatRows(state);
+    expect(rows.map((row) => row.modelId)).toEqual([
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+    ]);
     expect(selectCloudModelSection(state).status).toBe("ready");
   });
 });

--- a/src/tui/llm-panel/llm-panel-row-builders.ts
+++ b/src/tui/llm-panel/llm-panel-row-builders.ts
@@ -3,6 +3,8 @@ import type {
   LocalModelRow,
 } from "../local-models/local-models-panel-state.js";
 import { getCachedOpenAiCompatModelsForBaseUrl } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { getCachedGeminiModelsForPanel } from "../../llm/provider/gemini/fetch-gemini-models.js";
+import { GEMINI_DEFAULT_CHAT_MODEL } from "../../llm/provider/gemini/gemini-provider.js";
 import { filterModelIds, type ProviderRow } from "../providers/providers-panel-state.js";
 import {
   formatAimlapiChatModelDetails,
@@ -354,6 +356,28 @@ function inlineModelsForProvider(
   if (provider.kind === "aimlapi") {
     for (const option of listAimlapiChatModels()) out.add(option.id);
     return { models: [...out], status: "ready", error: null };
+  }
+  // gemini: no baseUrl on the entry, so the openai-compat URL-keyed cache
+  // can never hit. Read the gemini-keyed cache the orchestrator warms, and
+  // fall back to the gemini default — never the openai-compat placeholder
+  // (`gpt-5.4-mini` is not a gemini model).
+  if (provider.kind === "gemini") {
+    const inline = state.providersPanel.inlineModels;
+    if (inline && inline.providerId === provider.id) {
+      if (inline.status === "ready") {
+        for (const id of inline.models) out.add(id);
+        return { models: [...out], status: "ready", error: null };
+      }
+      if (out.size === 0) out.add(GEMINI_DEFAULT_CHAT_MODEL);
+      return { models: [...out], status: inline.status, error: inline.error };
+    }
+    const cached = getCachedGeminiModelsForPanel();
+    if (cached && cached.length > 0) {
+      for (const id of cached) out.add(id);
+      return { models: [...out], status: "ready", error: null };
+    }
+    if (out.size === 0) out.add(GEMINI_DEFAULT_CHAT_MODEL);
+    return { models: [...out], status: "loading", error: null };
   }
   // openai-compatible: live catalog state first, module cache second.
   const inline = state.providersPanel.inlineModels;

--- a/src/tui/persist-llm-provider.test.ts
+++ b/src/tui/persist-llm-provider.test.ts
@@ -9,6 +9,7 @@ describe("persist-llm-provider", () => {
   it("maps every wizard kind to its dotenv key", () => {
     expect(dotenvKeyForProviderKind("openrouter")).toBe("OPENROUTER_API_KEY");
     expect(dotenvKeyForProviderKind("aimlapi")).toBe("AIMLAPI_API_KEY");
+    expect(dotenvKeyForProviderKind("gemini")).toBe("GEMINI_API_KEY");
     expect(dotenvKeyForProviderKind("openai-compatible")).toBe(
       "OPENAI_COMPAT_API_KEY",
     );

--- a/src/tui/persist-llm-provider.ts
+++ b/src/tui/persist-llm-provider.ts
@@ -92,9 +92,14 @@ function readLlmBlockOrDefault(file: UserConfigFile): UserLlmFileConfig {
 
 export function dotenvKeyForProviderKind(
   kind: ProvidersWizardKind,
-): "OPENROUTER_API_KEY" | "AIMLAPI_API_KEY" | "OPENAI_COMPAT_API_KEY" {
+):
+  | "OPENROUTER_API_KEY"
+  | "AIMLAPI_API_KEY"
+  | "GEMINI_API_KEY"
+  | "OPENAI_COMPAT_API_KEY" {
   if (kind === "openrouter") return "OPENROUTER_API_KEY";
   if (kind === "aimlapi") return "AIMLAPI_API_KEY";
+  if (kind === "gemini") return "GEMINI_API_KEY";
   return "OPENAI_COMPAT_API_KEY";
 }
 

--- a/src/tui/providers/providers-model-options.ts
+++ b/src/tui/providers/providers-model-options.ts
@@ -6,6 +6,7 @@ import {
 import { listOpenRouterChatPicks } from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
 import { OPENROUTER_MODELS_CATALOG } from "../../llm/provider/openrouter/openrouter-models-catalog.js";
 import type { ModelCatalogEntry } from "../../llm/provider/model-resolver.js";
+import { GEMINI_DEFAULT_CHAT_MODEL } from "../../llm/provider/gemini/gemini-provider.js";
 
 export type ProviderModelOption = {
   id: string;
@@ -20,7 +21,7 @@ export const OPENROUTER_DEFAULT_CHAT_MODEL = "openrouter/auto";
 export const OPENAI_COMPAT_DEFAULT_BASE_URL = "https://api.openai.com";
 export const OPENAI_COMPAT_DEFAULT_CHAT_MODEL = "gpt-5.4-mini";
 
-export { AIMLAPI_DEFAULT_CHAT_MODEL };
+export { AIMLAPI_DEFAULT_CHAT_MODEL, GEMINI_DEFAULT_CHAT_MODEL };
 
 export function listOpenRouterChatModels(): readonly ProviderModelOption[] {
   return listOpenRouterChatPicks().map((p) => ({

--- a/src/tui/providers/providers-orchestrator.test.ts
+++ b/src/tui/providers/providers-orchestrator.test.ts
@@ -135,3 +135,11 @@ describe("ProvidersOrchestrator.prefetchCloudCatalogs", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 });
+
+describe("isCloudProviderKind", () => {
+  it("allows an existing Gemini provider to enter configure and key-repair flows", async () => {
+    const { isCloudProviderKind } = await importFreshOrchestrator();
+
+    expect(isCloudProviderKind("gemini")).toBe(true);
+  });
+});

--- a/src/tui/providers/providers-orchestrator.test.ts
+++ b/src/tui/providers/providers-orchestrator.test.ts
@@ -1,6 +1,34 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentRuntime } from "../../runtime/bootstrap.js";
+import type { AtomicAgentConfig } from "../../config/index.js";
+
+vi.mock("../../config/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../config/index.js")>();
+  return {
+    ...original,
+    getConfig: () => currentConfig,
+  };
+});
+
+let currentConfig: AtomicAgentConfig;
+
+function configWithGemini(): AtomicAgentConfig {
+  return {
+    llm: {
+      activeTextProvider: "gemini",
+      activeEmbeddingProvider: "local-llama-embed",
+      toolTransport: "auto",
+      providers: [
+        {
+          id: "gemini",
+          kind: "gemini",
+          defaultChatModel: "gemini-2.5-flash",
+        },
+      ],
+    },
+  } as AtomicAgentConfig;
+}
 
 /**
  * The catalog caches live at module scope inside the fetch modules, so
@@ -141,5 +169,70 @@ describe("isCloudProviderKind", () => {
     const { isCloudProviderKind } = await importFreshOrchestrator();
 
     expect(isCloudProviderKind("gemini")).toBe(true);
+  });
+});
+
+describe("ProvidersOrchestrator.ensureInlineModels", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("warms the Gemini model catalog through the Cloud pane path", async () => {
+    currentConfig = configWithGemini();
+    const fetchMock = vi.fn(async (url: unknown) => ({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "gemini-2.5-pro" }, { id: "gemini-2.5-flash" }],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { ProvidersOrchestrator } = await importFreshOrchestrator();
+    const bus = fakeBus();
+    const orchestrator = new ProvidersOrchestrator(
+      {} as AgentRuntime,
+      bus as never,
+    );
+
+    await orchestrator.ensureInlineModels("gemini");
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/openai/models",
+    );
+    expect(bus.emit).toHaveBeenCalledWith({
+      type: "providers_inline_models_loading",
+      providerId: "gemini",
+      generation: 1,
+    });
+    expect(bus.emit).toHaveBeenCalledWith({
+      type: "providers_inline_models_loaded",
+      providerId: "gemini",
+      generation: 1,
+      models: ["gemini-2.5-flash", "gemini-2.5-pro"],
+    });
+  });
+
+  it("reports failure without latching when the Gemini catalog fetch fails", async () => {
+    currentConfig = configWithGemini();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    const { ProvidersOrchestrator } = await importFreshOrchestrator();
+    const bus = fakeBus();
+    const orchestrator = new ProvidersOrchestrator(
+      {} as AgentRuntime,
+      bus as never,
+    );
+
+    await orchestrator.ensureInlineModels("gemini");
+
+    expect(bus.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "providers_inline_models_failed",
+        providerId: "gemini",
+      }),
+    );
   });
 });

--- a/src/tui/providers/providers-orchestrator.ts
+++ b/src/tui/providers/providers-orchestrator.ts
@@ -21,6 +21,7 @@ import {
   refreshOpenRouterChatCatalogFromApi,
 } from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { fetchGeminiModels } from "../../llm/provider/gemini/fetch-gemini-models.js";
 import { OPENAI_COMPAT_DEFAULT_BASE_URL } from "./providers-model-options.js";
 import { isProvidersAction } from "./providers-actions.js";
 import type { ProviderRow } from "./providers-panel-state.js";
@@ -149,9 +150,9 @@ export class ProvidersOrchestrator {
    * the catalog of `providerId` (`null` = active text provider).
    * Curated kinds (OpenRouter, aimlapi) resolve synchronously from
    * their catalog module and need no inline state, so they no-op here —
-   * the row builder reads them directly. `openai-compatible` providers:
-   * warm `/v1/models` cache loads immediately; a cold cache emits a
-   * visible `loading` state, then `loaded` or `failed`.
+   * the row builder reads them directly. `openai-compatible` and
+   * `gemini` providers warm their model cache immediately; a cold cache
+   * emits a visible `loading` state, then `loaded` or `failed`.
    *
    * Reached via the `onProvidersInlineModelsEnsureRequested` callback
    * (tab activation, `/model`) and internally after a provider switch —
@@ -165,7 +166,7 @@ export class ProvidersOrchestrator {
     const provider = resolved.providers.find((p) => p.id === id);
     const fileEntry = config.llm?.providers.find((e) => e.id === id);
     if (!provider || !isCloudProviderKind(provider.kind)) return;
-    if (provider.kind !== "openai-compatible") return;
+    if (provider.kind !== "openai-compatible" && provider.kind !== "gemini") return;
     const generation = ++this.inlineModelsGeneration;
     this.bus.emit({
       type: "providers_inline_models_loading",
@@ -177,7 +178,10 @@ export class ProvidersOrchestrator {
       const apiKey = resolveLlmProviderApiKey(provider) ?? undefined;
       // Warm 1h cache resolves without a network round-trip, so the
       // loading state is only ever visible on a genuinely cold fetch.
-      const models = await fetchOpenAiCompatModels(baseUrl, apiKey);
+      const models =
+        provider.kind === "gemini"
+          ? await fetchGeminiModels(apiKey)
+          : await fetchOpenAiCompatModels(baseUrl, apiKey);
       this.bus.emit({
         type: "providers_inline_models_loaded",
         providerId: id,

--- a/src/tui/providers/providers-orchestrator.ts
+++ b/src/tui/providers/providers-orchestrator.ts
@@ -373,7 +373,10 @@ export class ProvidersOrchestrator {
 
 export function isCloudProviderKind(kind: string): kind is ProvidersWizardKind {
   return (
-    kind === "openrouter" || kind === "aimlapi" || kind === "openai-compatible"
+    kind === "openrouter" ||
+    kind === "aimlapi" ||
+    kind === "gemini" ||
+    kind === "openai-compatible"
   );
 }
 

--- a/src/tui/providers/providers-wizard-build-entry.test.ts
+++ b/src/tui/providers/providers-wizard-build-entry.test.ts
@@ -54,6 +54,21 @@ describe("buildProviderEntryFromWizard", () => {
     expect(built.useLocalEmbedding).toBe(true);
   });
 
+  it("builds a usable Gemini entry without a manual base URL", () => {
+    const built = buildProviderEntryFromWizard({
+      kind: "gemini",
+      chatModelId: "",
+      embeddingChoiceId: LOCAL_EMBEDDING_CHOICE_ID,
+    });
+
+    expect(built.entry).toEqual({
+      id: "gemini",
+      kind: "gemini",
+      defaultChatModel: "gemini-2.5-flash",
+    });
+    expect(built.useLocalEmbedding).toBe(true);
+  });
+
   it("builds OpenAI-compatible entry with API root base URL", () => {
     const built = buildProviderEntryFromWizard({
       kind: "openai-compatible",

--- a/src/tui/providers/providers-wizard-build-entry.ts
+++ b/src/tui/providers/providers-wizard-build-entry.ts
@@ -5,6 +5,7 @@ import {
   suggestPresetEntryId,
 } from "./provider-presets.js";
 import {
+  GEMINI_DEFAULT_CHAT_MODEL,
   LOCAL_EMBEDDING_CHOICE_ID,
   OPENAI_COMPAT_DEFAULT_BASE_URL,
   OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
@@ -23,6 +24,7 @@ export type BuiltWizardProvider = {
 function baseIdForKind(kind: ProvidersWizardKind): string {
   if (kind === "openrouter") return "openrouter";
   if (kind === "aimlapi") return "aimlapi";
+  if (kind === "gemini") return "gemini";
   return "openai-compatible";
 }
 
@@ -76,7 +78,10 @@ export function buildProviderEntryFromWizard(input: {
   const preset = input.presetId ? findProviderPreset(input.presetId) : undefined;
   const chatModel = isCuratedCatalogKind(input.kind)
     ? input.chatModelId
-    : (input.customChatModel?.trim() || OPENAI_COMPAT_DEFAULT_CHAT_MODEL);
+    : (input.customChatModel?.trim() ||
+      (input.kind === "gemini"
+        ? GEMINI_DEFAULT_CHAT_MODEL
+        : OPENAI_COMPAT_DEFAULT_CHAT_MODEL));
   const useLocal =
     input.embeddingChoiceId === LOCAL_EMBEDDING_CHOICE_ID ||
     (input.kind === "openai-compatible" &&

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -32,6 +32,12 @@ function emptyKey(overrides: Partial<Key> = {}): Key {
   };
 }
 
+function presetRowIndex(id: string): number {
+  return KIND_ROW_ORDER.findIndex(
+    (row) => typeof row === "object" && row.presetId === id,
+  );
+}
+
 describe("createProvidersWizardState configure prefill", () => {
   it("prefills baseUrlLine from the stored base URL", () => {
     const wizard = createProvidersWizardState("configure", {
@@ -86,9 +92,10 @@ describe("KIND_ROW_ORDER", () => {
   it("lists catalogs first, presets alphabetically by label, manual last", () => {
     expect(KIND_ROW_ORDER[0]).toBe("openrouter");
     expect(KIND_ROW_ORDER[1]).toBe("aimlapi");
+    expect(KIND_ROW_ORDER[2]).toBe("gemini");
     expect(KIND_ROW_ORDER[KIND_ROW_ORDER.length - 1]).toBe("openai-compatible");
 
-    const presetRows = KIND_ROW_ORDER.slice(2, -1);
+    const presetRows = KIND_ROW_ORDER.slice(3, -1);
     expect(presetRows).toEqual(
       PROVIDER_PRESETS.map((preset) => ({ presetId: preset.id })),
     );
@@ -99,6 +106,17 @@ describe("KIND_ROW_ORDER", () => {
 });
 
 describe("handleProvidersWizardKey", () => {
+  it("takes Gemini from API key directly to model selection", () => {
+    let wizard = createProvidersWizardState("add");
+    wizard = { ...wizard, cursor: KIND_ROW_ORDER.indexOf("gemini") };
+    wizard = next(wizard, "", emptyKey({ return: true }));
+    expect(wizard).toMatchObject({ kind: "gemini", phase: "api_key" });
+
+    wizard = next(wizard, "", emptyKey({ return: true }));
+    expect(wizard.phase).toBe("chat_model_line");
+    expect(wizard.phase).not.toBe("base_url");
+  });
+
   it("walks the aimlapi onboarding flow when the cursor lands on it", () => {
     let wizard = createProvidersWizardState("add");
 
@@ -366,7 +384,7 @@ describe("handleProvidersWizardKey", () => {
 
     // Presets follow the two catalog kinds, alphabetically by label,
     // so the row index is computed instead of hardcoded.
-    const nousIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "nous");
+    const nousIdx = presetRowIndex("nous");
     for (let i = 0; i < nousIdx; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }
@@ -381,8 +399,8 @@ describe("handleProvidersWizardKey", () => {
 
   it("reaches a later preset by moving down the same list", () => {
     let wizard = createProvidersWizardState("add");
-    // Fourth row is the second preset (DeepSeek, alphabetical order).
-    for (let i = 0; i < 3; i += 1) {
+    const deepseekIdx = presetRowIndex("deepseek");
+    for (let i = 0; i < deepseekIdx; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }
     wizard = next(wizard, "", emptyKey({ return: true }));
@@ -393,7 +411,7 @@ describe("handleProvidersWizardKey", () => {
   it("takes a keyed preset through the key screen to the model list", () => {
     let wizard = createProvidersWizardState("add");
     // Groq is a keyed preset; two leading kind rows precede the presets.
-    const groqIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "groq");
+    const groqIdx = presetRowIndex("groq");
     for (let i = 0; i < groqIdx; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }
@@ -409,7 +427,7 @@ describe("handleProvidersWizardKey", () => {
 
   it("skips the key screen for a local server", () => {
     let wizard = createProvidersWizardState("add");
-    const lmIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "lmstudio");
+    const lmIdx = presetRowIndex("lmstudio");
     for (let i = 0; i < lmIdx; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }
@@ -423,7 +441,8 @@ describe("handleProvidersWizardKey", () => {
   it("a preset never shows the URL screen", () => {
     // Groq (keyed): service -> key -> models, base_url is never reached.
     let wizard = createProvidersWizardState("add");
-    for (let i = 0; i < 3; i += 1) {
+    const groqIdx = presetRowIndex("groq");
+    for (let i = 0; i < groqIdx; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }
     wizard = next(wizard, "", emptyKey({ return: true }));
@@ -448,7 +467,7 @@ describe("handleProvidersWizardKey", () => {
   it("Esc from a preset returns to the provider list, not out of the wizard", () => {
     let wizard = createProvidersWizardState("add");
     // Nous is keyless, so the wizard lands straight on chat_model_line.
-    const nousIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "nous");
+    const nousIdx = presetRowIndex("nous");
     for (let i = 0; i < nousIdx; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }
@@ -471,8 +490,7 @@ describe("handleProvidersWizardKey", () => {
 
   it("stepping back clears the previous pick so a new one starts clean", () => {
     let wizard = createProvidersWizardState("add");
-    wizard = next(wizard, "", emptyKey({ downArrow: true }));
-    wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    wizard = { ...wizard, cursor: presetRowIndex("cerebras") };
     wizard = next(wizard, "", emptyKey({ return: true }));
     wizard = next(wizard, "", emptyKey({ escape: true }));
     expect(wizard.presetId).toBeNull();
@@ -483,7 +501,7 @@ describe("handleProvidersWizardKey", () => {
     // The end-to-end main path: Nous from the provider list to a
     // submittable wizard without a URL screen and without a key screen.
     let wizard = createProvidersWizardState("add");
-    const nousIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "nous");
+    const nousIdx = presetRowIndex("nous");
     for (let i = 0; i < nousIdx; i += 1) {
       wizard = next(wizard, "", emptyKey({ downArrow: true }));
     }

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -1,6 +1,7 @@
 import type { Key } from "ink";
 import { resolveLlmProviderApiKey } from "../../config/resolve-llm-api-key.js";
 import { getCachedOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { getCachedGeminiModels } from "../../llm/provider/gemini/fetch-gemini-models.js";
 import { normalizeOpenAiBaseUrl } from "../../llm/provider/openai/normalize-openai-base-url.js";
 import { PICK_WINDOW } from "../components/wizard-pick-list.js";
 import { findProviderPreset } from "./provider-presets.js";
@@ -56,14 +57,19 @@ export function listCompatChatModelPicks(
   wizard: ProvidersWizardState,
 ): readonly string[] {
   if (wizard.phase !== "chat_model_line") return [];
-  if (wizard.kind !== "openai-compatible") return [];
   if (wizard.chatModelLine.length > 0) return [];
-  return (
-    getCachedOpenAiCompatModels(
-      baseUrlForWizard(wizard),
-      apiKeyForWizard(wizard),
-    ) ?? []
-  );
+  if (wizard.kind === "openai-compatible") {
+    return (
+      getCachedOpenAiCompatModels(
+        baseUrlForWizard(wizard),
+        apiKeyForWizard(wizard),
+      ) ?? []
+    );
+  }
+  if (wizard.kind === "gemini") {
+    return getCachedGeminiModels(apiKeyForWizard(wizard)) ?? [];
+  }
+  return [];
 }
 
 /**

--- a/src/tui/providers/providers-wizard-phases.ts
+++ b/src/tui/providers/providers-wizard-phases.ts
@@ -30,6 +30,7 @@ export type ProvidersWizardKindRow =
 export const KIND_ROW_ORDER: readonly ProvidersWizardKindRow[] = [
   "openrouter",
   "aimlapi",
+  "gemini",
   ...PROVIDER_PRESETS.map((preset) => ({ presetId: preset.id })),
   "openai-compatible",
 ];
@@ -66,6 +67,7 @@ function nextPhaseAfterApiKey(
 ): ProvidersWizardPhase {
   const kind = wizard.kind;
   if (kind && isCuratedCatalogKind(kind)) return "pick_chat_model";
+  if (kind === "gemini") return "chat_model_line";
   // A preset already knows its endpoint, so showing the URL step would
   // ask the operator to confirm something they never typed (#69). Only
   // the manual openai-compatible row still needs it.

--- a/src/tui/providers/providers-wizard-state.ts
+++ b/src/tui/providers/providers-wizard-state.ts
@@ -3,6 +3,7 @@ import { presetForEntryId } from "./provider-presets.js";
 export type ProvidersWizardKind =
   | "openrouter"
   | "aimlapi"
+  | "gemini"
   | "openai-compatible";
 
 export type ProvidersWizardPhase =

--- a/src/tui/providers/save-provider-wizard.test.ts
+++ b/src/tui/providers/save-provider-wizard.test.ts
@@ -11,6 +11,7 @@ import { createProvidersWizardState } from "./providers-wizard-state.js";
 const ENV_KEYS = [
   "OPENROUTER_API_KEY",
   "AIMLAPI_API_KEY",
+  "GEMINI_API_KEY",
   "OPENAI_COMPAT_API_KEY",
   "OPENAI_API_KEY",
   "GROQ_API_KEY",

--- a/src/tui/providers/save-provider-wizard.ts
+++ b/src/tui/providers/save-provider-wizard.ts
@@ -8,6 +8,7 @@ import {
 import { findProviderPreset } from "./provider-presets.js";
 import {
   AIMLAPI_DEFAULT_CHAT_MODEL,
+  GEMINI_DEFAULT_CHAT_MODEL,
   LOCAL_EMBEDDING_CHOICE_ID,
   OPENROUTER_DEFAULT_CHAT_MODEL,
 } from "./providers-model-options.js";
@@ -22,6 +23,7 @@ import type {
 
 function defaultChatModelForKind(kind: ProvidersWizardKind): string {
   if (kind === "aimlapi") return AIMLAPI_DEFAULT_CHAT_MODEL;
+  if (kind === "gemini") return GEMINI_DEFAULT_CHAT_MODEL;
   return OPENROUTER_DEFAULT_CHAT_MODEL;
 }
 


### PR DESCRIPTION
## Problem

Atomic's generic OpenAI-compatible provider appends `/v1/...`, while Google's documented OpenAI-compatible API root is `/v1beta/openai`. That made direct Gemini setup require a translating proxy.

## Change

- Add a first-class `gemini` provider backed by Atomic's existing OpenAI transport.
- Route chat completions and model discovery through Google's documented `/v1beta/openai/...` paths.
- Resolve Gemini credentials from `GEMINI_API_KEY` without including the key in logs or errors.
- Add Gemini to the provider setup flow with a stable default chat model and no manual base-URL step.
- Preserve the existing OpenAI-compatible, OpenRouter, and AIMLAPI paths unchanged.

## Scope

This PR fixes native provider setup and endpoint routing only. Gemini SSE reconstruction, parallel-tool-call control, and structured retry delays remain tracked by #103, #104, and #106 respectively.

## Testing

- `npm run lint`
- Post-review Gemini export/configure regressions: 5 passed, 0 failed
- Affected provider/config/TUI suite: 389 passed, 0 failed
- `npm run build`
- Full suite: 3,953 passed, 6 failed, 4 skipped; no new failure names were introduced versus the captured upstream baseline (one baseline failure did not reproduce)
- `git diff --check`
- Public diff credential/private-path audit

Closes #108

Implementation and test preparation were LLM-assisted, then independently reviewed by Yabloko Labs.
