### PR TITLE
fix(tui): make the empty cloud-providers hint bold instead of muted grey

### DIFF
--- a/src/tui/components/llm-mode-rows-cloud.test.tsx
+++ b/src/tui/components/llm-mode-rows-cloud.test.tsx
@@ -160,3 +160,21 @@ describe("CloudRows inline model section", () => {
     expect(frame).toContain("nous/m-000 [text]");
   });
 });
+
+describe("CloudRows empty provider list", () => {
+  // Styling is deliberately not asserted here: ink-testing-library renders at
+  // chalk level 0, so every SGR sequence is dropped before `lastFrame()` sees
+  // it — which is why every test in this file strips ANSI anyway. What is
+  // pinned is that the call to action reaches the user in the state where it
+  // is the only thing telling them what to do.
+  it("tells the user how to add a provider when none are configured", () => {
+    const frame = renderRows(cloudState([]), 30);
+    expect(frame).toContain("No cloud providers configured. Press n to add one.");
+  });
+
+  it("drops the hint once a provider exists", async () => {
+    await seedCompatCache("https://render.nous.example", ["m-000"]);
+    const frame = renderRows(cloudState([compatProvider()]), 30);
+    expect(frame).not.toContain("No cloud providers configured");
+  });
+});

--- a/src/tui/components/llm-mode-rows.tsx
+++ b/src/tui/components/llm-mode-rows.tsx
@@ -208,6 +208,7 @@ function CloudRows({
         rows={providerRows}
         state={state}
         empty="No cloud providers configured. Press n to add one."
+        emphasiseEmpty
       />
       <Box flexDirection="column" marginBottom={1}>
         <Text bold color={theme.colors.accentSoft}>
@@ -282,11 +283,20 @@ function RowsSection({
   rows,
   state,
   empty = "No rows in this section yet.",
+  emphasiseEmpty = false,
 }: {
   title: string;
   rows: readonly LlmPanelRow[];
   state: TuiState;
   empty?: string;
+  /**
+   * Render the empty hint bold in the terminal's default foreground instead of
+   * muted grey. For an empty state that is really a call to action — the pane
+   * is useless until you act on it — muted grey reads as "nothing to see here"
+   * and the instruction gets skipped. Left unset elsewhere: a section that is
+   * merely empty should stay quiet.
+   */
+  emphasiseEmpty?: boolean;
 }): ReactElement {
   return (
     <Box flexDirection="column" marginBottom={1}>
@@ -294,7 +304,13 @@ function RowsSection({
         {title}
       </Text>
       {rows.length === 0 ? (
-        <Text color={theme.colors.muted}>  {empty}</Text>
+        <Text
+          bold={emphasiseEmpty}
+          color={emphasiseEmpty ? undefined : theme.colors.muted}
+        >
+          {"  "}
+          {empty}
+        </Text>
       ) : (
         rows.map((row) => <Row key={row.id} row={row} state={state} />)
       )}


### PR DESCRIPTION
## What

`No cloud providers configured. Press n to add one.` was rendered in the same muted grey
as every other empty section, so the one line telling a new user what to do read like
"nothing to see here". It is now bold, in the terminal's default foreground.

Raw bytes from the rendered frame, before and after:

```diff
- [37m  No cloud providers configured. Press n to add one.[39m
+ [1m  No cloud providers configured. Press n to add one.[22m
```

## On "white"

There is no white/foreground token in `TuiColors` (`src/tui/theme/theme.ts:36-52`), and the
theme module exists specifically to keep bare colour literals out of components. A hardcoded
`color="white"` would also be near-invisible on the four light palettes (`GITHUB_LIGHT`,
`CATPPUCCIN_LATTE`, `GRUVBOX_LIGHT`, `SOLARIZED_LIGHT`).

Leaving `color` unset renders the terminal's default foreground — white on every dark theme,
readable on the light ones — which is already the pattern in this file (`Row` deliberately
leaves `baseColor` undefined) and at 14 other `<Text bold>` sites in the TUI.

## Scope

`RowsSection` is shared by five sections, so the emphasis is opt-in through a new
`emphasiseEmpty` prop and only Cloud providers passes it. Local text models, local embeddings,
cloud embeddings and external llama.cpp keep the quiet grey empty state — those are merely
empty, not a call to action.

## Testing

- `npx vitest run src/tui/components/llm-mode-rows-cloud.test.tsx` — 7 passed, including two
  new cases for the zero-provider state, which nothing exercised before
- `npm run lint` (`tsc --noEmit`) clean
- `llm-panel.test.tsx`, `manage-panel-fit.test.tsx`, `llm-fallback-rows.test.tsx` — 19 passed,
  so the fixed-height frame assertions still hold

The styling itself is not asserted in the committed test: `ink-testing-library` renders at
chalk level 0, so SGR sequences never reach `lastFrame()` — which is why every test in that
file strips ANSI anyway. The bytes quoted above came from raising `chalk.level` in a throwaway
harness that is not part of this change.
