### PR TITLE
fix(cli): honest exit codes — stalled runs fail, --cwd validated, lookup misses exit 1

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,32 @@ import { getAppVersion } from "../version.js";
 interface CommandDescriptor {
   name: string;
   summary: string;
+  /**
+   * Resolves to the process exit code:
+   *
+   *   0  success
+   *   1  operational failure — the command was invoked correctly and the
+   *      work did not succeed. A lookup miss ("no such skill") is a
+   *      failure, not a usage error.
+   *   2  usage error — unknown command or subcommand, missing required
+   *      argument, argument of the wrong kind. Nothing was attempted.
+   *
+   * `run`, `skill` and the dispatcher below implement this split. The
+   * rest of the table does not, and a caller must not read their codes
+   * through it:
+   *
+   *   - `config`, `serve`, `trace`, `task`, `models`, `import` predate
+   *     the split and return `1` for usage errors too, so their `1` does
+   *     not mean "the work failed".
+   *   - `trace replay` returns `2` for "stable-prefix drift detected", a
+   *     diff-style result code rather than a usage error.
+   *   - `tui` reports `0` or `1` from its own session, and when it
+   *     relaunches itself it passes the child process's status straight
+   *     through, so any code is possible (130 on SIGINT, say).
+   *   - `repl` is a scaffold and always returns `0`.
+   *
+   * Widening the split to those commands is a separate change.
+   */
   run: (args: string[]) => Promise<number>;
   /**
    * Omit the command from `--help` while keeping it dispatchable when

--- a/src/cli/run-agent.test.ts
+++ b/src/cli/run-agent.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+
+import type { CompletionResult } from "../llm/llama-server-client.js";
+import { resetConfigCache } from "../config/index.js";
 
 import { formatLlamaUnreachableHint } from "../llm/llama-server-health.js";
 import { formatAgentEvent } from "./run-agent.js";
@@ -88,4 +95,170 @@ describe("formatLlamaUnreachableHint", () => {
     expect(hint).toContain("atomic-agent models start");
     expect(hint).toContain("localModels.url");
   });
+});
+
+/** Raw model output the stubbed llama-server replays on every step. */
+const model = vi.hoisted(() => ({ emits: "" }));
+
+// `runAgentCommand` boots the real runtime and takes no injection seam of
+// its own, so the bootstrap module is wrapped to supply the same
+// `overrides` the HTTP harness uses. Everything else — tool registry,
+// agent loop, session status transitions, the exit-code branch under
+// test — stays on the production path. Nothing may be imported from
+// `../http/test-harness.js` in here: that module imports the very module
+// being mocked, so awaiting it inside the factory re-enters the mock and
+// deadlocks.
+vi.mock("../runtime/bootstrap.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../runtime/bootstrap.js")>();
+  const completion = (content: string): CompletionResult => ({
+    content,
+    reasoningContent: "",
+    stop: true,
+    truncated: false,
+    timing: {
+      promptMs: 0,
+      predictedMs: 0,
+      promptTokens: 5,
+      predictedTokens: 3,
+    },
+    cacheHitTokens: 0,
+    slotId: 0,
+    modelId: null,
+  });
+  const complete = async (params: {
+    sessionId: string;
+  }): Promise<CompletionResult> => {
+    // Post-turn reflection shares the completion seam but expects prose,
+    // not a tool call; feeding it the step payload would have it parse
+    // the fixture as notes.
+    if (params.sessionId.startsWith("reflection:")) return completion("");
+    return completion(model.emits);
+  };
+  return {
+    ...actual,
+    createAgentRuntime: (
+      options: Parameters<typeof actual.createAgentRuntime>[0],
+    ) =>
+      actual.createAgentRuntime({
+        ...options,
+        // No browser override: `PlaywrightBackend` launches lazily and
+        // these turns never touch a browser tool, so nothing spawns.
+        overrides: {
+          skipLlamaHealthCheck: true,
+          disableStreaming: true,
+          llamaComplete: complete,
+        },
+      }),
+  };
+});
+
+const { runAgentCommand } = await import("./run-agent.js");
+
+describe("runAgentCommand exit codes", () => {
+  let stateDir: string;
+  let workingDir: string;
+  let stderr = "";
+  const realStdin = process.stdin;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "atomic-cli-run-state-"));
+    workingDir = mkdtempSync(join(tmpdir(), "atomic-cli-run-cwd-"));
+    mkdirSync(join(workingDir, ".atomic-agent", "skills"), { recursive: true });
+    writeFileSync(join(workingDir, "note.txt"), "hello\n", "utf8");
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    process.env.ATOMIC_AGENT_GRAMMARS_DIR = join(process.cwd(), "grammars");
+    resetConfigCache();
+    model.emits = "";
+    stderr = "";
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderr += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "stdin", {
+      value: realStdin,
+      configurable: true,
+    });
+    rmSync(stateDir, { recursive: true, force: true });
+    rmSync(workingDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    delete process.env.ATOMIC_AGENT_GRAMMARS_DIR;
+    resetConfigCache();
+    vi.restoreAllMocks();
+  });
+
+  function feedStdin(lines: string[]): void {
+    Object.defineProperty(process, "stdin", {
+      value: Readable.from(lines),
+      configurable: true,
+    });
+  }
+
+  it("exits 2 when --cwd points at a path that does not exist", async () => {
+    const missing = join(workingDir, "definitely-not-here");
+    const code = await runAgentCommand(["--cwd", missing]);
+    expect(code).toBe(2);
+    expect(stderr).toContain(`--cwd is not a directory: ${missing}`);
+  });
+
+  it("exits 2 when --working-dir points at a file rather than a directory", async () => {
+    const file = join(workingDir, "note.txt");
+    const code = await runAgentCommand(["--working-dir", file]);
+    expect(code).toBe(2);
+    expect(stderr).toContain(`--working-dir is not a directory: ${file}`);
+  });
+
+  it("exits 2 on an unknown flag", async () => {
+    const code = await runAgentCommand(["--nope"]);
+    expect(code).toBe(2);
+    expect(stderr).toContain("unknown flag: --nope");
+  });
+
+  it(
+    "exits 1 when the turn exhausts the step budget and the session stalls",
+    async () => {
+      // A non-terminal tool on every step: the loop never reaches `reply`
+      // or `finish`, so it runs the budget out and lands on `stalled`.
+      model.emits = JSON.stringify({
+        tool: "os.fs.read",
+        args: { path: "note.txt" },
+      });
+      feedStdin(["read the note\n"]);
+      const code = await runAgentCommand([
+        "--cwd",
+        workingDir,
+        "--max-steps",
+        "2",
+        "--no-approval",
+      ]);
+      expect(stderr).toContain('"status": "stalled"');
+      expect(code).toBe(1);
+    },
+    60_000,
+  );
+
+  it(
+    "still exits 0 when the same turn ends on a reply",
+    async () => {
+      model.emits = JSON.stringify({
+        tool: "reply",
+        args: { text: "the note says hello" },
+      });
+      feedStdin(["read the note\n"]);
+      const code = await runAgentCommand([
+        "--cwd",
+        workingDir,
+        "--max-steps",
+        "2",
+        "--no-approval",
+      ]);
+      expect(stderr).not.toContain('"status": "stalled"');
+      expect(code).toBe(0);
+    },
+    60_000,
+  );
 });

--- a/src/cli/run-agent.ts
+++ b/src/cli/run-agent.ts
@@ -1,3 +1,4 @@
+import { statSync } from "node:fs";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline";
 import type { Interface as ReadlineInterface } from "node:readline";
@@ -60,7 +61,21 @@ function parseArgs(args: string[]): RunArgs | { error: string } | { help: true }
       case "--working-dir": {
         const value = args[++i];
         if (!value) return { error: `${flag} requires a value` };
-        workingDir = resolve(value);
+        const resolved = resolve(value);
+        // A typo'd path used to sail through: the run booted, printed the
+        // bogus directory in its banner as though healthy, ENOENT'd on
+        // every filesystem tool until the step budget ran out — and then
+        // exited 0. Catch it before anything boots.
+        let isDirectory = false;
+        try {
+          isDirectory = statSync(resolved).isDirectory();
+        } catch {
+          isDirectory = false;
+        }
+        if (!isDirectory) {
+          return { error: `${flag} is not a directory: ${resolved}` };
+        }
+        workingDir = resolved;
         break;
       }
       case "--max-steps": {
@@ -443,7 +458,13 @@ export async function runAgentCommand(args: string[]): Promise<number> {
         2,
       )}\n`,
     );
-    if (finalSession.status === "failed") exitCode = 1;
+    // `stalled` means the step budget ran out with nothing produced —
+    // that is not success, and a CI job watching this exit code must not
+    // read it as one. Only `completed` (and a clean EOF on an idle
+    // session) count as 0.
+    if (finalSession.status === "failed" || finalSession.status === "stalled") {
+      exitCode = 1;
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`fatal: ${msg}\n`);

--- a/src/cli/run-agent.ts
+++ b/src/cli/run-agent.ts
@@ -21,7 +21,10 @@ import {
   type ApprovalRequest,
 } from "../approval/approval-gate.js";
 import { stderrSink } from "../tracing/structured-logger.js";
-import type { SessionState } from "../session/session-state.js";
+import {
+  isFailedSessionStatus,
+  type SessionState,
+} from "../session/session-state.js";
 
 interface RunArgs {
   workingDir: string;
@@ -462,7 +465,7 @@ export async function runAgentCommand(args: string[]): Promise<number> {
     // that is not success, and a CI job watching this exit code must not
     // read it as one. Only `completed` (and a clean EOF on an idle
     // session) count as 0.
-    if (finalSession.status === "failed" || finalSession.status === "stalled") {
+    if (isFailedSessionStatus(finalSession.status)) {
       exitCode = 1;
     }
   } catch (err) {

--- a/src/cli/skill.test.ts
+++ b/src/cli/skill.test.ts
@@ -14,6 +14,21 @@ import {
   writeUserConfigFileSync,
 } from "../config/index.js";
 
+// Only `browseHub`/`searchHub` are stubbed; everything else in the hub
+// module (identifier parsing, installer, scan summary) stays real so the
+// install and tap tests below are unaffected.
+vi.mock("../skills/hub/index.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../skills/hub/index.js")>()),
+  browseHub: vi.fn(async () => ({
+    entries: [],
+    errors: [{ repo: "owner/repo", error: "boom" }],
+  })),
+  searchHub: vi.fn(async () => ({
+    entries: [],
+    errors: [{ repo: "owner/repo", error: "boom" }],
+  })),
+}));
+
 function writeSkill(globalDir: string, name: string): void {
   const dir = join(globalDir, name);
   mkdirSync(dir, { recursive: true });
@@ -182,10 +197,91 @@ describe("skillCommand", () => {
     expect(file?.skills.disabled).toEqual(["beta"]);
   });
 
-  it("uninstall on a skill not installed globally returns 2", async () => {
+  it("uninstall on a skill not installed globally returns 1", async () => {
     const code = await skillCommand(["uninstall", "ghost-skill"]);
-    expect(code).toBe(2);
+    expect(code).toBe(1);
     expect(stderr).toContain("not installed globally: ghost-skill");
+  });
+
+  it("show on a skill that is not installed returns 1", async () => {
+    writeSkill(globalSkillsDir, "alpha");
+    const code = await skillCommand(["show", "ghost-skill"]);
+    expect(code).toBe(1);
+    expect(stderr).toContain("skill not installed: ghost-skill");
+  });
+
+  it("install over an existing skill returns 1", async () => {
+    const sourceDir = mkdtempSync(join(tmpdir(), "atomic-cli-skill-src-"));
+    try {
+      writeSkill(sourceDir, "alpha");
+      expect(await skillCommand(["install", join(sourceDir, "alpha")])).toBe(0);
+      const code = await skillCommand(["install", join(sourceDir, "alpha")]);
+      expect(code).toBe(1);
+      expect(stderr).toContain("already installed");
+    } finally {
+      rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 2 for a missing required argument", async () => {
+    expect(await skillCommand(["show"])).toBe(2);
+    expect(await skillCommand(["uninstall"])).toBe(2);
+    expect(await skillCommand(["enable"])).toBe(2);
+    expect(await skillCommand(["disable"])).toBe(2);
+    expect(stderr).toContain("usage: atomic-agent skill show <name>");
+    expect(stderr).toContain("usage: atomic-agent skill uninstall <name>");
+  });
+
+  it("returns 2 for an unknown subcommand", async () => {
+    const code = await skillCommand(["frobnicate"]);
+    expect(code).toBe(2);
+    expect(stderr).toContain("unknown subcommand: frobnicate");
+  });
+
+  it("returns 2 for a tap repo argument of the wrong shape", async () => {
+    const code = await skillCommand(["tap", "add", "not-a-repo"]);
+    expect(code).toBe(2);
+    expect(stderr).toContain("not-a-repo");
+  });
+
+  it("returns 2 for the remaining argument-shape errors", async () => {
+    // The rest of the usage surface, which reaches its branch without any
+    // network: install with no source, browse with a valueless --source,
+    // search with an empty query, tap with a missing repo or a verb that
+    // does not exist.
+    expect(await skillCommand(["install"])).toBe(2);
+    expect(stderr).toContain("usage: atomic-agent skill install");
+
+    expect(await skillCommand(["browse", "--source"])).toBe(2);
+    expect(stderr).toContain("usage: atomic-agent skill browse");
+
+    expect(await skillCommand(["search"])).toBe(2);
+    expect(stderr).toContain("usage: atomic-agent skill search");
+
+    expect(await skillCommand(["tap", "add"])).toBe(2);
+    expect(await skillCommand(["tap", "remove"])).toBe(2);
+    expect(stderr).toContain("usage: atomic-agent skill tap add <owner/repo>");
+
+    expect(await skillCommand(["tap", "frobnicate"])).toBe(2);
+    expect(stderr).toContain("usage: atomic-agent skill tap list");
+  });
+
+  it("browse and search return 1 when every source failed and nothing was found", async () => {
+    // ClawHub off so the GitHub tap is the only source; it errors, so the
+    // command found nothing and every source it had failed.
+    writeUserConfigFileSync(getUserConfigPath(stateDir), {
+      ...USER_CONFIG_DEFAULTS,
+      skills: {
+        taps: ["owner/repo"],
+        clawhub: { ...USER_CONFIG_DEFAULTS.skills.clawhub, enabled: false },
+      },
+    });
+    resetConfigCache();
+
+    expect(await skillCommand(["browse"])).toBe(1);
+    expect(await skillCommand(["search", "anything"])).toBe(1);
+    expect(stderr).toContain("WARN: owner/repo: boom");
+    expect(stdout).toContain("(no skills found)");
   });
 
   it("enable/disable is idempotent across repeated invocations", async () => {

--- a/src/cli/skill.ts
+++ b/src/cli/skill.ts
@@ -79,7 +79,7 @@ export async function skillCommand(args: string[]): Promise<number> {
       default:
         process.stderr.write(`unknown subcommand: ${sub}\n`);
         process.stderr.write(HELP);
-        return 1;
+        return 2;
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -94,7 +94,7 @@ async function handleInstall(args: string[]): Promise<number> {
     process.stderr.write(
       "usage: atomic-agent skill install <path|owner/repo[/path]> [--force] [--acknowledge-risk]\n",
     );
-    return 1;
+    return 2;
   }
   const force = args.includes("--force");
   const acknowledgeRisk = args.includes("--acknowledge-risk");
@@ -132,7 +132,7 @@ async function handleInstall(args: string[]): Promise<number> {
   } catch (err) {
     if (err instanceof SkillInstallError && err.code === "already_installed") {
       process.stderr.write(`${err.message}\n`);
-      return 2;
+      return 1;
     }
     throw err;
   }
@@ -158,11 +158,11 @@ async function handleHubInstall(
   } catch (err) {
     if (err instanceof SkillInstallError && err.code === "already_installed") {
       process.stderr.write(`${err.message}\n`);
-      return 2;
+      return 1;
     }
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`${message}\n`);
-    return 2;
+    return 1;
   }
 }
 
@@ -189,11 +189,11 @@ async function handleClawHubInstall(
   } catch (err) {
     if (err instanceof SkillInstallError && err.code === "already_installed") {
       process.stderr.write(`${err.message}\n`);
-      return 2;
+      return 1;
     }
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`${message}\n`);
-    return 2;
+    return 1;
   }
 }
 
@@ -201,13 +201,13 @@ async function handleUninstall(args: string[]): Promise<number> {
   const name = args[0];
   if (!name) {
     process.stderr.write("usage: atomic-agent skill uninstall <name>\n");
-    return 1;
+    return 2;
   }
   const config = getConfig();
   const result = await uninstallSkill(config.paths.globalSkillsDir, name);
   if (!result.removed) {
     process.stderr.write(`skill not installed globally: ${name}\n`);
-    return 2;
+    return 1;
   }
   // Drop any stale disable entry so config.json does not accumulate
   // dangling names for skills that no longer exist on disk.
@@ -260,7 +260,7 @@ async function handleShow(args: string[]): Promise<number> {
   const name = args[0];
   if (!name) {
     process.stderr.write("usage: atomic-agent skill show <name>\n");
-    return 1;
+    return 2;
   }
   const config = getConfig();
   const projectDir = resolve(process.cwd(), config.paths.projectSkillsDirName);
@@ -270,8 +270,6 @@ async function handleShow(args: string[]): Promise<number> {
   });
   const record = skills.find((s) => s.manifest.name === name);
   if (!record) {
-    // "That skill does not exist" is a lookup failure, not a usage error:
-    // exit 1, so 2 keeps meaning "you invoked this wrong" across the CLI.
     process.stderr.write(`skill not installed: ${name}\n`);
     return 1;
   }
@@ -287,7 +285,7 @@ async function handleEnable(args: string[]): Promise<number> {
   const name = args[0];
   if (!name) {
     process.stderr.write("usage: atomic-agent skill enable <name>\n");
-    return 1;
+    return 2;
   }
   const result = mutateDisabledList((current) => {
     if (!current.includes(name)) return null;
@@ -305,7 +303,7 @@ async function handleDisable(args: string[]): Promise<number> {
   const name = args[0];
   if (!name) {
     process.stderr.write("usage: atomic-agent skill disable <name>\n");
-    return 1;
+    return 2;
   }
   const result = mutateDisabledList((current) => {
     if (current.includes(name)) return null;
@@ -345,7 +343,7 @@ async function handleBrowse(args: string[]): Promise<number> {
     sourceIdx !== -1 ? args[sourceIdx + 1]?.trim() : undefined;
   if (sourceIdx !== -1 && !source) {
     process.stderr.write("usage: atomic-agent skill browse [--source owner/repo]\n");
-    return 1;
+    return 2;
   }
   // ClawHub is the primary catalog; `--source owner/repo` narrows to a
   // single GitHub tap and skips ClawHub (the operator asked for a repo).
@@ -359,7 +357,7 @@ async function handleSearch(args: string[]): Promise<number> {
   const query = args.filter((a) => !a.startsWith("--")).join(" ").trim();
   if (query.length === 0) {
     process.stderr.write("usage: atomic-agent skill search <query>\n");
-    return 1;
+    return 2;
   }
   const clawEntries = await browseClawHubSafe(query);
   const client = new GithubSkillClient();
@@ -423,7 +421,10 @@ function printHubEntries(
   for (const e of errors) {
     process.stderr.write(`WARN: ${e.repo}: ${e.error}\n`);
   }
-  return 0;
+  // Partial results still succeed — one dead tap should not fail a browse
+  // that found skills elsewhere. Nothing found and every source failing is
+  // an operational failure, not an empty catalog.
+  return entries.length === 0 && errors.length > 0 ? 1 : 0;
 }
 
 async function handleTap(args: string[]): Promise<number> {
@@ -441,14 +442,14 @@ async function handleTap(args: string[]): Promise<number> {
     const repo = args[1]?.trim();
     if (!repo) {
       process.stderr.write(`usage: atomic-agent skill tap ${verb} <owner/repo>\n`);
-      return 1;
+      return 2;
     }
     try {
       parseTapRepo(repo);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`${message}\n`);
-      return 1;
+      return 2;
     }
     const result = mutateTapsList((current) => {
       if (verb === "add") {
@@ -470,7 +471,7 @@ async function handleTap(args: string[]): Promise<number> {
   process.stderr.write(
     "usage: atomic-agent skill tap list | add <owner/repo> | remove <owner/repo>\n",
   );
-  return 1;
+  return 2;
 }
 
 /**

--- a/src/cli/skill.ts
+++ b/src/cli/skill.ts
@@ -270,8 +270,10 @@ async function handleShow(args: string[]): Promise<number> {
   });
   const record = skills.find((s) => s.manifest.name === name);
   if (!record) {
+    // "That skill does not exist" is a lookup failure, not a usage error:
+    // exit 1, so 2 keeps meaning "you invoked this wrong" across the CLI.
     process.stderr.write(`skill not installed: ${name}\n`);
-    return 2;
+    return 1;
   }
   process.stdout.write(`# path: ${record.manifestPath}\n`);
   process.stdout.write(`# source: ${record.source}\n\n`);

--- a/src/session/session-exit-status.test.ts
+++ b/src/session/session-exit-status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isFailedSessionStatus,
+  type SessionStatus,
+} from "./session-state.js";
+
+describe("isFailedSessionStatus", () => {
+  it("treats failed and stalled as non-zero exits", () => {
+    expect(isFailedSessionStatus("failed")).toBe(true);
+    expect(isFailedSessionStatus("stalled")).toBe(true);
+  });
+
+  it("leaves every other status a success", () => {
+    const rest: SessionStatus[] = [
+      "pending",
+      "running",
+      "awaiting_approval",
+      "awaiting_llm",
+      "completed",
+      "cancelled",
+    ];
+    for (const status of rest) {
+      expect(isFailedSessionStatus(status)).toBe(false);
+    }
+  });
+
+  it("covers every member of SessionStatus", () => {
+    // Guards the list above: a new status added to the union without a
+    // decision here would otherwise silently default to "success".
+    const all: Record<SessionStatus, boolean> = {
+      pending: false,
+      running: false,
+      awaiting_approval: false,
+      awaiting_llm: false,
+      completed: false,
+      failed: true,
+      cancelled: false,
+      stalled: true,
+    };
+    for (const [status, expected] of Object.entries(all)) {
+      expect(isFailedSessionStatus(status as SessionStatus)).toBe(expected);
+    }
+  });
+});

--- a/src/session/session-state.ts
+++ b/src/session/session-state.ts
@@ -25,6 +25,20 @@ export type SessionStatus =
    */
   | "stalled";
 
+/**
+ * Whether a session in this state should make the process exit non-zero.
+ * Both entry points that own an exit code — `atomic-agent run` and the
+ * TUI's chat orchestrator — read it from here so they cannot drift: they
+ * previously each carried their own copy of the rule, and only one was
+ * updated when `stalled` stopped counting as success.
+ *
+ * `cancelled` stays truthful to its own contract (the operator asked to
+ * stop) and is deliberately not a failure.
+ */
+export function isFailedSessionStatus(status: SessionStatus): boolean {
+  return status === "failed" || status === "stalled";
+}
+
 export interface KnownFact {
   text: string;
   source?: string;

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -4,7 +4,10 @@ import { join } from "node:path";
 import type { ProfileFact } from "../memory/profile-store.js";
 import type { SkillCatalogEntry } from "../prompt/stable-prefix.js";
 import type { AgentRuntime } from "../runtime/bootstrap.js";
-import type { SessionState } from "../session/session-state.js";
+import {
+  isFailedSessionStatus,
+  type SessionState,
+} from "../session/session-state.js";
 import { checkForAppUpdate, runAppUpdate, canSelfUpdate } from "../update/index.js";
 import { clearTtyScreen } from "./clear-tty-screen.js";
 import { captureAndWriteDebugBundle } from "./debug-bundle/index.js";
@@ -384,7 +387,7 @@ export class ChatOrchestrator {
         origin: "tui",
       });
       this.session = result.session;
-      if (this.session.status === "failed") this.exitCode = 1;
+      if (isFailedSessionStatus(this.session.status)) this.exitCode = 1;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.bus.emit({ type: "runtime_info", line: `turn error: ${msg}` });


### PR DESCRIPTION
## What

Exit codes that scripts and CI can trust. The CLI now separates *usage errors* from
*operational failures*:

| exit | meaning |
|---|---|
| 0 | success |
| 1 | operational failure — invoked correctly, the work did not succeed (lookup misses included) |
| 2 | usage error — unknown flag/subcommand, missing required argument, argument of the wrong kind. Nothing was attempted |

`run`, `skill` and the top-level dispatcher implement this. The split is documented on
`CommandDescriptor.run` in `src/cli/index.ts`, including the commands that do **not**
follow it, so a caller is not misled: `config`, `serve`, `trace`, `task`, `models` and
`import` predate the split and return `1` for usage errors too; `trace replay` returns `2`
for "stable-prefix drift detected" (a diff-style result code); `tui` passes a relaunched
child's status straight through, so any code is possible; `repl` is a scaffold and always
returns `0`. Widening the split to those is a separate change.

## ⚠️ Breaking

Reference point is pre-PR. Every previously-failing case was already non-zero, so scripts
testing `if ! atomic-agent …` are unaffected by the `skill` rows; scripts comparing against
a literal `1`/`2` need updating. The two `run` rows turn previously-silent successes into
failures — that is the point of the PR.

| command / situation | before | after |
|---|---|---|
| `run` — turn exhausts `agent.maxSteps` (session `stalled`) | **0** | **1** |
| bare `atomic-agent` (TUI) — same stalled turn | **0** | **1** |
| `run --cwd <nonexistent>` | 0 (booted, ENOENT'd every tool) | **2** |
| `run --cwd <file>` / `--working-dir <file>` | 0 | **2** |
| `skill show <missing>` | 2 | 1 |
| `skill uninstall <missing>` | 2 | 1 |
| `skill install` already installed | 2 | 1 |
| `skill install <owner/repo>` hub failure | 2 | 1 |
| `skill install @owner/slug` ClawHub failure | 2 | 1 |
| `skill browse` / `search` when every source failed and nothing was found | 0 | 1 |
| `skill <unknown-subcommand>` | 1 | 2 |
| `skill install` with no source | 1 | 2 |
| `skill show\|uninstall\|enable\|disable` with no `<name>` | 1 | 2 |
| `skill browse --source` with no value | 1 | 2 |
| `skill search` with an empty query | 1 | 2 |
| `skill tap add\|remove` with no repo, or a malformed `owner/repo` | 1 | 2 |
| `skill tap <unknown-verb>` | 1 | 2 |

**Known in-repo consumers.** The eval harnesses gate on `atomic-agent run` exiting 0 —
`eval/harness/run-case.ts:104` (the actual pass/fail gate), `eval/cases.eval.ts:74`,
`eval/harness/append-jsonl-row.ts:109` (failure-reason telemetry), and the three
`eval-memory/experiments/*/runner.ts`. A scenario that exhausts the step budget now flags
as a subprocess failure where it previously scored as a normal run. Arguably correct — a
stalled turn is degraded — but it will move eval bookkeeping.

## Why `skill.ts` moved in both directions

The original version of this PR claimed "2 means you invoked this wrong across the CLI"
while `skill.ts` did the opposite: missing-argument usage errors returned `1` and
operational failures returned `2`. Fixing only `skill show` split it further —
`show <missing>` exiting 1 while `uninstall <missing>` exited 2 for the same class of error.
The file is now internally consistent, and the false blanket claim is replaced by the
documented contract above.

The `stalled` rule also lived in two places: `run-agent.ts` was updated and
`chat-orchestrator.ts` (the TUI, i.e. bare `atomic-agent`) was not, so the default command
still exited 0 on the exact condition this PR is named for. Both now read
`isFailedSessionStatus` from `src/session/session-state.ts`, so they cannot drift again.
`cancelled` deliberately stays a success — the operator asked to stop.

## Testing

- `npm run lint` (tsc) clean, verified against the branch as pushed to origin.
- `npx vitest run src/cli src/session` — 100 passed.
- Full repo suite — 3996 passed / 8 failed, against 3982 / 7 on the same branch before
  these commits. The extra failure is `llm-health-poller`, a pre-existing flake reproduced
  at baseline (~40%, passes 12/12 solo); no new failure.
- New `src/cli/run-agent.test.ts` (5 tests) drives the **real** agent loop, tool registry
  and status transitions to step-budget exhaustion with only the LLM stubbed — the stalled
  assertion checks `"status": "stalled"` in the run summary, not a mock.
- `src/session/session-exit-status.test.ts` pins the shared predicate across every member
  of `SessionStatus`, so a future status cannot silently default to "success".
- Every new test verified to fail without its fix (reverting the production hunk and
  re-running): stalled → `expected +0 to be 1`; `--cwd` guard → both path tests fail;
  `uninstall`/`show` → `expected 2 to be 1`; usage codes → `expected 1 to be 2`;
  `browse`/`search` → `expected 0 to be 1`.

## Not done here

- The six legacy commands still conflate `1`. Documented rather than changed, to keep the
  breaking surface deliberate.
- `skill enable <not-installed>` returns 0 (`disable` at least warns).
- A `cancelled` session exits 0 in both `run` and the TUI. Probably intended, but a
  SIGINT-killed CI run exiting 0 is arguably the same class of dishonesty.