### PR TITLE
fix: correct Local AI-First Agent text expectation in test

### DIFF
--- a/src/tui/components/chat-log.test.tsx
+++ b/src/tui/components/chat-log.test.tsx
@@ -25,7 +25,7 @@ describe("ChatLog", () => {
     const state = createInitialTuiState(BASE_SESSION);
     const { lastFrame } = render(<ChatLog state={state} />);
     const text = strip(lastFrame() ?? "");
-    expect(text).toContain("Local-First AI Agent");
+    expect(text).toContain("Local AI-First Agent");
     expect(text).toContain("/help");
   });
 

--- a/src/tui/components/splash-banner.tsx
+++ b/src/tui/components/splash-banner.tsx
@@ -22,10 +22,13 @@ export function SplashBanner(): ReactElement {
         <Tip left="Enter" right="submit message to the agent" />
         <Tip left="/help" right="list all slash commands" />
         <Tip left="/sessions" right="switch to a previous thread" />
+        <Tip left="/observe" right="view diagnostics and world state" />
+        <Tip left="/manage" right="jump to the Manage tab" />
         <Tip left="/new" right="start a fresh session" />
         <Tip left="/model" right="change the chat model" />
         <Tip left="/tasks" right="jump to the Tasks tab (Option 4 cron + ingress UI)" />
         <Tip left="/import" right="open the Import tab (one-shot Hermes -> atomic-agent migration)" />
+        <Tip left="/run" right="start a new run" />
         <Tip left="Ctrl+C ×2" right="quit (once aborts a running turn)" />
       </Box>
       <Box flexGrow={1} />


### PR DESCRIPTION
## Summary
- Update the chat-log splash test to expect the current “Local AI-First Agent” title.
- Includes the splash-banner command tips from `fix/splash-banner-commands` (this branch is stacked on that one).

## Test plan
- [ ] `npm test -- src/tui/components/chat-log.test.tsx`
- [ ] Confirm the splash banner title and `/observe` `/manage` `/run` tips render in TUI.