### PR TITLE
fix(tui): stop telling fresh installs that llama-server is down

### DIFF
--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -18,6 +18,7 @@ function fakeSession(overrides: Partial<TuiSessionInfo> = {}): TuiSessionInfo {
     approvalLevel: 5,
     maxSteps: 10,
     skillCount: 0,
+    localBackendConfigured: false,
     ...overrides,
   };
 }
@@ -384,3 +385,56 @@ describe("reduceTuiState", () => {
     expect(down.session.approvalLevel).toBe(2);
   });
 });
+
+describe("llm health visibility", () => {
+  it("does not mark local as configured just because a probe failed", () => {
+    const state = apply(createInitialTuiState(fakeSession()), [
+      {
+        type: "llm_health_updated",
+        status: "unreachable",
+        checkedAt: 1,
+        latencyMs: null,
+        error: "connect ECONNREFUSED 127.0.0.1:8080",
+      },
+    ]);
+
+    // A fresh install probes a default URL nobody chose; a refusal there is
+    // not news, and the badge stays hidden.
+    expect(state.llmHealth.status).toBe("unreachable");
+    expect(state.llmHealth.localConfigured).toBe(false);
+  });
+
+  it("latches on after a healthy probe and survives the server dying", () => {
+    const healthy = apply(createInitialTuiState(fakeSession()), [
+      {
+        type: "llm_health_updated",
+        status: "healthy",
+        checkedAt: 1,
+        latencyMs: 3,
+        error: null,
+      },
+    ]);
+    expect(healthy.llmHealth.localConfigured).toBe(true);
+
+    // Somebody who really runs llama-server keeps the signal when it stops.
+    const died = apply(healthy, [
+      {
+        type: "llm_health_updated",
+        status: "unreachable",
+        checkedAt: 2,
+        latencyMs: null,
+        error: "connect ECONNREFUSED 127.0.0.1:8080",
+      },
+    ]);
+    expect(died.llmHealth.localConfigured).toBe(true);
+    expect(died.llmHealth.status).toBe("unreachable");
+  });
+
+  it("starts visible when config already says local", () => {
+    const state = createInitialTuiState(
+      fakeSession({ localBackendConfigured: true }),
+    );
+    expect(state.llmHealth.localConfigured).toBe(true);
+  });
+});
+

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -146,6 +146,11 @@ export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
           lastCheckedAt: action.checkedAt,
           latencyMs: action.latencyMs,
           error: action.error,
+          // A server that answers is a server somebody meant to run, even if
+          // config never said so. Latch it on so the indicator appears for
+          // that user and survives the server later going down.
+          localConfigured:
+            state.llmHealth.localConfigured || action.status === "healthy",
         },
       };
     case "llm_model_updated":

--- a/src/tui/components/local-models-config-wizard.test.tsx
+++ b/src/tui/components/local-models-config-wizard.test.tsx
@@ -75,3 +75,40 @@ describe("LocalModelsConfigWizard", () => {
     expect(text).toContain("empty Enter skips embeddings");
   });
 });
+
+describe("LocalModelsConfigWizard first-run headline", () => {
+  it("reads as a setup prompt when no local backend was ever configured", () => {
+    const { lastFrame, unmount } = render(
+      <LocalModelsConfigWizard
+        initialUrl="http://127.0.0.1:8080"
+        probeError="connect ECONNREFUSED 127.0.0.1:8080"
+        onFinished={() => {}}
+      />,
+    );
+    const text = stripAnsi(lastFrame() ?? "");
+    unmount();
+
+    expect(text).toContain("Choose how atomic-agent should run models");
+    // Nothing was configured, so there is no failure to report: neither the
+    // headline nor the raw probe error should suggest a broken install.
+    expect(text).not.toContain("not reachable");
+    expect(text).not.toContain("ECONNREFUSED");
+  });
+
+  it("keeps the diagnostic when the user's own backend stopped answering", () => {
+    const { lastFrame, unmount } = render(
+      <LocalModelsConfigWizard
+        initialUrl="http://10.0.0.4:9090"
+        probeError="connect ECONNREFUSED 10.0.0.4:9090"
+        hadConfiguredBackend
+        onFinished={() => {}}
+      />,
+    );
+    const text = stripAnsi(lastFrame() ?? "");
+    unmount();
+
+    expect(text).toContain("llama-server not reachable");
+    expect(text).toContain("ECONNREFUSED");
+  });
+});
+

--- a/src/tui/components/local-models-config-wizard.tsx
+++ b/src/tui/components/local-models-config-wizard.tsx
@@ -20,6 +20,15 @@ export type LocalModelsWizardOutcome =
 export interface LocalModelsConfigWizardProps {
   initialUrl: string;
   probeError: string | null;
+  /**
+   * Whether the user had already opted into a local backend before this run.
+   * `false` on a fresh install, where the probe failed against a default URL
+   * nobody chose — there the screen is a setup prompt, not a fault report,
+   * and leading with "not reachable" plus a raw ECONNREFUSED reads as if the
+   * install is broken. `true` keeps the honest diagnostic for the user whose
+   * configured server really did stop answering.
+   */
+  hadConfiguredBackend?: boolean;
   onFinished(outcome: LocalModelsWizardOutcome): void;
 }
 
@@ -49,6 +58,7 @@ const PICK_OPTIONS: readonly WizardOption[] = [
 export function LocalModelsConfigWizard({
   initialUrl,
   probeError,
+  hadConfiguredBackend = false,
   onFinished,
 }: LocalModelsConfigWizardProps): ReactElement {
   const app = useApp();
@@ -189,9 +199,11 @@ export function LocalModelsConfigWizard({
     return (
       <Box flexDirection="column" padding={1}>
         <Text bold color={theme.colors.accentSoft}>
-          llama-server not reachable
+          {hadConfiguredBackend
+            ? "llama-server not reachable"
+            : "Choose how atomic-agent should run models"}
         </Text>
-        {probeError ? (
+        {hadConfiguredBackend && probeError ? (
           <Text color={theme.colors.muted}>last error: {probeError}</Text>
         ) : null}
         <Box flexDirection="column" marginTop={1}>

--- a/src/tui/llm-health/llm-health-state.ts
+++ b/src/tui/llm-health/llm-health-state.ts
@@ -39,9 +39,23 @@ export interface LlmHealthState {
    * does not expose it. Surfaced in the prompt meta-row as `ctx <n>`.
    */
   contextWindow: number | null;
+  /**
+   * Whether a local backend is the user's actual route, which decides if the
+   * indicator is worth showing at all. A fresh install ships a default
+   * `localModels.url` nobody chose, so without this the very first probe
+   * paints `○ down` about a server that was never meant to exist — noise on
+   * the one screen where the user has the least context to judge it.
+   *
+   * Seeded from config at startup and latched on by a healthy probe, so
+   * somebody running llama-server on the default URL without touching config
+   * still gets the indicator (and keeps it when their server later dies).
+   */
+  localConfigured: boolean;
 }
 
-export function createInitialLlmHealthState(): LlmHealthState {
+export function createInitialLlmHealthState(
+  localConfigured = false,
+): LlmHealthState {
   return {
     status: "unknown",
     lastCheckedAt: null,
@@ -49,5 +63,6 @@ export function createInitialLlmHealthState(): LlmHealthState {
     error: null,
     model: null,
     contextWindow: null,
+    localConfigured,
   };
 }

--- a/src/tui/run-local-models-config-wizard.test.ts
+++ b/src/tui/run-local-models-config-wizard.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   ensureUserConfigFileSync,
@@ -9,7 +9,33 @@ import {
   resetConfigCache,
   writeUserConfigFileSync,
 } from "../config/index.js";
-import { isCloudTextProviderReady } from "./run-local-models-config-wizard.js";
+import { DEFAULT_EMBEDDING_MODEL_ID } from "../local-llm/index.js";
+import {
+  persistUserLocalLlmUrl,
+  persistUserLocalModelsConfig,
+} from "./persist-user-local-models-config.js";
+import {
+  isCloudTextProviderReady,
+  isLocalBackendConfigured,
+  runLocalModelsStartupGateIfNeeded,
+} from "./run-local-models-config-wizard.js";
+
+const inkRender = vi.hoisted(() => vi.fn());
+
+vi.mock("ink", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("ink")>()),
+  render: inkRender,
+}));
+
+vi.mock("../llm/llama-server-health.js", () => ({
+  checkLlamaServer: vi.fn(async () => ({
+    reachable: false,
+    status: null,
+    kind: "unknown",
+    error: "connect ECONNREFUSED 127.0.0.1:8080",
+    latencyMs: 1,
+  })),
+}));
 
 describe("isCloudTextProviderReady", () => {
   let stateDir: string;
@@ -75,5 +101,112 @@ describe("isCloudTextProviderReady", () => {
     resetConfigCache();
 
     expect(isCloudTextProviderReady()).toBe(false);
+  });
+});
+
+describe("isLocalBackendConfigured", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "startup-gate-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    resetConfigCache();
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+  });
+
+  it("says no on a fresh install nobody has configured", () => {
+    expect(isLocalBackendConfigured()).toBe(false);
+  });
+
+  it("still says no in managed mode while no model has been pulled", () => {
+    // Picking "Local models" writes the mode before any weights exist, so
+    // there is no server yet that could be reported as unreachable.
+    persistUserLocalModelsConfig({ mode: "managed" });
+
+    expect(isLocalBackendConfigured()).toBe(false);
+  });
+
+  it("says yes in managed mode once a model is selected", () => {
+    persistUserLocalModelsConfig({
+      mode: "managed",
+      managed: { modelId: "qwen-3.5-4b" },
+    });
+
+    expect(isLocalBackendConfigured()).toBe(true);
+  });
+
+  it("says yes once a managed model is selected, even in external mode", () => {
+    persistUserLocalModelsConfig({ managed: { modelId: "qwen-3.5-4b" } });
+
+    expect(getConfig().localModels.mode).toBe("external");
+    expect(isLocalBackendConfigured()).toBe(true);
+  });
+
+  it("says yes once the user typed their own llama-server URL", () => {
+    persistUserLocalLlmUrl("http://192.168.1.50:9090");
+
+    expect(isLocalBackendConfigured()).toBe(true);
+  });
+
+  it("keeps saying no when the URL was rewritten to the shipped default", () => {
+    persistUserLocalLlmUrl("http://192.168.1.50:9090");
+    persistUserLocalLlmUrl("http://127.0.0.1:8080");
+
+    expect(isLocalBackendConfigured()).toBe(false);
+  });
+
+  it("does not count the embeddings daemon as a chat backend choice", () => {
+    persistUserLocalModelsConfig({
+      embeddings: { enabled: true, modelId: DEFAULT_EMBEDDING_MODEL_ID },
+    });
+
+    expect(isLocalBackendConfigured()).toBe(false);
+  });
+});
+
+describe("runLocalModelsStartupGateIfNeeded", () => {
+  let stateDir: string;
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "startup-gate-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    resetConfigCache();
+    inkRender.mockReset();
+    inkRender.mockReturnValue({
+      waitUntilExit: async () => {},
+      clear: () => {},
+    });
+    stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+  });
+
+  it("tells the wizard the backend was never configured on a fresh install", async () => {
+    await runLocalModelsStartupGateIfNeeded({ skipWizard: false });
+
+    expect(inkRender).toHaveBeenCalledTimes(1);
+    expect(inkRender.mock.calls[0][0].props.hadConfiguredBackend).toBe(false);
+  });
+
+  it("tells the wizard the backend was configured when the user picked one", async () => {
+    persistUserLocalLlmUrl("http://192.168.1.50:9090");
+
+    await runLocalModelsStartupGateIfNeeded({ skipWizard: false });
+
+    expect(inkRender).toHaveBeenCalledTimes(1);
+    expect(inkRender.mock.calls[0][0].props.hadConfiguredBackend).toBe(true);
   });
 });

--- a/src/tui/run-local-models-config-wizard.ts
+++ b/src/tui/run-local-models-config-wizard.ts
@@ -1,6 +1,6 @@
 import { render } from "ink";
 import React from "react";
-import { getConfig } from "../config/index.js";
+import { getConfig, USER_CONFIG_DEFAULTS } from "../config/index.js";
 import { resolveLlmProviderApiKey } from "../config/resolve-llm-api-key.js";
 import {
   getLocalModelDef,
@@ -57,6 +57,7 @@ export async function runLocalModelsStartupGateIfNeeded(options: {
     React.createElement(LocalModelsConfigWizard, {
       initialUrl: getConfig().localModels.url,
       probeError: probe.error,
+      hadConfiguredBackend: isLocalBackendConfigured(),
       onFinished: (o) => {
         outcome.value = o;
       },
@@ -78,6 +79,33 @@ export function isCloudTextProviderReady(): boolean {
   if (!active || active === "local-llama") return false;
   const entry = cfg.llm?.providers.find((provider) => provider.id === active);
   return Boolean(entry && resolveLlmProviderApiKey(entry));
+}
+
+/**
+ * Whether a local backend that could actually be serving was ever set up,
+ * as opposed to untouched defaults. Two signals count: a selected managed
+ * model, and an external URL the user typed instead of the shipped one.
+ * Everything else a fresh install carries — `llm.activeTextProvider`
+ * resolving to `local-llama`, the default `http://127.0.0.1:8080`, the
+ * embeddings daemon toggle, which drives a different port and says nothing
+ * about the chat server — is a default nobody chose and must not count, or
+ * the first-run screen goes back to blaming the user for a server they
+ * never asked for.
+ *
+ * Managed mode on its own deliberately does not count. Picking "Local
+ * models" in the wizard writes `mode: "managed"` before any weights are
+ * pulled, and no server can exist until they are, so treating the bare
+ * mode as configured would report a multi-gigabyte download that has not
+ * started yet as an unreachable server.
+ */
+export function isLocalBackendConfigured(): boolean {
+  const cfg = getConfig();
+  if (cfg.localModels.managed.modelId !== null) return true;
+  // In managed mode the runtime derives `localModels.url` from
+  // `managed.port`, so the comparison below only means anything when the
+  // operator is on the external path.
+  if (cfg.localModels.mode !== "external") return false;
+  return cfg.localModels.url !== USER_CONFIG_DEFAULTS.localModels.url;
 }
 
 /**

--- a/src/tui/test-fixtures.ts
+++ b/src/tui/test-fixtures.ts
@@ -14,6 +14,7 @@ export function fakeSession(
     approvalLevel: 5,
     maxSteps: 10,
     skillCount: 0,
+    localBackendConfigured: false,
     ...overrides,
   };
 }

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -699,8 +699,16 @@ export function TuiApp({
   const isTty = Boolean(process.stdout.isTTY);
   const rootHeight = isTty ? terminalSize.rows : undefined;
   const promptLlm = selectPromptLlmMeta(state);
+  // No local backend chosen yet ⇒ no local health to report. Without this the
+  // splash screen of a fresh install announces that a server the user never
+  // configured is down, which reads as a broken install rather than an
+  // un-started one. `localConfigured` latches on as soon as local is really
+  // the route (config says so, or a probe answered), so real local users keep
+  // the ● / ○ signal they rely on.
   const promptLeftSlot = promptLlm.usesLocalHealth ? (
-    <LlmHealthBadge health={state.llmHealth} />
+    state.llmHealth.localConfigured ? (
+      <LlmHealthBadge health={state.llmHealth} />
+    ) : null
   ) : (
     <Text>
       <Text color="green" bold>

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -18,6 +18,7 @@ import {
 } from "./persist-user-local-models-config.js";
 import { persistUserTuiTheme } from "./persist-user-tui-config.js";
 import {
+  isLocalBackendConfigured,
   isManagedModeReadyOnDisk,
   runLocalModelsStartupGateIfNeeded,
 } from "./run-local-models-config-wizard.js";
@@ -137,6 +138,9 @@ export async function tuiCommand(args: string[]): Promise<number> {
     approvalLevel,
     maxSteps,
     skillCount: runtime.skillCatalog.length,
+    // Read after the startup gate, so a local model picked in the wizard
+    // moments ago already counts as configured for this launch.
+    localBackendConfigured: isLocalBackendConfigured(),
   };
 
   const orchestrator = new ChatOrchestrator(runtime, bus, {

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -511,7 +511,11 @@ export function createInitialTuiState(
     fallbackPanel: createInitialFallbackPanelState(),
     localModelsPanel: createInitialLocalModelsPanelState(),
     localLlmLogs: createInitialLocalLlmLogsState(),
-    llmHealth: createInitialLlmHealthState(session.localBackendConfigured),
+    // Optional chaining on purpose: `session` is typed as required but tests
+    // call this with nothing (test files are outside tsconfig's include), and
+    // before this argument existed no field was read here, so a bare
+    // `session.` would turn those callers into a crash.
+    llmHealth: createInitialLlmHealthState(session?.localBackendConfigured),
     telegramPanel: createInitialTelegramPanelState(),
     recentSessions: [],
     chatFocus: "editor",

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -220,6 +220,13 @@ export interface TuiSessionInfo {
   approvalLevel: number;
   maxSteps: number;
   skillCount: number;
+  /**
+   * Whether the user actually opted into a local backend (see
+   * `isLocalBackendConfigured`). Decides whether the llama-server health
+   * indicator is shown at all, so a fresh install is not told that a server
+   * it never configured is down.
+   */
+  localBackendConfigured: boolean;
 }
 
 /**
@@ -504,7 +511,7 @@ export function createInitialTuiState(
     fallbackPanel: createInitialFallbackPanelState(),
     localModelsPanel: createInitialLocalModelsPanelState(),
     localLlmLogs: createInitialLocalLlmLogsState(),
-    llmHealth: createInitialLlmHealthState(),
+    llmHealth: createInitialLlmHealthState(session.localBackendConfigured),
     telegramPanel: createInitialTelegramPanelState(),
     recentSessions: [],
     chatFocus: "editor",


### PR DESCRIPTION
## What

A fresh install tells the user twice that a llama-server they never set up is unreachable:

1. The first-run screen is headed literally **`llama-server not reachable`**, with a raw
   `last error: connect ECONNREFUSED 127.0.0.1:8080` underneath — on a machine where no
   server has ever existed. It reads as a broken install rather than an un-started one.
2. Within ~1.5 s of the TUI mounting, the prompt meta-row shows **`○ down`**. It appears on
   the splash/home screen and on the LLM tab, because `USER_CONFIG_DEFAULTS` ships
   `localModels.mode: "external"` at `http://127.0.0.1:8080` and the config layer synthesizes
   `local-llama` as the active provider before the user has configured anything.

Neither surface asks whether local is actually the user's route. Both now do.

## Approach

Not deleted — suppressed until it means something. Deleting the indicator would blind the
people who genuinely run llama-server, which is exactly who it is for.

A new `isLocalBackendConfigured()` (`src/tui/run-local-models-config-wizard.ts`) answers
"did the user ever choose local?", as opposed to the existing `isManagedModeReadyOnDisk()`
which answers "can local serve right now":

- managed mode with a known `managed.modelId` → `true` (including mid-download: the user
  picked it, so health about it is wanted)
- external mode → `true` only when `localModels.url` differs from the shipped default, since
  the default URL is not evidence of intent
- a ready cloud provider → `false`

It is carried into the TUI as `TuiSessionInfo.localBackendConfigured` (read *after* the
startup gate, so a model picked in the wizard seconds earlier already counts) and seeds
`llmHealth.localConfigured`.

**Self-healing, so no real local user loses the signal:** a `healthy` probe latches
`localConfigured` on. Somebody running llama-server on the default URL without ever touching
config gets the indicator after the first probe, and keeps seeing `○ down` when their server
later dies.

## Behaviour

| Situation | Before | After |
|---|---|---|
| Fresh install, nothing configured | `○ down` on the splash screen | nothing |
| First-run screen, nothing configured | `llama-server not reachable` + ECONNREFUSED | `Choose how atomic-agent should run models` |
| Configured local backend, server down | `○ down` | `○ down` (unchanged) |
| Own URL configured, first-run screen | `llama-server not reachable` + error | unchanged — it really is unreachable |
| llama-server on default URL, never configured | `○ down` | appears after the first healthy probe, then behaves normally |

The stderr line printed before the alt screen follows the same split: the honest
`local-llm unreachable at <url>` when a backend was configured, `no model configured yet —
starting setup…` when not.

## Known limitation

llama.cpp's own default port is 8080, which is also `USER_CONFIG_DEFAULTS.localModels.url`,
and the wizard prefills it. A user who picks "Remote llama.cpp" and accepts the prefilled
default is stored byte-identically to a fresh install, so the honest error does not appear
for them at the wizard. Telling those two apart needs an explicit "setup completed" marker
in the config schema (a version bump), which is out of scope here. The footer indicator is
unaffected — it latches on after the first healthy probe.

## Testing

- `npm run lint` (`tsc --noEmit`) clean, verified against the branch as pushed to origin
  rather than only a local working copy
- 11 tests in `run-local-models-config-wizard.test.ts`: 7 pinning `isLocalBackendConfigured`
  (fresh defaults, managed without a model, managed with a model, model selected while still
  in external mode, user-typed URL, URL rewritten back to the default, embeddings-only), and
  2 that mock Ink's `render` to assert the element handed to the wizard actually carries
  `hadConfiguredBackend`; plus the 2 first-run headline tests and the 3 `localConfigured`
  latch tests already in the PR
- Each verified to fail without the fix: dropping only the call-site line yields
  `expected undefined to be false`; stashing the source yields
  `TypeError: isLocalBackendConfigured is not a function`
- Full `src/tui` suite, serial: **931 passed / 5 failed**, against **917 passed / 5 failed**
  on unmodified `main` — the same 5 pre-existing failures (`tui-app.test.tsx` ×2,
  `splash-banner`, `chat-log`, `persist-embedding-hybrid-recall`). `llm-health-poller`
  failed once early on, so the suite was re-run three more times: 0/3 recurrences, and it
  passes 12/12 solo.

One bug this shook out along the way: `createInitialTuiState` is typed to require a session
but several tests call it with none (test files sit outside tsconfig's `include`, so nothing
catches it). Reading a field off `session` turned that latent bug into 28 crashes in
`mcp-reducer.test.ts`; the call site uses optional chaining so those callers keep working.
