### PR TITLE
feat: add /observe /manage /run tips to splash banner

### DIFF
--- a/src/tui/components/splash-banner.tsx
+++ b/src/tui/components/splash-banner.tsx
@@ -22,10 +22,13 @@ export function SplashBanner(): ReactElement {
         <Tip left="Enter" right="submit message to the agent" />
         <Tip left="/help" right="list all slash commands" />
         <Tip left="/sessions" right="switch to a previous thread" />
+        <Tip left="/observe" right="view diagnostics and world state" />
+        <Tip left="/manage" right="jump to the Manage tab" />
         <Tip left="/new" right="start a fresh session" />
         <Tip left="/model" right="change the chat model" />
         <Tip left="/tasks" right="jump to the Tasks tab (Option 4 cron + ingress UI)" />
         <Tip left="/import" right="open the Import tab (one-shot Hermes -> atomic-agent migration)" />
+        <Tip left="/run" right="start a new run" />
         <Tip left="Ctrl+C ×2" right="quit (once aborts a running turn)" />
       </Box>
       <Box flexGrow={1} />


### PR DESCRIPTION
## Summary
- Add splash-banner tips so `/observe`, `/manage`, and `/run` are discoverable from the empty chat screen.

## Test plan
- [x] Open TUI with an empty chat and confirm the splash banner lists `/observe`, `/manage`, and `/run`.
- [x] Related tests pass (`src/tui/components/chat-log.test.tsx` if covered).