### PR TITLE
analytics: resolve model pricing from the provider catalog

### DIFF
--- a/src/llm/provider/catalog-for-provider.test.ts
+++ b/src/llm/provider/catalog-for-provider.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { catalogForProvider } from "./catalog-for-provider.js";
+import { resolveModel } from "./model-resolver.js";
+import type { LlmProviderConfigEntry } from "./registry/provider-types.js";
+
+const entry = (
+  kind: string,
+  extra: Partial<LlmProviderConfigEntry> = {},
+): LlmProviderConfigEntry => ({ id: kind, kind, ...extra });
+
+describe("catalogForProvider", () => {
+  it("returns a populated catalog for the aggregators", () => {
+    expect(catalogForProvider(entry("openrouter")).size).toBeGreaterThan(0);
+    expect(catalogForProvider(entry("aimlapi")).size).toBeGreaterThan(0);
+  });
+
+  it("returns an empty catalog for providers that ship none", () => {
+    for (const kind of ["llama-server", "openai-compatible", "gemini"]) {
+      expect(catalogForProvider(entry(kind)).size).toBe(0);
+    }
+  });
+
+  it("returns an empty catalog for an unknown kind", () => {
+    expect(catalogForProvider(entry("some-future-provider")).size).toBe(0);
+  });
+});
+
+describe("resolveModel with a provider catalog", () => {
+  const openrouter = entry("openrouter");
+  const [catalogId] = [...catalogForProvider(openrouter).keys()];
+
+  it("prices a catalog model that carries no userModels entry", () => {
+    const resolved = resolveModel(
+      openrouter,
+      catalogId,
+      catalogForProvider(openrouter),
+    );
+
+    expect(resolved.source).toBe("catalog");
+    expect(resolved.pricing).toBeDefined();
+  });
+
+  it("reports no pricing for the same model without the catalog", () => {
+    // The pre-fix call shape: `resolveModel` defaults to an empty map, so
+    // an unpriced cloud model fell through to DEFAULT_CHAT and `cost_usd`
+    // was never emitted.
+    const resolved = resolveModel(openrouter, catalogId);
+
+    expect(resolved.source).not.toBe("catalog");
+    expect(resolved.pricing).toBeUndefined();
+  });
+
+  it("keeps hand-configured pricing ahead of the catalog", () => {
+    const priced = entry("openrouter", {
+      userModels: [
+        {
+          id: catalogId,
+          kind: "chat",
+          pricing: { input: 1.25, output: 4.5 },
+        },
+      ],
+    });
+
+    const resolved = resolveModel(
+      priced,
+      catalogId,
+      catalogForProvider(priced),
+    );
+
+    expect(resolved.source).toBe("user");
+    expect(resolved.pricing).toEqual({ input: 1.25, output: 4.5 });
+  });
+
+  it("leaves local runners unpriced", () => {
+    const local = entry("llama-server");
+    const resolved = resolveModel(
+      local,
+      "some-local.gguf",
+      catalogForProvider(local),
+    );
+
+    expect(resolved.pricing).toBeUndefined();
+  });
+});

--- a/src/llm/provider/catalog-for-provider.ts
+++ b/src/llm/provider/catalog-for-provider.ts
@@ -1,0 +1,34 @@
+import type { LlmProviderConfigEntry } from "./registry/provider-types.js";
+import { AIMLAPI_MODELS_CATALOG } from "./aimlapi/aimlapi-models-catalog.js";
+import type { ModelCatalogEntry } from "./model-resolver.js";
+import { OPENROUTER_MODELS_CATALOG } from "./openrouter/openrouter-models-catalog.js";
+
+const EMPTY: ReadonlyMap<string, ModelCatalogEntry> = new Map();
+
+/**
+ * The bundled model catalog for a provider, or an empty map when the
+ * provider ships none.
+ *
+ * Only the two aggregators carry one. `llama-server` runs local weights
+ * that have no list price, and `openai-compatible` / `gemini` point at
+ * whatever endpoint the operator configured, so neither has a catalog to
+ * look a model up in. An empty map is the honest answer for those: it
+ * leaves `resolveModel` on its `userModels` -> defaults path, which is
+ * where a hand-configured price would live.
+ *
+ * These are the static snapshots. `refreshOpenRouterChatCatalogFromApi`
+ * and its aimlapi counterpart fetch live rows, including current prices,
+ * but only the TUI model picker holds that cache today.
+ */
+export function catalogForProvider(
+  entry: LlmProviderConfigEntry,
+): ReadonlyMap<string, ModelCatalogEntry> {
+  switch (entry.kind) {
+    case "openrouter":
+      return OPENROUTER_MODELS_CATALOG;
+    case "aimlapi":
+      return AIMLAPI_MODELS_CATALOG;
+    default:
+      return EMPTY;
+  }
+}

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -70,6 +70,7 @@ import {
   resolveLlmConfig,
 } from "../llm/provider/index.js";
 import { resolveActiveToolTransport } from "../llm/provider/registry/resolve-tool-transport.js";
+import { catalogForProvider } from "../llm/provider/catalog-for-provider.js";
 import { CostAccumulator } from "../llm/provider/cost-accumulator.js";
 import {
   resolveModel,
@@ -1170,10 +1171,16 @@ export async function createAgentRuntime(
   const turnUsageMeter = new TurnUsageMeter();
 
   /**
-   * Pricing for a model id on the active provider, when the operator
-   * configured any. Cloud entries carry `userModels[].pricing`; local
-   * runners have none, which is why turn cost is reported as absent
-   * rather than zero for them.
+   * Pricing for a model id on the active provider, when any is known.
+   *
+   * Two sources, in `resolveModel`'s own precedence: a hand-configured
+   * `userModels[].pricing` first, then the provider's bundled catalog.
+   * The catalog is what makes cost work out of the box on OpenRouter and
+   * aimlapi, whose published prices ship with the agent; without it only
+   * operators who priced their models by hand ever saw a `cost_usd`.
+   *
+   * Local runners still resolve to no pricing, which is why turn cost is
+   * reported as absent rather than zero for them.
    */
   const resolveModelPricing = (
     modelId: string | null,
@@ -1184,7 +1191,7 @@ export async function createAgentRuntime(
       (p) => p.id === resolved.activeTextProvider,
     );
     if (!entry) return undefined;
-    return resolveModel(entry, modelId);
+    return resolveModel(entry, modelId, catalogForProvider(entry));
   };
 
   // Vision reuses the active text provider when it exposes describeImage.


### PR DESCRIPTION
Follow-up to #85, which attached `prompt_tokens`, `completion_tokens` and `cost_usd` to `message_sent`. The token fields arrive. `cost_usd` never has.

## The problem

`resolveModelPricing` calls `resolveModel(entry, modelId)` and stops there. The third parameter is the model catalog, and it defaults to an empty map, so the lookup skips its catalog branch and falls through to `userModels` and then to `DEFAULT_CHAT`, which carries no pricing.

The effect is that a cloud model resolves unpriced unless the operator wrote a price into their config by hand. `estimateCost` returns 0 on absent pricing, the field is omitted rather than sent, and no install has reported a `cost_usd` since #85 landed.

The prices were there the whole time. `OPENROUTER_MODELS_CATALOG` and `AIMLAPI_MODELS_CATALOG` both carry `pricing` on every entry, and the OpenRouter live fetch reads `pricing.prompt` / `pricing.completion` off the API. Nothing reached the analytics seam.

## What this changes

`catalogForProvider` maps a provider entry to its bundled catalog, and the call site passes it.

Only the two aggregators have one. `llama-server` runs local weights with no list price; `openai-compatible` and `gemini` point at whatever endpoint the operator configured. An empty map is the honest answer for those, and it leaves them on exactly the path they take today.

Precedence is unchanged. `resolveModel` already orders `userModels` above the catalog, so a hand-configured price still wins.

## Absent stays absent

The rule #85 set holds. Local runners still resolve to no pricing and still omit `cost_usd` rather than reporting a misleading `0.00`. What changes is that a priced cloud model now reports what it actually cost.

## Scope note

Pricing comes from the static catalogs, which are a May 2026 snapshot and will drift. `refreshOpenRouterChatCatalogFromApi` already fetches live rows with current prices and caches them for an hour, but only the TUI model picker holds that cache today. Wiring the live catalog into this path is a separate change.

## Testing

- `tsc` clean.
- 7 new tests in `catalog-for-provider.test.ts`, including the regression: the same model resolves unpriced through the old no-catalog call shape and priced through the new one.
- Provider and analytics suites pass: 164 tests.
- Full suite shows 9 failures against 10 on `main` (TUI, sidecar, timing-sensitive integration tests). None introduced here; the delta is the known flaky set.
