### PR TITLE
fix(cli): config --help example generated from the live schema, rot-proofed by test

### DIFF
--- a/src/cli/config-command.test.ts
+++ b/src/cli/config-command.test.ts
@@ -155,4 +155,20 @@ describe("configCommand", () => {
     expect(code).toBe(1);
     expect(stderr).toContain("unknown subcommand: wat");
   });
+
+  it("the set example in --help runs through the real set path", async () => {
+    // Rot-proofing: extract the example payload straight out of the rendered
+    // help text and feed it to `config set` for real. If the schema moves and
+    // the example is left behind (as happened with `"version":1` + `llama`),
+    // this test fails instead of a user's paste.
+    await configCommand(["--help"]);
+    const match = stdout.match(/config set '(\{.*\})'/);
+    expect(match).not.toBeNull();
+    stdout = "";
+    const code = await configCommand(["set", match![1]]);
+    expect(code).toBe(0);
+    const onDisk = JSON.parse(readFileSync(join(stateDir, "config.json"), "utf8"));
+    expect(onDisk.version).toBe(USER_CONFIG_VERSION);
+    expect(onDisk.localModels.url).toBe("http://127.0.0.1:19091");
+  });
 });

--- a/src/cli/config-command.ts
+++ b/src/cli/config-command.ts
@@ -4,8 +4,23 @@ import {
   getConfig,
   parseUserConfigFile,
   resetConfigCache,
+  USER_CONFIG_VERSION,
   writeUserConfigFileSync,
 } from "../config/index.js";
+
+/**
+ * Copy-pasteable `config set` payload, assembled from the live schema
+ * constants so the help text cannot drift from what `parseUserConfigFile`
+ * accepts (the previous hand-written example carried `"version":1` and a
+ * `llama` key, both long dead). `config-command.test.ts` extracts this
+ * exact line from the rendered help and runs it through the real `set`
+ * path.
+ */
+const CONFIG_SET_EXAMPLE = JSON.stringify({
+  version: USER_CONFIG_VERSION,
+  localModels: { url: "http://127.0.0.1:19091" },
+  log: { level: "info" },
+});
 
 const HELP =
   [
@@ -18,12 +33,12 @@ const HELP =
     "  get                       Print the whole config file as JSON",
     "  set '<json>'              Replace the whole config file with a JSON payload",
     "",
+    "Keys left out of the payload are filled with their defaults; the result is",
+    "validated before anything is written.",
+    "",
     "Example:",
     "  atomic-agent config get",
-    "  atomic-agent config set '{\"version\":1,\"llama\":{\"url\":\"http://127.0.0.1:19091\"},",
-    "                            \"log\":{\"level\":\"info\"},",
-    "                            \"agent\":{\"tokenBudget\":3000,\"maxSteps\":25,",
-    "                                     \"toolTimeoutMs\":60000,\"approvalLevel\":1}}'",
+    `  atomic-agent config set '${CONFIG_SET_EXAMPLE}'`,
   ].join("\n") + "\n";
 
 export async function configCommand(args: string[]): Promise<number> {


### PR DESCRIPTION
## What

The `config --help` example was hand-written long ago and no longer runs:
it says `"version":1` (supported versions start at 5, so `config set` rejects it
outright) and configures a `llama` key that was renamed to `localModels` back in
config v5. Anyone pasting the official example got a validation error.

The example is now assembled at module load from the live schema constants —
`USER_CONFIG_VERSION` and a `localModels.url` override — so it can never say a
version the parser refuses. The help also states the actual `set` semantics: keys
left out of the payload are filled with defaults, and the result is validated
before anything is written.

## Rot-proofing

The new test does not check the example against a copy of itself — it extracts the
payload straight out of the rendered help text with a regex and feeds it through
the real `config set` path against a temp state dir, then asserts the written
file carries the values the example promises. If the schema moves and the help is
left behind again, this test fails instead of a user's paste.

Verified the test fails against the previous help text (no extractable valid
payload) and passes with the generated one.

## Testing

- `npm run lint` (tsc) clean
- `npx vitest run src/cli/config-command.test.ts` — 9/9 (8 existing + the new rot-proofing test)