### PR TITLE
fix(http): make /health answer in one probe and admit when llama is down

### DIFF
--- a/src/http/route-health.test.ts
+++ b/src/http/route-health.test.ts
@@ -1,0 +1,95 @@
+import { createServer, type Server } from "node:http";
+import { createServer as createTcpServer } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { startTestHarness, type Harness } from "./test-harness.js";
+
+/** A port that was just bound and released — as closed as a port gets. */
+async function closedPort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = createTcpServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const address = srv.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+/** Minimal llama-server imitation: answers `/health` the way llama.cpp does. */
+async function startFakeLlama(): Promise<{ url: string; stop: () => Promise<void> }> {
+  const srv: Server = createServer((req, res) => {
+    if (req.url === "/health") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise<void>((resolve) => srv.listen(0, "127.0.0.1", resolve));
+  const address = srv.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    stop: () => new Promise((resolve) => srv.close(() => resolve())),
+  };
+}
+
+describe("GET /health", () => {
+  let harness: Harness | null = null;
+  let fakeLlama: { url: string; stop: () => Promise<void> } | null = null;
+
+  afterEach(async () => {
+    if (harness) await harness.cleanup();
+    harness = null;
+    if (fakeLlama) await fakeLlama.stop();
+    fakeLlama = null;
+  });
+
+  it("answers fast and says degraded when llama is down", async () => {
+    harness = await startTestHarness({
+      localModelsUrl: `http://127.0.0.1:${await closedPort()}`,
+    });
+
+    const started = Date.now();
+    const res = await fetch(`${harness.baseUrl}/health`);
+    const elapsed = Date.now() - started;
+    const body = (await res.json()) as {
+      status: string;
+      llama: { reachable: boolean; error: string | null };
+    };
+
+    // One probe, no retry ladder: the full ladder was 15.5 s of backoff,
+    // far beyond any orchestrator's patience. A refused connection fails
+    // in milliseconds; five seconds is a generous ceiling.
+    expect(elapsed).toBeLessThan(5000);
+    // Sidecar alive → 200 by default; the body tells the truth about llama.
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("degraded");
+    expect(body.llama.reachable).toBe(false);
+  });
+
+  it("returns 503 for ?strict=1 when llama is down", async () => {
+    harness = await startTestHarness({
+      localModelsUrl: `http://127.0.0.1:${await closedPort()}`,
+    });
+
+    const res = await fetch(`${harness.baseUrl}/health?strict=1`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("degraded");
+  });
+
+  it("reports ok — strict or not — when llama answers", async () => {
+    fakeLlama = await startFakeLlama();
+    harness = await startTestHarness({ localModelsUrl: fakeLlama.url });
+
+    const plain = await fetch(`${harness.baseUrl}/health`);
+    expect(plain.status).toBe(200);
+    expect(((await plain.json()) as { status: string }).status).toBe("ok");
+
+    const strict = await fetch(`${harness.baseUrl}/health?strict=1`);
+    expect(strict.status).toBe(200);
+    expect(((await strict.json()) as { status: string }).status).toBe("ok");
+  });
+});

--- a/src/http/route-health.ts
+++ b/src/http/route-health.ts
@@ -3,16 +3,34 @@ import { sendJson, type HttpHandler } from "./request-context.js";
 
 /**
  * `GET /health` — liveness probe. Reports the sidecar's own status plus
- * a passthrough summary of the external llama-server reachability. We
- * intentionally return 200 even when llama is down so orchestrators
- * can tell the sidecar apart from the LLM runtime (which may legally
- * be absent during indexing/degraded mode).
+ * a passthrough summary of the external llama-server reachability.
+ *
+ * The llama probe is a single attempt on purpose. This route used to
+ * inherit `checkLlamaServer`'s full retry ladder (5 attempts with
+ * exponential backoff — 15.5 s worst case), which is the one budget a
+ * liveness endpoint does not have: orchestrators typically allow 1–10 s
+ * before declaring the process dead, so the slow answer read as a hang
+ * and restart-looped the sidecar exactly when llama was down. Retrying
+ * inside one probe buys nothing anyway — the orchestrator's next poll
+ * IS the retry.
+ *
+ * Status contract:
+ * - HTTP 200, `status: "ok"`       — sidecar up, llama reachable.
+ * - HTTP 200, `status: "degraded"` — sidecar up, llama down. Still 200
+ *   by default: the LLM runtime may legally be absent (indexing,
+ *   degraded mode), and restarting the sidecar would not revive llama.
+ * - `?strict=1` turns the degraded case into HTTP 503 for orchestrators
+ *   that do want restart-on-down semantics.
  */
 export function createHealthHandler(): HttpHandler {
-  return async (_req, res, ctx) => {
-    const llama = await checkLlamaServer();
-    sendJson(res, 200, {
-      status: "ok",
+  return async (req, res, ctx) => {
+    const llama = await checkLlamaServer({ retries: 0 });
+    const strict =
+      new URL(req.url ?? "/", "http://localhost").searchParams.get("strict") ===
+      "1";
+    const degraded = !llama.reachable;
+    sendJson(res, degraded && strict ? 503 : 200, {
+      status: degraded ? "degraded" : "ok",
       runtime: "atomic-agent",
       workingDir: ctx.runtime.capabilities.workingDir,
       llama: {

--- a/src/http/test-harness.ts
+++ b/src/http/test-harness.ts
@@ -78,6 +78,14 @@ export class FakeBrowserBackend implements BrowserBackend {
 export interface HarnessOptions {
   /** When set, the HTTP server requires this bearer token. */
   apiKey?: string | null;
+  /**
+   * Point `localModels.url` at a specific server so llama health probes
+   * are deterministic — e.g. a stub that answers `/health`, or a port
+   * that is known to be closed. Without this the probe hits the config
+   * default (127.0.0.1:8080), which may or may not be occupied on the
+   * machine running the tests.
+   */
+  localModelsUrl?: string;
   /** Replace the llama completion implementation. Default: one `reply` turn. */
   llamaComplete?: (params: {
     prompt: string;
@@ -142,11 +150,22 @@ export async function startTestHarness(
   mkdirSync(join(workingDir, ".atomic-agent", "skills"), { recursive: true });
   process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
   process.env.ATOMIC_AGENT_GRAMMARS_DIR = join(process.cwd(), "grammars");
-  if (options.webhooks) {
+  if (options.webhooks || options.localModelsUrl) {
     writeFileSync(
       join(stateDir, "config.json"),
       JSON.stringify(
-        { ...USER_CONFIG_DEFAULTS, webhooks: options.webhooks },
+        {
+          ...USER_CONFIG_DEFAULTS,
+          ...(options.webhooks ? { webhooks: options.webhooks } : {}),
+          ...(options.localModelsUrl
+            ? {
+                localModels: {
+                  ...USER_CONFIG_DEFAULTS.localModels,
+                  url: options.localModelsUrl,
+                },
+              }
+            : {}),
+        },
         null,
         2,
       ),


### PR DESCRIPTION
## What

`GET /health` blocked for **15.5 seconds** when llama-server was down, then answered
HTTP 200 with `status: "ok"` — its own body admitting `reachable: false` in the same
breath. Measured three consecutive calls before the fix: 15.55 / 15.55 / 15.56 s.

For the documented liveness probe that fails in both directions at once: too slow to
survive a typical 1–10 s orchestrator timeout (so the sidecar restart-loops exactly when
llama is down), and untruthful when it does answer.

## Fix

- The route probes llama **once** (`checkLlamaServer({ retries: 0 })`). The 15.5 s came
  from inheriting the full retry ladder (5 attempts, exponential backoff); a liveness
  endpoint has no such budget, and the orchestrator's next poll is the retry anyway.
- The body says the truth: `status: "ok"` only when llama answers, `status: "degraded"`
  when it does not. HTTP stays 200 by default — the existing comment is right that the
  sidecar being alive is a separate fact from llama being up, and nothing that polls for
  200 today breaks.
- New: `GET /health?strict=1` returns **503** in the degraded case, for orchestrators
  that do want restart-on-down semantics. Opt-in, so default behaviour is unchanged.

## Testing

New `route-health.test.ts` (the route had none), on the real HTTP harness with
`localModels.url` pointed at a just-released port / a stub llama:

- degraded: 200, `status: "degraded"`, `reachable: false`, and **elapsed < 5 s** —
  against the unpatched route these tests literally hit vitest's 15 s timeout, which is
  the bug demonstrating itself
- strict: 503 + `degraded` when down; 200 + `ok` when up
- healthy: `ok` with and without `strict`

`test-harness.ts` gained an optional `localModelsUrl` so llama-probe tests are
deterministic instead of depending on whatever occupies 127.0.0.1:8080 on the test
machine. Full `src/http` suite: 49/49. `npm run lint` clean.
