### PR TITLE
feat(tui): first-class provider preset for local Ollama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+/node_modules
 dist/
 dist-sea/
 bundle/

--- a/README.md
+++ b/README.md
@@ -280,6 +280,33 @@ The LLM tab in the TUI has an External pane for this setup. Saving a URL runs an
 </details>
 
 <details>
+<summary><b>Ollama and LM Studio (local)</b></summary>
+
+Running models under [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai)? Both are OpenAI-compatible servers, and both are presets in the provider wizard, so there is no base URL to type.
+
+```bash
+ollama serve
+ollama pull qwen2.5:0.5b
+
+atomic-agent tui --cwd /path/to/work
+```
+
+In the TUI, open the LLM tab, add a provider, and pick **Ollama (local)** (or **LM Studio (local)**). A local server has no API key, so the wizard skips the key screen and goes straight to the model choice: two screens, service then model.
+
+Model ids are the tags the server reports, `qwen2.5:0.5b` or `llama3.2:latest` for Ollama, so use the same name you passed to `ollama pull`. The list comes from the server's own `/v1/models`, which means anything you have pulled shows up without a restart.
+
+| Preset | Endpoint |
+| --- | --- |
+| Ollama (local) | `http://localhost:11434` |
+| LM Studio (local) | `http://localhost:1234` |
+
+Two things to know. Ollama's OpenAI-compatible surface lives under `/v1`, but the base URL is stored without it, since every call site appends `/v1/...` itself. And **Ollama (local)** is a different entry from **Ollama Cloud**: the first is the server on your machine and needs no key, the second is the hosted endpoint.
+
+Tool calling works over this path, so the agent loop runs normally, but it is only as reliable as the model you picked. Very small models emit malformed tool calls more often; if the loop stalls, try a larger one before assuming the provider is at fault.
+
+</details>
+
+<details>
 <summary><b>OpenAI-compatible HTTP</b></summary>
 
 Run `atomic-agent` as a local HTTP service:

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/sosidudku/atomic-agent/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/sosidudku/atomic-agent/node_modules

--- a/src/tui/providers/provider-presets.test.ts
+++ b/src/tui/providers/provider-presets.test.ts
@@ -44,6 +44,29 @@ describe("PROVIDER_PRESETS", () => {
     expect(findProviderPreset("lmstudio")?.local).toBe(true);
   });
 
+  it("offers local Ollama on its default port, marked local", () => {
+    // `ollama serve` listens on 11434 and needs no credentials, so the
+    // wizard can save the entry without a key screen. Verified against a
+    // live server: GET /v1/models answers 200 with an OpenAI-shaped list.
+    const preset = findProviderPreset("ollama");
+    expect(preset?.local).toBe(true);
+    expect(preset?.baseUrl).toBe("http://localhost:11434");
+  });
+
+  it("keeps local Ollama separate from the hosted Ollama Cloud", () => {
+    // Same vendor, different services: one is the operator's own machine
+    // with no key, the other is a hosted endpoint keyed by its own var.
+    const local = findProviderPreset("ollama");
+    const cloud = findProviderPreset("ollama-cloud");
+    expect(local?.baseUrl).not.toBe(cloud?.baseUrl);
+    expect(local?.envVar).not.toBe(cloud?.envVar);
+    expect(cloud?.local).toBeUndefined();
+    // The `-\d+` suffix rule must not turn the hosted id into the local
+    // preset: `ollama` is a prefix of `ollama-cloud`.
+    expect(presetForEntryId("ollama-cloud")?.id).toBe("ollama-cloud");
+    expect(presetForEntryId("ollama-2")?.id).toBe("ollama");
+  });
+
   it("keeps the verified keyless-listing services marked", () => {
     // Presence checks, not an exact list: a new keyless preset must not
     // break this test, it only has to keep the verified ones flagged.

--- a/src/tui/providers/provider-presets.ts
+++ b/src/tui/providers/provider-presets.ts
@@ -105,6 +105,14 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "open-weight models, 350+ ids listed without a key",
   },
   {
+    id: "ollama",
+    label: "Ollama (local)",
+    baseUrl: "http://localhost:11434",
+    envVar: "OLLAMA_API_KEY",
+    local: true,
+    note: "the server `ollama serve` runs on your machine; no API key needed",
+  },
+  {
     id: "ollama-cloud",
     label: "Ollama Cloud",
     baseUrl: "https://ollama.com",

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -420,6 +420,71 @@ describe("handleProvidersWizardKey", () => {
     expect(wizard.phase).toBe("chat_model_line");
   });
 
+  it("saves local Ollama in two screens, with its own localhost URL", () => {
+    // Local Ollama is the second local preset, and its host:port differs
+    // from LM Studio's. Picking it must fill in 11434 and skip both the
+    // URL and the key screens: `ollama serve` has no key at all.
+    let wizard = createProvidersWizardState("add");
+    const ollamaIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "ollama");
+    for (let i = 0; i < ollamaIdx; i += 1) {
+      wizard = next(wizard, "", emptyKey({ downArrow: true }));
+    }
+    wizard = next(wizard, "", emptyKey({ return: true }));
+    expect(wizard.kind).toBe("openai-compatible");
+    expect(wizard.presetId).toBe("ollama");
+    // Stored without `/v1`: call sites append it, so a suffix here would
+    // send requests to `/v1/v1/models`, which Ollama answers with a 404.
+    expect(wizard.baseUrlLine).toBe("http://localhost:11434");
+    expect(wizard.phase).toBe("chat_model_line");
+
+    // Model ids are Ollama tags, typed as the server reports them.
+    for (const ch of "llama3.2:latest") wizard = next(wizard, ch, emptyKey());
+    const result = handleProvidersWizardKey("", emptyKey({ return: true }), wizard);
+    expect(result).toMatchObject({ handled: true, submit: true });
+    if ("wizard" in result) {
+      expect(result.wizard.chatModelLine).toBe("llama3.2:latest");
+    }
+  });
+
+  it("keeps local Ollama and Ollama Cloud on separate rows", () => {
+    // The two share an id prefix and a vendor name; picking the local row
+    // must not land on the hosted service (or vice versa).
+    const localIdx = 2 + PROVIDER_PRESETS.findIndex((p) => p.id === "ollama");
+    const cloudIdx =
+      2 + PROVIDER_PRESETS.findIndex((p) => p.id === "ollama-cloud");
+    expect(localIdx).not.toBe(cloudIdx);
+
+    for (const [idx, expected] of [
+      [localIdx, "ollama"],
+      [cloudIdx, "ollama-cloud"],
+    ] as const) {
+      let wizard = createProvidersWizardState("add");
+      for (let i = 0; i < idx; i += 1) {
+        wizard = next(wizard, "", emptyKey({ downArrow: true }));
+      }
+      wizard = next(wizard, "", emptyKey({ return: true }));
+      expect(wizard.presetId).toBe(expected);
+    }
+  });
+
+  it("recovers the local Ollama preset when reconfiguring its entry", () => {
+    // `ollama` is a prefix of `ollama-cloud`, so the lookup must not
+    // confuse a hosted entry for the local one.
+    const local = createProvidersWizardState("configure", {
+      providerId: "ollama",
+      kind: "openai-compatible",
+      baseUrl: "http://localhost:11434",
+    });
+    expect(local.presetId).toBe("ollama");
+
+    const cloud = createProvidersWizardState("configure", {
+      providerId: "ollama-cloud",
+      kind: "openai-compatible",
+      baseUrl: "https://ollama.com",
+    });
+    expect(cloud.presetId).toBe("ollama-cloud");
+  });
+
   it("a preset never shows the URL screen", () => {
     // Groq (keyed): service -> key -> models, base_url is never reached.
     let wizard = createProvidersWizardState("add");


### PR DESCRIPTION
## Why

We publicly claim Ollama compatibility, including an open PR to [ollama/ollama#17727](https://github.com/ollama/ollama/pull/17727) stating that Atomic Agent "works with Ollama via its OpenAI-compatible endpoint". That claim was architecturally true but unverified and undocumented.

Before this PR the only Ollama preset was `ollama-cloud`, which points at `https://ollama.com`: the **hosted** service. A local `ollama serve` worked only through the manual `openai-compatible` row with a hand-typed base URL, which is exactly the dead end presets exist to remove (#69). `11434` appeared nowhere in `src/`, docs, or the README.

## What

- **`ollama` preset** next to LM Studio: `http://localhost:11434`, `local: true`, no API key. `presetNeedsKeyScreen` already keys off `local`, so no wiring changes were needed: picking the row skips both the URL and the key screens and lands on the model choice.
- **README section** covering both local presets. Local provider setup was not documented anywhere, so this adds the section rather than extending one.
- **Tests** following the existing patterns in `providers-wizard-key-bindings.test.ts` and `provider-presets.test.ts`.

## Two details worth review attention

**The base URL is stored without `/v1`.** Every compat call site appends `/v1/...` itself, so a stored suffix would produce `/v1/v1/chat/completions`. I confirmed Ollama answers that path with a 404. This also matches the existing test asserting no preset ends in `/v1`.

**`ollama` is a prefix of `ollama-cloud`.** The `-\d+` suffix rule in `presetForEntryId` could plausibly confuse them, so both ids are covered by a test: the direct lookup resolves the hosted id first and never degrades it to the local preset.

## Verification

Run against a live **Ollama 0.32.9** on macOS with `qwen2.5:0.5b`, driving the shipped code paths (`buildProviderEntryFromWizard`, `fetchOpenAiCompatModels`, `OpenAiProvider`) rather than hand-written URLs:

| Check | Result |
| --- | --- |
| `GET /v1/models`, no `Authorization` header | 200, 7 models listed |
| Saved entry from the wizard builder | `baseUrl: http://localhost:11434`, `apiKeyEnvVar: OLLAMA_API_KEY` |
| `presetNeedsKeyScreen("ollama")` | `false` |
| Non-streaming `complete()` | content returned, `modelId: qwen2.5:0.5b`, usage counted |
| Streaming `completeStream()` | `"Red, Blue, Green"` over 6 chunks |
| Native tool call | well-formed `get_weather{"city":"Paris"}`, `finish: tool_calls` |
| Wrong port | clean `OpenAiHttpError` labeled `ollama`, no hang |

`npm run lint` passes. Provider tests: 46 passing in the two touched files. Full suite: 3940 passed / 10 failed, and those 10 fail identically on a clean `origin/main` checkout (`llm-health-poller`, `tui-app`, `chat-log`, and other timing-sensitive files, none provider-related).

## Note

One deliberate deviation from the task I was given: it specified `http://localhost:11434/v1`. I stored it without the suffix for the reason above; with `/v1` the existing preset test would have failed and requests would have 404'd.