### PR TITLE
fix: llama-down failures answer fast and say what to do

### DIFF
--- a/src/cli/run-agent.test.ts
+++ b/src/cli/run-agent.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { formatLlamaUnreachableHint } from "../llm/llama-server-health.js";
+import { formatAgentEvent } from "./run-agent.js";
+
+const HINT = formatLlamaUnreachableHint("http://127.0.0.1:8080");
+
+function transportError(message: string) {
+  return {
+    type: "llm_event" as const,
+    event: {
+      type: "step_error" as const,
+      error: new Error(message),
+      category: "transport" as const,
+    },
+  };
+}
+
+describe("formatAgentEvent llama hint", () => {
+  it("turns a bare transport failure into something actionable on the local route", () => {
+    const line = formatAgentEvent(transportError("fetch failed"), {
+      llamaHint: HINT,
+      hintShown: { value: false },
+    });
+    expect(line).toContain("! [transport] fetch failed");
+    expect(line).toContain("llama-server is not reachable at http://127.0.0.1:8080");
+    expect(line).toContain("atomic-agent models start");
+    expect(line).toContain("config set localModels.url");
+  });
+
+  it("prints the hint once, not on every retry", () => {
+    const hintShown = { value: false };
+    const first = formatAgentEvent(transportError("fetch failed"), {
+      llamaHint: HINT,
+      hintShown,
+    });
+    const second = formatAgentEvent(transportError("fetch failed"), {
+      llamaHint: HINT,
+      hintShown,
+    });
+    expect(first).toContain("llama-server is not reachable");
+    expect(second).toBe("  ! [transport] fetch failed");
+  });
+
+  it("stays out of the way on a cloud route", () => {
+    // No hint is computed when the active text provider is not local —
+    // a transport failure there points at the provider, not at llama.
+    const line = formatAgentEvent(transportError("fetch failed"), {
+      llamaHint: null,
+      hintShown: { value: false },
+    });
+    expect(line).toBe("  ! [transport] fetch failed");
+  });
+
+  it("stays out of the way for non-transport failures", () => {
+    const line = formatAgentEvent(
+      {
+        type: "llm_event",
+        event: {
+          type: "step_error",
+          error: new Error("grammar rejected the completion"),
+          category: "model" as never,
+        },
+      },
+      { llamaHint: HINT, hintShown: { value: false } },
+    );
+    expect(line).toBe("  ! [model] grammar rejected the completion");
+  });
+
+  it("decorates loop_failed the same way", () => {
+    const line = formatAgentEvent(
+      {
+        type: "loop_failed",
+        error: new Error("fetch failed"),
+        category: "transport" as never,
+      },
+      { llamaHint: HINT, hintShown: { value: false } },
+    );
+    expect(line).toContain("» loop failed [transport]: fetch failed");
+    expect(line).toContain("llama-server is not reachable");
+  });
+});
+
+describe("formatLlamaUnreachableHint", () => {
+  it("names the URL, the start command and the config key", () => {
+    const hint = formatLlamaUnreachableHint("http://10.0.0.4:9090");
+    expect(hint).toContain("http://10.0.0.4:9090");
+    expect(hint).toContain("atomic-agent models start");
+    expect(hint).toContain("localModels.url");
+  });
+});

--- a/src/cli/run-agent.ts
+++ b/src/cli/run-agent.ts
@@ -8,6 +8,8 @@ import {
   resolveBootApprovalLevel,
 } from "../approval/approval-level.js";
 import { getConfig } from "../config/index.js";
+import { formatLlamaUnreachableHint } from "../llm/llama-server-health.js";
+import { resolveLlmConfig } from "../llm/provider/registry/provider-types.js";
 import { createAgentRuntime } from "../runtime/bootstrap.js";
 import type { AgentRuntime } from "../runtime/bootstrap.js";
 import type { AgentLoopEvent } from "../agent/agent-loop.js";
@@ -127,7 +129,40 @@ async function promptApproval(
   }
 }
 
-function formatAgentEvent(event: AgentLoopEvent): string | null {
+/** Transport failures that mean "nothing answered at the configured URL". */
+const TRANSPORT_NO_ANSWER = /fetch failed|ECONNREFUSED|ECONNRESET|socket hang up|timeout/i;
+
+function withLlamaHint(
+  base: string,
+  category: string,
+  message: string,
+  ctx?: { llamaHint?: string | null; hintShown?: { value: boolean } },
+): string {
+  if (!ctx?.llamaHint || ctx.hintShown?.value) return base;
+  if (category !== "transport" || !TRANSPORT_NO_ANSWER.test(message)) return base;
+  if (ctx.hintShown) ctx.hintShown.value = true;
+  const indented = ctx.llamaHint
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n");
+  return `${base}\n${indented}`;
+}
+
+/**
+ * Render one agent-loop event as a diagnostic stderr line, or null for
+ * events other surfaces own. Exported for tests.
+ *
+ * `ctx.llamaHint` carries the actionable llama-server message when the
+ * active text route is the local server: a transport failure there is
+ * almost always "llama-server is not running", and the raw undici string
+ * ("fetch failed") tells the operator none of URL / cause / fix. The hint
+ * is appended once per process — every retry repeating three lines of
+ * advice would bury the log.
+ */
+export function formatAgentEvent(
+  event: AgentLoopEvent,
+  ctx?: { llamaHint?: string | null; hintShown?: { value: boolean } },
+): string | null {
   switch (event.type) {
     case "user_message":
       return null;
@@ -148,15 +183,18 @@ function formatAgentEvent(event: AgentLoopEvent): string | null {
         return `  ← ${inner.result.tool} ${inner.result.status}: ${inner.result.summary}${inner.result.truncated ? " (truncated)" : ""}`;
       }
       if (inner.type === "step_error") {
-        return `  ! [${inner.category}] ${inner.error.message}`;
+        const base = `  ! [${inner.category}] ${inner.error.message}`;
+        return withLlamaHint(base, inner.category, inner.error.message, ctx);
       }
       // assistant_reply / reasoning are emitted to stdout from the chat loop instead.
       return null;
     }
     case "loop_completed":
       return null;
-    case "loop_failed":
-      return `» loop failed [${event.category}]: ${event.error.message}`;
+    case "loop_failed": {
+      const base = `» loop failed [${event.category}]: ${event.error.message}`;
+      return withLlamaHint(base, event.category, event.error.message, ctx);
+    }
     default:
       return null;
   }
@@ -298,6 +336,15 @@ export async function runAgentCommand(args: string[]): Promise<number> {
 
   let approvalChain: Promise<unknown> = Promise.resolve();
 
+  // The hint only applies when a transport failure means "local llama is
+  // down" — i.e. the active text route IS the local server. On a cloud
+  // route the same category points at the provider, not at llama.
+  const llamaHint =
+    resolveLlmConfig(config).activeTextProvider === "local-llama"
+      ? formatLlamaUnreachableHint(config.localModels.url)
+      : null;
+  const hintShown = { value: false };
+
   const runtime = await createAgentRuntime({
     workingDir: parsed.workingDir,
     approvalLevel,
@@ -308,7 +355,7 @@ export async function runAgentCommand(args: string[]): Promise<number> {
         // `eventHook` argument of `runTurn` (see `driveTurn`). This
         // global handler only feeds the diagnostic stderr stream so
         // the operator can watch the macro-turn lifecycle.
-        const line = formatAgentEvent(event);
+        const line = formatAgentEvent(event, { llamaHint, hintShown });
         if (line) process.stderr.write(`${line}\n`);
       },
       onApprovalRequest: (request) => {

--- a/src/llm/llama-server-health.ts
+++ b/src/llm/llama-server-health.ts
@@ -231,3 +231,21 @@ export async function checkLlamaServer(
   }
   return failed;
 }
+
+/**
+ * The message a human can act on when llama-server does not answer.
+ *
+ * "fetch failed" is undici's transport error verbatim: it names neither the
+ * URL that was tried, nor the fact that the missing piece is llama-server,
+ * nor what to do about it — and it is the single most common failure a new
+ * local-model user sees. Every surface that reports an unreachable llama
+ * should say this instead.
+ */
+export function formatLlamaUnreachableHint(url: string): string {
+  return [
+    `llama-server is not reachable at ${url}`,
+    "  start it with:       atomic-agent models start",
+    `  or point elsewhere:  atomic-agent config set localModels.url <url>`,
+  ].join("\n");
+}
+

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -733,7 +733,11 @@ export async function createAgentRuntime(
     !options.overrides?.deferLlamaHealthCheck &&
     !options.overrides?.llamaComplete
   ) {
-    const health = await checkLlamaServer();
+    // One attempt, not the retry ladder: this probe exists to log a line,
+    // and with llama down the default ladder (5 attempts, exponential
+    // backoff) stalled every boot for 15.5 s before the loop then failed
+    // fast anyway. The first real completion is the retry.
+    const health = await checkLlamaServer({ retries: 0 });
     if (!health.reachable) {
       logger.warn("llama-server health check failed", {
         error: health.error,

--- a/src/sidecar/main.ts
+++ b/src/sidecar/main.ts
@@ -240,7 +240,9 @@ export async function bootstrapSidecar(): Promise<{
       await disposeActive();
       const workingDir = resolve(request.payload.workingDir);
       const runtime = await buildRuntime(workingDir);
-      const health = await checkLlamaServer();
+      // Status probe for the desktop shell — one attempt; the retry
+      // ladder only delayed the `llm_unavailable` event by 15.5 s.
+      const health = await checkLlamaServer({ retries: 0 });
       if (!health.reachable) {
         const hint =
           config.localModels.mode === "managed"


### PR DESCRIPTION
## What

With llama-server down, the most common first-run failure was **17 seconds of dead air**
followed by the two words `fetch failed` — no URL, no diagnosis, no fix. After this change
the same run fails in ~2 seconds and says:

```
! [transport] fetch failed
    llama-server is not reachable at http://127.0.0.1:8080
      start it with:       atomic-agent models start
      or point elsewhere:  atomic-agent config set localModels.url <url>
```

## Where the 17 seconds went

`createAgentRuntime` runs `checkLlamaServer()` with the default retry ladder — 5 attempts,
exponential backoff, 500·(1+2+4+8+16) = 15.5 s — purely to log a warning
(`bootstrap.ts`, the probe never throws). The sidecar's `start_session` status probe had
the same ladder. Both now probe **once**: these are observability probes, and with a
refused connection the retries change nothing — the first real completion is the retry.
The TUI startup gate already probed with `retries: 0`; now every probe agrees.

## The message

New `formatLlamaUnreachableHint(url)` in `llama-server-health.ts` — the shared, actionable
wording. `run` appends it to the first transport failure (`step_error` / `loop_failed`)
**only when the active text route is the local server** — on a cloud route the same
category points at the provider, not llama — and only **once per process**, so retries
don't bury the log in repeated advice.

## Testing

- 6 new unit tests: hint content; appended on local-route transport failures; printed
  once, not per retry; untouched on cloud routes; untouched for non-transport categories;
  `loop_failed` decorated the same way. Plus the existing health-check suite (15/15 total).
- End-to-end against the built CLI, llama down, fresh state dir:
  **before 17.3 s + bare `fetch failed` → after 2 s, exit 1**, hint printed with URL and
  both fix commands.
- `npm run lint` clean.

Not covered here: the TUI feed still prints the bare `! [transport] fetch failed` line —
that surface already has the health pill and the startup wizard, and enriching it touches
the reducer path, so it is left for a separate change.
