### PR TITLE
feat: add Sarvam AI provider support

### DIFF
--- a/src/config/llm-config.ts
+++ b/src/config/llm-config.ts
@@ -49,6 +49,7 @@ const PROVIDER_KINDS = new Set([
   "openrouter",
   "aimlapi",
   "gemini",
+  "sarvam",
 ]);
 
 function parseProviderId(raw: unknown, field: string): string {

--- a/src/llm/provider/registry/register-built-in-providers.ts
+++ b/src/llm/provider/registry/register-built-in-providers.ts
@@ -124,4 +124,23 @@ export function registerBuiltInProviderKinds(): void {
       requestTimeoutMs: entry.requestTimeoutMs,
     });
   });
-}
+
+  registerProviderKind("sarvam", (ctx) => {
+      const entry = ctx.entry;
+      if (!entry.baseUrl || !entry.defaultChatModel) {
+        throw new Error(
+          `sarvam provider "${entry.id}" requires baseUrl and defaultChatModel`,
+        );
+      }
+      return new OpenAiProvider({
+        id: entry.id,
+        baseUrl: entry.baseUrl,
+        apiKey: entry.apiKey ?? "",
+        defaultChatModel: entry.defaultChatModel,
+        headers: entry.headers,
+        supportsVision: entry.supportsVision ?? false,
+        supportsParallelTools: entry.supportsTools ?? true,
+        requestTimeoutMs: entry.requestTimeoutMs,
+      });
+    });
+  }

--- a/src/tui/providers/provider-presets.ts
+++ b/src/tui/providers/provider-presets.ts
@@ -121,6 +121,13 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "hosted Ollama, models listed without a key",
   },
   {
+    id: "sarvam",
+    label: "Sarvam",
+    baseUrl: "https://api.sarvam.ai",
+    envVar: "SARVAM_API_KEY",
+    note: "Sarvam AI models with OpenAI-compatible API",
+  },
+  {
     id: "together",
     label: "Together AI",
     baseUrl: "https://api.together.xyz",


### PR DESCRIPTION
## Summary

Adds first-class [Sarvam AI](https://www.sarvam.ai) provider support, routed through the existing OpenAI-compatible `OpenAiProvider` — the same pattern as every other compat provider.

## Changes

| File | Change |
|---|---|
| `src/config/llm-config.ts` | Add `sarvam` to `PROVIDER_KINDS` so `kind: "sarvam"` entries validate |
| `src/llm/provider/registry/register-built-in-providers.ts` | Register the `sarvam` provider kind (OpenAI-compatible transport, vision defaulted off, parallel tools on) |
| `src/tui/providers/provider-presets.ts` | Add the Sarvam preset (`https://api.sarvam.ai`, `SARVAM_API_KEY`) to the TUI provider wizard |

## Features

- Sarvam AI integration with OpenAI-compatible API (no custom transport needed)
- New TUI wizard preset: pick "Sarvam", paste `SARVAM_API_KEY`, done
- CLI/config support via `llm.providers[].kind = "sarvam"` or the openai-compatible flow
- Support for `sarvam-105b` and `sarvam-105b-conversations` (model list comes from the live `/v1/models` endpoint, per existing preset convention)
- `SARVAM_API_KEY` env-var authentication with the preset's own env var (no cross-service key collisions)
- Preserves xAI (Grok) and all existing providers — purely additive

## Verification

- `npm run lint` (tsc noEmit): passes
- `npm test`: 3982+ passed; the only failures are pre-existing on `main` (splash-banner, llm-health-poller, send-message-concurrency, persist-embedding-hybrid-recall) and unrelated to this change — verified on a clean `main` checkout
- `npm run build`: passes
- Preset ordering pinned by `provider-presets.test.ts` ("is sorted alphabetically by label") and `providers-wizard-key-bindings.test.ts`: Sarvam sits between "Ollama Cloud" and "Together AI"

## Notes

- Sarvam advertises an OpenAI-compatible API, so no dedicated provider class is needed; `supportsVision` defaults to `false` (Sarvam models are text-only today).
