### PR TITLE
feat(tui): Esc returns to Run from an idle panel; hint strip stops repeating itself

### DIFF
--- a/src/tui/app-key-bindings.test.ts
+++ b/src/tui/app-key-bindings.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Key } from "ink";
 
-import { handleAppKey } from "./app-key-bindings.js";
+import { handleAppKey, handlePanelEscape } from "./app-key-bindings.js";
 import { createInitialTuiState, type TuiSessionInfo } from "./tui-state.js";
 import type { ApprovalRequest } from "../approval/approval-gate.js";
 
@@ -543,5 +543,56 @@ describe("handleAppKey", () => {
       sidebarVisible: true,
     });
     expect(onSidebarTaskActivated).toHaveBeenCalledWith("task-id-42");
+  });
+});
+
+describe("handlePanelEscape", () => {
+  it("sends an unclaimed Esc home to Run", () => {
+    const dispatch = vi.fn();
+    const consumed = handlePanelEscape(emptyKey({ escape: true }), {
+      panelHandled: false,
+      editorFocus: false,
+      dispatch,
+    });
+    expect(consumed).toBe(true);
+    expect(dispatch).toHaveBeenCalledWith({ type: "ui_mode_set", mode: "chat" });
+  });
+
+  it("leaves the panel alone when its own layer already claimed Esc", () => {
+    // A modal, an open search input or a detail view returns `true` from
+    // the panel's key layer — the operator meant "close that", not
+    // "leave the panel", so the fallback must stay out of the way.
+    const dispatch = vi.fn();
+    const consumed = handlePanelEscape(emptyKey({ escape: true }), {
+      panelHandled: true,
+      editorFocus: false,
+      dispatch,
+    });
+    expect(consumed).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("defers to the chat editor when the editor holds focus", () => {
+    // On tabs that keep the editor focused, Esc already means
+    // abort / scroll-reset / quit inside the editor's own hook.
+    const dispatch = vi.fn();
+    const consumed = handlePanelEscape(emptyKey({ escape: true }), {
+      panelHandled: false,
+      editorFocus: true,
+      dispatch,
+    });
+    expect(consumed).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("ignores every key that is not Esc", () => {
+    const dispatch = vi.fn();
+    const consumed = handlePanelEscape(emptyKey({ tab: true }), {
+      panelHandled: false,
+      editorFocus: false,
+      dispatch,
+    });
+    expect(consumed).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -271,6 +271,34 @@ export function handleAppKey(
   return false;
 }
 
+/**
+ * Last-resort Esc handling for the debug (Observe / Manage) panels,
+ * called by `TuiApp` after the active panel's own key layer declined
+ * the key. Esc that nobody claimed goes home to Run — the single
+ * "back" gesture out of a panel, which previously did not exist (the
+ * only way back was cycling Tab through every remaining sub-tab).
+ *
+ * Precedence is preserved by the caller passing `panelHandled`: modals,
+ * search inputs, detail views and half-typed forms consume Esc in their
+ * own layer first and never reach here. `editorFocus` guards the tabs
+ * that leave the chat editor focused — there the editor's own input
+ * hook owns Esc (abort / scroll-reset / quit) and must not double-act.
+ *
+ * Returns `true` when the key was consumed.
+ */
+export function handlePanelEscape(
+  key: Key,
+  opts: {
+    panelHandled: boolean;
+    editorFocus: boolean;
+    dispatch: (action: TuiAction) => void;
+  },
+): boolean {
+  if (!key.escape || opts.panelHandled || opts.editorFocus) return false;
+  opts.dispatch({ type: "ui_mode_set", mode: "chat" });
+  return true;
+}
+
 function shouldTreatArrowAsChatScroll(
   input: string,
   key: Key,

--- a/src/tui/components/hotkey-hint.test.tsx
+++ b/src/tui/components/hotkey-hint.test.tsx
@@ -71,6 +71,19 @@ describe("HotkeyHint scroll chip", () => {
   });
 });
 
+describe("HotkeyHint debug footer", () => {
+  it("advertises the way back to Run and drops the duplicate ctrl+b chip", () => {
+    const out = renderHint(chatState({ uiMode: "debug" }));
+    expect(out).toContain("[esc]");
+    expect(out).toContain("back to Run");
+    expect(out).toContain("next panel");
+    expect(out).toContain("prev panel");
+    // Ctrl+B still cycles panels, but its chip repeated the tab chip
+    // word-for-word; the freed slot now pays for the esc hint.
+    expect(out).not.toContain("ctrl+b");
+  });
+});
+
 describe("HotkeyHint scroll key spelling per platform", () => {
   const realPlatform = process.platform;
 

--- a/src/tui/components/hotkey-hint.tsx
+++ b/src/tui/components/hotkey-hint.tsx
@@ -78,10 +78,13 @@ function resolveChips(state: TuiState, ctrlCArmed: boolean): HotkeyChip[] {
     ];
   }
   if (state.uiMode === "debug") {
+    // Ctrl+B still cycles panels but is unadvertised: it duplicated the
+    // Tab chip word-for-word, and the freed slot pays for the one hint
+    // panels actually lacked — the way back to Run.
     return [
       { key: "tab", label: "next panel" },
       { key: "shift+tab", label: "prev panel" },
-      { key: "ctrl+b", label: "next panel" },
+      { key: "esc", label: "back to Run" },
       { key: "/", label: "commands" },
       {
         key: "ctrl+c",

--- a/src/tui/tui-app.test.tsx
+++ b/src/tui/tui-app.test.tsx
@@ -325,4 +325,23 @@ describe("TuiApp (smoke)", () => {
     expect(text).not.toContain("/dump");
     unmount();
   });
+
+  it("Esc from an idle Manage panel returns to the Run screen", async () => {
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={noopCallbacks()} />,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    bus.emit({ type: "ui_mode_set", mode: "debug" });
+    bus.emit({ type: "tab_changed", tab: "tasks" });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(strip(lastFrame() ?? "")).toContain("▸ Manage");
+
+    stdin.write("\u001b");
+    await new Promise((r) => setTimeout(r, 60));
+    const text = strip(lastFrame() ?? "");
+    expect(text).toContain("▸ Run");
+    expect(text).not.toContain("▸ Manage");
+    unmount();
+  });
 });

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -10,7 +10,7 @@ import {
 import { reduceTuiState } from "./agent-event-reducer.js";
 import type { ApprovalGrantScope } from "../approval/approval-gate.js";
 import type { TuiAction } from "./tui-action.js";
-import { handleAppKey } from "./app-key-bindings.js";
+import { handleAppKey, handlePanelEscape } from "./app-key-bindings.js";
 import { ApprovalModal } from "./approval-modal.js";
 import { ChatLog } from "./components/chat-log.js";
 import { DebugPane } from "./components/debug-pane.js";
@@ -537,44 +537,34 @@ export function TuiApp({
     // navigation, tab completion, enter to run, esc to close. Routing to
     // a debug-tab panel here would re-interpret letters as hotkeys.
     if (state.slashPaletteOpen) return;
+    let panelHandled: boolean | null = null;
     if (tasksTabActive) {
-      handleTasksTabKey(input, key, { state, dispatch, callbacks });
-      return;
+      panelHandled = handleTasksTabKey(input, key, { state, dispatch, callbacks });
+    } else if (skillsTabActive) {
+      panelHandled = handleSkillsTabKey(input, key, { state, dispatch, callbacks });
+    } else if (memoryTabActive) {
+      panelHandled = handleMemoryTabKey(input, key, { state, dispatch, callbacks });
+    } else if (mcpTabActive) {
+      panelHandled = handleMcpTabKey(input, key, { state, dispatch, callbacks });
+    } else if (providersTabActive) {
+      panelHandled = handleProvidersTabKey(input, key, { state, dispatch, callbacks });
+    } else if (llmTabActive) {
+      panelHandled = handleLlmPanelKey(input, key, { state, dispatch, callbacks });
+    } else if (localModelsTabActive) {
+      panelHandled = handleLocalModelsTabKey(input, key, {
+        state,
+        dispatch,
+        callbacks,
+      });
+    } else if (telegramTabActive) {
+      panelHandled = handleTelegramTabKey(input, key, { state, dispatch, callbacks });
+    } else if (importTabActive) {
+      panelHandled = handleImportTabKey(input, key, { state, dispatch, callbacks });
+    } else if (privacyTabActive) {
+      panelHandled = handlePrivacyTabKey(input, key, { state, dispatch, callbacks });
     }
-    if (skillsTabActive) {
-      handleSkillsTabKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (memoryTabActive) {
-      handleMemoryTabKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (mcpTabActive) {
-      handleMcpTabKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (providersTabActive) {
-      handleProvidersTabKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (llmTabActive) {
-      handleLlmPanelKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (localModelsTabActive) {
-      handleLocalModelsTabKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (telegramTabActive) {
-      handleTelegramTabKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (importTabActive) {
-      handleImportTabKey(input, key, { state, dispatch, callbacks });
-      return;
-    }
-    if (privacyTabActive) {
-      handlePrivacyTabKey(input, key, { state, dispatch, callbacks });
+    if (panelHandled !== null) {
+      handlePanelEscape(key, { panelHandled, editorFocus, dispatch });
       return;
     }
   });


### PR DESCRIPTION
## What

Once you were inside an Observe/Manage panel there was no way back to the chat
screen except cycling Tab through every remaining sub-tab — Esc did nothing. The
hint strip did not help either: it spent one of its five slots on
`[ctrl+b] next panel`, which repeated `[tab] next panel` word-for-word.

1. **Esc goes home.** After the active panel's own key layer declines the key,
   `handlePanelEscape` dispatches `ui_mode_set: chat`.
2. **The freed hint slot pays for it.** The debug footer now reads
   `[tab] next panel · [shift+tab] prev panel · [esc] back to Run · [/] commands ·
   [ctrl+c] quit`. Ctrl+B still cycles panels, it is just no longer advertised.

## Precedence

The panel layers keep Esc when they mean something by it. `TuiApp` now threads each
panel handler's return value into `handlePanelEscape`, which fires **only** when the
panel returned `false` (nothing consumed the key) — so a cancel-confirm modal, an open
tasks search, a skills hub, a detail view or a half-typed create form still closes
itself first and stays on the panel. The `editorFocus` guard covers tabs that leave
the chat editor focused, where Esc already means abort / scroll-reset / quit in the
editor's own hook and must not double-act.

The decision lives in one exported pure function rather than inline in the `useInput`
callback so all four branches are directly unit-testable.

## Testing

- 4 unit tests on `handlePanelEscape` (unclaimed Esc → `ui_mode_set: chat`; panel-claimed
  Esc → no dispatch; editor-focused → no dispatch; non-Esc keys ignored).
- 1 Ink test: Esc on an idle Manage/Tasks panel moves the nav marker from `▸ Manage` to `▸ Run`.
- 1 hint-strip test: the debug footer contains `[esc] back to Run` and no longer contains `ctrl+b`.
- All 6 verified to fail against unpatched code.
- `npm run lint` (tsc) clean.
- Full `npx vitest run src/tui --no-file-parallelism`: **923 passed, 5 failed — the same 5
  that fail on `main` today** (tui-app ×2, chat-log, splash-banner, persist-embedding-hybrid-recall).
  Baseline on main for comparison: 917 passed, same 5 failed.