### PR TITLE
fix(tui): make model download progress feel alive and stop offering a running download

### DIFF
--- a/src/local-llm/download-file.test.ts
+++ b/src/local-llm/download-file.test.ts
@@ -90,6 +90,82 @@ describe("download-file", () => {
     expect(existsSync(dest)).toBe(false);
     expect(existsSync(`${dest}.tmp`)).toBe(false);
   });
+
+  it("keeps the byte counter moving when chunks are smaller than one percent", async () => {
+    // A real GGUF pull: one percent of the declared total is far larger than
+    // a single chunk, so tying updates to whole-percent changes leaves the
+    // counter frozen for seconds. Here the transfer never even reaches 1%.
+    const declaredTotal = 1_000_000_000;
+    const chunkSize = 1_000;
+    const count = 5;
+    let emitted = 0;
+    const body = new ReadableStream({
+      async pull(controller) {
+        if (emitted >= count) {
+          controller.close();
+          return;
+        }
+        emitted += 1;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        controller.enqueue(Buffer.alloc(chunkSize));
+      },
+    });
+
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(body, {
+        status: 200,
+        headers: { "content-length": String(declaredTotal) },
+      });
+    }) as typeof fetch;
+
+    const seen: Array<{ percent: number; transferred: number }> = [];
+    await downloadFile("https://example.invalid/big.bin", join(dir, "big.bin"), {
+      onProgress: (percent, transferred) => {
+        seen.push({ percent, transferred });
+      },
+    });
+
+    // Percent rounds to 0 throughout — the bytes are the only signal the
+    // user has, and they must keep arriving.
+    expect(seen.every((s) => s.percent === 0)).toBe(true);
+    expect(seen.length).toBeGreaterThanOrEqual(count);
+    for (let i = 1; i < seen.length; i++) {
+      expect(seen[i].transferred).toBeGreaterThan(seen[i - 1].transferred);
+    }
+    expect(seen.at(-1)?.transferred).toBe(chunkSize * count);
+  });
+
+  it("still reports progress when the server sends no content-length", async () => {
+    // total === 0 pins percent at 0 forever, which used to wedge the old
+    // guard shut after the very first chunk.
+    let emitted = 0;
+    const body = new ReadableStream({
+      async pull(controller) {
+        if (emitted >= 5) {
+          controller.close();
+          return;
+        }
+        emitted += 1;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        controller.enqueue(Buffer.alloc(1_000));
+      },
+    });
+
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(body, { status: 200 });
+    }) as typeof fetch;
+
+    const seen: number[] = [];
+    await downloadFile("https://example.invalid/nolen.bin", join(dir, "nolen.bin"), {
+      onProgress: (_percent, transferred) => {
+        seen.push(transferred);
+      },
+    });
+
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen.at(-1)).toBe(5_000);
+  });
+
 });
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/src/local-llm/download-file.ts
+++ b/src/local-llm/download-file.ts
@@ -57,7 +57,30 @@ export async function downloadFile(
   const totalRaw = res.headers.get("content-length");
   const total = totalRaw ? parseInt(totalRaw, 10) : 0;
   let transferred = 0;
-  let lastReportedPercent = -1;
+  let lastEmitAt = 0;
+  let lastEmittedBytes = -1;
+
+  /**
+   * Progress used to be emitted only when the whole-number percentage
+   * changed, which left the byte counter frozen between those moments: one
+   * percent of a 4 GB GGUF is ~41 MB, so at realistic speeds the UI sat
+   * still for seconds at a time and the download looked stalled. Worse, a
+   * response without `content-length` pins `percent` at 0 forever, so after
+   * the first chunk the counter never moved again.
+   *
+   * Emit on a time base instead. The percentage still only changes when it
+   * changes; the bytes advance visibly, which is the part that tells the
+   * user the transfer is alive.
+   */
+  const PROGRESS_INTERVAL_MS = 200;
+
+  const emitProgress = (now: number): void => {
+    if (transferred === lastEmittedBytes) return;
+    lastEmitAt = now;
+    lastEmittedBytes = transferred;
+    const percent = total > 0 ? Math.round((transferred / total) * 100) : 0;
+    opts?.onProgress?.(percent, transferred, total);
+  };
 
   const reader = res.body.getReader();
   const trackingStream = new ReadableStream({
@@ -66,14 +89,16 @@ export async function downloadFile(
       const { done, value } = await reader.read();
       throwIfAborted(opts?.signal);
       if (done) {
+        // The last partial interval still owes the user its final numbers,
+        // including the terminal 100%.
+        emitProgress(Date.now());
         controller.close();
         return;
       }
       transferred += value.byteLength;
-      const percent = total > 0 ? Math.round((transferred / total) * 100) : 0;
-      if (percent !== lastReportedPercent) {
-        lastReportedPercent = percent;
-        opts?.onProgress?.(percent, transferred, total);
+      const now = Date.now();
+      if (now - lastEmitAt >= PROGRESS_INTERVAL_MS) {
+        emitProgress(now);
       }
       controller.enqueue(value);
     },

--- a/src/tui/components/local-models-panel.tsx
+++ b/src/tui/components/local-models-panel.tsx
@@ -247,7 +247,20 @@ export function LocalModelsPanel({
     }
     const row = ref.row;
     const m = row.def;
-    const enterHint = !row.downloaded
+    // A pull for this very row is in flight: offering "Enter — download"
+    // again is both wrong and re-triggerable.
+    const rowPull =
+      panel.pull &&
+      !panel.pull.error &&
+      panel.pull.kind === "chat" &&
+      panel.pull.modelId === row.id
+        ? panel.pull
+        : null;
+    const enterHint = rowPull
+      ? rowPull.totalBytes > 0
+        ? `downloading… ${rowPull.percent}%`
+        : "downloading…"
+      : !row.downloaded
       ? row.def.supportsVision
         ? "Enter — download (gguf + mmproj)"
         : "Enter — download"

--- a/src/tui/llm-panel/llm-panel-primary-actions.ts
+++ b/src/tui/llm-panel/llm-panel-primary-actions.ts
@@ -114,11 +114,27 @@ function triggerCloudProvider(
   stopLocalDaemonsForCloudSelection(state, callbacks);
 }
 
+/** A pull already in flight for this exact model — pressing Enter again must not restart it. */
+function isPullInFlight(
+  state: TuiState,
+  kind: "chat" | "embedding",
+  modelId: string,
+): boolean {
+  const pull =
+    kind === "chat"
+      ? state.localModelsPanel.pull
+      : state.localModelsPanel.embeddingPull;
+  return Boolean(
+    pull && !pull.error && pull.kind === kind && pull.modelId === modelId,
+  );
+}
+
 function triggerLocalChatModel(
   model: LocalModelRow,
   state: TuiState,
   callbacks: TuiAppCallbacks,
 ): void {
+  if (isPullInFlight(state, "chat", model.id)) return;
   if (!model.downloaded) {
     callbacks.onLocalModelsPullRequested?.(model.id, "with-mmproj");
     return;
@@ -146,6 +162,7 @@ function triggerLocalEmbeddingModel(
   const localProviderActive = state.providersPanel.rows.some(
     (row) => row.id === "local-llama" && row.isActiveEmbedding,
   );
+  if (isPullInFlight(state, "embedding", model.id)) return;
   if (!model.downloaded) {
     callbacks.onLocalModelsEmbeddingPullRequested?.(model.id);
     callbacks.onProvidersSetActiveEmbedding?.("local-llama");

--- a/src/tui/llm-panel/llm-panel-row-builders.ts
+++ b/src/tui/llm-panel/llm-panel-row-builders.ts
@@ -17,6 +17,7 @@ import {
   listOpenRouterChatModels,
   OPENAI_COMPAT_DEFAULT_CHAT_MODEL,
 } from "../providers/providers-model-options.js";
+import type { LocalModelsPullState } from "../local-models/local-models-panel-state.js";
 import type { TuiState } from "../tui-state.js";
 import type { LlmPanelRow } from "./llm-panel-selectors.js";
 
@@ -121,12 +122,43 @@ export function selectCloudRows(state: TuiState): readonly LlmPanelRow[] {
   return rows;
 }
 
+/**
+ * Live pull for this row, if any. The panel keeps one chat pull and one
+ * embedding pull at a time, so a row is "downloading" when the in-flight
+ * pull names it. Without this the list keeps offering `Enter: download` for
+ * a model that is already coming down, which reads as if nothing happened
+ * and invites a second press.
+ */
+function pullFor(
+  state: TuiState,
+  kind: "chat" | "embedding",
+  modelId: string,
+): LocalModelsPullState | null {
+  const pull =
+    kind === "chat"
+      ? state.localModelsPanel.pull
+      : state.localModelsPanel.embeddingPull;
+  if (!pull || pull.error) return null;
+  return pull.kind === kind && pull.modelId === modelId ? pull : null;
+}
+
+/** `Downloading… 42%` — the percentage is the part that moves. */
+function downloadingLabel(pull: LocalModelsPullState): string {
+  return pull.totalBytes > 0
+    ? `Downloading… ${pull.percent}%`
+    : "Downloading…";
+}
+
 function localTextRow(state: TuiState, model: LocalModelRow): LlmPanelRow {
   const localActive = state.providersPanel.rows.some(
     (row) => row.id === "local-llama" && row.isActiveText,
   );
   const daemonWorks = state.localModelsPanel.daemon.healthy;
   const active = localActive && model.active && daemonWorks;
+  const pull = pullFor(state, "chat", model.id);
+  if (pull) {
+    return buildLocalTextRow(model, active, false, "downloading", downloadingLabel(pull));
+  }
   if (!model.downloaded) {
     return buildLocalTextRow(model, active, false, "download", "Enter: download");
   }
@@ -140,7 +172,7 @@ function localTextRow(state: TuiState, model: LocalModelRow): LlmPanelRow {
     );
   }
   if (!localActive || !model.active) {
-    return buildLocalTextRow(model, active, true, "use", `Enter: use local-llama/${model.id}`);
+    return buildLocalTextRow(model, active, true, "use", "Enter: select model");
   }
   const running =
     state.localModelsPanel.daemon.running ||
@@ -180,6 +212,16 @@ function localEmbeddingRow(state: TuiState, model: EmbeddingModelRow): LlmPanelR
   );
   const daemonWorks = Boolean(daemon?.running && daemon.healthy);
   const active = localEmbeddingActive && model.active && daemonWorks;
+  const pull = pullFor(state, "embedding", model.id);
+  if (pull) {
+    return buildLocalEmbeddingRow(
+      model,
+      active,
+      false,
+      "downloading",
+      downloadingLabel(pull),
+    );
+  }
   if (!model.downloaded) {
     return buildLocalEmbeddingRow(
       model,
@@ -195,7 +237,7 @@ function localEmbeddingRow(state: TuiState, model: EmbeddingModelRow): LlmPanelR
       active,
       true,
       "use",
-      `Enter: use local embedding ${model.id}`,
+      "Enter: select model",
     );
   }
   if (!daemon?.enabled) {

--- a/src/tui/llm-panel/llm-panel-selectors.test.ts
+++ b/src/tui/llm-panel/llm-panel-selectors.test.ts
@@ -90,7 +90,7 @@ describe("llm-panel selectors", () => {
       expect.objectContaining({
         kind: "localTextModel",
         available: true,
-        enterEffect: "Enter: use local-llama/qwen-3.5-4b",
+        enterEffect: "Enter: select model",
       }),
     );
     const route = selectLlmActiveRouteSummary(state);
@@ -163,3 +163,97 @@ function embeddingDef(id: EmbeddingModelDef["id"]): EmbeddingModelDef {
     recommendedRamGb: 1,
   };
 }
+
+describe("local model rows during a pull", () => {
+  function stateWithPull(pull: unknown, downloaded: boolean) {
+    const base = createInitialTuiState(fakeSession());
+    return {
+      ...base,
+      providersPanel: {
+        ...base.providersPanel,
+        rows: [
+          {
+            id: "local-llama",
+            kind: "llama-server" as const,
+            isActiveText: false,
+            isActiveEmbedding: false,
+            hasApiKey: false,
+            chatModel: null,
+            embeddingModel: null,
+          },
+        ],
+      },
+      localModelsPanel: {
+        ...base.localModelsPanel,
+        pull: pull as never,
+        rows: [
+          {
+            id: "qwen-3.5-4b" as const,
+            def: localDef("qwen-3.5-4b"),
+            downloaded,
+            active: false,
+            mmprojStatus: "n/a" as const,
+          },
+        ],
+      },
+    };
+  }
+
+  const pullFor = (percent: number) => ({
+    kind: "chat" as const,
+    modelId: "qwen-3.5-4b" as const,
+    label: "qwen-3.5-4b",
+    percent,
+    transferredBytes: 1_000,
+    totalBytes: 100_000,
+    error: null,
+  });
+
+  it("says the model is downloading instead of offering the download again", () => {
+    const rows = selectLlmPanelRows(stateWithPull(pullFor(42), false), "local");
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        kind: "localTextModel",
+        primaryAction: "downloading",
+        enterEffect: "Downloading… 42%",
+        available: false,
+      }),
+    );
+  });
+
+  it("offers selection once the pull is finished", () => {
+    const rows = selectLlmPanelRows(stateWithPull(null, true), "local");
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        kind: "localTextModel",
+        primaryAction: "use",
+        enterEffect: "Enter: select model",
+        available: true,
+      }),
+    );
+  });
+
+  it("falls back to the download hint when a pull failed", () => {
+    const failed = { ...pullFor(7), error: "connection reset" };
+    const rows = selectLlmPanelRows(stateWithPull(failed, false), "local");
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        kind: "localTextModel",
+        primaryAction: "download",
+        enterEffect: "Enter: download",
+      }),
+    );
+  });
+
+  it("does not claim a different model is downloading", () => {
+    const other = { ...pullFor(50), modelId: "gemma-4-12b" as never };
+    const rows = selectLlmPanelRows(stateWithPull(other, false), "local");
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        kind: "localTextModel",
+        primaryAction: "download",
+      }),
+    );
+  });
+});
+

--- a/src/tui/llm-panel/llm-panel-selectors.ts
+++ b/src/tui/llm-panel/llm-panel-selectors.ts
@@ -17,7 +17,13 @@ export type LlmPanelRow =
       model: LocalModelRow;
       active: boolean;
       available: boolean;
-      primaryAction: "download" | "download-mmproj" | "use" | "start" | "current";
+      primaryAction:
+        | "download"
+        | "downloading"
+        | "download-mmproj"
+        | "use"
+        | "start"
+        | "current";
       enterEffect: string;
     }
   | {
@@ -27,7 +33,13 @@ export type LlmPanelRow =
       model: EmbeddingModelRow;
       active: boolean;
       available: boolean;
-      primaryAction: "download" | "use" | "enable" | "start" | "current";
+      primaryAction:
+        | "download"
+        | "downloading"
+        | "use"
+        | "enable"
+        | "start"
+        | "current";
       enterEffect: string;
     }
   | {


### PR DESCRIPTION
Two problems while a local model is downloading: the numbers barely move, and the list keeps
offering a download that is already running.

## 1. The byte counter freezes

`downloadFile` emitted progress only when the whole-number percentage changed
(`src/local-llm/download-file.ts`, `if (percent !== lastReportedPercent)`). Since
`transferred` was sampled only at those moments, the KB/MB figure sat still in between: one
percent of a 4 GB GGUF is ~41 MB, so at 5–20 MB/s the number moved once every 2–8 seconds and
the download looked stalled.

Worse, with no `content-length` the total is 0, which pins `percent` at 0 — after the first
chunk the guard never opened again and the counter was frozen for the entire download.

Progress is now emitted on a 200 ms time base, with a forced final emit at the end so the
terminal 100% is never lost. Nothing downstream throttles (the orchestrator forwards each
callback, and Ink's default `maxFps: 30` is far faster than this), so the UI now updates
about five times a second.

## 2. The list still says `Enter: download`

The row builders only looked at `model.downloaded`; they never consulted
`state.localModelsPanel.pull` / `.embeddingPull`, which is the live per-model download state
the Models tab already renders. A model being pulled right now therefore advertised
`Enter: download`, which reads as if the keypress did nothing and invites a second press —
and pressing Enter really did re-fire the pull.

| Row state | Before | After |
|---|---|---|
| Downloading | `Enter: download` | `Downloading… 42%` |
| Downloaded, not selected | `Enter: use local-llama/<id>` | `Enter: select model` |
| Pull failed | `Enter: download` | `Enter: download` (unchanged) |
| Different model downloading | `Enter: download` | `Enter: download` (unchanged) |

`primaryAction` gains a `"downloading"` variant on both the chat and embedding row unions, and
`triggerLocalChatModel` / `triggerLocalEmbeddingModel` now no-op while that model's pull is in
flight instead of starting it again. The Models-tab detail pane got the same treatment — it
was showing `Enter — download` mid-pull too.

## Testing

- `npm run lint` (`tsc --noEmit`) clean
- 2 new tests in `download-file.test.ts`, both verified to **fail against the old
  implementation** (1 progress callback where the test requires 5+) and pass against the new
  one: chunks smaller than one percent, and a response with no `content-length`
- 4 new selector tests: downloading, downloaded, failed pull, and a pull for a *different*
  model (which must not mark this row as downloading)
- One existing assertion updated: `llm-panel-selectors.test.ts` pinned
  `"Enter: use local-llama/qwen-3.5-4b"`, now `"Enter: select model"`
- Full `src/tui` + `src/local-llm` suites, serial: **111 files passed, 4 failed** — the same
  four that fail on unmodified `main` (`tui-app` ×2 stale snapshots, `splash-banner`,
  `chat-log`, `persist-embedding-hybrid-recall`)

The 200 ms interval is a deliberate choice over exactly 1 s: it is frequent enough that the
counter reads as live, and still ~6× cheaper than the render throttle above it.
