### PR TITLE
fix(tui): one sentence instead of a stack trace on non-interactive stdin

### DIFF
--- a/src/tui/tui-args.test.ts
+++ b/src/tui/tui-args.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { nonInteractiveStdinError, parseTuiArgs } from "./tui-args.js";
+
+describe("nonInteractiveStdinError", () => {
+  it("refuses a piped stdin with an actionable sentence", () => {
+    const message = nonInteractiveStdinError({ isTTY: undefined });
+    expect(message).toContain("needs an interactive terminal");
+    expect(message).toContain("atomic-agent run");
+  });
+
+  it("stays silent on a real terminal", () => {
+    expect(nonInteractiveStdinError({ isTTY: true })).toBeNull();
+  });
+
+  it("defaults to the real process.stdin", () => {
+    // Vitest workers run with piped stdio, so the default argument is the
+    // non-TTY case — the exact environment the guard exists for.
+    expect(nonInteractiveStdinError()).not.toBeNull();
+  });
+});
+
+describe("parseTuiArgs", () => {
+  it("still reports unknown flags as usage errors", () => {
+    expect(parseTuiArgs(["--definitely-not-a-flag"])).toHaveProperty("error");
+  });
+});

--- a/src/tui/tui-args.ts
+++ b/src/tui/tui-args.ts
@@ -65,3 +65,20 @@ export function parseTuiArgs(args: string[]): TuiArgsResult {
     skipLlamaSetup,
   };
 }
+
+/**
+ * The one-sentence refusal for a stdin that is not a terminal, or `null`
+ * when the TUI can mount. A pipe (CI, cron, `echo hi | atomic-agent`, a
+ * Dockerfile RUN) used to reach Ink's raw-mode requirement and die with a
+ * React stack trace of minified bundle offsets — and bare `atomic-agent` /
+ * `atomic-agent tui` are exactly the commands new users and scripts run
+ * first. Lives here rather than in tui-command.ts so it is unit-testable:
+ * that module imports the SEA bridge, which vitest cannot load.
+ */
+export function nonInteractiveStdinError(
+  stdin: { isTTY?: boolean } = process.stdin,
+): string | null {
+  if (stdin.isTTY) return null;
+  return "atomic-agent needs an interactive terminal — use 'atomic-agent run' for scripts.";
+}
+

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -11,7 +11,9 @@ import type { MetricSample, MetricSink } from "../tracing/metrics-collector.js";
 import { registerSession } from "../local-llm/session-registry.js";
 import { enterAltScreen } from "./alt-screen.js";
 import { ChatOrchestrator } from "./chat-orchestrator.js";
-import { parseTuiArgs } from "./tui-args.js";
+import { parseTuiArgs,
+  nonInteractiveStdinError,
+} from "./tui-args.js";
 import {
   persistUserLocalLlmUrl,
   pointsAtManagedDaemon,
@@ -41,6 +43,14 @@ export async function tuiCommand(args: string[]): Promise<number> {
   if ("error" in parsed) {
     process.stderr.write(`${parsed.error}\n`);
     return 2;
+  }
+  // A TUI needs a terminal — refuse a piped stdin with one sentence
+  // instead of letting Ink's raw-mode requirement crash with a stack
+  // trace. See `nonInteractiveStdinError` for the reasoning.
+  const stdinError = nonInteractiveStdinError();
+  if (stdinError) {
+    process.stderr.write(`${stdinError}\n`);
+    return 1;
   }
   // Theme selection BEFORE any Ink render or stdin listener (the startup-gate
   // wizard and the main render). An explicit


### PR DESCRIPTION
## What

Bare `atomic-agent` and `atomic-agent tui` on a non-interactive stdin — CI, cron,
`echo hi | atomic-agent`, a Dockerfile `RUN` — died with a React duplicate-key warning
followed by `ERROR Raw mode is not supported on the current process.stdin` and a stack
trace of minified bundle offsets. These are the two most likely first commands a new
user or a script runs, and nothing in the output said what the actual problem was.

Now:

```
$ echo hi | atomic-agent
atomic-agent needs an interactive terminal — use 'atomic-agent run' for scripts.
$ echo $?
1
```

## How

One check before any Ink work in `tuiCommand`. The predicate lives in `tui-args.ts`
(`nonInteractiveStdinError`) rather than `tui-command.ts` because the latter imports the
SEA bridge, which vitest cannot load — this way the guard is unit-testable. Usage errors
still win: a bad flag exits 2 before the TTY check, unchanged.

## Testing

- 4 unit tests: piped stdin → actionable sentence; real TTY → null; default argument
  under vitest's piped stdio → non-null (the guard's own environment); unknown flags
  still parse to usage errors
- End-to-end against the built CLI with piped stdin, fresh state dir: both `atomic-agent`
  and `atomic-agent tui` print the one sentence, exit 1, and the output contains neither
  `Raw mode` nor a stack frame
- `npm run lint` clean

Not addressed: the React "two children with the same key" warning that used to precede
the crash. With this guard the non-TTY mount never happens, and inspection of the
components mounted at boot (logo, status bar, hint strip) found no keyless or
empty-string-keyed `.map` — so the warning's source remains unlocated and may still
exist for interactive users. Left out rather than guessed at.