### PR TITLE
fix(install): collapse the download meter to a single blue progress line

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,16 +52,196 @@ elif [ "$OS_NAME" = "Linux" ]; then
   ARCHIVE_EXT="tar.gz"
 fi
 
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Progress UI ---------------------------------------------------------------
+#
+# curl's default meter paints a three-line table (two header rows plus the
+# data row) per transfer, so a plain install scrolls six lines of numbers.
+# Both fetchers are silenced below and progress is drawn here instead: a
+# single line, redrawn in place, terminated by exactly one newline.
+#
+# Degrades in this order: no TTY (CI logs, `| tee`) prints one plain line and
+# no bar; NO_COLOR or TERM=dumb keeps the bar but drops the colour; a
+# non-UTF-8 locale swaps the block glyphs for ASCII.
+
+UI_TTY=0
+UI_COLOUR=0
+[ -t 1 ] && UI_TTY=1
+
+# Keep a handle on the real stdout. Inside a command substitution fd 1 is the
+# capture pipe, so terminal queries made there must go through this instead.
+exec 3>&1
+if [ "$UI_TTY" = "1" ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-dumb}" != "dumb" ]; then
+  UI_COLOUR=1
+fi
+
+if [ "$UI_COLOUR" = "1" ]; then
+  # Atomic blue (#0b63f6), 24-bit where the terminal advertises it.
+  case "${COLORTERM:-}" in
+    truecolor|24bit) C_ACCENT="$(printf '\033[38;2;11;99;246m')" ;;
+    *) C_ACCENT="$(printf '\033[38;5;33m')" ;;
+  esac
+  C_TRACK="$(printf '\033[38;5;239m')"
+  C_DIM="$(printf '\033[2m')"
+  C_OFF="$(printf '\033[0m')"
+else
+  C_ACCENT=""
+  C_TRACK=""
+  C_DIM=""
+  C_OFF=""
+fi
+
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+  *[Uu][Tt][Ff]8* | *[Uu][Tt][Ff]-8*)
+    BAR_FULL="█"
+    BAR_EMPTY="░"
+    ;;
+  *)
+    BAR_FULL="#"
+    BAR_EMPTY="-"
+    ;;
+esac
+
+# Terminal width. Both obvious approaches are wrong inside the command
+# substitution that captures this value: fd 1 is the pipe, not the terminal,
+# so `stty size` sees nothing, and `tput cols` falls back to the terminfo
+# default of 80 regardless of the real window. fd 3 (duped from stdout above)
+# still refers to the terminal, so ask through that.
+term_cols() {
+  _tc="${COLUMNS:-}"
+  case "$_tc" in
+    '' | *[!0-9]*) _tc="" ;;
+  esac
+  if [ -z "$_tc" ] && have stty; then
+    _tc="$(stty size <&3 2>/dev/null | awk '{ print $2 }')"
+    case "$_tc" in
+      '' | *[!0-9]*) _tc="" ;;
+    esac
+  fi
+  if [ -z "$_tc" ] && have tput; then
+    _tc="$(tput cols 2>/dev/null || echo '')"
+    case "$_tc" in
+      '' | *[!0-9]*) _tc="" ;;
+    esac
+  fi
+  [ -n "$_tc" ] || _tc=80
+  printf '%s' "$_tc"
+}
+
+# Line budget: the label, percentage and byte counter take ~52 columns; the
+# bar gets what is left, so a narrow window still renders on one line.
+BAR_WIDTH=16
+if [ "$UI_TTY" = "1" ]; then
+  _cols="$(term_cols)"
+  if [ "$_cols" -ge 100 ]; then
+    BAR_WIDTH=24
+  elif [ "$_cols" -lt 78 ]; then
+    BAR_WIDTH=8
+  fi
+fi
+
+file_size() {
+  _fs=0
+  if [ -f "$1" ]; then
+    _fs="$(wc -c < "$1" 2>/dev/null | tr -d ' \t' || echo 0)"
+  fi
+  case "$_fs" in
+    '' | *[!0-9]*) _fs=0 ;;
+  esac
+  printf '%s' "$_fs"
+}
+
+# Total transfer size, or 0 when the server does not say. Redirects are
+# followed so this reports the length of the object, not of the 302.
+content_length() {
+  have curl || { printf '0'; return 0; }
+  curl -fsIL --retry 2 "$1" 2>/dev/null | awk '
+    { if (tolower($1) == "content-length:") { v = $2; gsub(/\r/, "", v) } }
+    END { print (v == "" ? 0 : v) }
+  '
+}
+
+render_progress() {
+  # $1 label, $2 bytes so far, $3 total bytes (0 when unknown)
+  _bar="$(awk -v label="$1" -v got="$2" -v total="$3" -v w="$BAR_WIDTH" \
+    -v full="$BAR_FULL" -v empty="$BAR_EMPTY" \
+    -v a="$C_ACCENT" -v t="$C_TRACK" -v d="$C_DIM" -v o="$C_OFF" '
+    function human(b) {
+      if (b < 1024) return sprintf("%d B", b)
+      if (b < 1048576) return sprintf("%.0f KB", b / 1024)
+      return sprintf("%.1f MB", b / 1048576)
+    }
+    BEGIN {
+      if (total <= 0) {
+        printf "%s  %s%s%s", label, d, human(got), o
+        exit
+      }
+      frac = got / total
+      if (frac > 1) frac = 1
+      n = int(frac * w + 0.5)
+      done = ""; left = ""
+      for (i = 0; i < n; i++) done = done full
+      for (i = n; i < w; i++) left = left empty
+      printf "%s  %s%s%s%s%s%s  %3d%%  %s%s of %s%s", \
+        label, a, done, o, t, left, o, int(frac * 100 + 0.5), d, human(got), human(total), o
+    }
+  ')"
+  printf '\r%s\033[K' "$_bar"
+}
+
+fetch() {
+  # Silent transfer; the caller owns all output.
+  if have curl; then
+    curl -fsS -L --retry 3 -o "$2" "$1"
+  else
+    wget -q -O "$2" "$1"
+  fi
+}
+
 download() {
+  # $1 url, $2 destination, $3 label (omit for a silent transfer)
   _url="$1"
   _out="$2"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fL --retry 3 -o "$_out" "$_url"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q -O "$_out" "$_url"
-  else
+  _label="${3:-}"
+
+  if ! have curl && ! have wget; then
     echo "install curl or wget" >&2
     exit 1
+  fi
+
+  # Small side files (checksums) and non-interactive runs get no bar.
+  if [ -z "$_label" ]; then
+    fetch "$_url" "$_out"
+    return 0
+  fi
+  if [ "$UI_TTY" != "1" ]; then
+    printf '%s\n' "$_label"
+    fetch "$_url" "$_out"
+    return 0
+  fi
+
+  _total="$(content_length "$_url")"
+  : > "$_out"
+
+  fetch "$_url" "$_out" &
+  _dl_pid=$!
+
+  while kill -0 "$_dl_pid" 2>/dev/null; do
+    render_progress "$_label" "$(file_size "$_out")" "$_total"
+    sleep 0.2
+  done
+
+  if wait "$_dl_pid"; then
+    render_progress "$_label" "$(file_size "$_out")" "$_total"
+    printf '\n'
+  else
+    _rc=$?
+    printf '\r\033[K'
+    echo "download failed: $_url" >&2
+    exit "$_rc"
   fi
 }
 
@@ -76,14 +256,12 @@ else
   SHA_URL="${BASE}/releases/latest/download/${TAR_NAME}.sha256"
 fi
 
-echo "downloading ${TAR_NAME} from ${REPO} …"
-
 TMPDIR="${TMPDIR:-/tmp}"
 WORK="$(mktemp -d "$TMPDIR/atomic-agent-install.XXXXXX")"
 # shellcheck disable=SC2064
 trap 'rm -rf "$WORK"' EXIT
 
-download "$TAR_URL" "$WORK/${TAR_NAME}"
+download "$TAR_URL" "$WORK/${TAR_NAME}" "downloading atomic-agent"
 download "$SHA_URL" "$WORK/${TAR_NAME}.sha256"
 
 if command -v shasum >/dev/null 2>&1; then


### PR DESCRIPTION
## What

Installing the CLI currently prints curl's default transfer meter — a three-line table, twice
(once for the tarball, once for the checksum):

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 47.5M  100 47.5M    0     0  4372k      0  0:00:11  0:00:11 --:--:-- 5142k
```

This replaces it with a single line that stays on one line, in the project's own accent blue:

```
downloading atomic-agent  ████████████░░░░  76%  36.1 MB of 47.5 MB
```

## How

- Both fetchers are silenced (`curl -fsS -L`, `wget -q`) and run in the background; the
  progress line is drawn from the growing output file against `Content-Length`, redrawn with
  `\r` + `\033[K`, and terminated by exactly one newline.
- The checksum file (99 bytes) downloads silently — no bar for a file that finishes instantly.
- Colour is `#0b63f6`, matching the badges in the README: 24-bit when `COLORTERM` advertises
  truecolor, 256-colour otherwise.

## Degradation

| Condition | Behaviour |
|---|---|
| Not a TTY (CI, `\| tee`) | one plain line, no bar, no escape codes |
| `NO_COLOR` set, or `TERM=dumb` | bar kept, colour dropped |
| Non-UTF-8 locale | `#`/`-` instead of `█`/`░` |
| No `Content-Length` (chunked) | byte counter only, no percentage |
| `wget` instead of `curl` | same line, byte counter only |

Bar width adapts to the terminal (24 / 16 / 8 blocks) so the line never wraps — a wrapped
line would smear across redraws. Width is read via `stty size <&3`, because inside the
command substitution that captures it fd 1 is the pipe, not the terminal, and `tput cols`
reports the terminfo default of 80 regardless of the real window.

## Failure handling is unchanged

A failed transfer still aborts the install with curl's exit status; the progress line is
cleared first and the failing URL is printed. Checksum verification, the codesign check, and
the atomic binary/directory replacement are all untouched.

## Testing

Verified on macOS arm64 against the real v0.2.1 release (47.5 MB):

- one line, 260 in-place redraws, zero newlines emitted during the download
- terminal widths 120 / 100 / 80 / 64 — bar 24 / 24 / 16 / 8, line always fits
- `NO_COLOR=1`, `TERM=dumb`, `LANG=C`, and piped-to-`cat` paths each checked
- full install verified end to end: checksum OK, 141 MB binary in place, binary runs
- failure path: `ATOMIC_AGENT_VERSION=v0.0.0-does-not-exist` exits non-zero, prints the URL,
  installs nothing

`scripts/install.ps1` is untouched; the Windows meter is a separate change.
