### PR TITLE
feat(cli): run/tui --help, --version, and a help alias

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { taskCommand } from "./task-command.js";
 import { modelsCommand } from "./models-command.js";
 import { importCommand } from "./import-command.js";
 import { tuiCommand } from "../tui/index.js";
+import { getAppVersion } from "../version.js";
 
 interface CommandDescriptor {
   name: string;
@@ -130,6 +131,25 @@ async function main(): Promise<number> {
   if (command === "-h" || command === "--help") {
     printHelp();
     return 0;
+  }
+  if (command === "-v" || command === "--version" || command === "version") {
+    process.stdout.write(`atomic-agent ${getAppVersion()}\n`);
+    return 0;
+  }
+  // `help <cmd>` reads as naturally as `<cmd> --help`; alias one to the other.
+  if (command === "help") {
+    const target = rest[0];
+    if (!target) {
+      printHelp();
+      return 0;
+    }
+    const aliased = COMMANDS.find((c) => c.name === target);
+    if (!aliased) {
+      process.stderr.write(`unknown command: ${target}\n`);
+      printHelp();
+      return 2;
+    }
+    return aliased.run(["--help"]);
   }
   if (!command) {
     return tuiCommand([]);

--- a/src/cli/run-agent.ts
+++ b/src/cli/run-agent.ts
@@ -28,13 +28,34 @@ interface RunArgs {
   noApproval: boolean;
 }
 
-function parseArgs(args: string[]): RunArgs | { error: string } {
+const HELP =
+  [
+    "atomic-agent run — chat with the agent over stdin",
+    "",
+    "Usage:",
+    "  atomic-agent run [options]           interactive: one message per line",
+    "  echo \"<goal>\" | atomic-agent run     one-shot: answer on stdout, logs on stderr",
+    "",
+    "Options:",
+    "  --cwd <dir>          Working directory for OS tools (default: current directory)",
+    "  --working-dir <dir>  Alias for --cwd",
+    "  --max-steps <n>      Step budget for one turn (default: agent.maxSteps from config)",
+    "  --no-approval        Force approval level 5: auto-approve every dangerous tool call",
+    "",
+    "In-session:  /quit exits · /abort cancels the current turn",
+    "Exit codes:  0 replied · 1 failed · 2 usage error",
+  ].join("\n") + "\n";
+
+function parseArgs(args: string[]): RunArgs | { error: string } | { help: true } {
   let workingDir: string | null = null;
   let maxSteps: number | null = null;
   let noApproval = false;
   for (let i = 0; i < args.length; i += 1) {
     const flag = args[i];
     switch (flag) {
+      case "--help":
+      case "-h":
+        return { help: true };
       case "--cwd":
       case "--working-dir": {
         const value = args[++i];
@@ -324,6 +345,10 @@ async function runChatLoop(opts: ChatLoopOptions): Promise<SessionState> {
  */
 export async function runAgentCommand(args: string[]): Promise<number> {
   const parsed = parseArgs(args);
+  if ("help" in parsed) {
+    process.stdout.write(HELP);
+    return 0;
+  }
   if ("error" in parsed) {
     process.stderr.write(`${parsed.error}\n`);
     return 2;

--- a/src/tui/tui-args.help.test.ts
+++ b/src/tui/tui-args.help.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTuiArgs, TUI_HELP } from "./tui-args.js";
+
+describe("parseTuiArgs --help", () => {
+  it("returns the help marker for --help and -h", () => {
+    expect(parseTuiArgs(["--help"])).toEqual({ help: true });
+    expect(parseTuiArgs(["-h"])).toEqual({ help: true });
+  });
+
+  it("keeps unknown flags as usage errors", () => {
+    expect(parseTuiArgs(["--nope"])).toHaveProperty("error");
+  });
+
+  it("documents every real flag in the help text", () => {
+    for (const flag of ["--cwd", "--working-dir", "--max-steps", "--no-approval", "--skip-llama-setup"]) {
+      expect(TUI_HELP).toContain(flag);
+    }
+  });
+});

--- a/src/tui/tui-args.ts
+++ b/src/tui/tui-args.ts
@@ -13,7 +13,24 @@ export interface TuiArgs {
   skipLlamaSetup: boolean;
 }
 
-export type TuiArgsResult = TuiArgs | { error: string };
+export type TuiArgsResult = TuiArgs | { error: string } | { help: true };
+
+export const TUI_HELP =
+  [
+    "atomic-agent tui — the interactive terminal dashboard",
+    "",
+    "Usage:",
+    "  atomic-agent tui [options]     (also the default when no command is given)",
+    "",
+    "Options:",
+    "  --cwd <dir>          Working directory for OS tools (default: current directory)",
+    "  --working-dir <dir>  Alias for --cwd",
+    "  --max-steps <n>      Step budget per turn (default: agent.maxSteps from config)",
+    "  --no-approval        Force approval level 5: auto-approve every dangerous tool call",
+    "  --skip-llama-setup   Skip the first-run local-model setup gate",
+    "",
+    "Needs an interactive terminal; in scripts use `atomic-agent run`.",
+  ].join("\n") + "\n";
 
 /**
  * Parses the CLI arguments accepted by `tuiCommand`. Returns either the
@@ -34,6 +51,9 @@ export function parseTuiArgs(args: string[]): TuiArgsResult {
   for (let i = 0; i < args.length; i += 1) {
     const flag = args[i];
     switch (flag) {
+      case "--help":
+      case "-h":
+        return { help: true };
       case "--cwd":
       case "--working-dir": {
         const value = args[++i];

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -13,6 +13,7 @@ import { enterAltScreen } from "./alt-screen.js";
 import { ChatOrchestrator } from "./chat-orchestrator.js";
 import { parseTuiArgs,
   nonInteractiveStdinError,
+  TUI_HELP,
 } from "./tui-args.js";
 import {
   persistUserLocalLlmUrl,
@@ -41,6 +42,10 @@ import type { InitialTuiLayoutOptions, TuiSessionInfo } from "./tui-state.js";
  */
 export async function tuiCommand(args: string[]): Promise<number> {
   const parsed = parseTuiArgs(args);
+  if ("help" in parsed) {
+    process.stdout.write(TUI_HELP);
+    return 0;
+  }
   if ("error" in parsed) {
     process.stderr.write(`${parsed.error}\n`);
     return 2;


### PR DESCRIPTION
## What

`run` is the first command in the top-level help and had no help of its own: `run --help`,
`run -h`, `tui --help` and a bare `help` all exited 2 with `unknown flag` / `unknown
command`, and there was no way to ask which version is installed.

Now:

- `atomic-agent run --help` / `-h` — usage, every flag with its default, the piping
  behaviour (one-shot vs interactive), `/quit` & `/abort`, and the exit-code contract
- `atomic-agent tui --help` — same shape; also points scripts at `run`
- `atomic-agent --version` / `-v` / `version` — prints `atomic-agent 0.2.1` (from the
  existing `getAppVersion()`)
- `atomic-agent help [command]` — alias for `<command> --help`; bare `help` prints the
  top-level page; unknown targets exit 2

## Shape

The HELP constants copy `serve-command.ts` verbatim in structure, so all subcommand help
pages read alike. `--help` is parsed as a first-class parse result (`{ help: true }`)
before flag validation, so it always works, and unknown flags still exit 2.

## Testing

- 3 unit tests on `parseTuiArgs`: `--help`/`-h` marker, unknown flags still error, and
  every real flag appears in the help text (rot guard)
- End-to-end against the built CLI: `run --help` exit 0, `run -h` exit 0, `tui --help`
  exit 0, `--version`/`-v`/`version` all print the version, `help run` mirrors
  `run --help`, `help nonsense` exits 2, `run --nope` still exits 2
- `npm run lint` clean; full build passes

Note: this branch touches `parseArgs` in `run-agent.ts` and `tui-args.ts`, which #141 and
#142 also modify in different regions — whichever merges last may need a trivial rebase.