### PR TITLE
fix(tui): stop the first keystroke after entering a panel from leaking into the chat buffer

### DIFF
--- a/src/tui/components/multi-line-editor.test.tsx
+++ b/src/tui/components/multi-line-editor.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { MultiLineEditor } from "./multi-line-editor.js";
+
+describe("MultiLineEditor", () => {
+  function editor(focus: boolean, onChange: (v: string) => void) {
+    return (
+      <MultiLineEditor
+        value=""
+        focus={focus}
+        onChange={onChange}
+        onSubmit={() => {}}
+      />
+    );
+  }
+
+  it("accepts input while focused", async () => {
+    const onChange = vi.fn();
+    const { stdin, unmount } = render(editor(true, onChange));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    stdin.write("h");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(onChange).toHaveBeenCalledWith("h");
+    unmount();
+  });
+
+  it("ignores input while unfocused", async () => {
+    const onChange = vi.fn();
+    const { stdin, unmount } = render(editor(false, onChange));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    stdin.write("h");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(onChange).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  // The stale-subscription window this component guards against (focus
+  // flipped by a render, unsubscribe effect not yet flushed, keypress
+  // arrives in between) cannot be reproduced through ink-testing-library's
+  // `rerender`, which flushes effects before returning. The regression
+  // test for that window lives at the app level: see "a keypress landing
+  // between a tab switch and its focus teardown stays out of the chat
+  // buffer" in ../tui-app.test.tsx.
+});

--- a/src/tui/components/multi-line-editor.tsx
+++ b/src/tui/components/multi-line-editor.tsx
@@ -106,8 +106,21 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
     [onChange],
   );
 
+  // Ink tears the `isActive` subscription down in a passive effect, one
+  // frame after the render that flipped `focus`. A keypress that arrives in
+  // that gap — always the case when the flip and the key are processed in
+  // the same stdin batch, e.g. Tab into a panel followed by the panel's
+  // hotkey — is still delivered here and lands in the chat buffer of an
+  // editor that is no longer focused. The ref is written during render, so
+  // the callback checks the *current* focus, not the focus the subscription
+  // was created with. (Render-phase write is safe: the value is derived
+  // from props, never from state updated here.)
+  const activeRef = useRef(focus && !disabled);
+  activeRef.current = focus && !disabled;
+
   useInput(
     (input, key) => {
+      if (!activeRef.current) return;
       if (disabled) return;
       handleKey({
         input,

--- a/src/tui/tui-app.test.tsx
+++ b/src/tui/tui-app.test.tsx
@@ -293,4 +293,36 @@ describe("TuiApp (smoke)", () => {
     expect(text).not.toContain("Local runtime");
     unmount();
   });
+
+  it("a keypress landing between a tab switch and its focus teardown stays out of the chat buffer", async () => {
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={noopCallbacks()} />,
+    );
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Switch to the Tasks panel via the bus (state update outside React's
+    // event system), then yield exactly two immediates: the first lets the
+    // render commit — panel active, editor focus computed false, useInput
+    // handler refs updated — the second lands BEFORE the passive effect
+    // that tears the editor's stale isActive subscription down. A key
+    // written in that window used to be delivered to the panel AND the
+    // editor at once: the tasks search row, the slash palette and a "/"
+    // in the prompt all opened from one keystroke.
+    bus.emit({ type: "ui_mode_set", mode: "debug" });
+    bus.emit({ type: "tab_changed", tab: "tasks" });
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    stdin.write("/");
+
+    await new Promise((r) => setTimeout(r, 60));
+    const text = strip(lastFrame() ?? "");
+    // The panel owns the key: its search row opens…
+    expect(text).toContain("Tasks");
+    // …and nothing leaks into the chat surface: no seeded "/" in the
+    // prompt, no slash palette riding along with it.
+    expect(text).not.toMatch(/❯\s*\//);
+    expect(text).not.toContain("/dump");
+    unmount();
+  });
 });


### PR DESCRIPTION
## What

The first keystroke after entering a panel tab was delivered to the panel **and** the chat
editor at once. On Tasks, a single `/` opened the panel's search row, the global slash
palette, and seeded `/` into the prompt buffer — three surfaces from one key — and the stray
character survived the trip back to Run, prefixing the next message.

## Why it happens

Ink keeps the latest `useInput` handler current on every render, but applies `isActive`
through a passive effect. Between the commit that flips `editorFocus` to `false` and that
effect's flush there is a window where the editor's subscription is still live — and the
handler body only checked `disabled`, never `focus`. A keypress landing in the window is
processed by the freshly-active panel bindings *and* the stale editor subscription. The
palette then rides along for free: it opens whenever the buffer becomes `/…`
(`onEditorChange` → `slash_palette_opened`), so the leaked `/` is what summons it.

## Fix

`multi-line-editor.tsx`: a ref written during render mirrors `focus && !disabled`, and the
`useInput` callback early-returns when it is false. The focus flip now takes effect the same
frame; no new focus model, no new state.

## Testing

The window is invisible to `rerender()` (ink-testing-library flushes effects before
returning), so the regression test drives it the way the app really hits it: a bus-originated
tab switch, two `setImmediate` yields — render committed, teardown effect not yet run — then
the keystroke. Verified **stable 3/3 in both directions**: on unpatched code the frame shows
the seeded `❯ /` plus the palette (test fails); patched, only the tasks search opens.

- `npm run lint` clean
- New: `multi-line-editor.test.tsx` (focused/unfocused basics) + the app-level window test
- Full `src/tui` serial: failure set identical to `main`'s pre-existing five (`tui-app` ×2
  stale copy, `splash-banner`, `chat-log`, `persist-embedding-hybrid-recall`;
  `llm-health-poller` 12/12 solo, fails only under parallel load)
