### PR TITLE
fix(cli): hide the repl scaffold from --help, answer repl --help instead of hijacking the terminal

### DIFF
--- a/src/cli/debug-repl.test.ts
+++ b/src/cli/debug-repl.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { debugReplCommand, REPL_HELP } from "./debug-repl.js";
+
+describe("debugReplCommand --help", () => {
+  it("prints usage and resolves without opening the interactive prompt", async () => {
+    // Under vitest stdin is a pipe that never closes, so if --help fell
+    // through to the readline loop (as it did before) this await would
+    // hang until the test timeout instead of resolving.
+    let stdout = "";
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdout += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    });
+    try {
+      const code = await debugReplCommand(["--help"]);
+      expect(code).toBe(0);
+      expect(stdout).toBe(REPL_HELP);
+      expect(stdout).toContain("not yet implemented");
+      expect(stdout).not.toContain("atomic-agent> ");
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("-h behaves the same as --help", async () => {
+    let stdout = "";
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdout += typeof chunk === "string" ? chunk : String(chunk);
+      return true;
+    });
+    try {
+      const code = await debugReplCommand(["-h"]);
+      expect(code).toBe(0);
+      expect(stdout).toBe(REPL_HELP);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/src/cli/debug-repl.ts
+++ b/src/cli/debug-repl.ts
@@ -1,11 +1,27 @@
 import { createInterface } from "node:readline";
 
+export const REPL_HELP =
+  [
+    "atomic-agent repl — interactive debug scaffold (not yet implemented)",
+    "",
+    "Currently a stub: only 'help' and 'quit' work inside. The real",
+    "step-the-agent-manually REPL lands with a later milestone, and the",
+    "command is hidden from `atomic-agent --help` until then.",
+  ].join("\n") + "\n";
+
 /**
  * Interactive REPL to step the agent manually. The real implementation is
  * wired up once the agent loop (M4) and retrieval (M6) land. For M1 we
  * provide a minimal line-reader so the binary has a stable command surface.
  */
-export async function debugReplCommand(_args: string[]): Promise<number> {
+export async function debugReplCommand(args: string[]): Promise<number> {
+  // Answer --help before touching readline: opening the interface grabs
+  // stdin, so a help request used to drop the user into the (empty)
+  // interactive prompt instead of printing anything.
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(REPL_HELP);
+    return 0;
+  }
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   rl.setPrompt("atomic-agent> ");
   process.stdout.write(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,11 @@ interface CommandDescriptor {
   name: string;
   summary: string;
   run: (args: string[]) => Promise<number>;
+  /**
+   * Omit the command from `--help` while keeping it dispatchable when
+   * typed. Used for scaffolds that are not ready to be advertised.
+   */
+  hidden?: boolean;
 }
 
 const COMMANDS: CommandDescriptor[] = [
@@ -38,6 +43,9 @@ const COMMANDS: CommandDescriptor[] = [
     name: "repl",
     summary: "Interactive debug REPL: step the agent manually",
     run: debugReplCommand,
+    // Still a stub (help/quit only) — dispatchable if typed, but not
+    // advertised until the real implementation lands.
+    hidden: true,
   },
   {
     name: "tui",
@@ -80,7 +88,9 @@ function printHelp(): void {
     "  atomic-agent <command> [options]",
     "",
     "Commands:",
-    ...COMMANDS.map((c) => `  ${c.name.padEnd(8)} ${c.summary}`),
+    ...COMMANDS.filter((c) => !c.hidden).map(
+      (c) => `  ${c.name.padEnd(8)} ${c.summary}`,
+    ),
     "",
     "User config (edit via `atomic-agent config`):",
     "  <stateDir>/config.json         localModels.url, localModels.mode, log.level, agent.{tokenBudget,maxSteps,toolTimeoutMs,approvalLevel}",


### PR DESCRIPTION
## What

`atomic-agent --help` advertised `repl  Interactive debug REPL: step the agent
manually` — but the command is an M1 scaffold whose only working inputs are `help`
and `quit`. Worse, `repl --help` did not answer the help request: it opened the
readline prompt, swallowed the terminal, and answered `unknown command: --help`.

Two small changes:

1. **Hidden from the top-level help.** `CommandDescriptor` gains a `hidden` flag;
   `printHelp` filters on it. The command still dispatches when typed — nothing
   breaks for anyone who uses it — it is just no longer advertised as a feature.
2. **`repl --help` / `-h` answers before readline starts.** Prints a short usage
   note that states the scaffold status and exits 0, instead of dropping into the
   interactive prompt.

## Testing

- 2 new unit tests. The discriminator is built in: under vitest, stdin is a pipe
  that never closes, so on the unpatched code both tests hang in the readline loop
  until the 15 s timeout (verified: 2/2 fail on main, 2/2 pass with the patch).
- e2e against the built CLI: `--help` no longer lists `repl` (the only remaining
  match is the word "replace" in the config summary); `repl --help` prints the
  note and exits 0 immediately.
- `npm run lint` (tsc) clean.