### PR TITLE
fix(llm): adapt Qwen tagged tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,36 @@ Shell-exported variables win over `.env`. The built-in parser intentionally supp
 
 </details>
 
+<details>
+<summary><b>Qwen / Tinker tagged tool calls</b> (opt-in compatibility provider)</summary>
+
+Some Qwen-serving OpenAI-compatible backends (Tinker, certain vLLM/llama.cpp front-ends) emit tool calls as inline `<tool_call><function=…>…</function></tool_call>` text instead of the native `tool_calls` field — they show up as assistant prose and never execute (#105).
+
+To enable the adapter, set the provider `kind` to **`qwen-openai-compatible`** in `config.json` (with `baseUrl` + `defaultChatModel`). Plain `openai-compatible` does **not** enable it — the generic kind is left untouched on purpose. There is no TUI wizard row for this kind yet; it is config-only for now.
+
+```json
+{
+  "llm": {
+    "providers": [
+      {
+        "id": "tinker",
+        "kind": "qwen-openai-compatible",
+        "baseUrl": "https://your-tinker-host",
+        "defaultChatModel": "Qwen3-32B"
+      }
+    ]
+  }
+}
+```
+
+Behavior:
+- The tagged call is read from `content`, or from `reasoning_content` when content is empty or holds unparseable tag noise.
+- Argument values are coerced against the offered tool's JSON schema; a call that does not match is dropped (fail-closed) rather than executed with guessed args.
+- Streaming stays live: text/reasoning deltas stream as usual and the buffered final message is adapted once the stream closes.
+
+**Limitation — MCP tools:** the schema coercion supports a fixed JSON-Schema subset and rejects unknown keywords such as `$ref`. Atomic's built-in tools are fine, but MCP tools that ship a draft-07 `inputSchema` with `$ref` (or other unsupported keywords) will fail coercion and remain prose. MCP + tagged Qwen is therefore unsupported for now.
+</details>
+
 ## Development
 
 ```bash

--- a/src/config/llm-config.test.ts
+++ b/src/config/llm-config.test.ts
@@ -56,6 +56,36 @@ describe("llm-config", () => {
     );
   });
 
+  it("accepts qwen-openai-compatible as an explicit compatibility provider", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      llm: {
+        activeTextProvider: "qwen",
+        activeEmbeddingProvider: "local-llama",
+        toolTransport: "auto",
+        providers: [
+          {
+            id: "local-llama",
+            kind: "llama-server",
+            url: "http://127.0.0.1:19091",
+          },
+          {
+            id: "qwen",
+            kind: "qwen-openai-compatible",
+            baseUrl: "https://example.invalid",
+            defaultChatModel: "qwen-test",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.llm?.providers.find((provider) => provider.id === "qwen")).toMatchObject({
+      kind: "qwen-openai-compatible",
+      baseUrl: "https://example.invalid",
+      defaultChatModel: "qwen-test",
+    });
+  });
+
   const baseLlm = (fallback: unknown) => ({
     version: USER_CONFIG_VERSION,
     llm: {

--- a/src/config/llm-config.ts
+++ b/src/config/llm-config.ts
@@ -45,6 +45,7 @@ const PROVIDER_ID_RE = /^[a-z][a-z0-9-]{0,31}$/;
 const PROVIDER_KINDS = new Set([
   "llama-server",
   "openai-compatible",
+  "qwen-openai-compatible",
   "openrouter",
   "aimlapi",
 ]);

--- a/src/config/resolve-llm-api-key.ts
+++ b/src/config/resolve-llm-api-key.ts
@@ -28,7 +28,10 @@ export function resolveLlmProviderApiKey(
     const key = process.env.AIMLAPI_API_KEY;
     return key && key.length > 0 ? key : undefined;
   }
-  if (entry.kind === "openai-compatible") {
+  if (
+    entry.kind === "openai-compatible" ||
+    entry.kind === "qwen-openai-compatible"
+  ) {
     const key =
       process.env.OPENAI_COMPAT_API_KEY ??
       process.env.OPENAI_API_KEY ??

--- a/src/llm/provider/openai/coerce-json-schema-value.ts
+++ b/src/llm/provider/openai/coerce-json-schema-value.ts
@@ -1,0 +1,226 @@
+type JsonSchema = Record<string, unknown>;
+
+import { assertSupportedJsonSchema } from "./json-schema-support.js";
+
+export function coerceJsonSchemaValue(value: string, schema: JsonSchema): unknown {
+  assertSupportedJsonSchema(schema);
+  const candidates: unknown[] = [];
+  for (const type of coercionTypes(schema)) {
+    try {
+      const candidate = coerceByType(value, type);
+      if (
+        matchesSchema(candidate, schema) &&
+        !candidates.some((existing) => jsonEqual(existing, candidate))
+      ) {
+        candidates.push(candidate);
+      }
+    } catch {
+      // Try the next type admitted by the schema.
+    }
+  }
+  if (candidates.length === 0) throw new Error("value does not match schema");
+  return candidates[0];
+}
+
+export function validateJsonSchemaValue(value: unknown, schema: JsonSchema): boolean {
+  assertSupportedJsonSchema(schema);
+  return matchesSchema(value, schema);
+}
+
+function coercionTypes(schema: JsonSchema): string[] {
+  const types = new Set<string>();
+  collectTypes(schema, types);
+  if (types.size === 0) types.add("string");
+  return [...types];
+}
+
+function collectTypes(schema: JsonSchema, out: Set<string>): void {
+  if (typeof schema.type === "string") out.add(schema.type);
+  if (Array.isArray(schema.type)) {
+    for (const type of schema.type) if (typeof type === "string") out.add(type);
+  }
+  for (const keyword of ["anyOf", "oneOf"] as const) {
+    const branches = schema[keyword];
+    if (Array.isArray(branches)) {
+      for (const branch of branches) collectTypes(asSchema(branch), out);
+    }
+  }
+  if (out.size === 0 && Object.hasOwn(schema, "const")) {
+    out.add(jsonType(schema.const));
+  }
+  if (out.size === 0 && Array.isArray(schema.enum)) {
+    for (const entry of schema.enum) out.add(jsonType(entry));
+  }
+}
+
+function coerceByType(value: string, type: string): unknown {
+  switch (type) {
+    case "integer": {
+      if (!/^[+-]?\d+$/.test(value)) throw new Error("invalid integer");
+      const parsed = Number(value);
+      if (!Number.isSafeInteger(parsed)) throw new Error("invalid integer");
+      return parsed;
+    }
+    case "number": {
+      if (value.length === 0) throw new Error("invalid number");
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed)) throw new Error("invalid number");
+      return parsed;
+    }
+    case "boolean":
+      if (value.toLowerCase() === "true") return true;
+      if (value.toLowerCase() === "false") return false;
+      throw new Error("invalid boolean");
+    case "array": {
+      const parsed: unknown = JSON.parse(value);
+      if (!Array.isArray(parsed)) throw new Error("invalid array");
+      return parsed;
+    }
+    case "object": {
+      const parsed: unknown = JSON.parse(value);
+      if (!isRecord(parsed)) throw new Error("invalid object");
+      return parsed;
+    }
+    case "null":
+      if (value.toLowerCase() !== "null") throw new Error("invalid null");
+      return null;
+    case "string":
+      return value;
+    default:
+      throw new Error("unsupported schema type");
+  }
+}
+
+function matchesSchema(value: unknown, schema: JsonSchema): boolean {
+  const anyOf = schema.anyOf;
+  if (Array.isArray(anyOf) && !anyOf.some((entry) => matchesSchema(value, asSchema(entry)))) {
+    return false;
+  }
+  const oneOf = schema.oneOf;
+  if (
+    Array.isArray(oneOf) &&
+    oneOf.filter((entry) => matchesSchema(value, asSchema(entry))).length !== 1
+  ) {
+    return false;
+  }
+  const allOf = schema.allOf;
+  if (Array.isArray(allOf) && !allOf.every((entry) => matchesSchema(value, asSchema(entry)))) {
+    return false;
+  }
+  if (isRecord(schema.not) && matchesSchema(value, schema.not)) return false;
+  if (Object.hasOwn(schema, "const") && !jsonEqual(value, schema.const)) return false;
+  if (Array.isArray(schema.enum) && !schema.enum.some((entry) => jsonEqual(value, entry))) {
+    return false;
+  }
+  if (!matchesType(value, schema.type)) return false;
+
+  if (typeof value === "string") {
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) return false;
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) return false;
+    if (typeof schema.pattern === "string" && !new RegExp(schema.pattern, "u").test(value)) {
+      return false;
+    }
+  }
+  if (typeof value === "number") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) return false;
+    if (typeof schema.maximum === "number" && value > schema.maximum) return false;
+    if (typeof schema.exclusiveMinimum === "number" && value <= schema.exclusiveMinimum) {
+      return false;
+    }
+    if (typeof schema.exclusiveMaximum === "number" && value >= schema.exclusiveMaximum) {
+      return false;
+    }
+    if (
+      typeof schema.multipleOf === "number" &&
+      !isMultipleOf(value, schema.multipleOf)
+    ) {
+      return false;
+    }
+  }
+  if (Array.isArray(value)) {
+    if (typeof schema.minItems === "number" && value.length < schema.minItems) return false;
+    if (typeof schema.maxItems === "number" && value.length > schema.maxItems) return false;
+    if (
+      schema.uniqueItems === true &&
+      value.some((entry, index) => value.slice(0, index).some((prior) => jsonEqual(prior, entry)))
+    ) {
+      return false;
+    }
+    const items = isRecord(schema.items) ? schema.items : null;
+    if (items && !value.every((entry) => matchesSchema(entry, items))) return false;
+  }
+  if (isRecord(value)) {
+    const properties = isRecord(schema.properties) ? schema.properties : {};
+    const required = Array.isArray(schema.required)
+      ? schema.required.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    const keys = Object.keys(value);
+    if (typeof schema.minProperties === "number" && keys.length < schema.minProperties) {
+      return false;
+    }
+    if (typeof schema.maxProperties === "number" && keys.length > schema.maxProperties) {
+      return false;
+    }
+    if (!required.every((name) => Object.hasOwn(value, name))) return false;
+    for (const [name, entry] of Object.entries(value)) {
+      if (Object.hasOwn(properties, name)) {
+        if (!matchesSchema(entry, asSchema(properties[name]))) return false;
+      } else if (schema.additionalProperties === false) {
+        return false;
+      } else if (
+        isRecord(schema.additionalProperties) &&
+        !matchesSchema(entry, schema.additionalProperties)
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function matchesType(value: unknown, type: unknown): boolean {
+  if (type === undefined) return true;
+  if (Array.isArray(type)) return type.some((entry) => matchesType(value, entry));
+  if (type === "null") return value === null;
+  if (type === "array") return Array.isArray(value);
+  if (type === "object") return isRecord(value);
+  if (type === "integer") return typeof value === "number" && Number.isSafeInteger(value);
+  return typeof value === type;
+}
+
+function isMultipleOf(value: number, multiple: number): boolean {
+  const quotient = value / multiple;
+  return Number.isFinite(quotient) && Math.abs(quotient - Math.round(quotient)) < 1e-10;
+}
+
+function jsonType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (isRecord(value)) return "object";
+  if (typeof value === "number" && Number.isSafeInteger(value)) return "integer";
+  return typeof value;
+}
+
+function jsonEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((entry, i) => jsonEqual(entry, right[i]));
+  }
+  if (isRecord(left) && isRecord(right)) {
+    const keys = Object.keys(left);
+    return (
+      keys.length === Object.keys(right).length &&
+      keys.every((key) => Object.hasOwn(right, key) && jsonEqual(left[key], right[key]))
+    );
+  }
+  return false;
+}
+
+function asSchema(value: unknown): JsonSchema {
+  if (!isRecord(value)) throw new Error("invalid schema");
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/llm/provider/openai/index.ts
+++ b/src/llm/provider/openai/index.ts
@@ -8,3 +8,4 @@ export {
   openAiToolCallsToBatch,
 } from "./openai-tool-call-adapter.js";
 export { filterCloudCompletionRequest } from "./sampling-filter.js";
+export { adaptQwenTaggedToolResponse } from "./qwen-tagged-tool-response-adapter.js";

--- a/src/llm/provider/openai/json-schema-support.ts
+++ b/src/llm/provider/openai/json-schema-support.ts
@@ -1,0 +1,129 @@
+type JsonSchema = Record<string, unknown>;
+
+const SUPPORTED_TYPES = new Set([
+  "string",
+  "integer",
+  "number",
+  "boolean",
+  "array",
+  "object",
+  "null",
+]);
+
+const SUPPORTED_KEYWORDS = new Set([
+  "$anchor",
+  "$comment",
+  "$defs",
+  "$id",
+  "$schema",
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "const",
+  "contentEncoding",
+  "contentMediaType",
+  "default",
+  "deprecated",
+  "description",
+  "enum",
+  "examples",
+  "exclusiveMaximum",
+  "exclusiveMinimum",
+  "items",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+  "minItems",
+  "minLength",
+  "minProperties",
+  "minimum",
+  "multipleOf",
+  "not",
+  "oneOf",
+  "pattern",
+  "properties",
+  "readOnly",
+  "required",
+  "title",
+  "type",
+  "uniqueItems",
+  "writeOnly",
+]);
+
+export function assertSupportedJsonSchema(schema: JsonSchema): void {
+  for (const key of Object.keys(schema)) {
+    if (!SUPPORTED_KEYWORDS.has(key)) throw new Error(`unsupported schema keyword: ${key}`);
+  }
+  const types = typeof schema.type === "string" ? [schema.type] : schema.type;
+  if (types !== undefined) {
+    if (!Array.isArray(types) || types.length === 0) throw new Error("invalid schema type");
+    for (const type of types) {
+      if (typeof type !== "string" || !SUPPORTED_TYPES.has(type)) {
+        throw new Error("unsupported schema type");
+      }
+    }
+  }
+  for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
+    const branches = schema[keyword];
+    if (branches !== undefined) {
+      if (!Array.isArray(branches) || branches.length === 0) {
+        throw new Error(`invalid ${keyword}`);
+      }
+      for (const branch of branches) assertSupportedJsonSchema(asSchema(branch));
+    }
+  }
+  if (schema.not !== undefined) assertSupportedJsonSchema(asSchema(schema.not));
+  if (schema.items !== undefined) assertSupportedJsonSchema(asSchema(schema.items));
+  if (
+    schema.additionalProperties !== undefined &&
+    typeof schema.additionalProperties !== "boolean"
+  ) {
+    assertSupportedJsonSchema(asSchema(schema.additionalProperties));
+  }
+  for (const container of [schema.properties, schema.$defs] as unknown[]) {
+    if (container === undefined) continue;
+    const entries = asSchema(container);
+    for (const child of Object.values(entries)) {
+      assertSupportedJsonSchema(asSchema(child));
+    }
+  }
+  if (schema.enum !== undefined && (!Array.isArray(schema.enum) || schema.enum.length === 0)) {
+    throw new Error("invalid enum");
+  }
+  if (schema.required !== undefined && !Array.isArray(schema.required)) {
+    throw new Error("invalid required");
+  }
+  if (schema.pattern !== undefined) {
+    if (typeof schema.pattern !== "string") throw new Error("invalid pattern");
+    new RegExp(schema.pattern, "u");
+  }
+  for (const keyword of [
+    "exclusiveMaximum",
+    "exclusiveMinimum",
+    "maxItems",
+    "maxLength",
+    "maxProperties",
+    "maximum",
+    "minItems",
+    "minLength",
+    "minProperties",
+    "minimum",
+    "multipleOf",
+  ] as const) {
+    const assertion = schema[keyword];
+    if (assertion !== undefined && (typeof assertion !== "number" || !Number.isFinite(assertion))) {
+      throw new Error(`invalid ${keyword}`);
+    }
+  }
+  if (typeof schema.multipleOf === "number" && schema.multipleOf <= 0) {
+    throw new Error("invalid multipleOf");
+  }
+}
+
+function asSchema(value: unknown): JsonSchema {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("invalid schema");
+  }
+  return value as JsonSchema;
+}

--- a/src/llm/provider/openai/openai-provider.test.ts
+++ b/src/llm/provider/openai/openai-provider.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { CompletionRequest } from "../completion-types.js";
+import { OpenAiProvider } from "./openai-provider.js";
+
+const tools: NonNullable<CompletionRequest["tools"]> = [
+  {
+    type: "function",
+    function: {
+      name: "os__fs__read",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+      },
+    },
+  },
+];
+
+function fakeFetch(message: Record<string, unknown>) {
+  return vi.fn(async () =>
+    new Response(
+      JSON.stringify({
+        model: "qwen-test",
+        choices: [{ message, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ),
+  );
+}
+
+function provider(
+  fetchImpl: typeof fetch,
+  taggedToolCompatibility: "qwen" | undefined,
+): OpenAiProvider {
+  return new OpenAiProvider({
+    id: "test",
+    baseUrl: "https://example.invalid",
+    apiKey: "",
+    defaultChatModel: "qwen-test",
+    fetchImpl,
+    taggedToolCompatibility,
+  });
+}
+
+describe("OpenAiProvider qwen tagged-tool compatibility", () => {
+  it("adapts non-streaming responses with request tools only when opted in", async () => {
+    const fetchImpl = fakeFetch({
+      role: "assistant",
+      content:
+        "<tool_call><function=os.fs.read><parameter=path>/tmp/a</parameter></function></tool_call>",
+    });
+
+    const result = await provider(
+      fetchImpl as unknown as typeof fetch,
+      "qwen",
+    ).complete({ prompt: "read", tools });
+
+    expect(result.content).toBe("");
+    expect(result.finishReason).toBe("tool_calls");
+    expect(result.toolCalls).toMatchObject([
+      {
+        type: "function",
+        function: { name: "os__fs__read", arguments: '{"path":"/tmp/a"}' },
+      },
+    ]);
+  });
+
+  it("leaves the existing OpenAI provider path unchanged by default", async () => {
+    const tagged =
+      "<tool_call><function=os.fs.read><parameter=path>/tmp/a</parameter></function></tool_call>";
+    const result = await provider(
+      fakeFetch({ role: "assistant", content: tagged }) as unknown as typeof fetch,
+      undefined,
+    ).complete({ prompt: "read", tools });
+
+    expect(result.content).toBe(tagged);
+    expect(result.toolCalls).toBeUndefined();
+    expect(result.finishReason).toBe("stop");
+  });
+
+  it("preserves ordered distinct calls through compatibility streaming", async () => {
+    const fetchImpl = fakeFetch({
+      role: "assistant",
+      content: [
+        "<tool_call><function=os.fs.read><parameter=path>/tmp/a</parameter></function></tool_call>",
+        "<tool_call><function=os.fs.read><parameter=path>/tmp/b</parameter></function></tool_call>",
+      ].join(""),
+    });
+    const stream = provider(
+      fetchImpl as unknown as typeof fetch,
+      "qwen",
+    ).completeStream({ prompt: "read", tools });
+
+    const first = await stream.next();
+    expect(first.done).toBe(true);
+    if (!first.done) throw new Error("compatibility stream unexpectedly emitted text");
+    expect(first.value.toolCalls?.map((call) => call.id)).toEqual([
+      "call_qwen_tagged_0",
+      "call_qwen_tagged_1",
+    ]);
+    expect(
+      first.value.toolCalls?.map((call) => JSON.parse(call.function.arguments)),
+    ).toEqual([{ path: "/tmp/a" }, { path: "/tmp/b" }]);
+
+    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toMatchObject({ stream: false, tools });
+  });
+});

--- a/src/llm/provider/openai/openai-provider.test.ts
+++ b/src/llm/provider/openai/openai-provider.test.ts
@@ -29,6 +29,29 @@ function fakeFetch(message: Record<string, unknown>) {
   );
 }
 
+/** SSE-shaped fake for the streaming path: emits `content` as one delta, then done. */
+function fakeStreamFetch(content: string) {
+  const frame = (obj: Record<string, unknown>) => `data: ${JSON.stringify(obj)}\n\n`;
+  const body =
+    frame({
+      model: "qwen-test",
+      choices: [{ index: 0, delta: { role: "assistant", content }, finish_reason: null }],
+    }) +
+    frame({
+      model: "qwen-test",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+    }) +
+    "data: [DONE]\n\n";
+  return vi.fn(
+    async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+  );
+}
+
 function provider(
   fetchImpl: typeof fetch,
   taggedToolCompatibility: "qwen" | undefined,
@@ -79,31 +102,42 @@ describe("OpenAiProvider qwen tagged-tool compatibility", () => {
     expect(result.finishReason).toBe("stop");
   });
 
-  it("preserves ordered distinct calls through compatibility streaming", async () => {
-    const fetchImpl = fakeFetch({
-      role: "assistant",
-      content: [
-        "<tool_call><function=os.fs.read><parameter=path>/tmp/a</parameter></function></tool_call>",
-        "<tool_call><function=os.fs.read><parameter=path>/tmp/b</parameter></function></tool_call>",
-      ].join(""),
-    });
+  it("streams deltas, then adapts the buffered tagged calls (buffer-then-adapt)", async () => {
+    const tagged = [
+      "<tool_call><function=os.fs.read><parameter=path>/tmp/a</parameter></function></tool_call>",
+      "<tool_call><function=os.fs.read><parameter=path>/tmp/b</parameter></function></tool_call>",
+    ].join("");
+    const fetchImpl = fakeStreamFetch(tagged);
     const stream = provider(
       fetchImpl as unknown as typeof fetch,
       "qwen",
     ).completeStream({ prompt: "read", tools });
 
+    // First yield is the live text delta (raw tagged text), not the final result.
     const first = await stream.next();
-    expect(first.done).toBe(true);
-    if (!first.done) throw new Error("compatibility stream unexpectedly emitted text");
-    expect(first.value.toolCalls?.map((call) => call.id)).toEqual([
+    expect(first.done).toBe(false);
+    // Drain to the returned CompletionResult.
+    let final: Awaited<ReturnType<typeof stream.next>> | undefined;
+    while (true) {
+      const next = await stream.next();
+      if (next.done) {
+        final = next;
+        break;
+      }
+    }
+    if (!final || !final.done) throw new Error("stream never completed");
+    // The buffered final has the tagged text rewritten into tool_calls.
+    expect(final.value.toolCalls?.map((call) => call.id)).toEqual([
       "call_qwen_tagged_0",
       "call_qwen_tagged_1",
     ]);
     expect(
-      first.value.toolCalls?.map((call) => JSON.parse(call.function.arguments)),
+      final.value.toolCalls?.map((call) => JSON.parse(call.function.arguments)),
     ).toEqual([{ path: "/tmp/a" }, { path: "/tmp/b" }]);
+    expect(final.value.content).toBe("");
+    expect(final.value.finishReason).toBe("tool_calls");
 
     const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
-    expect(JSON.parse(String(init.body))).toMatchObject({ stream: false, tools });
+    expect(JSON.parse(String(init.body))).toMatchObject({ stream: true, tools });
   });
 });

--- a/src/llm/provider/openai/openai-provider.ts
+++ b/src/llm/provider/openai/openai-provider.ts
@@ -28,7 +28,7 @@ import {
 import { normaliseOpenAiChatResponse } from "./openai-normalise-response.js";
 import { normalizeOpenAiBaseUrl } from "./normalize-openai-base-url.js";
 import { describeImageViaOpenAi } from "./openai-describe-image.js";
-import { adaptQwenTaggedToolResponse } from "./qwen-tagged-tool-response-adapter.js";
+import { adaptQwenCompletionResult, adaptQwenTaggedToolResponse } from "./qwen-tagged-tool-response-adapter.js";
 
 export interface OpenAiProviderOptions {
   id: string;
@@ -99,9 +99,6 @@ export class OpenAiProvider implements LlmProvider {
   async *completeStream(
     request: CompletionRequest,
   ): AsyncGenerator<StreamChunk, CompletionResult, void> {
-    if (this.taggedToolCompatibility === "qwen") {
-      return await this.complete(request);
-    }
     const body = buildOpenAiChatBody(request, this.defaultChatModel, true);
     // Opening the stream (connect + status check) happens inside the
     // client's bounded retry, strictly before the first chunk exists.
@@ -140,6 +137,13 @@ export class OpenAiProvider implements LlmProvider {
     }
     if (accumulatedReasoning.length > 0 && final.reasoningContent.length === 0) {
       final.reasoningContent = accumulatedReasoning;
+    }
+    if (this.taggedToolCompatibility === "qwen") {
+      // Buffer-then-adapt: the tagged `<tool_call>` payload may be split
+      // across deltas, so adapt only the fully-buffered message. Text and
+      // reasoning deltas were already yielded above for live UX; the adapt
+      // seam just rewrites the final result (content → tool_calls).
+      return adaptQwenCompletionResult(final, request);
     }
     return final;
   }

--- a/src/llm/provider/openai/openai-provider.ts
+++ b/src/llm/provider/openai/openai-provider.ts
@@ -28,6 +28,7 @@ import {
 import { normaliseOpenAiChatResponse } from "./openai-normalise-response.js";
 import { normalizeOpenAiBaseUrl } from "./normalize-openai-base-url.js";
 import { describeImageViaOpenAi } from "./openai-describe-image.js";
+import { adaptQwenTaggedToolResponse } from "./qwen-tagged-tool-response-adapter.js";
 
 export interface OpenAiProviderOptions {
   id: string;
@@ -43,6 +44,7 @@ export interface OpenAiProviderOptions {
   fetchImpl?: typeof fetch;
   toolCallAdapter?: ToolCallAdapter;
   streamConsumer?: StreamConsumer;
+  taggedToolCompatibility?: "qwen";
 }
 
 export class OpenAiProvider implements LlmProvider {
@@ -54,6 +56,7 @@ export class OpenAiProvider implements LlmProvider {
 
   private readonly http: OpenAiHttpDeps;
   private readonly defaultChatModel: string;
+  private readonly taggedToolCompatibility: "qwen" | undefined;
 
   constructor(options: OpenAiProviderOptions) {
     this.id = options.id;
@@ -72,6 +75,7 @@ export class OpenAiProvider implements LlmProvider {
       reasoningFormat: options.reasoningFormat ?? "delta_reasoning",
     };
     this.defaultChatModel = options.defaultChatModel;
+    this.taggedToolCompatibility = options.taggedToolCompatibility;
     this.http = {
       baseUrl: normalizeOpenAiBaseUrl(options.baseUrl),
       apiKey: options.apiKey,
@@ -85,12 +89,19 @@ export class OpenAiProvider implements LlmProvider {
   async complete(request: CompletionRequest): Promise<CompletionResult> {
     const body = buildOpenAiChatBody(request, this.defaultChatModel, false);
     const json = await openAiPostJson(this.http, "/v1/chat/completions", body, request);
-    return normaliseOpenAiChatResponse(json, this.defaultChatModel);
+    const adapted =
+      this.taggedToolCompatibility === "qwen"
+        ? adaptQwenTaggedToolResponse(json, request)
+        : json;
+    return normaliseOpenAiChatResponse(adapted, this.defaultChatModel);
   }
 
   async *completeStream(
     request: CompletionRequest,
   ): AsyncGenerator<StreamChunk, CompletionResult, void> {
+    if (this.taggedToolCompatibility === "qwen") {
+      return await this.complete(request);
+    }
     const body = buildOpenAiChatBody(request, this.defaultChatModel, true);
     // Opening the stream (connect + status check) happens inside the
     // client's bounded retry, strictly before the first chunk exists.

--- a/src/llm/provider/openai/qwen-tagged-tool-response-adapter.test.ts
+++ b/src/llm/provider/openai/qwen-tagged-tool-response-adapter.test.ts
@@ -1,0 +1,498 @@
+import { describe, expect, it } from "vitest";
+
+import type { CompletionRequest } from "../completion-types.js";
+import { adaptQwenTaggedToolResponse } from "./qwen-tagged-tool-response-adapter.js";
+
+const offeredTools: NonNullable<CompletionRequest["tools"]> = [
+  {
+    type: "function",
+    function: {
+      name: "os__fs__read",
+      parameters: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          count: { type: "integer" },
+          ratio: { type: "number" },
+          enabled: { type: "boolean" },
+          paths: { type: "array", items: { type: "string" } },
+          options: { type: "object" },
+          nothing: { type: "null" },
+        },
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "reply",
+      parameters: {
+        type: "object",
+        properties: { text: { type: "string" } },
+        required: ["text"],
+      },
+    },
+  },
+];
+
+function responseWith(message: Record<string, unknown>): Record<string, unknown> {
+  return {
+    model: "qwen",
+    choices: [{ message, finish_reason: "stop" }],
+  };
+}
+
+function firstMessage(response: Record<string, unknown>): Record<string, unknown> {
+  const choices = response.choices as Array<Record<string, unknown>>;
+  return choices[0]!.message as Record<string, unknown>;
+}
+
+describe("adaptQwenTaggedToolResponse", () => {
+  it("converts ordered dotted and escaped calls to the exact offered wire name", () => {
+    const tagged = [
+      "<tool_call><function=os.fs.read>",
+      "<parameter=text> hello </parameter>",
+      "<parameter=count>42</parameter>",
+      "<parameter=ratio>3.5</parameter>",
+      "<parameter=enabled>true</parameter>",
+      '<parameter=paths>["a","b"]</parameter>',
+      '<parameter=options>{"recursive":false}</parameter>',
+      "<parameter=nothing>null</parameter>",
+      "</function></tool_call>",
+      "<tool_call><function=os__fs__read>",
+      "<parameter=text>second</parameter>",
+      "</function></tool_call>",
+    ].join("");
+
+    const adapted = adaptQwenTaggedToolResponse(
+      responseWith({ role: "assistant", content: tagged }),
+      { prompt: "read", tools: offeredTools },
+    );
+    const message = firstMessage(adapted);
+    const calls = message.tool_calls as Array<{
+      id: string;
+      function: { name: string; arguments: string };
+    }>;
+
+    expect(message.content).toBeNull();
+    expect(calls.map((call) => call.function.name)).toEqual([
+      "os__fs__read",
+      "os__fs__read",
+    ]);
+    expect(new Set(calls.map((call) => call.id)).size).toBe(2);
+    expect(JSON.parse(calls[0]!.function.arguments)).toEqual({
+      text: "hello",
+      count: 42,
+      ratio: 3.5,
+      enabled: true,
+      paths: ["a", "b"],
+      options: { recursive: false },
+      nothing: null,
+    });
+    expect(JSON.parse(calls[1]!.function.arguments)).toEqual({ text: "second" });
+  });
+
+  it("converts a tagged call from reasoning_content", () => {
+    const adapted = adaptQwenTaggedToolResponse(
+      responseWith({
+        role: "assistant",
+        content: "brief rationale",
+        reasoning_content:
+          "<tool_call><function=reply><parameter=text>done</parameter></function></tool_call>",
+      }),
+      { prompt: "answer", tools: offeredTools },
+    );
+    const message = firstMessage(adapted);
+
+    expect(message.content).toBe("brief rationale");
+    expect(message.reasoning_content).toBeNull();
+    expect(message.tool_calls).toMatchObject([
+      { type: "function", function: { name: "reply", arguments: '{"text":"done"}' } },
+    ]);
+  });
+
+  it("rejects the entire tagged response when any call is invalid", () => {
+    const inputs = [
+      [
+        "<tool_call><function=os.fs.read><parameter=count>four</parameter></function></tool_call>",
+        "<tool_call><function=reply><parameter=text>must-not-run</parameter></function></tool_call>",
+      ].join(""),
+      [
+        "<tool_call><function=not.offered><parameter=x>1</parameter></function></tool_call>",
+        "<tool_call><function=reply><parameter=text>must-not-run</parameter></function></tool_call>",
+      ].join(""),
+    ];
+
+    for (const content of inputs) {
+      const original = responseWith({ role: "assistant", content });
+      const adapted = adaptQwenTaggedToolResponse(original, {
+        tools: offeredTools,
+      });
+
+      expect(adapted).toBe(original);
+      expect(firstMessage(adapted).tool_calls).toBeUndefined();
+    }
+  });
+
+  it("rejects undeclared, duplicate, and missing required parameters", () => {
+    const inputs = [
+      "<tool_call><function=reply><parameter=text>ok</parameter><parameter=extra>no</parameter></function></tool_call>",
+      "<tool_call><function=reply><parameter=text>one</parameter><parameter=text>two</parameter></function></tool_call>",
+      "<tool_call><function=reply></function></tool_call>",
+    ];
+
+    for (const content of inputs) {
+      const original = responseWith({ role: "assistant", content });
+      expect(
+        adaptQwenTaggedToolResponse(original, { tools: offeredTools }),
+      ).toBe(original);
+    }
+  });
+
+  it("does not convert absent, unknown, malformed, or prose-mixed tags", () => {
+    const inputs = [
+      "ordinary assistant prose",
+      "<tool_call><function=not.offered><parameter=x>1</parameter></function></tool_call>",
+      "<tool_call><function=reply><parameter=text>missing close</function></tool_call>",
+      "Here is an example: <tool_call><function=reply><parameter=text>no</parameter></function></tool_call>",
+    ];
+
+    for (const content of inputs) {
+      const original = responseWith({ role: "assistant", content });
+      const adapted = adaptQwenTaggedToolResponse(original, {
+        prompt: "x",
+        tools: offeredTools,
+      });
+      expect(adapted).toBe(original);
+      expect(firstMessage(adapted).tool_calls).toBeUndefined();
+    }
+  });
+
+  it("leaves non-empty native tool_calls unchanged and preferred", () => {
+    const native = [
+      {
+        id: "native-1",
+        type: "function",
+        function: { name: "reply", arguments: '{"text":"native"}' },
+      },
+    ];
+    const original = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=reply><parameter=text>tagged</parameter></function></tool_call>",
+      tool_calls: native,
+    });
+
+    const adapted = adaptQwenTaggedToolResponse(original, {
+      prompt: "x",
+      tools: offeredTools,
+    });
+
+    expect(adapted).toBe(original);
+    expect(firstMessage(adapted).tool_calls).toBe(native);
+  });
+
+  it("treats an empty native tool_calls array as absent", () => {
+    const adapted = adaptQwenTaggedToolResponse(
+      responseWith({
+        role: "assistant",
+        content:
+          "<tool_call><function=reply><parameter=text>tagged</parameter></function></tool_call>",
+        tool_calls: [],
+      }),
+      { prompt: "x", tools: offeredTools },
+    );
+
+    expect(firstMessage(adapted).tool_calls).toMatchObject([
+      { function: { name: "reply", arguments: '{"text":"tagged"}' } },
+    ]);
+  });
+
+  it("accepts only the literal null token for null parameters", () => {
+    const original = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=os.fs.read><parameter=nothing>not-null</parameter></function></tool_call>",
+    });
+
+    expect(
+      adaptQwenTaggedToolResponse(original, { prompt: "x", tools: offeredTools }),
+    ).toBe(original);
+  });
+
+  it("rejects values that violate offered nested, enum, and union schemas", () => {
+    const tools: NonNullable<CompletionRequest["tools"]> = [
+      {
+        type: "function",
+        function: {
+          name: "constrained",
+          parameters: {
+            type: "object",
+            properties: {
+              paths: { type: "array", items: { type: "string" } },
+              mode: { type: "string", enum: ["safe"] },
+              limit: {
+                anyOf: [{ type: "integer" }, { type: "null" }],
+                maximum: 10,
+              },
+              options: {
+                type: "object",
+                properties: { recursive: { type: "boolean" } },
+                required: ["recursive"],
+                additionalProperties: false,
+              },
+            },
+            required: ["paths", "mode", "limit", "options"],
+          },
+        },
+      },
+    ];
+    const invalidValues = [
+      ["paths", '["a",2]'],
+      ["mode", "unsafe"],
+      ["limit", "1.5"],
+      ["limit", "20"],
+      ["options", '{"recursive":"false"}'],
+      ["options", '{"recursive":false,"extra":true}'],
+    ] as const;
+
+    for (const [invalidName, invalidValue] of invalidValues) {
+      const values = {
+        paths: '["a","b"]',
+        mode: "safe",
+        limit: "2",
+        options: '{"recursive":false}',
+        [invalidName]: invalidValue,
+      };
+      const parameters = Object.entries(values)
+        .map(([name, value]) => `<parameter=${name}>${value}</parameter>`)
+        .join("");
+      const original = responseWith({
+        role: "assistant",
+        content: `<tool_call><function=constrained>${parameters}</function></tool_call>`,
+      });
+
+      expect(adaptQwenTaggedToolResponse(original, { tools })).toBe(original);
+    }
+  });
+
+  it("accepts a payload that satisfies nested, enum, and union schemas", () => {
+    const tools: NonNullable<CompletionRequest["tools"]> = [
+      {
+        type: "function",
+        function: {
+          name: "constrained",
+          parameters: {
+            type: "object",
+            properties: {
+              paths: { type: "array", items: { type: "string" } },
+              mode: { type: "string", enum: ["safe"] },
+              limit: {
+                anyOf: [{ type: "integer" }, { type: "null" }],
+                maximum: 10,
+              },
+              options: {
+                type: "object",
+                properties: { recursive: { type: "boolean" } },
+                required: ["recursive"],
+                additionalProperties: false,
+              },
+            },
+            required: ["paths", "mode", "limit", "options"],
+          },
+        },
+      },
+    ];
+    const adapted = adaptQwenTaggedToolResponse(
+      responseWith({
+        role: "assistant",
+        content:
+          '<tool_call><function=constrained><parameter=paths>["a","b"]</parameter><parameter=mode>safe</parameter><parameter=limit>2</parameter><parameter=options>{"recursive":false}</parameter></function></tool_call>',
+      }),
+      { tools },
+    );
+    const calls = firstMessage(adapted).tool_calls as Array<{
+      function: { arguments: string };
+    }>;
+
+    expect(JSON.parse(calls[0]!.function.arguments)).toEqual({
+      paths: ["a", "b"],
+      mode: "safe",
+      limit: 2,
+      options: { recursive: false },
+    });
+  });
+
+  it("validates root combinators before emitting executable arguments", () => {
+    const tools: NonNullable<CompletionRequest["tools"]> = [
+      {
+        type: "function",
+        function: {
+          name: "root-constrained",
+          parameters: {
+            type: "object",
+            properties: {
+              left: { type: "string" },
+              right: { type: "string" },
+            },
+            oneOf: [{ required: ["left"] }, { required: ["right"] }],
+            additionalProperties: false,
+          },
+        },
+      },
+    ];
+    const missing = responseWith({
+      role: "assistant",
+      content: "<tool_call><function=root-constrained></function></tool_call>",
+    });
+    const both = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=root-constrained><parameter=left>a</parameter><parameter=right>b</parameter></function></tool_call>",
+    });
+    const valid = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=root-constrained><parameter=left>a</parameter></function></tool_call>",
+    });
+
+    expect(adaptQwenTaggedToolResponse(missing, { tools })).toBe(missing);
+    expect(adaptQwenTaggedToolResponse(both, { tools })).toBe(both);
+    expect(firstMessage(adaptQwenTaggedToolResponse(valid, { tools })).tool_calls).toBeDefined();
+  });
+
+  it("inherits parent types while coercing oneOf alternatives", () => {
+    const tools: NonNullable<CompletionRequest["tools"]> = [
+      {
+        type: "function",
+        function: {
+          name: "typed-union",
+          parameters: {
+            type: "object",
+            properties: {
+              value: {
+                type: "integer",
+                oneOf: [{ maximum: 10 }, { minimum: 20 }],
+              },
+            },
+            required: ["value"],
+          },
+        },
+      },
+    ];
+    const valid = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=typed-union><parameter=value>5</parameter></function></tool_call>",
+    });
+    const invalid = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=typed-union><parameter=value>15</parameter></function></tool_call>",
+    });
+
+    const adapted = adaptQwenTaggedToolResponse(valid, { tools });
+    const calls = firstMessage(adapted).tool_calls as Array<{
+      function: { arguments: string };
+    }>;
+    expect(JSON.parse(calls[0]!.function.arguments)).toEqual({ value: 5 });
+    expect(adaptQwenTaggedToolResponse(invalid, { tools })).toBe(invalid);
+  });
+
+  it("enforces common assertions and fails closed on unsupported schemas", () => {
+    const assertedTools: NonNullable<CompletionRequest["tools"]> = [
+      {
+        type: "function",
+        function: {
+          name: "asserted",
+          parameters: {
+            type: "object",
+            properties: {
+              even: { type: "integer", multipleOf: 2 },
+              tags: { type: "array", items: { type: "string" }, uniqueItems: true },
+              mode: { type: "string", not: { const: "blocked" } },
+            },
+            required: ["even", "tags", "mode"],
+          },
+        },
+      },
+    ];
+    const invalidParameters = [
+      '<parameter=even>3</parameter><parameter=tags>["a"]</parameter><parameter=mode>safe</parameter>',
+      '<parameter=even>4</parameter><parameter=tags>["a","a"]</parameter><parameter=mode>safe</parameter>',
+      '<parameter=even>4</parameter><parameter=tags>["a"]</parameter><parameter=mode>blocked</parameter>',
+    ];
+    for (const parameters of invalidParameters) {
+      const original = responseWith({
+        role: "assistant",
+        content: `<tool_call><function=asserted>${parameters}</function></tool_call>`,
+      });
+      expect(adaptQwenTaggedToolResponse(original, { tools: assertedTools })).toBe(
+        original,
+      );
+    }
+
+    const unsupportedTools: NonNullable<CompletionRequest["tools"]> = [
+      {
+        type: "function",
+        function: {
+          name: "unsupported",
+          parameters: {
+            type: "object",
+            properties: { value: { $ref: "#/$defs/value" } },
+            required: ["value"],
+            $defs: { value: { type: "string" } },
+          },
+        },
+      },
+    ];
+    const unsupported = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=unsupported><parameter=value>x</parameter></function></tool_call>",
+    });
+    expect(adaptQwenTaggedToolResponse(unsupported, { tools: unsupportedTools })).toBe(
+      unsupported,
+    );
+  });
+
+  it("uses own-property checks for prototype-named parameters", () => {
+    const tools: NonNullable<CompletionRequest["tools"]> = [
+      {
+        type: "function",
+        function: {
+          name: "prototype-safe",
+          parameters: {
+            type: "object",
+            properties: { constructor: { type: "string" } },
+            required: ["constructor"],
+          },
+        },
+      },
+    ];
+    const missing = responseWith({
+      role: "assistant",
+      content: "<tool_call><function=prototype-safe></function></tool_call>",
+    });
+    const supplied = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=prototype-safe><parameter=constructor>own</parameter></function></tool_call>",
+    });
+    const unofferedPrototype = responseWith({
+      role: "assistant",
+      content:
+        "<tool_call><function=prototype-safe><parameter=__proto__>no</parameter><parameter=constructor>own</parameter></function></tool_call>",
+    });
+
+    expect(adaptQwenTaggedToolResponse(missing, { tools })).toBe(missing);
+    expect(adaptQwenTaggedToolResponse(unofferedPrototype, { tools })).toBe(
+      unofferedPrototype,
+    );
+    const adapted = adaptQwenTaggedToolResponse(supplied, { tools });
+    const calls = firstMessage(adapted).tool_calls as Array<{
+      function: { arguments: string };
+    }>;
+    expect(JSON.parse(calls[0]!.function.arguments)).toEqual({ constructor: "own" });
+  });
+});

--- a/src/llm/provider/openai/qwen-tagged-tool-response-adapter.test.ts
+++ b/src/llm/provider/openai/qwen-tagged-tool-response-adapter.test.ts
@@ -111,6 +111,26 @@ describe("adaptQwenTaggedToolResponse", () => {
     ]);
   });
 
+  it("salvages reasoning_content when content holds unparseable tag noise (#105)", () => {
+    // Regression for the review finding: a malformed `<tool_call>` in content
+    // must not fail closed and leave a valid call in reasoning_content as prose.
+    const adapted = adaptQwenTaggedToolResponse(
+      responseWith({
+        role: "assistant",
+        content: "let me call <tool_call><function=os.fs.read><parameter=path>/x",
+        reasoning_content:
+          "<tool_call><function=reply><parameter=text>done</parameter></function></tool_call>",
+      }),
+      { prompt: "answer", tools: offeredTools },
+    );
+    const message = firstMessage(adapted);
+
+    expect(message.tool_calls).toMatchObject([
+      { type: "function", function: { name: "reply", arguments: '{"text":"done"}' } },
+    ]);
+    expect(message.reasoning_content).toBeNull();
+  });
+
   it("rejects the entire tagged response when any call is invalid", () => {
     const inputs = [
       [

--- a/src/llm/provider/openai/qwen-tagged-tool-response-adapter.ts
+++ b/src/llm/provider/openai/qwen-tagged-tool-response-adapter.ts
@@ -1,4 +1,4 @@
-import type { CompletionRequest, OpenAiToolCall } from "../completion-types.js";
+import type { CompletionRequest, CompletionResult, OpenAiToolCall } from "../completion-types.js";
 import {
   coerceJsonSchemaValue,
   validateJsonSchemaValue,
@@ -37,8 +37,11 @@ export function adaptQwenTaggedToolResponse(
 
   const offered = indexOfferedTools(request.tools);
   const contentCalls = parseSource(message.content, offered);
-  if (contentCalls === null) return response;
-  const fromReasoning = contentCalls.length === 0;
+  // #105 allows the tagged call in either field. `null` means content held
+  // tag noise that failed to parse — fail open to reasoning_content rather
+  // than fail closed on the first field alone. An empty-but-clean content
+  // (`[]`) takes the same reasoning path, so `fromReasoning` covers both.
+  const fromReasoning = contentCalls === null || contentCalls.length === 0;
   const toolCalls = fromReasoning
     ? parseSource(message.reasoning_content, offered)
     : contentCalls;
@@ -53,6 +56,52 @@ export function adaptQwenTaggedToolResponse(
   const nextChoices = [...choices];
   nextChoices[0] = { ...choice, message: nextMessage, finish_reason: "tool_calls" };
   return { ...response, choices: nextChoices };
+}
+
+/**
+ * CompletionResult-shaped wrapper for the streaming path. The provider
+ * buffers deltas into a `CompletionResult`, so it cannot call the raw
+ * wire-shape adapter above; this rebuilds the minimal wire envelope the
+ * adapter inspects (`content` / `reasoning_content`), runs the same adapt
+ * seam, and maps the result back. `usage`/`modelId`/`finishReason` come
+ * from the buffered stream so they survive the round-trip untouched.
+ */
+export function adaptQwenCompletionResult(
+  result: CompletionResult,
+  request: Pick<CompletionRequest, "tools">,
+): CompletionResult {
+  const wire = {
+    choices: [
+      {
+        message: {
+          content: result.content,
+          reasoning_content: result.reasoningContent,
+          tool_calls: result.toolCalls ?? [],
+        },
+        finish_reason: result.finishReason ?? null,
+      },
+    ],
+  };
+  const adapted = adaptQwenTaggedToolResponse(wire, request);
+  const choice = (adapted.choices as Array<Record<string, unknown>>)[0];
+  const message = choice?.message as Record<string, unknown> | undefined;
+  if (!message) return result;
+  const toolCalls = Array.isArray(message.tool_calls)
+    ? (message.tool_calls as CompletionResult["toolCalls"])
+    : result.toolCalls;
+  return {
+    ...result,
+    content: typeof message.content === "string" ? message.content : "",
+    reasoningContent:
+      typeof message.reasoning_content === "string"
+        ? message.reasoning_content
+        : "",
+    toolCalls,
+    finishReason:
+      typeof choice?.finish_reason === "string"
+        ? choice.finish_reason
+        : result.finishReason,
+  };
 }
 
 function indexOfferedTools(

--- a/src/llm/provider/openai/qwen-tagged-tool-response-adapter.ts
+++ b/src/llm/provider/openai/qwen-tagged-tool-response-adapter.ts
@@ -1,0 +1,181 @@
+import type { CompletionRequest, OpenAiToolCall } from "../completion-types.js";
+import {
+  coerceJsonSchemaValue,
+  validateJsonSchemaValue,
+} from "./coerce-json-schema-value.js";
+
+type OfferedTool = {
+  wireName: string;
+  schema: Record<string, unknown>;
+  properties: Record<string, Record<string, unknown>>;
+  required: ReadonlySet<string>;
+};
+
+type TaggedCall = {
+  name: string;
+  parameters: Array<{ name: string; value: string }>;
+};
+
+const TOOL_CALL_RE = /\s*<tool_call>\s*<function=([^>\n]+)>([\s\S]*?)<\/function>\s*<\/tool_call>/gy;
+const PARAMETER_RE = /\s*<parameter=([^>\n]+)>([\s\S]*?)<\/parameter>/gy;
+
+export function adaptQwenTaggedToolResponse(
+  response: Record<string, unknown>,
+  request: Pick<CompletionRequest, "tools">,
+): Record<string, unknown> {
+  const choices = response.choices as Array<Record<string, unknown>> | undefined;
+  const choice = choices?.[0];
+  const message = choice?.message as Record<string, unknown> | undefined;
+  if (
+    !choice ||
+    !message ||
+    (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) ||
+    !request.tools?.length
+  ) {
+    return response;
+  }
+
+  const offered = indexOfferedTools(request.tools);
+  const contentCalls = parseSource(message.content, offered);
+  if (contentCalls === null) return response;
+  const fromReasoning = contentCalls.length === 0;
+  const toolCalls = fromReasoning
+    ? parseSource(message.reasoning_content, offered)
+    : contentCalls;
+  if (!toolCalls || toolCalls.length === 0) return response;
+
+  const nextMessage: Record<string, unknown> = {
+    ...message,
+    content: fromReasoning ? message.content : null,
+    tool_calls: toolCalls,
+  };
+  if (fromReasoning) nextMessage.reasoning_content = null;
+  const nextChoices = [...choices];
+  nextChoices[0] = { ...choice, message: nextMessage, finish_reason: "tool_calls" };
+  return { ...response, choices: nextChoices };
+}
+
+function indexOfferedTools(
+  tools: NonNullable<CompletionRequest["tools"]>,
+): ReadonlyMap<string, OfferedTool> {
+  const offered = new Map<string, OfferedTool>();
+  for (const tool of tools) {
+    const fn = asRecord(tool.function);
+    if (!fn || typeof fn.name !== "string") continue;
+    const parameters = asRecord(fn.parameters);
+    const properties = asRecord(parameters?.properties) ?? {};
+    const entry: OfferedTool = {
+      wireName: fn.name,
+      schema: parameters ?? { type: "object", properties: {} },
+      properties: Object.fromEntries(
+        Object.entries(properties).map(([name, schema]) => [name, asRecord(schema) ?? {}]),
+      ),
+      required: new Set(
+        Array.isArray(parameters?.required)
+          ? parameters.required.filter((name): name is string => typeof name === "string")
+          : [],
+      ),
+    };
+    offered.set(fn.name, entry);
+  }
+  for (const entry of [...offered.values()]) {
+    const dotted = entry.wireName.replace(/__/g, ".");
+    const escaped = entry.wireName.replace(/\./g, "__");
+    if (!offered.has(dotted)) offered.set(dotted, entry);
+    if (!offered.has(escaped)) offered.set(escaped, entry);
+  }
+  return offered;
+}
+
+function parseSource(
+  source: unknown,
+  offered: ReadonlyMap<string, OfferedTool>,
+): OpenAiToolCall[] | null {
+  if (typeof source !== "string" || source.trim().length === 0) return [];
+  if (!source.includes("<tool_call>")) return [];
+  const tagged = parseTaggedCalls(source);
+  if (!tagged) return null;
+
+  const calls: OpenAiToolCall[] = [];
+  for (const taggedCall of tagged) {
+    const tool = offered.get(taggedCall.name.trim());
+    if (!tool) return null;
+    const args = coerceArguments(taggedCall.parameters, tool);
+    if (!args) return null;
+    calls.push({
+      id: `call_qwen_tagged_${calls.length}`,
+      type: "function",
+      function: {
+        name: tool.wireName,
+        arguments: JSON.stringify(args),
+      },
+    });
+  }
+  return calls;
+}
+
+function parseTaggedCalls(source: string): TaggedCall[] | null {
+  const calls: TaggedCall[] = [];
+  let offset = 0;
+  while (offset < source.length) {
+    TOOL_CALL_RE.lastIndex = offset;
+    const match = TOOL_CALL_RE.exec(source);
+    if (!match) return source.slice(offset).trim().length === 0 ? calls : null;
+    const parameters = parseParameters(match[2] ?? "");
+    if (!parameters) return null;
+    calls.push({ name: match[1] ?? "", parameters });
+    offset = TOOL_CALL_RE.lastIndex;
+  }
+  return calls;
+}
+
+function parseParameters(
+  source: string,
+): Array<{ name: string; value: string }> | null {
+  const parameters: Array<{ name: string; value: string }> = [];
+  let offset = 0;
+  while (offset < source.length) {
+    PARAMETER_RE.lastIndex = offset;
+    const match = PARAMETER_RE.exec(source);
+    if (!match) return source.slice(offset).trim().length === 0 ? parameters : null;
+    parameters.push({ name: (match[1] ?? "").trim(), value: (match[2] ?? "").trim() });
+    offset = PARAMETER_RE.lastIndex;
+  }
+  return parameters;
+}
+
+function coerceArguments(
+  parameters: TaggedCall["parameters"],
+  tool: OfferedTool,
+): Record<string, unknown> | null {
+  const args = Object.create(null) as Record<string, unknown>;
+  try {
+    for (const parameter of parameters) {
+      if (
+        !Object.hasOwn(tool.properties, parameter.name) ||
+        Object.hasOwn(args, parameter.name)
+      ) {
+        throw new Error("invalid parameter");
+      }
+      args[parameter.name] = coerceJsonSchemaValue(
+        parameter.value,
+        tool.properties[parameter.name] ?? {},
+      );
+    }
+    for (const name of tool.required) {
+      if (!Object.hasOwn(args, name)) throw new Error("missing required parameter");
+    }
+    if (!validateJsonSchemaValue(args, tool.schema)) {
+      throw new Error("arguments do not match offered schema");
+    }
+    return args;
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}

--- a/src/llm/provider/registry/provider-registry.test.ts
+++ b/src/llm/provider/registry/provider-registry.test.ts
@@ -15,6 +15,7 @@ describe("ProviderRegistry", () => {
     const kinds = knownProviderKinds();
     expect(kinds).toContain("llama-server");
     expect(kinds).toContain("openai-compatible");
+    expect(kinds).toContain("qwen-openai-compatible");
     expect(kinds).toContain("openrouter");
   });
 

--- a/src/llm/provider/registry/register-built-in-providers.ts
+++ b/src/llm/provider/registry/register-built-in-providers.ts
@@ -56,6 +56,26 @@ export function registerBuiltInProviderKinds(): void {
     });
   });
 
+  registerProviderKind("qwen-openai-compatible", (ctx) => {
+    const entry = ctx.entry;
+    if (!entry.baseUrl || !entry.defaultChatModel) {
+      throw new Error(
+        `qwen-openai-compatible provider "${entry.id}" requires baseUrl and defaultChatModel`,
+      );
+    }
+    return new OpenAiProvider({
+      id: entry.id,
+      baseUrl: entry.baseUrl,
+      apiKey: entry.apiKey ?? "",
+      defaultChatModel: entry.defaultChatModel,
+      headers: entry.headers,
+      supportsVision: entry.supportsVision ?? true,
+      supportsParallelTools: entry.supportsTools ?? true,
+      requestTimeoutMs: entry.requestTimeoutMs,
+      taggedToolCompatibility: "qwen",
+    });
+  });
+
   registerProviderKind("openrouter", (ctx) => {
     const entry = ctx.entry;
     return new OpenRouterProvider({


### PR DESCRIPTION
## Problem

Some Qwen deployments behind OpenAI-compatible endpoints return tool calls as tagged text in `content` or `reasoning_content`, rather than native `message.tool_calls`. Atomic therefore treated valid calls as assistant prose. The model may also emit dotted names such as `os.fs.read` while Atomic advertises `os__fs__read`.

## Change

- Add an explicit opt-in OpenAI-compatible Qwen adapter instead of changing every OpenAI provider globally.
- Prefer native `message.tool_calls`; parse tagged calls only when native calls are absent.
- Resolve dotted and escaped names only against tools actually offered in the request.
- Coerce and validate tagged parameter values against the offered JSON schema, including nested arrays/objects, unions, enums, required fields, and additional-property rules.
- Preserve multiple-call order and distinct IDs through `completeStream()`; Atomic's existing executor then assigns deterministic batch indices.
- Fail closed for malformed tags, unknown tools or parameters, duplicate or missing required parameters, prototype-named edge cases, and invalid values; ordinary prose remains prose.

## Scope

The adapter is provider-specific and does not change generic OpenAI, OpenRouter, AIMLAPI, or Gemini behavior. Generic SSE reconstruction remains tracked separately by #103.

## Testing

- `npm run lint`
- Focused adapter/provider suite: 14 passed, 0 failed
- Affected provider/config/TUI suite: 392 passed, 0 failed
- `npm run build`
- Full suite: 3,956 passed, 6 failed, 4 skipped; all six failure names exactly match the captured upstream baseline (one upstream baseline failure — LlmHealthPoller re-probe — no longer reproduces) and no new failures were introduced
- `git diff --check`
- Public diff credential/private-path audit

Closes #105

Implementation and test preparation were LLM-assisted, then independently reviewed by Yabloko Labs.
