### PR TITLE
feat(tui): start page adapts to terminal size

### DIFF
--- a/src/tui/components/chat-log.test.tsx
+++ b/src/tui/components/chat-log.test.tsx
@@ -25,10 +25,11 @@ describe("ChatLog", () => {
     const state = createInitialTuiState(BASE_SESSION);
     const { lastFrame } = render(<ChatLog state={state} />);
     const text = strip(lastFrame() ?? "");
-    // The mark shrinks with the surface, so assert on the plus bar the
-    // artwork always keeps rather than on a wordmark that only a tall
-    // terminal earns. See `splash-fit.render.test.tsx`.
-    expect(text).toContain(":::");
+    // The mark shrinks with the surface — shaded art at full size, half
+    // block art below it — so assert that *some* mark is drawn rather
+    // than on a wordmark only a tall terminal earns. See
+    // `splash-fit.render.test.tsx`.
+    expect(text).toMatch(/:::|[█▀▄]/u);
     expect(text).toContain("/help");
   });
 

--- a/src/tui/components/chat-log.test.tsx
+++ b/src/tui/components/chat-log.test.tsx
@@ -25,7 +25,10 @@ describe("ChatLog", () => {
     const state = createInitialTuiState(BASE_SESSION);
     const { lastFrame } = render(<ChatLog state={state} />);
     const text = strip(lastFrame() ?? "");
-    expect(text).toContain("Local-First AI Agent");
+    // The mark shrinks with the surface, so assert on the plus bar the
+    // artwork always keeps rather than on a wordmark that only a tall
+    // terminal earns. See `splash-fit.render.test.tsx`.
+    expect(text).toContain(":::");
     expect(text).toContain("/help");
   });
 

--- a/src/tui/components/chat-log.tsx
+++ b/src/tui/components/chat-log.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, measureElement, type DOMElement } from "ink";
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import { useTerminalSize } from "../hooks/use-terminal-size.js";
+import { computeChatViewportRows } from "../layout.js";
 import type { TuiAction } from "../tui-action.js";
 import type { ChatMessage, TuiState } from "../tui-state.js";
 import { theme } from "../theme/theme.js";
@@ -15,15 +16,6 @@ import { SystemBubble } from "./system-bubble.js";
 import { ThinkingIndicator } from "./thinking-indicator.js";
 import { ToolCard } from "./tool-card.js";
 import { UserBubble } from "./user-bubble.js";
-
-/**
- * Rows of "chrome" outside the chat surface: status bar + prompt
- * meta-row + prompt input + prompt tail-cap + hotkey hint + a small
- * safety pad. Used to convert `terminal.rows` into the chat-area
- * viewport height. Slightly conservative — better to leave one empty
- * row than to clip the prompt.
- */
-const CHROME_ROWS = 8;
 
 interface ChatLogProps {
   state: TuiState;
@@ -89,7 +81,10 @@ export function ChatLog({ state, dispatch }: ChatLogProps): ReactElement {
   // All hooks must run unconditionally — only the JSX branches on
   // `isEmpty`. Compute viewport / measured-K / clamp regardless,
   // even when the early return for the splash branch fires below.
-  const viewport = Math.max(5, terminalSize.rows - CHROME_ROWS);
+  const viewport = computeChatViewportRows(
+    terminalSize.rows,
+    terminalSize.columns,
+  );
   // First-frame fallback for `K` until the post-mount `measureElement`
   // call returns the truth. Estimates are unreliable (text wraps, Yoga
   // collapses some margins, reasoning blocks expand mid-turn) so we

--- a/src/tui/components/logo-fit.test.ts
+++ b/src/tui/components/logo-fit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { LOGO_ART, TAGLINE, WORDMARK_ROWS } from "./logo.js";
+import { LOGO_METRICS, WORDMARK_WIDTH, type LogoVariant } from "./splash-fit.js";
+
+function measure(rows: readonly string[]): { width: number; height: number } {
+  return {
+    width: rows.reduce((acc, row) => Math.max(acc, row.length), 0),
+    height: rows.length,
+  };
+}
+
+/**
+ * `splash-fit.ts` picks a mark from numbers it keeps in `LOGO_METRICS`;
+ * the artwork itself lives in `logo.tsx`. If the two ever drift the
+ * breakpoints silently start lying, so measure the real rows here.
+ */
+describe("logo artwork", () => {
+  const variants: readonly LogoVariant[] = ["full", "small", "mini"];
+
+  it.each(variants)("matches the declared metrics for %s", (variant) => {
+    expect(measure(LOGO_ART[variant])).toEqual(LOGO_METRICS[variant]);
+  });
+
+  it("orders the variants strictly smallest-last", () => {
+    expect(LOGO_METRICS.full.width).toBeGreaterThan(LOGO_METRICS.small.width);
+    expect(LOGO_METRICS.small.width).toBeGreaterThan(LOGO_METRICS.mini.width);
+    expect(LOGO_METRICS.full.height).toBeGreaterThan(LOGO_METRICS.small.height);
+    expect(LOGO_METRICS.small.height).toBeGreaterThan(LOGO_METRICS.mini.height);
+  });
+
+  it("matches the declared wordmark width and keeps the tagline narrower", () => {
+    expect(measure(WORDMARK_ROWS).width).toBe(WORDMARK_WIDTH);
+    expect(TAGLINE.length).toBeLessThanOrEqual(WORDMARK_WIDTH);
+  });
+});

--- a/src/tui/components/logo-raster.test.ts
+++ b/src/tui/components/logo-raster.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { LOGO_ART } from "./logo.js";
+import { rasteriseMark, toInkMask } from "./logo-raster.js";
+import { LOGO_METRICS } from "./splash-fit.js";
+
+const source = toInkMask(LOGO_ART.full);
+
+/** Ink coverage as a fraction of the box — a crude "does it look like the mark". */
+function density(rows: readonly string[]): number {
+  const total = rows.reduce((acc, row) => acc + row.length, 0);
+  if (total === 0) return 0;
+  const ink = rows.reduce(
+    (acc, row) => acc + [...row].filter((ch) => ch !== " ").length,
+    0,
+  );
+  return ink / total;
+}
+
+describe("rasteriseMark", () => {
+  it("returns exactly the box it was asked for", () => {
+    for (const [columns, rows] of [
+      [20, 12],
+      [13, 8],
+      [7, 4],
+    ] as const) {
+      const art = rasteriseMark(source, { columns, rows });
+      expect(art).toHaveLength(rows);
+      for (const line of art) expect(line).toHaveLength(columns);
+    }
+  });
+
+  it("keeps the mark's aspect ratio instead of stretching it", () => {
+    // The source is 34 cells wide and 20 tall = 34x40 half-block pixels.
+    // Asked for a box twice as wide as that shape needs, the drawing must
+    // stay its own shape and sit centred, not stretch to the edges.
+    const art = rasteriseMark(source, { columns: 60, rows: 12 });
+    const drawn = art.filter((row) => row.trim().length > 0);
+    const leading = Math.min(
+      ...drawn.map((row) => row.length - row.trimStart().length),
+    );
+    const trailing = Math.min(
+      ...drawn.map((row) => row.length - row.trimEnd().length),
+    );
+    // 12 cell rows = 24 pixels tall, so a 34x40 source scales to 0.6 and
+    // draws ~20 columns wide — nowhere near the 60 it was offered.
+    const inkWidth = 60 - leading - trailing;
+    expect(inkWidth).toBeLessThanOrEqual(22);
+    expect(leading).toBeGreaterThan(0);
+  });
+
+  it("still draws something recognisable at the smallest size", () => {
+    // Regression on the reason this module exists: the hand-drawn
+    // half-size mark had lost its arms and read as a solid blob.
+    // A blob is ~100% ink; empty is 0. The real mark sits in between.
+    const mini = rasteriseMark(source, {
+      columns: LOGO_METRICS.mini.width,
+      rows: LOGO_METRICS.mini.height,
+    });
+    expect(mini).toHaveLength(LOGO_METRICS.mini.height);
+    expect(density(mini)).toBeGreaterThan(0.25);
+    expect(density(mini)).toBeLessThan(0.85);
+  });
+
+  it("never scales the drawing up past its natural size", () => {
+    const art = rasteriseMark(source, { columns: 200, rows: 60 });
+    const widest = art.reduce(
+      (acc, row) => Math.max(acc, row.trimEnd().length),
+      0,
+    );
+    expect(widest).toBeLessThanOrEqual(200);
+    const drawn = art.filter((row) => row.trim().length > 0);
+    expect(drawn.length).toBeLessThanOrEqual(20);
+  });
+
+  it("degrades to nothing rather than throwing on a zero-sized box", () => {
+    expect(rasteriseMark(source, { columns: 0, rows: 0 })).toEqual([]);
+    expect(rasteriseMark([], { columns: 10, rows: 4 })).toEqual([]);
+  });
+});

--- a/src/tui/components/logo-raster.ts
+++ b/src/tui/components/logo-raster.ts
@@ -1,0 +1,174 @@
+/**
+ * Scales the brand mark to any size from one drawing.
+ *
+ * The mark used to ship as three hand-drawn copies — 34×20, 17×10 and a
+ * one-line text fallback. Hand copies drift: the half-size one had lost
+ * the taper of the lower-right tail and read as a blob, and every new
+ * breakpoint meant drawing the shape again by eye.
+ *
+ * So there is one drawing now, and every smaller size is measured off it.
+ * Two details make that work in a terminal:
+ *
+ * - **Half blocks.** `▀` `▄` `█` split a cell into an upper and a lower
+ *   pixel, so a cell grid of W×H carries a pixel grid of W×2H. Vertical
+ *   resolution doubles, which is what stops a downscaled mark turning
+ *   into a staircase.
+ * - **Cell aspect.** A terminal cell is about twice as tall as it is
+ *   wide, so one half-block pixel is roughly square. Scaling in that
+ *   pixel space — rather than in cells — is what keeps the mark from
+ *   being squashed, and it is why the source is measured as 34×40 rather
+ *   than 34×20.
+ *
+ * Sampling is an area average with a coverage threshold, not
+ * nearest-neighbour: at small sizes a thin arm covers only part of a
+ * destination pixel, and nearest-neighbour drops exactly those arms —
+ * which is what made the old half-size copy look broken.
+ */
+
+/** Upper pixel set. */
+const UPPER = "▀";
+/** Lower pixel set. */
+const LOWER = "▄";
+/** Both set. */
+const BOTH = "█";
+
+/**
+ * Fraction of a destination pixel that must be covered by ink for it to
+ * be drawn. Below 0.5 the mark fattens and the counter-space between the
+ * arms fills in; above it, thin arms drop out at the smallest sizes.
+ */
+const COVERAGE_THRESHOLD = 0.38;
+
+export interface RasterSize {
+  /** Width in terminal cells. */
+  columns: number;
+  /** Height in terminal cells. */
+  rows: number;
+}
+
+/**
+ * A boolean ink mask. `true` is drawn, `false` is background — the
+ * source art's shading characters (`:`, `-`, `@`, `#`, …) all count as
+ * ink, because at any reduced size shading is noise.
+ */
+export type InkMask = readonly (readonly boolean[])[];
+
+/** Turn character rows into an ink mask, padded to the widest row. */
+export function toInkMask(rows: readonly string[]): InkMask {
+  const width = rows.reduce((acc, row) => Math.max(acc, row.length), 0);
+  return rows.map((row) => {
+    const cells: boolean[] = [];
+    for (let x = 0; x < width; x += 1) {
+      const ch = row[x] ?? " ";
+      cells.push(ch !== " ");
+    }
+    return cells;
+  });
+}
+
+/**
+ * Expand a cell mask into a pixel mask by doubling every row — one cell
+ * row is two half-block pixels tall. This is what puts the source into
+ * the square-pixel space the scaling maths assumes.
+ */
+function toPixels(mask: InkMask): InkMask {
+  return mask.flatMap((row) => [row, row]);
+}
+
+/**
+ * Fraction of the source rectangle `[x0,x1) × [y0,y1)` that is ink.
+ * Partial cells at the edges count partially, which is the whole point:
+ * it is what keeps a one-pixel arm visible when it lands between two
+ * destination pixels.
+ */
+function coverage(
+  pixels: InkMask,
+  x0: number,
+  x1: number,
+  y0: number,
+  y1: number,
+): number {
+  let ink = 0;
+  let total = 0;
+  const yStart = Math.floor(y0);
+  const yEnd = Math.ceil(y1);
+  const xStart = Math.floor(x0);
+  const xEnd = Math.ceil(x1);
+  for (let y = yStart; y < yEnd; y += 1) {
+    const row = pixels[y];
+    if (!row) continue;
+    const yWeight = Math.min(y + 1, y1) - Math.max(y, y0);
+    if (yWeight <= 0) continue;
+    for (let x = xStart; x < xEnd; x += 1) {
+      const xWeight = Math.min(x + 1, x1) - Math.max(x, x0);
+      if (xWeight <= 0) continue;
+      const weight = yWeight * xWeight;
+      total += weight;
+      if (row[x]) ink += weight;
+    }
+  }
+  return total === 0 ? 0 : ink / total;
+}
+
+/**
+ * Draw `source` at `size`, preserving its aspect ratio and centring the
+ * result in the requested box. Returns exactly `size.rows` strings, each
+ * exactly `size.columns` wide.
+ *
+ * The mark is never scaled **up** past its natural size — the source is
+ * a drawing, not a vector, and enlarging it only exposes the pixel grid.
+ * Callers that have room for the full mark should draw the source art
+ * directly.
+ */
+export function rasteriseMark(
+  source: InkMask,
+  size: RasterSize,
+): readonly string[] {
+  const columns = Math.max(0, Math.floor(size.columns));
+  const rows = Math.max(0, Math.floor(size.rows));
+  if (columns === 0 || rows === 0) return [];
+
+  const pixels = toPixels(source);
+  const srcWidth = pixels[0]?.length ?? 0;
+  const srcHeight = pixels.length;
+  if (srcWidth === 0 || srcHeight === 0) return [];
+
+  // Destination pixel grid: full width, two pixels per cell row.
+  const boxWidth = columns;
+  const boxHeight = rows * 2;
+  const scale = Math.min(boxWidth / srcWidth, boxHeight / srcHeight, 1);
+  const drawWidth = Math.max(1, Math.round(srcWidth * scale));
+  const drawHeight = Math.max(2, Math.round(srcHeight * scale));
+  const padX = Math.floor((boxWidth - drawWidth) / 2);
+  const padY = Math.floor((boxHeight - drawHeight) / 2);
+
+  const lit: boolean[][] = [];
+  for (let y = 0; y < boxHeight; y += 1) {
+    const row: boolean[] = new Array(boxWidth).fill(false);
+    const srcY0 = ((y - padY) * srcHeight) / drawHeight;
+    const srcY1 = ((y - padY + 1) * srcHeight) / drawHeight;
+    if (y >= padY && y < padY + drawHeight) {
+      for (let x = 0; x < boxWidth; x += 1) {
+        if (x < padX || x >= padX + drawWidth) continue;
+        const srcX0 = ((x - padX) * srcWidth) / drawWidth;
+        const srcX1 = ((x - padX + 1) * srcWidth) / drawWidth;
+        row[x] = coverage(pixels, srcX0, srcX1, srcY0, srcY1) >= COVERAGE_THRESHOLD;
+      }
+    }
+    lit.push(row);
+  }
+
+  const out: string[] = [];
+  for (let r = 0; r < rows; r += 1) {
+    const top = lit[r * 2] ?? [];
+    const bottom = lit[r * 2 + 1] ?? [];
+    let line = "";
+    for (let x = 0; x < boxWidth; x += 1) {
+      const t = top[x] === true;
+      const b = bottom[x] === true;
+      line += t && b ? BOTH : t ? UPPER : b ? LOWER : " ";
+    }
+    out.push(line.trimEnd().padEnd(boxWidth));
+  }
+  return out;
+}

--- a/src/tui/components/logo.tsx
+++ b/src/tui/components/logo.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
 import { theme } from "../theme/theme.js";
+import { rasteriseMark, toInkMask } from "./logo-raster.js";
 import type { LogoVariant } from "./splash-fit.js";
 
 /**
@@ -12,9 +13,17 @@ import type { LogoVariant } from "./splash-fit.js";
  * Rendered as plain Ink primitives — no animations, no alpha. The mark
  * comes in three sizes so the same component can serve a 200-column
  * desktop terminal and a 40-column SSH window: `full` (34×20), `small`
- * (17×10) and `mini` (a single 14-column line). `SplashBanner` picks
- * one via `computeSplashFit`; callers that just want the classic
- * artwork can keep using the defaults.
+ * (20×12) and `mini` (9×5). `SplashBanner` picks one via
+ * `computeSplashFit`; callers that just want the classic artwork can
+ * keep using the defaults.
+ *
+ * Only `full` is drawn by hand. The smaller two are **measured off it**
+ * by `logo-raster.ts` — half-block glyphs at the terminal's ~2:1 cell
+ * aspect, so they are the same shape at a smaller scale rather than a
+ * second and third attempt at drawing it. The hand-drawn half-size copy
+ * they replace had lost the taper of the lower-right tail and read as a
+ * blob; a redrawn mark also drifts from the original every time either
+ * is touched, which is a maintenance cost with no upside.
  */
 export interface LogoProps {
   /** Which mark to draw. Defaults to the full 34×20 artwork. */
@@ -37,44 +46,42 @@ export interface LogoProps {
  * single line. `splash-fit.ts` mirrors these dimensions in
  * `LOGO_METRICS`; `logo-fit.test.ts` fails if the two ever disagree.
  */
-export const LOGO_ART: Readonly<Record<LogoVariant, readonly string[]>> = {
+const FULL_ART: readonly string[] = [
   // Leading padding has been uniformly trimmed so the middle bar sits
   // at column 0 — keeps the art within ~34 columns for narrow terminals.
-  full: [
-    "            -:::::::--",
-    "            -::::::::-",
-    "           -:::::::::-",
-    "          -::::::::::-",
-    "         -:::::::::::-",
-    "       -:::::::::::::-",
-    "    -::::::::::::::::-",
-    "-::::::::::::::::::::::::::::::::-",
-    "::::::::::::::::::::::::::::::::::",
-    "::::::::::::::::::::::::::::::::::",
-    "-:::::::::::::::::::::::::::::::::",
-    "=------------:::::::::::::::::---=",
-    " @@@@@@@@@@@*-::::::::::::-=+#%%@",
-    "            -:::::::::::-+#@",
-    "            -::::::::::=#@",
-    "            -:::::::::=#",
-    "            -::::::::-*",
-    "            -::::::::=",
-    "            +--------*",
-    "              %%%%%%",
-  ],
-  small: [
-    "      -:::--",
-    "      -::::-",
-    "     -:::::-",
-    "   -:::::::-",
-    "-:::::::::::::::-",
-    ":::::::::::::::::",
-    "=-----:::::::::-=",
-    " @@@@@*-::::-=#%",
-    "      -::::-*",
-    "      +----*",
-  ],
-  mini: ["+ ATOMIC AGENT"],
+  "            -:::::::--",
+  "            -::::::::-",
+  "           -:::::::::-",
+  "          -::::::::::-",
+  "         -:::::::::::-",
+  "       -:::::::::::::-",
+  "    -::::::::::::::::-",
+  "-::::::::::::::::::::::::::::::::-",
+  "::::::::::::::::::::::::::::::::::",
+  "::::::::::::::::::::::::::::::::::",
+  "-:::::::::::::::::::::::::::::::::",
+  "=------------:::::::::::::::::---=",
+  " @@@@@@@@@@@*-::::::::::::-=+#%%@",
+  "            -:::::::::::-+#@",
+  "            -::::::::::=#@",
+  "            -:::::::::=#",
+  "            -::::::::-*",
+  "            -::::::::=",
+  "            +--------*",
+  "              %%%%%%",
+];
+
+/**
+ * Mark artwork keyed by variant. `full` is the original drawing and the
+ * single source of truth; `small` and `mini` are scaled from it at load
+ * time, so all three are the same shape by construction. `splash-fit.ts`
+ * mirrors these dimensions in `LOGO_METRICS`; `logo-fit.test.ts` fails if
+ * the two ever disagree.
+ */
+export const LOGO_ART: Readonly<Record<LogoVariant, readonly string[]>> = {
+  full: FULL_ART,
+  small: rasteriseMark(toInkMask(FULL_ART), { columns: 20, rows: 12 }),
+  mini: rasteriseMark(toInkMask(FULL_ART), { columns: 7, rows: 4 }),
 };
 
 export const WORDMARK_ROWS: readonly string[] = [
@@ -92,13 +99,6 @@ export function Logo({
 }: LogoProps): ReactElement {
   const showWordmark = wordmark ?? !compact;
   const showTagline = tagline ?? showWordmark;
-  if (variant === "mini") {
-    return (
-      <Text color={theme.colors.system} bold wrap="truncate">
-        {LOGO_ART.mini[0]}
-      </Text>
-    );
-  }
   return (
     <Box flexDirection="row" alignItems="center">
       <LogoMark variant={variant} />
@@ -122,7 +122,7 @@ function LogoMark({ variant }: { variant: LogoVariant }): ReactElement {
   return (
     <Box flexDirection="column">
       {LOGO_ART[variant].map((row, idx) => (
-        <Text key={idx} color={theme.colors.system} bold wrap="truncate">
+        <Text key={idx} color={theme.colors.brandMark} bold wrap="truncate">
           {row}
         </Text>
       ))}

--- a/src/tui/components/logo.tsx
+++ b/src/tui/components/logo.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
 import { theme } from "../theme/theme.js";
+import type { LogoVariant } from "./splash-fit.js";
 
 /**
  * Atomic-plus mark + `ATOMIC AGENT` wordmark, rendered side-by-side and
@@ -8,35 +9,38 @@ import { theme } from "../theme/theme.js";
  * can be reused in any centered "home" layout (e.g. the empty-chat
  * landing surface) without copying the row data.
  *
- * Rendered as plain Ink primitives — no animations, no alpha. Use the
- * `compact` variant in narrow layouts where the wordmark would wrap.
+ * Rendered as plain Ink primitives — no animations, no alpha. The mark
+ * comes in three sizes so the same component can serve a 200-column
+ * desktop terminal and a 40-column SSH window: `full` (34×20), `small`
+ * (17×10) and `mini` (a single 14-column line). `SplashBanner` picks
+ * one via `computeSplashFit`; callers that just want the classic
+ * artwork can keep using the defaults.
  */
 export interface LogoProps {
+  /** Which mark to draw. Defaults to the full 34×20 artwork. */
+  variant?: LogoVariant;
+  /**
+   * Legacy switch for "mark only, no wordmark". Still honoured so
+   * existing callers keep working; prefer `wordmark={false}`.
+   */
   compact?: boolean;
+  /** Draw the `ATOMIC AGENT` wordmark beside the mark. */
+  wordmark?: boolean;
+  /** Draw the "Local AI-First Agent" tagline under the wordmark. */
+  tagline?: boolean;
 }
 
-export function Logo({ compact = false }: LogoProps): ReactElement {
-  return (
-    <Box flexDirection="row" alignItems="center">
-      <LogoMark />
-      {compact ? null : (
-        <Box flexDirection="column" marginLeft={3}>
-          <WordMark />
-          <Box marginTop={1}>
-            <Text color={theme.colors.muted}>
-              Local AI-First Agent
-            </Text>
-          </Box>
-        </Box>
-      )}
-    </Box>
-  );
-}
-
-function LogoMark(): ReactElement {
+/**
+ * Mark artwork keyed by variant. `full` is the original drawing; the
+ * others preserve its silhouette — upper-left flare, full-width cross
+ * bar, tapering lower-right tail — at roughly half scale and as a
+ * single line. `splash-fit.ts` mirrors these dimensions in
+ * `LOGO_METRICS`; `logo-fit.test.ts` fails if the two ever disagree.
+ */
+export const LOGO_ART: Readonly<Record<LogoVariant, readonly string[]>> = {
   // Leading padding has been uniformly trimmed so the middle bar sits
   // at column 0 — keeps the art within ~34 columns for narrow terminals.
-  const rows: readonly string[] = [
+  full: [
     "            -:::::::--",
     "            -::::::::-",
     "           -:::::::::-",
@@ -57,11 +61,68 @@ function LogoMark(): ReactElement {
     "            -::::::::=",
     "            +--------*",
     "              %%%%%%",
-  ];
+  ],
+  small: [
+    "      -:::--",
+    "      -::::-",
+    "     -:::::-",
+    "   -:::::::-",
+    "-:::::::::::::::-",
+    ":::::::::::::::::",
+    "=-----:::::::::-=",
+    " @@@@@*-::::-=#%",
+    "      -::::-*",
+    "      +----*",
+  ],
+  mini: ["+ ATOMIC AGENT"],
+};
+
+export const WORDMARK_ROWS: readonly string[] = [
+  "▄▀█ ▀█▀ █▀█ █▀▄▀█ █ █▀▀   ▄▀█ █▀▀ █▀▀ █▄ █ ▀█▀",
+  "█▀█  █  █▄█ █ ▀ █ █ █▄▄   █▀█ █▄█ ██▄ █ ▀█  █ ",
+];
+
+export const TAGLINE = "Local AI-First Agent";
+
+export function Logo({
+  variant = "full",
+  compact = false,
+  wordmark,
+  tagline,
+}: LogoProps): ReactElement {
+  const showWordmark = wordmark ?? !compact;
+  const showTagline = tagline ?? showWordmark;
+  if (variant === "mini") {
+    return (
+      <Text color={theme.colors.system} bold wrap="truncate">
+        {LOGO_ART.mini[0]}
+      </Text>
+    );
+  }
+  return (
+    <Box flexDirection="row" alignItems="center">
+      <LogoMark variant={variant} />
+      {showWordmark || showTagline ? (
+        <Box flexDirection="column" marginLeft={3}>
+          {showWordmark ? <WordMark /> : null}
+          {showTagline ? (
+            <Box marginTop={showWordmark ? 1 : 0}>
+              <Text color={theme.colors.muted} wrap="truncate">
+                {TAGLINE}
+              </Text>
+            </Box>
+          ) : null}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function LogoMark({ variant }: { variant: LogoVariant }): ReactElement {
   return (
     <Box flexDirection="column">
-      {rows.map((row, idx) => (
-        <Text key={idx} color={theme.colors.system} bold>
+      {LOGO_ART[variant].map((row, idx) => (
+        <Text key={idx} color={theme.colors.system} bold wrap="truncate">
           {row}
         </Text>
       ))}
@@ -70,14 +131,10 @@ function LogoMark(): ReactElement {
 }
 
 function WordMark(): ReactElement {
-  const rows: readonly string[] = [
-    "▄▀█ ▀█▀ █▀█ █▀▄▀█ █ █▀▀   ▄▀█ █▀▀ █▀▀ █▄ █ ▀█▀",
-    "█▀█  █  █▄█ █ ▀ █ █ █▄▄   █▀█ █▄█ ██▄ █ ▀█  █ ",
-  ];
   return (
     <Box flexDirection="column">
-      {rows.map((row, idx) => (
-        <Text key={idx} color={theme.colors.accentSoft} bold>
+      {WORDMARK_ROWS.map((row, idx) => (
+        <Text key={idx} color={theme.colors.accentSoft} bold wrap="truncate">
           {row}
         </Text>
       ))}

--- a/src/tui/components/sidebar-fit.test.tsx
+++ b/src/tui/components/sidebar-fit.test.tsx
@@ -1,0 +1,117 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import {
+  computeSidebarRowBudget,
+  isSidebarVisible,
+  SIDEBAR_CHROME_ROWS,
+  SIDEBAR_MIN_COLUMNS,
+  SIDEBAR_MIN_ROWS,
+} from "../layout.js";
+import type { TaskSummaryRow } from "../tasks/tasks-panel-state.js";
+import type { SessionPickerEntry } from "../tui-state.js";
+import { Sidebar } from "./sidebar.js";
+
+/** Colour codes never carry a newline, so the raw frame counts fine. */
+function frameRows(frame: string): number {
+  return frame.split("\n").length;
+}
+
+/** Long enough that both panes always hide a tail and draw a footer. */
+const SESSIONS: readonly SessionPickerEntry[] = Array.from(
+  { length: 40 },
+  (_, idx) => ({
+    sessionId: `s-${idx}`,
+    workingDir: "/tmp/fit",
+    turnCount: 1,
+    stepCount: 1,
+    updatedAt: 0,
+    preview: `session ${idx}`,
+  }),
+);
+
+const TASKS: readonly TaskSummaryRow[] = Array.from(
+  { length: 40 },
+  (_, idx) => ({
+    id: `t-${idx}`,
+    status: "pending",
+    origin: "tui",
+    triggerSource: "user",
+    sessionId: null,
+    userMessage: `task ${idx}`,
+    scheduleKind: null,
+    scheduleLabel: "-",
+    recurring: false,
+    scheduledFor: null,
+    createdAt: 0,
+    updatedAt: 0,
+    startedAt: null,
+    completedAt: null,
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+  }),
+);
+
+function renderRail(rows: number): number {
+  const budget = computeSidebarRowBudget(rows);
+  const { lastFrame } = render(
+    <Sidebar
+      width={30}
+      maxSessionRows={budget.sessions}
+      maxTaskRows={budget.tasks}
+      sessions={SESSIONS}
+      sessionsCursor={0}
+      currentSessionId={null}
+      tasks={TASKS}
+      tasksCursor={0}
+      activeSection="sessions"
+      focused={false}
+    />,
+  );
+  return frameRows(lastFrame() ?? "");
+}
+
+/**
+ * Regression guard for "a wide but short terminal garbles the rail",
+ * the sibling of `splash-fit.render.test.tsx`. Ink 7 does NOT clip a
+ * frame taller than the terminal — it overlaps earlier lines — so the
+ * row budget has to be a promise the rendered component keeps, and a
+ * window too short to keep it must lose the rail entirely.
+ *
+ * The rail is drawn under a one-row status bar, so its own frame gets
+ * `rows - 1` at most.
+ */
+describe("Sidebar fit", () => {
+  it("renders inside every terminal height that still draws it", () => {
+    // 24 rows is where the budget saturates at its 10/5 caps, so every
+    // distinct split the arithmetic can produce is covered here. The
+    // exact cost — two section headers, the blank row between the
+    // panes and a "↓ N more" footer per pane — is asserted alongside
+    // the fit so `SIDEBAR_CHROME_ROWS` cannot drift away from the
+    // component it describes. The left border is the only border edge
+    // the rail draws, so it costs columns, not rows.
+    for (let rows = SIDEBAR_MIN_ROWS; rows <= 24; rows += 1) {
+      expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS, rows)).toBe(true);
+      const budget = computeSidebarRowBudget(rows);
+      const rendered = renderRail(rows);
+      expect(rendered).toBe(
+        budget.sessions + budget.tasks + SIDEBAR_CHROME_ROWS,
+      );
+      expect(rendered).toBeLessThanOrEqual(rows - 1);
+    }
+  });
+
+  it("is dropped rather than squeezed in a wide but short window", () => {
+    // 100x8 is a split tmux pane; 100x5 is a terminal docked under an
+    // editor. Both used to budget three list rows into a rail that
+    // rendered ten rows deep.
+    for (const [columns, rows] of [
+      [100, 8],
+      [100, 5],
+      [1, 1],
+      [0, 0],
+    ] as const) {
+      expect(isSidebarVisible(columns, rows)).toBe(false);
+    }
+  });
+});

--- a/src/tui/components/sidebar.test.tsx
+++ b/src/tui/components/sidebar.test.tsx
@@ -147,4 +147,83 @@ describe("Sidebar", () => {
     expect(text).toContain("running task");
     expect(text).toContain("pending task");
   });
+  it("honours the per-pane row budget instead of a fixed 10/5 split", () => {
+    const manySessions = Array.from({ length: 12 }, (_, idx) => ({
+      ...SESSIONS[0]!,
+      sessionId: `s-${idx}`,
+      preview: `session number ${idx}`,
+    }));
+    const manyTasks = Array.from({ length: 8 }, (_, idx) =>
+      taskRow({ id: `t-${idx}`, userMessage: `task number ${idx}` }),
+    );
+    const { lastFrame } = render(
+      <Sidebar
+        width={32}
+        sessions={manySessions}
+        sessionsCursor={0}
+        currentSessionId={null}
+        tasks={manyTasks}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={false}
+        maxSessionRows={3}
+        maxTaskRows={2}
+      />,
+    );
+    const text = strip(lastFrame() ?? "");
+    expect(text).toContain("session number 2");
+    expect(text).not.toContain("session number 3");
+    expect(text).toContain("task number 1");
+    expect(text).not.toContain("task number 2");
+    // Both panes admit what they are hiding.
+    expect(text).toContain("9 more");
+    expect(text).toContain("6 more");
+    // Two headers + 3 sessions + 2 tasks + 2 "more" rows + blank row.
+    expect(strip(lastFrame() ?? "").split("\n").length).toBeLessThanOrEqual(10);
+  });
+
+  it("scrolls the Tasks pane to keep the cursor visible", () => {
+    const manyTasks = Array.from({ length: 8 }, (_, idx) =>
+      taskRow({ id: `t-${idx}`, userMessage: `task number ${idx}` }),
+    );
+    const { lastFrame } = render(
+      <Sidebar
+        width={32}
+        sessions={SESSIONS}
+        sessionsCursor={0}
+        currentSessionId={null}
+        tasks={manyTasks}
+        tasksCursor={7}
+        activeSection="tasks"
+        focused={true}
+        maxTaskRows={2}
+      />,
+    );
+    const text = strip(lastFrame() ?? "");
+    expect(text).toContain("task number 7");
+    expect(text).not.toContain("task number 0");
+    // The chevron sits on the selected row, not on whatever row 0 is.
+    expect(text).toMatch(/▸ [^\n]*task number 7/);
+  });
+
+  it("narrows the previews with the rail rather than overflowing it", () => {
+    const long = [{ ...SESSIONS[0]!, preview: "a very long session preview indeed" }];
+    const { lastFrame } = render(
+      <Sidebar
+        width={24}
+        sessions={long}
+        sessionsCursor={0}
+        currentSessionId={null}
+        tasks={[]}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={false}
+      />,
+    );
+    const widest = strip(lastFrame() ?? "")
+      .split("\n")
+      .reduce((acc, line) => Math.max(acc, line.replace(/\s+$/, "").length), 0);
+    expect(widest).toBeLessThanOrEqual(24);
+    expect(strip(lastFrame() ?? "")).toContain("…");
+  });
 });

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
+import { computeRowWindow } from "../row-window.js";
 import type { TaskSummaryRow } from "../tasks/tasks-panel-state.js";
 import { theme } from "../theme/theme.js";
 import type { SessionPickerEntry } from "../tui-state.js";
@@ -17,10 +18,26 @@ export interface SidebarProps {
   activeSection: SidebarSection;
   /** Whether the sidebar owns keyboard focus right now. */
   focused: boolean;
+  /**
+   * Row budget for each pane, normally derived from the terminal height
+   * by `computeSidebarRowBudget` in `../layout.ts`. The defaults keep
+   * the pre-adaptive behaviour for callers that do not measure.
+   */
+  maxSessionRows?: number;
+  maxTaskRows?: number;
 }
 
-const MAX_SESSION_ROWS = 10;
-const MAX_TASK_ROWS = 5;
+const DEFAULT_MAX_SESSION_ROWS = 10;
+const DEFAULT_MAX_TASK_ROWS = 5;
+
+/**
+ * Cells each list row spends before the preview text: the border, the
+ * two padding columns, the selection chevron and the status marker,
+ * plus the spaces between them.
+ */
+const ROW_CHROME_COLUMNS = 7;
+/** Never squeeze a preview below this — an ellipsis alone helps nobody. */
+const MIN_PREVIEW_COLUMNS = 6;
 
 /**
  * Always-on right-rail sidebar. Two stacked panes — Sessions (top) and
@@ -29,6 +46,8 @@ const MAX_TASK_ROWS = 5;
  * `app-key-bindings.ts`); the sidebar component itself is purely
  * presentational and never measures the terminal directly so the
  * same component works under ink-testing-library's static viewport.
+ * Its width and per-pane row budgets arrive as props from `TuiApp`,
+ * which owns the terminal measurement.
  *
  * Focus is layered: `focused` toggles the section header colour for
  * the active pane, and `activeSection` decides which pane gets the
@@ -45,12 +64,22 @@ export function Sidebar(props: SidebarProps): ReactElement {
     tasksCursor,
     activeSection,
     focused,
+    maxSessionRows = DEFAULT_MAX_SESSION_ROWS,
+    maxTaskRows = DEFAULT_MAX_TASK_ROWS,
   } = props;
   const sessionsActive = focused && activeSection === "sessions";
   const tasksActive = focused && activeSection === "tasks";
+  const previewWidth = Math.max(
+    MIN_PREVIEW_COLUMNS,
+    width - ROW_CHROME_COLUMNS,
+  );
+  // `flexShrink={0}`: Yoga shrinks flex children by default, so a wide
+  // chat column used to steal columns back from the rail — which made
+  // the width the splash was told to plan for a lie.
   return (
     <Box
       width={width}
+      flexShrink={0}
       flexDirection="column"
       borderStyle="single"
       borderTop={false}
@@ -67,6 +96,8 @@ export function Sidebar(props: SidebarProps): ReactElement {
         cursor={sessionsCursor}
         focused={sessionsActive}
         currentSessionId={currentSessionId}
+        maxRows={maxSessionRows}
+        previewWidth={previewWidth}
       />
       <Box marginTop={1}>
         <SectionHeader title="Tasks" active={tasksActive} />
@@ -75,6 +106,8 @@ export function Sidebar(props: SidebarProps): ReactElement {
         tasks={tasks}
         cursor={tasksCursor}
         focused={tasksActive}
+        maxRows={maxTaskRows}
+        previewWidth={previewWidth}
       />
     </Box>
   );
@@ -98,6 +131,8 @@ interface SessionsListProps {
   cursor: number;
   focused: boolean;
   currentSessionId: string | null;
+  maxRows: number;
+  previewWidth: number;
 }
 
 function SessionsList({
@@ -105,17 +140,20 @@ function SessionsList({
   cursor,
   focused,
   currentSessionId,
+  maxRows,
+  previewWidth,
 }: SessionsListProps): ReactElement {
   if (sessions.length === 0) {
     return (
-      <Text color={theme.colors.muted}>(no sessions yet)</Text>
+      <Text color={theme.colors.muted} wrap="truncate">
+        (no sessions yet)
+      </Text>
     );
   }
-  const clamped = Math.max(0, Math.min(cursor, sessions.length - 1));
-  const windowStart = computeWindowStart(clamped, sessions.length, MAX_SESSION_ROWS);
-  const visible = sessions.slice(windowStart, windowStart + MAX_SESSION_ROWS);
-  const visibleCursor = clamped - windowStart;
-  const hiddenAfter = Math.max(0, sessions.length - windowStart - visible.length);
+  const window = computeRowWindow(sessions.length, cursor, maxRows);
+  const visible = sessions.slice(window.start, window.start + window.count);
+  const visibleCursor =
+    Math.max(0, Math.min(cursor, sessions.length - 1)) - window.start;
   return (
     <Box flexDirection="column">
       {visible.map((entry, idx) => (
@@ -124,11 +162,10 @@ function SessionsList({
           entry={entry}
           selected={focused && idx === visibleCursor}
           current={entry.sessionId === currentSessionId}
+          previewWidth={previewWidth}
         />
       ))}
-      {hiddenAfter > 0 ? (
-        <Text color={theme.colors.muted}>↓ {hiddenAfter} more</Text>
-      ) : null}
+      <MoreRow hidden={window.hiddenAfter} />
     </Box>
   );
 }
@@ -137,10 +174,16 @@ interface SessionRowProps {
   entry: SessionPickerEntry;
   selected: boolean;
   current: boolean;
+  previewWidth: number;
 }
 
-function SessionRow({ entry, selected, current }: SessionRowProps): ReactElement {
-  const preview = truncate(entry.preview, 28);
+function SessionRow({
+  entry,
+  selected,
+  current,
+  previewWidth,
+}: SessionRowProps): ReactElement {
+  const preview = truncate(entry.preview, previewWidth);
   const marker = current ? theme.glyphs.assistantMarker : " ";
   const chevron = selected ? theme.glyphs.chevronRight : " ";
   return (
@@ -158,15 +201,28 @@ interface TasksListProps {
   tasks: readonly TaskSummaryRow[];
   cursor: number;
   focused: boolean;
+  maxRows: number;
+  previewWidth: number;
 }
 
-function TasksList({ tasks, cursor, focused }: TasksListProps): ReactElement {
+function TasksList({
+  tasks,
+  cursor,
+  focused,
+  maxRows,
+  previewWidth,
+}: TasksListProps): ReactElement {
   if (tasks.length === 0) {
-    return <Text color={theme.colors.muted}>(no active tasks)</Text>;
+    return (
+      <Text color={theme.colors.muted} wrap="truncate">
+        (no active tasks)
+      </Text>
+    );
   }
-  const clamped = Math.max(0, Math.min(cursor, tasks.length - 1));
-  const visible = tasks.slice(0, MAX_TASK_ROWS);
-  const visibleCursor = Math.min(clamped, visible.length - 1);
+  const window = computeRowWindow(tasks.length, cursor, maxRows);
+  const visible = tasks.slice(window.start, window.start + window.count);
+  const visibleCursor =
+    Math.max(0, Math.min(cursor, tasks.length - 1)) - window.start;
   return (
     <Box flexDirection="column">
       {visible.map((row, idx) => (
@@ -174,8 +230,10 @@ function TasksList({ tasks, cursor, focused }: TasksListProps): ReactElement {
           key={row.id}
           row={row}
           selected={focused && idx === visibleCursor}
+          previewWidth={previewWidth}
         />
       ))}
+      <MoreRow hidden={window.hiddenAfter} />
     </Box>
   );
 }
@@ -183,10 +241,11 @@ function TasksList({ tasks, cursor, focused }: TasksListProps): ReactElement {
 interface TaskRowProps {
   row: TaskSummaryRow;
   selected: boolean;
+  previewWidth: number;
 }
 
-function TaskRow({ row, selected }: TaskRowProps): ReactElement {
-  const preview = truncate(row.userMessage, 24);
+function TaskRow({ row, selected, previewWidth }: TaskRowProps): ReactElement {
+  const preview = truncate(row.userMessage, previewWidth);
   const chevron = selected ? theme.glyphs.chevronRight : " ";
   const badge = statusBadge(row);
   return (
@@ -196,6 +255,16 @@ function TaskRow({ row, selected }: TaskRowProps): ReactElement {
       wrap="truncate"
     >
       {chevron} {badge} {preview}
+    </Text>
+  );
+}
+
+/** "↓ N more" footer, or nothing at all when the tail is visible. */
+function MoreRow({ hidden }: { hidden: number }): ReactElement | null {
+  if (hidden <= 0) return null;
+  return (
+    <Text color={theme.colors.muted} wrap="truncate">
+      ↓ {hidden} more
     </Text>
   );
 }
@@ -216,11 +285,5 @@ function truncate(text: string, max: number): string {
   const oneLine = text.replace(/\s+/g, " ").trim();
   if (oneLine.length === 0) return "(empty)";
   if (oneLine.length <= max) return oneLine;
-  return `${oneLine.slice(0, max - 1)}…`;
-}
-
-function computeWindowStart(cursor: number, total: number, size: number): number {
-  if (total <= size) return 0;
-  if (cursor < size) return 0;
-  return Math.min(cursor - size + 1, total - size);
+  return `${oneLine.slice(0, Math.max(1, max - 1))}…`;
 }

--- a/src/tui/components/splash-banner.test.tsx
+++ b/src/tui/components/splash-banner.test.tsx
@@ -50,16 +50,25 @@ describe("SplashBanner", () => {
     expect(frame).not.toContain("list all slash commands");
   });
 
-  it("still shows a brand mark and a tip on a 40x12 window", () => {
+  it("keeps the tips and drops the mark when four rows is all there is", () => {
+    // The mark is scaled artwork at every size now — the smallest is 4
+    // rows, so on a 4-row surface it would leave nothing for the tips
+    // and Ink would paint it over the chat above. Tips win.
     const frame = frameAt(38, 4);
-    expect(frame).toContain("+ ATOMIC AGENT");
+    expect(frame).toContain("Enter");
+    expect(frame).not.toMatch(/:::|[█▀▄]/u);
+  });
+
+  it("still shows a brand mark and a tip once there is room for both", () => {
+    const frame = frameAt(38, 8);
+    expect(frame).toMatch(/:::|[█▀▄]/u);
     expect(frame).toContain("Enter");
   });
 
   it("measures the terminal itself when no size is given", () => {
     const { lastFrame } = render(<SplashBanner />);
     const frame = strip(lastFrame() ?? "");
-    expect(frame).toContain(":::");
+    expect(frame).toMatch(/:::|[█▀▄]/u);
     expect(frame).toContain("/help");
   });
 });

--- a/src/tui/components/splash-banner.test.tsx
+++ b/src/tui/components/splash-banner.test.tsx
@@ -4,14 +4,18 @@ import { SplashBanner } from "./splash-banner.js";
 
 function strip(value: string): string {
   return value
-    .replace(/\u001b\[[0-9;]*m/g, "")
-    .replace(/\u001b\]8;;[^\u0007]*\u0007/g, "");
+    .replace(/\[[0-9;]*m/g, "")
+    .replace(/\]8;;[^]*/g, "");
+}
+
+function frameAt(columns: number, rows: number): string {
+  const { lastFrame } = render(<SplashBanner size={{ columns, rows }} />);
+  return strip(lastFrame() ?? "");
 }
 
 describe("SplashBanner", () => {
-  it("renders the plus-mark middle bar and the wordmark", () => {
-    const { lastFrame } = render(<SplashBanner />);
-    const frame = strip(lastFrame() ?? "");
+  it("renders the plus-mark middle bar and the wordmark on a roomy surface", () => {
+    const frame = frameAt(96, 40);
     // Middle bar of the plus — longest uninterrupted `:` run in the art.
     expect(frame).toContain("::::::::::::::::::::::::::::::::::");
     // Both halves of the `ATOMIC AGENT` half-block wordmark.
@@ -21,14 +25,41 @@ describe("SplashBanner", () => {
   });
 
   it("advertises the core slash commands and hotkeys", () => {
-    const { lastFrame } = render(<SplashBanner />);
-    const frame = strip(lastFrame() ?? "");
+    const frame = frameAt(96, 40);
     expect(frame).toContain("/help");
     expect(frame).toContain("/sessions");
     expect(frame).toContain("/new");
-    expect(frame).toContain("/observe");
-    expect(frame).toContain("/manage");
-    expect(frame).toContain("/run");
+    expect(frame).toContain("/model");
+    expect(frame).toContain("/tasks");
+    expect(frame).toContain("/import");
     expect(frame).toContain("Ctrl+C");
+  });
+
+  it("keeps the most useful tips when the surface is too short for all of them", () => {
+    const frame = frameAt(96, 16);
+    expect(frame).toContain("/help");
+    expect(frame).toContain("/sessions");
+    // The tail of the list is what gives way first.
+    expect(frame).not.toContain("/import");
+  });
+
+  it("swaps in terse descriptions on a narrow surface", () => {
+    const frame = frameAt(44, 20);
+    expect(frame).toContain("/help");
+    expect(frame).toContain("all commands");
+    expect(frame).not.toContain("list all slash commands");
+  });
+
+  it("still shows a brand mark and a tip on a 40x12 window", () => {
+    const frame = frameAt(38, 4);
+    expect(frame).toContain("+ ATOMIC AGENT");
+    expect(frame).toContain("Enter");
+  });
+
+  it("measures the terminal itself when no size is given", () => {
+    const { lastFrame } = render(<SplashBanner />);
+    const frame = strip(lastFrame() ?? "");
+    expect(frame).toContain(":::");
+    expect(frame).toContain("/help");
   });
 });

--- a/src/tui/components/splash-banner.tsx
+++ b/src/tui/components/splash-banner.tsx
@@ -41,7 +41,7 @@ export interface SplashBannerProps {
 export function SplashBanner({ size }: SplashBannerProps = {}): ReactElement {
   const terminal = useTerminalSize();
   const surface: SplashSize = size ?? {
-    columns: computeChatWidth(terminal.columns),
+    columns: computeChatWidth(terminal.columns, terminal.rows),
     rows: computeChatViewportRows(terminal.rows, terminal.columns),
   };
   const fit = computeSplashFit(surface);

--- a/src/tui/components/splash-banner.tsx
+++ b/src/tui/components/splash-banner.tsx
@@ -1,7 +1,17 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
-import { Logo } from "./logo.js";
+import { useTerminalSize } from "../hooks/use-terminal-size.js";
+import { computeChatViewportRows, computeChatWidth } from "../layout.js";
 import { theme } from "../theme/theme.js";
+import { Logo } from "./logo.js";
+import {
+  computeSplashFit,
+  SPLASH_TIPS,
+  type SplashFit,
+  type SplashSize,
+  type SplashTip,
+  type TipDescriptions,
+} from "./splash-fit.js";
 
 /**
  * Welcome screen shown in place of an empty chat-log. Renders the brand
@@ -9,41 +19,68 @@ import { theme } from "../theme/theme.js";
  * spacers, with a compact tip-list underneath that surfaces the most
  * useful slash commands and hotkeys.
  *
+ * Everything on it is sized against the live terminal: the mark shrinks
+ * (34×20 → 17×10 → one line) as the window narrows or shortens, the tip
+ * list drops entries from its tail, and the tip descriptions collapse to
+ * terse copy before disappearing entirely. See `splash-fit.ts` for the
+ * breakpoints — this component only renders the plan it is handed.
+ *
  * Visibility is decided by the parent (`ChatLog`) based on
  * `messages.length === 0`, so restoring a historical session via
  * `/sessions` swaps the banner out for the transcript.
  */
-export function SplashBanner(): ReactElement {
+export interface SplashBannerProps {
+  /**
+   * Explicit surface size, bypassing the terminal measurement. Only
+   * used by tests — ink-testing-library's stdout stub reports a fixed
+   * 100×0, which would pin every rendered frame to one breakpoint.
+   */
+  size?: SplashSize;
+}
+
+export function SplashBanner({ size }: SplashBannerProps = {}): ReactElement {
+  const terminal = useTerminalSize();
+  const surface: SplashSize = size ?? {
+    columns: computeChatWidth(terminal.columns),
+    rows: computeChatViewportRows(terminal.rows, terminal.columns),
+  };
+  const fit = computeSplashFit(surface);
+  const tips = SPLASH_TIPS.slice(0, fit.tipCount);
   return (
     <Box flexDirection="column" flexGrow={1} alignItems="center" paddingX={2}>
       <Box flexGrow={1} />
-      <Logo />
-      <Box marginTop={1} flexDirection="column">
-        <Tip left="Enter" right="submit message to the agent" />
-        <Tip left="/help" right="list all slash commands" />
-        <Tip left="/sessions" right="switch to a previous thread" />
-        <Tip left="/new" right="start a fresh session" />
-        <Tip left="/model" right="change the chat model" />
-        <Tip left="/tasks" right="jump to the Tasks tab (Option 4 cron + ingress UI)" />
-        <Tip left="/import" right="open the Import tab (one-shot Hermes -> atomic-agent migration)" />
-        <Tip left="Ctrl+C ×2" right="quit (once aborts a running turn)" />
-      </Box>
+      <Logo variant={fit.logo} wordmark={fit.wordmark} tagline={fit.tagline} />
+      {tips.length > 0 ? (
+        <Box marginTop={1} flexDirection="column">
+          {tips.map((tip) => (
+            <Tip key={tip.label} tip={tip} fit={fit} />
+          ))}
+        </Box>
+      ) : null}
       <Box flexGrow={1} />
     </Box>
   );
 }
 
 interface TipProps {
-  left: string;
-  right: string;
+  tip: SplashTip;
+  fit: SplashFit;
 }
 
-function Tip({ left, right }: TipProps): ReactElement {
+function Tip({ tip, fit }: TipProps): ReactElement {
+  const label =
+    fit.labelWidth > 0 ? tip.label.padEnd(fit.labelWidth, " ") : tip.label;
   return (
-    <Text>
+    <Text wrap="truncate">
       <Text color={theme.colors.muted}>  {theme.glyphs.bullet} </Text>
-      <Text color={theme.colors.accent}>{left.padEnd(24, " ")}</Text>
-      <Text color={theme.colors.muted}>{right}</Text>
+      <Text color={theme.colors.accent}>{label}</Text>
+      <Text color={theme.colors.muted}>{description(tip, fit.descriptions)}</Text>
     </Text>
   );
+}
+
+function description(tip: SplashTip, mode: TipDescriptions): string {
+  if (mode === "full") return tip.description;
+  if (mode === "short") return tip.short;
+  return "";
 }

--- a/src/tui/components/splash-banner.tsx
+++ b/src/tui/components/splash-banner.tsx
@@ -49,9 +49,14 @@ export function SplashBanner({ size }: SplashBannerProps = {}): ReactElement {
   return (
     <Box flexDirection="column" flexGrow={1} alignItems="center" paddingX={2}>
       <Box flexGrow={1} />
-      <Logo variant={fit.logo} wordmark={fit.wordmark} tagline={fit.tagline} />
+      {fit.logo === "none" ? null : (
+        <Logo variant={fit.logo} wordmark={fit.wordmark} tagline={fit.tagline} />
+      )}
       {tips.length > 0 ? (
-        <Box marginTop={1} flexDirection="column">
+        <Box
+          marginTop={fit.logo === "none" ? 0 : 1}
+          flexDirection="column"
+        >
           {tips.map((tip) => (
             <Tip key={tip.label} tip={tip} fit={fit} />
           ))}

--- a/src/tui/components/splash-fit.render.test.tsx
+++ b/src/tui/components/splash-fit.render.test.tsx
@@ -46,8 +46,13 @@ describe("SplashBanner fit", () => {
     const widest = rendered.reduce((acc, line) => Math.max(acc, line.length), 0);
     expect(widest).toBeLessThanOrEqual(size.columns);
     expect(rendered.length).toBeLessThanOrEqual(size.rows);
-    // A splash with no recognisable brand mark is not a splash.
-    expect(rendered.join("\n")).toMatch(/ATOMIC AGENT|:::/);
+    // A splash with no recognisable brand mark is not a splash — except
+    // on a surface with no room for one, where drawing it anyway is the
+    // bug this file guards against. The mark is half-block art below
+    // full size, so match the glyphs rather than the source shading.
+    if (size.rows >= 6) {
+      expect(rendered.join("\n")).toMatch(/ATOMIC AGENT|:::|[█▀▄]/u);
+    }
   });
 
   it("renders the full artwork, wordmark and every tip when there is room", () => {
@@ -64,7 +69,7 @@ describe("SplashBanner fit", () => {
     expect(frame).toContain("/import");
   });
 
-  it("collapses to the one-line mark and bare labels on a tiny surface", () => {
+  it("collapses to the smallest mark and bare labels on a tiny surface", () => {
     const size = { columns: 24, rows: 10 };
     const { lastFrame } = render(
       <Box width={size.columns}>
@@ -72,7 +77,8 @@ describe("SplashBanner fit", () => {
       </Box>,
     );
     const frame = lines(lastFrame() ?? "").join("\n");
-    expect(frame).toContain("+ ATOMIC AGENT");
+    // The mini mark is scaled from the full drawing, not a text stand-in.
+    expect(frame).toMatch(/[█▀▄]/u);
     expect(frame).not.toContain("▄▀█ ▀█▀ █▀█");
     expect(frame).toContain("/help");
     expect(frame).not.toContain("list all slash commands");

--- a/src/tui/components/splash-fit.render.test.tsx
+++ b/src/tui/components/splash-fit.render.test.tsx
@@ -1,0 +1,80 @@
+import { render } from "ink-testing-library";
+import { Box } from "ink";
+import { describe, expect, it } from "vitest";
+import { computeChatViewportRows, computeChatWidth } from "../layout.js";
+import { SplashBanner } from "./splash-banner.js";
+
+function lines(frame: string): string[] {
+  return frame
+    .replace(/\[[0-9;]*m/g, "")
+    .split("\n")
+    .map((line) => line.replace(/\s+$/, ""));
+}
+
+/**
+ * Regression guard for the "small window garbles the start page" bug,
+ * modelled on `manage-panel-fit.test.tsx`. Ink 7 does NOT clip a frame
+ * taller than the terminal — it overlaps earlier lines — and it wraps a
+ * line wider than the surface into confetti. The splash therefore has
+ * to plan its own size, and the plan has to survive contact with Yoga.
+ *
+ * ink-testing-library pins its stdout at 100 columns and reports no
+ * rows at all, so each case renders `SplashBanner` at an explicit
+ * surface size inside a `Box` of that width — the same geometry the
+ * chat column hands it in production.
+ */
+const TERMINALS: ReadonlyArray<{ columns: number; rows: number }> = [
+  { columns: 40, rows: 12 },
+  { columns: 60, rows: 20 },
+  { columns: 80, rows: 24 },
+  { columns: 100, rows: 30 },
+  { columns: 100, rows: 50 },
+];
+
+describe("SplashBanner fit", () => {
+  it.each(TERMINALS)("fits a $columns x $rows terminal", (terminal) => {
+    const size = {
+      columns: computeChatWidth(terminal.columns),
+      rows: computeChatViewportRows(terminal.rows),
+    };
+    const { lastFrame } = render(
+      <Box width={size.columns}>
+        <SplashBanner size={size} />
+      </Box>,
+    );
+    const rendered = lines(lastFrame() ?? "");
+    const widest = rendered.reduce((acc, line) => Math.max(acc, line.length), 0);
+    expect(widest).toBeLessThanOrEqual(size.columns);
+    expect(rendered.length).toBeLessThanOrEqual(size.rows);
+    // A splash with no recognisable brand mark is not a splash.
+    expect(rendered.join("\n")).toMatch(/ATOMIC AGENT|:::/);
+  });
+
+  it("renders the full artwork, wordmark and every tip when there is room", () => {
+    const size = { columns: 96, rows: 40 };
+    const { lastFrame } = render(
+      <Box width={size.columns}>
+        <SplashBanner size={size} />
+      </Box>,
+    );
+    const frame = lines(lastFrame() ?? "").join("\n");
+    expect(frame).toContain("::::::::::::::::::::::::::::::::::");
+    expect(frame).toContain("▄▀█ ▀█▀ █▀█");
+    expect(frame).toContain("Local AI-First Agent");
+    expect(frame).toContain("/import");
+  });
+
+  it("collapses to the one-line mark and bare labels on a tiny surface", () => {
+    const size = { columns: 24, rows: 10 };
+    const { lastFrame } = render(
+      <Box width={size.columns}>
+        <SplashBanner size={size} />
+      </Box>,
+    );
+    const frame = lines(lastFrame() ?? "").join("\n");
+    expect(frame).toContain("+ ATOMIC AGENT");
+    expect(frame).not.toContain("▄▀█ ▀█▀ █▀█");
+    expect(frame).toContain("/help");
+    expect(frame).not.toContain("list all slash commands");
+  });
+});

--- a/src/tui/components/splash-fit.render.test.tsx
+++ b/src/tui/components/splash-fit.render.test.tsx
@@ -34,7 +34,7 @@ const TERMINALS: ReadonlyArray<{ columns: number; rows: number }> = [
 describe("SplashBanner fit", () => {
   it.each(TERMINALS)("fits a $columns x $rows terminal", (terminal) => {
     const size = {
-      columns: computeChatWidth(terminal.columns),
+      columns: computeChatWidth(terminal.columns, terminal.rows),
       rows: computeChatViewportRows(terminal.rows),
     };
     const { lastFrame } = render(

--- a/src/tui/components/splash-fit.test.ts
+++ b/src/tui/components/splash-fit.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeSplashFit,
+  LOGO_METRICS,
+  SPLASH_TIPS,
+  type LogoVariant,
+} from "./splash-fit.js";
+
+const SIZE_ORDER: readonly LogoVariant[] = ["mini", "small", "full"];
+
+describe("computeSplashFit", () => {
+  it("gives a roomy terminal the full artwork, the wordmark and every tip", () => {
+    expect(computeSplashFit({ columns: 92, rows: 40 })).toEqual({
+      logo: "full",
+      wordmark: true,
+      tagline: true,
+      tipCount: SPLASH_TIPS.length,
+      labelWidth: 24,
+      descriptions: "full",
+    });
+  });
+
+  it("drops the wordmark before the mark when the surface narrows", () => {
+    // 82 inner columns — one short of mark + gap + wordmark.
+    const fit = computeSplashFit({ columns: 86, rows: 40 });
+    expect(fit.logo).toBe("full");
+    expect(fit.wordmark).toBe(false);
+    expect(fit.tagline).toBe(false);
+  });
+
+  it("shrinks the mark when the surface is too short for the tall artwork", () => {
+    // A 100x24 terminal leaves the chat surface 73x16.
+    expect(computeSplashFit({ columns: 73, rows: 16 })).toEqual({
+      logo: "small",
+      wordmark: false,
+      tagline: false,
+      tipCount: 5,
+      labelWidth: 24,
+      descriptions: "full",
+    });
+  });
+
+  it("falls back to the one-line mark and terse copy on a small window", () => {
+    expect(computeSplashFit({ columns: 38, rows: 12 })).toEqual({
+      logo: "mini",
+      wordmark: false,
+      tagline: false,
+      tipCount: SPLASH_TIPS.length,
+      labelWidth: 10,
+      descriptions: "short",
+    });
+  });
+
+  it("keeps bare labels when there is no room for any description", () => {
+    const fit = computeSplashFit({ columns: 20, rows: 10 });
+    expect(fit.logo).toBe("mini");
+    expect(fit.descriptions).toBe("none");
+    expect(fit.labelWidth).toBe(0);
+    expect(fit.tipCount).toBeGreaterThan(0);
+  });
+
+  it("drops the tip list entirely rather than overflow a two-row surface", () => {
+    expect(computeSplashFit({ columns: 92, rows: 2 })).toMatchObject({
+      logo: "mini",
+      tipCount: 0,
+      descriptions: "none",
+    });
+  });
+
+  it("survives a degenerate surface without going negative", () => {
+    const fit = computeSplashFit({ columns: 0, rows: 0 });
+    expect(fit.tipCount).toBe(0);
+    expect(fit.labelWidth).toBe(0);
+    expect(fit.logo).toBe("mini");
+  });
+
+  it("plans a layout that fits the surface it was given", () => {
+    for (let columns = 10; columns <= 200; columns += 3) {
+      for (let rows = 2; rows <= 60; rows += 3) {
+        const fit = computeSplashFit({ columns, rows });
+        const height =
+          LOGO_METRICS[fit.logo].height + (fit.tipCount > 0 ? 1 + fit.tipCount : 0);
+        expect(height).toBeLessThanOrEqual(Math.max(rows, LOGO_METRICS.mini.height));
+        expect(fit.tipCount).toBeGreaterThanOrEqual(0);
+        expect(fit.labelWidth).toBeGreaterThanOrEqual(0);
+        if (fit.wordmark) expect(fit.logo).toBe("full");
+      }
+    }
+  });
+
+  it("never shrinks the mark as the terminal gets wider", () => {
+    let previous = 0;
+    for (let columns = 10; columns <= 200; columns += 1) {
+      const rank = SIZE_ORDER.indexOf(computeSplashFit({ columns, rows: 60 }).logo);
+      expect(rank).toBeGreaterThanOrEqual(previous);
+      previous = rank;
+    }
+  });
+
+  it("never shows fewer tips as the terminal grows, for a fixed mark", () => {
+    // Across a variant change the count legitimately drops: a taller
+    // window buys a taller mark, which is paid for in tip rows. Within
+    // one variant the list may only grow.
+    const perVariant = new Map<string, number>();
+    for (let rows = 2; rows <= 80; rows += 1) {
+      const { logo, tipCount } = computeSplashFit({ columns: 92, rows });
+      expect(tipCount).toBeGreaterThanOrEqual(perVariant.get(logo) ?? 0);
+      perVariant.set(logo, tipCount);
+    }
+    expect(perVariant.get("full")).toBe(SPLASH_TIPS.length);
+  });
+});

--- a/src/tui/components/splash-fit.test.ts
+++ b/src/tui/components/splash-fit.test.ts
@@ -34,18 +34,23 @@ describe("computeSplashFit", () => {
       logo: "small",
       wordmark: false,
       tagline: false,
-      tipCount: 5,
+      // `small` is 12 rows now, not 10 — it is scaled from the full mark
+      // rather than hand-drawn, and the honest half-scale of a 20-row
+      // drawing is 12 half-block rows. Two of those rows come out of the
+      // tip list, which is the documented mark-over-tips priority.
+      tipCount: 3,
       labelWidth: 24,
       descriptions: "full",
     });
   });
 
-  it("falls back to the one-line mark and terse copy on a small window", () => {
+  it("falls back to the smallest mark and terse copy on a small window", () => {
     expect(computeSplashFit({ columns: 38, rows: 12 })).toEqual({
       logo: "mini",
       wordmark: false,
       tagline: false,
-      tipCount: SPLASH_TIPS.length,
+      // 12 rows − 4 for the mark − 1 margin leaves 7 of the 8 tips.
+      tipCount: SPLASH_TIPS.length - 1,
       labelWidth: 10,
       descriptions: "short",
     });
@@ -59,11 +64,15 @@ describe("computeSplashFit", () => {
     expect(fit.tipCount).toBeGreaterThan(0);
   });
 
-  it("drops the tip list entirely rather than overflow a two-row surface", () => {
+  it("drops the mark rather than overflow a two-row surface", () => {
+    // Reversed deliberately. The old floor was a one-line text mark, so
+    // the tips were what got dropped. The mark is real artwork at every
+    // size now, and on a two-row surface the tips are the half worth
+    // keeping — Ink paints an over-tall frame over the rows above it, so
+    // "draw the mark anyway" is the bug this whole module exists for.
     expect(computeSplashFit({ columns: 92, rows: 2 })).toMatchObject({
-      logo: "mini",
-      tipCount: 0,
-      descriptions: "none",
+      logo: "none",
+      tipCount: 2,
     });
   });
 
@@ -71,16 +80,19 @@ describe("computeSplashFit", () => {
     const fit = computeSplashFit({ columns: 0, rows: 0 });
     expect(fit.tipCount).toBe(0);
     expect(fit.labelWidth).toBe(0);
-    expect(fit.logo).toBe("mini");
+    expect(fit.logo).toBe("none");
   });
 
   it("plans a layout that fits the surface it was given", () => {
     for (let columns = 10; columns <= 200; columns += 3) {
       for (let rows = 2; rows <= 60; rows += 3) {
         const fit = computeSplashFit({ columns, rows });
+        const markHeight =
+          fit.logo === "none" ? 0 : LOGO_METRICS[fit.logo].height;
         const height =
-          LOGO_METRICS[fit.logo].height + (fit.tipCount > 0 ? 1 + fit.tipCount : 0);
-        expect(height).toBeLessThanOrEqual(Math.max(rows, LOGO_METRICS.mini.height));
+          markHeight +
+          (fit.tipCount > 0 ? (markHeight > 0 ? 1 : 0) + fit.tipCount : 0);
+        expect(height).toBeLessThanOrEqual(rows);
         expect(fit.tipCount).toBeGreaterThanOrEqual(0);
         expect(fit.labelWidth).toBeGreaterThanOrEqual(0);
         if (fit.wordmark) expect(fit.logo).toBe("full");
@@ -89,9 +101,10 @@ describe("computeSplashFit", () => {
   });
 
   it("never shrinks the mark as the terminal gets wider", () => {
-    let previous = 0;
+    let previous = -1;
     for (let columns = 10; columns <= 200; columns += 1) {
-      const rank = SIZE_ORDER.indexOf(computeSplashFit({ columns, rows: 60 }).logo);
+      const choice = computeSplashFit({ columns, rows: 60 }).logo;
+      const rank = choice === "none" ? -1 : SIZE_ORDER.indexOf(choice);
       expect(rank).toBeGreaterThanOrEqual(previous);
       previous = rank;
     }

--- a/src/tui/components/splash-fit.ts
+++ b/src/tui/components/splash-fit.ts
@@ -21,6 +21,15 @@
 
 export type LogoVariant = "full" | "small" | "mini";
 
+/**
+ * What the splash draws for a mark. `"none"` is a real outcome, not a
+ * failure: below ~8 rows the mark and the tips cannot both fit, and Ink
+ * paints an over-tall frame *over* the rows above it rather than
+ * clipping — so drawing it anyway is what garbled the start page in the
+ * first place. The tips are the useful half at that size.
+ */
+export type LogoChoice = LogoVariant | "none";
+
 export interface SplashSize {
   columns: number;
   rows: number;
@@ -29,8 +38,8 @@ export interface SplashSize {
 export type TipDescriptions = "full" | "short" | "none";
 
 export interface SplashFit {
-  /** Which brand mark to draw. */
-  logo: LogoVariant;
+  /** Which brand mark to draw, or `"none"` when nothing fits. */
+  logo: LogoChoice;
   /** Whether the `ATOMIC AGENT` wordmark sits beside the mark. */
   wordmark: boolean;
   /** Whether the "Local AI-First Agent" tagline is drawn. */
@@ -103,8 +112,8 @@ interface LogoMetrics {
  */
 export const LOGO_METRICS: Readonly<Record<LogoVariant, LogoMetrics>> = {
   full: { width: 34, height: 20 },
-  small: { width: 17, height: 10 },
-  mini: { width: 14, height: 1 },
+  small: { width: 20, height: 12 },
+  mini: { width: 7, height: 4 },
 };
 
 /** `ATOMIC AGENT` half-block wordmark, plus the gap that precedes it. */
@@ -158,14 +167,25 @@ export function computeSplashFit(size: SplashSize): SplashFit {
   ) {
     index += 1;
   }
-  const logo = VARIANTS_WIDEST_FIRST[index]!;
+  let logo: LogoChoice = VARIANTS_WIDEST_FIRST[index]!;
+  if (
+    LOGO_METRICS[VARIANTS_WIDEST_FIRST[index]!]!.height +
+      TIP_LIST_MARGIN_ROWS +
+      1 >
+      rows ||
+    LOGO_METRICS[VARIANTS_WIDEST_FIRST[index]!]!.width > inner
+  ) {
+    logo = "none";
+  }
 
   // The wordmark is a 46-column luxury; it only rides along with the
   // full mark, and only once both fit side by side.
   const wordmark = logo === "full" && inner >= FULL_WITH_WORDMARK_WIDTH;
   const tagline = wordmark;
 
-  const spare = rows - LOGO_METRICS[logo].height - TIP_LIST_MARGIN_ROWS;
+  const markRows =
+    logo === "none" ? 0 : LOGO_METRICS[logo].height + TIP_LIST_MARGIN_ROWS;
+  const spare = rows - markRows;
   const tipCount = Math.max(0, Math.min(SPLASH_TIPS.length, spare));
   const visible = SPLASH_TIPS.slice(0, tipCount);
 

--- a/src/tui/components/splash-fit.ts
+++ b/src/tui/components/splash-fit.ts
@@ -1,0 +1,192 @@
+/**
+ * Fit maths for the start-page splash — which brand mark to draw, how
+ * many tips to keep, and how wide the tip columns may be for a given
+ * chat-surface size.
+ *
+ * The splash used to be a fixed 83×20 mark plus eight fixed tip rows,
+ * i.e. it needed 90 columns and ~29 rows no matter what the terminal
+ * offered. Ink 7 does not clip an over-tall frame — it overlaps
+ * earlier lines (see `../row-window.ts`) — so a short window garbled
+ * the whole start page, and a narrow one wrapped the artwork into
+ * confetti.
+ *
+ * The mark has priority over the tip list: a window that grows tall
+ * enough for a bigger mark spends its new rows on the artwork first, so
+ * the tip count can legitimately drop across a variant change. Within a
+ * variant the list only ever grows.
+ *
+ * This module is deliberately React-free so the breakpoints can be
+ * unit-tested as a table instead of through rendered frames.
+ */
+
+export type LogoVariant = "full" | "small" | "mini";
+
+export interface SplashSize {
+  columns: number;
+  rows: number;
+}
+
+export type TipDescriptions = "full" | "short" | "none";
+
+export interface SplashFit {
+  /** Which brand mark to draw. */
+  logo: LogoVariant;
+  /** Whether the `ATOMIC AGENT` wordmark sits beside the mark. */
+  wordmark: boolean;
+  /** Whether the "Local AI-First Agent" tagline is drawn. */
+  tagline: boolean;
+  /** How many tips fit, taken from the head of `SPLASH_TIPS`. */
+  tipCount: number;
+  /** Padded width of the tip label column (0 when unpadded). */
+  labelWidth: number;
+  /** Which description text to pair with each tip label. */
+  descriptions: TipDescriptions;
+}
+
+export interface SplashTip {
+  label: string;
+  /** Roomy copy, used when the surface can carry it. */
+  description: string;
+  /** Terse copy for narrow surfaces. */
+  short: string;
+}
+
+/**
+ * Start-page tips in priority order — the tail is dropped first when
+ * the surface runs out of rows, so the entries that keep a first-run
+ * operator moving have to come first.
+ */
+export const SPLASH_TIPS: readonly SplashTip[] = [
+  {
+    label: "Enter",
+    description: "submit message to the agent",
+    short: "send message",
+  },
+  {
+    label: "/help",
+    description: "list all slash commands",
+    short: "all commands",
+  },
+  {
+    label: "/sessions",
+    description: "switch to a previous thread",
+    short: "past threads",
+  },
+  { label: "/new", description: "start a fresh session", short: "new session" },
+  { label: "/model", description: "change the chat model", short: "pick model" },
+  {
+    label: "/tasks",
+    description: "jump to the Tasks tab (cron + ingress UI)",
+    short: "Tasks tab",
+  },
+  {
+    label: "/import",
+    description: "open the Import tab (Hermes migration)",
+    short: "Hermes import",
+  },
+  {
+    label: "Ctrl+C ×2",
+    description: "quit (once aborts a running turn)",
+    short: "quit",
+  },
+];
+
+interface LogoMetrics {
+  width: number;
+  height: number;
+}
+
+/**
+ * Rendered footprint of each mark, in cells. Kept beside the art in
+ * `logo.tsx` by `logo-fit.test.ts`, which re-measures the row data and
+ * fails if the two ever drift apart.
+ */
+export const LOGO_METRICS: Readonly<Record<LogoVariant, LogoMetrics>> = {
+  full: { width: 34, height: 20 },
+  small: { width: 17, height: 10 },
+  mini: { width: 14, height: 1 },
+};
+
+/** `ATOMIC AGENT` half-block wordmark, plus the gap that precedes it. */
+export const WORDMARK_WIDTH = 46;
+const WORDMARK_GAP = 3;
+
+/** `paddingX` on the splash container. */
+const SPLASH_PADDING_X = 2;
+/** `"  • "` in front of every tip label. */
+const TIP_PREFIX_WIDTH = 4;
+/** Roomy tip-label column, matching the pre-adaptive layout. */
+const TIP_LABEL_WIDE = 24;
+/** Tips are worth keeping only if a few of them survive together. */
+const MIN_TIPS = 3;
+/** One blank row separates the mark from the tip list. */
+const TIP_LIST_MARGIN_ROWS = 1;
+
+const VARIANTS_WIDEST_FIRST: readonly LogoVariant[] = ["full", "small", "mini"];
+
+/** Width at which the mark and the wordmark fit side by side. */
+const FULL_WITH_WORDMARK_WIDTH =
+  LOGO_METRICS.full.width + WORDMARK_GAP + WORDMARK_WIDTH;
+
+function maxLength(values: readonly string[]): number {
+  return values.reduce((acc, value) => Math.max(acc, value.length), 0);
+}
+
+/**
+ * Resolve the splash layout for a chat surface of `size`.
+ *
+ * `size` is the space the splash itself owns — already net of the root
+ * padding, the right rail and the prompt chrome (see `../layout.ts`).
+ * Width picks the mark, height then downgrades it until at least
+ * {@link MIN_TIPS} tips can sit underneath, and whatever rows are left
+ * decide how much of the tip list survives.
+ */
+export function computeSplashFit(size: SplashSize): SplashFit {
+  const inner = Math.max(0, size.columns - SPLASH_PADDING_X * 2);
+  const rows = Math.max(0, size.rows);
+
+  let index = VARIANTS_WIDEST_FIRST.findIndex(
+    (variant) => LOGO_METRICS[variant].width <= inner,
+  );
+  if (index === -1) index = VARIANTS_WIDEST_FIRST.length - 1;
+  while (
+    index < VARIANTS_WIDEST_FIRST.length - 1 &&
+    LOGO_METRICS[VARIANTS_WIDEST_FIRST[index]!]!.height +
+      TIP_LIST_MARGIN_ROWS +
+      MIN_TIPS >
+      rows
+  ) {
+    index += 1;
+  }
+  const logo = VARIANTS_WIDEST_FIRST[index]!;
+
+  // The wordmark is a 46-column luxury; it only rides along with the
+  // full mark, and only once both fit side by side.
+  const wordmark = logo === "full" && inner >= FULL_WITH_WORDMARK_WIDTH;
+  const tagline = wordmark;
+
+  const spare = rows - LOGO_METRICS[logo].height - TIP_LIST_MARGIN_ROWS;
+  const tipCount = Math.max(0, Math.min(SPLASH_TIPS.length, spare));
+  const visible = SPLASH_TIPS.slice(0, tipCount);
+
+  if (visible.length === 0) {
+    return { logo, wordmark, tagline, tipCount: 0, labelWidth: 0, descriptions: "none" };
+  }
+
+  const longestLabel = maxLength(visible.map((tip) => tip.label));
+  const longestFull = maxLength(visible.map((tip) => tip.description));
+  const longestShort = maxLength(visible.map((tip) => tip.short));
+  const tightLabel = longestLabel + 1;
+  const budget = inner - TIP_PREFIX_WIDTH;
+
+  if (budget >= TIP_LABEL_WIDE + longestFull) {
+    return { logo, wordmark, tagline, tipCount, labelWidth: TIP_LABEL_WIDE, descriptions: "full" };
+  }
+  if (budget >= tightLabel + longestFull) {
+    return { logo, wordmark, tagline, tipCount, labelWidth: tightLabel, descriptions: "full" };
+  }
+  if (budget >= tightLabel + longestShort) {
+    return { logo, wordmark, tagline, tipCount, labelWidth: tightLabel, descriptions: "short" };
+  }
+  return { logo, wordmark, tagline, tipCount, labelWidth: 0, descriptions: "none" };
+}

--- a/src/tui/layout.test.ts
+++ b/src/tui/layout.test.ts
@@ -5,15 +5,40 @@ import {
   computeSidebarRowBudget,
   computeSidebarWidth,
   isSidebarVisible,
+  SIDEBAR_CHROME_ROWS,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_COLUMNS,
+  SIDEBAR_MIN_ROWS,
   SIDEBAR_MIN_WIDTH,
 } from "./layout.js";
 
+/** Comfortably taller than anything the rail needs. */
+const TALL = 40;
+
 describe("isSidebarVisible", () => {
   it("collapses the rail one column below the threshold", () => {
-    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS - 1)).toBe(false);
-    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS)).toBe(true);
+    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS - 1, TALL)).toBe(false);
+    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS, TALL)).toBe(true);
+  });
+
+  it("collapses the rail one row below the threshold", () => {
+    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS, SIDEBAR_MIN_ROWS - 1)).toBe(
+      false,
+    );
+    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS, SIDEBAR_MIN_ROWS)).toBe(true);
+  });
+
+  it("hides the rail in a wide but short window", () => {
+    // A split tmux pane, or a terminal docked under an editor: wide
+    // enough for the rail and nowhere near tall enough for it.
+    expect(isSidebarVisible(100, 8)).toBe(false);
+    expect(isSidebarVisible(100, 5)).toBe(false);
+    expect(isSidebarVisible(200, 4)).toBe(false);
+  });
+
+  it("hides the rail in a degenerate window", () => {
+    expect(isSidebarVisible(1, 1)).toBe(false);
+    expect(isSidebarVisible(0, 0)).toBe(false);
   });
 });
 
@@ -36,15 +61,19 @@ describe("computeSidebarWidth", () => {
 
 describe("computeChatWidth", () => {
   it("only subtracts the rail once it is actually drawn", () => {
-    expect(computeChatWidth(80)).toBe(78);
-    expect(computeChatWidth(100)).toBe(100 - 2 - 25);
-    expect(computeChatWidth(120)).toBe(120 - 2 - 30);
+    expect(computeChatWidth(80, TALL)).toBe(78);
+    expect(computeChatWidth(100, TALL)).toBe(100 - 2 - 25);
+    expect(computeChatWidth(120, TALL)).toBe(120 - 2 - 30);
+  });
+
+  it("hands the chat column the full width when the rail is too short to draw", () => {
+    expect(computeChatWidth(120, 8)).toBe(118);
   });
 
   it("grows monotonically with the terminal", () => {
     let previous = 0;
     for (let columns = 40; columns <= 400; columns += 1) {
-      const width = computeChatWidth(columns);
+      const width = computeChatWidth(columns, TALL);
       expect(width).toBeGreaterThanOrEqual(0);
       // The rail appearing at 100 columns is the one allowed step back.
       if (columns !== SIDEBAR_MIN_COLUMNS) {
@@ -64,11 +93,24 @@ describe("computeSidebarRowBudget", () => {
     expect(computeSidebarRowBudget(16).tasks).toBe(3);
   });
 
-  it("keeps both panes alive on a very short window", () => {
-    for (let rows = 4; rows <= 12; rows += 1) {
+  it("keeps both panes alive at every height the rail is drawn at", () => {
+    for (let rows = SIDEBAR_MIN_ROWS; rows <= 12; rows += 1) {
       const budget = computeSidebarRowBudget(rows);
       expect(budget.sessions).toBeGreaterThanOrEqual(1);
       expect(budget.tasks).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("never budgets more rows than the window has", () => {
+    // The rail renders `sessions + tasks + SIDEBAR_CHROME_ROWS` rows,
+    // under a status bar that takes one more. Ink 7 overlaps rather
+    // than clips, so overshooting here is what garbles the frame.
+    for (let rows = 0; rows <= 60; rows += 1) {
+      if (!isSidebarVisible(SIDEBAR_MIN_COLUMNS, rows)) continue;
+      const budget = computeSidebarRowBudget(rows);
+      expect(
+        budget.sessions + budget.tasks + SIDEBAR_CHROME_ROWS + 1,
+      ).toBeLessThanOrEqual(rows);
     }
   });
 

--- a/src/tui/layout.test.ts
+++ b/src/tui/layout.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeChatViewportRows,
+  computeChatWidth,
+  computeSidebarRowBudget,
+  computeSidebarWidth,
+  isSidebarVisible,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_COLUMNS,
+  SIDEBAR_MIN_WIDTH,
+} from "./layout.js";
+
+describe("isSidebarVisible", () => {
+  it("collapses the rail one column below the threshold", () => {
+    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS - 1)).toBe(false);
+    expect(isSidebarVisible(SIDEBAR_MIN_COLUMNS)).toBe(true);
+  });
+});
+
+describe("computeSidebarWidth", () => {
+  it("scales with the terminal between the two clamps", () => {
+    expect(computeSidebarWidth(100)).toBe(25);
+    expect(computeSidebarWidth(120)).toBe(30);
+  });
+
+  it("never leaves the [min, max] band", () => {
+    expect(computeSidebarWidth(60)).toBe(SIDEBAR_MIN_WIDTH);
+    expect(computeSidebarWidth(400)).toBe(SIDEBAR_MAX_WIDTH);
+    for (let columns = 20; columns <= 400; columns += 1) {
+      const width = computeSidebarWidth(columns);
+      expect(width).toBeGreaterThanOrEqual(SIDEBAR_MIN_WIDTH);
+      expect(width).toBeLessThanOrEqual(SIDEBAR_MAX_WIDTH);
+    }
+  });
+});
+
+describe("computeChatWidth", () => {
+  it("only subtracts the rail once it is actually drawn", () => {
+    expect(computeChatWidth(80)).toBe(78);
+    expect(computeChatWidth(100)).toBe(100 - 2 - 25);
+    expect(computeChatWidth(120)).toBe(120 - 2 - 30);
+  });
+
+  it("grows monotonically with the terminal", () => {
+    let previous = 0;
+    for (let columns = 40; columns <= 400; columns += 1) {
+      const width = computeChatWidth(columns);
+      expect(width).toBeGreaterThanOrEqual(0);
+      // The rail appearing at 100 columns is the one allowed step back.
+      if (columns !== SIDEBAR_MIN_COLUMNS) {
+        expect(width).toBeGreaterThanOrEqual(previous);
+      }
+      previous = width;
+    }
+  });
+});
+
+describe("computeSidebarRowBudget", () => {
+  it("splits the usable height roughly 2:1 in favour of sessions", () => {
+    const budget = computeSidebarRowBudget(24);
+    expect(budget.sessions).toBe(10);
+    expect(budget.tasks).toBe(5);
+    expect(computeSidebarRowBudget(16).sessions).toBe(6);
+    expect(computeSidebarRowBudget(16).tasks).toBe(3);
+  });
+
+  it("keeps both panes alive on a very short window", () => {
+    for (let rows = 4; rows <= 12; rows += 1) {
+      const budget = computeSidebarRowBudget(rows);
+      expect(budget.sessions).toBeGreaterThanOrEqual(1);
+      expect(budget.tasks).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("stops growing once the caps are reached", () => {
+    expect(computeSidebarRowBudget(200)).toEqual({ sessions: 10, tasks: 5 });
+  });
+});
+
+describe("computeChatViewportRows", () => {
+  it("reserves the prompt chrome but never returns less than five rows", () => {
+    expect(computeChatViewportRows(40)).toBe(32);
+    expect(computeChatViewportRows(10)).toBe(4);
+    expect(computeChatViewportRows(2)).toBe(4);
+  });
+
+  it("reserves more chrome on a narrow terminal, where it wraps", () => {
+    expect(computeChatViewportRows(24, 45)).toBe(12);
+    expect(computeChatViewportRows(24, 80)).toBe(16);
+  });
+});

--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared terminal-geometry maths for the chat shell.
+ *
+ * Two components need to agree on how the terminal width is carved up:
+ * `TuiApp` decides whether the right rail is drawn and how wide it is,
+ * and `SplashBanner` has to know how much room is left for the brand
+ * artwork. Keeping the arithmetic here means the splash can never
+ * disagree with the rail about where the boundary sits.
+ *
+ * Nothing in this module touches React or `process.stdout` — callers
+ * pass the size they already read via `useTerminalSize()`.
+ */
+
+/** `paddingLeft` on the TUI root box (`tui-app.tsx`). */
+export const ROOT_PADDING_LEFT = 2;
+
+/**
+ * Minimum terminal width (in columns) at which the right-rail sidebar
+ * is rendered. Narrower terminals collapse the layout back to the
+ * single-column form so cramped sessions over SSH stay usable. Picked
+ * to match opencode's threshold.
+ */
+export const SIDEBAR_MIN_COLUMNS = 100;
+
+/** Narrowest rail that still fits a chevron, a badge and a preview. */
+export const SIDEBAR_MIN_WIDTH = 24;
+/** Widest rail — beyond this the previews stop gaining information. */
+export const SIDEBAR_MAX_WIDTH = 34;
+/** Share of the terminal the rail is allowed to claim. */
+const SIDEBAR_WIDTH_RATIO = 0.25;
+
+/**
+ * Rows the rail spends on its own chrome before a single list row is
+ * drawn: the status bar above it, the two section headers, the blank
+ * row between the panes, a "↓ N more" footer per pane and one row of
+ * slack.
+ */
+const SIDEBAR_CHROME_ROWS = 7;
+
+/**
+ * Rows of "chrome" outside the chat surface: status bar + prompt
+ * meta-row + prompt input + prompt tail-cap + hotkey hint + a small
+ * safety pad. Used to convert `terminal.rows` into the chat-area
+ * viewport height. Slightly conservative — better to leave one empty
+ * row than to clip the prompt.
+ */
+export const CHROME_ROWS = 8;
+
+/**
+ * Below this width the status bar, the hotkey hint strip and the prompt
+ * placeholder all start wrapping onto extra lines, so the chat surface
+ * gets less room than `CHROME_ROWS` alone would suggest. Measured
+ * against the real TUI at 45 columns: the status bar takes 2 rows, the
+ * hint strip 3, and the longer rotating placeholders push the prompt to
+ * 2 — hence one row of slack on top of the three observed.
+ */
+const NARROW_COLUMNS = 60;
+const NARROW_CHROME_EXTRA = 4;
+
+/** Floor for the chat viewport — below this nothing readable survives. */
+const MIN_VIEWPORT_ROWS = 4;
+
+/** Row caps at which extra height stops buying useful context. */
+const SIDEBAR_MAX_SESSION_ROWS = 10;
+const SIDEBAR_MAX_TASK_ROWS = 5;
+
+export interface SidebarRowBudget {
+  sessions: number;
+  tasks: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** Whether the terminal is wide enough to carry the right rail. */
+export function isSidebarVisible(columns: number): boolean {
+  return columns >= SIDEBAR_MIN_COLUMNS;
+}
+
+/**
+ * Rail width as a share of the terminal rather than a flat 30 columns.
+ * A flat width left a 100-column terminal with only 70 columns of chat
+ * — not enough for the full-size brand artwork — while a 200-column
+ * terminal got a rail that looked stranded.
+ */
+export function computeSidebarWidth(columns: number): number {
+  return clamp(
+    Math.round(columns * SIDEBAR_WIDTH_RATIO),
+    SIDEBAR_MIN_WIDTH,
+    SIDEBAR_MAX_WIDTH,
+  );
+}
+
+/**
+ * Columns available to the chat column (and therefore to the splash)
+ * once the root padding and the rail have taken their share.
+ */
+export function computeChatWidth(columns: number): number {
+  const rail = isSidebarVisible(columns) ? computeSidebarWidth(columns) : 0;
+  return Math.max(0, columns - ROOT_PADDING_LEFT - rail);
+}
+
+/**
+ * Split the rail's usable height between the Sessions and Tasks panes,
+ * roughly 2:1 in favour of sessions. Both panes keep at least one row
+ * so neither header is ever left dangling over an empty pane, and both
+ * stay under the caps that used to be hard-coded in `sidebar.tsx`.
+ *
+ * Ink 7 does not clip a frame taller than the terminal — it overlaps
+ * earlier lines (see `row-window.ts`) — so this budget is what keeps a
+ * short window from garbling the rail.
+ */
+export function computeSidebarRowBudget(rows: number): SidebarRowBudget {
+  const usable = Math.max(2, rows - SIDEBAR_CHROME_ROWS);
+  const sessions = clamp(
+    Math.ceil((usable * 2) / 3),
+    1,
+    SIDEBAR_MAX_SESSION_ROWS,
+  );
+  const tasks = clamp(usable - sessions, 1, SIDEBAR_MAX_TASK_ROWS);
+  return { sessions, tasks };
+}
+
+/**
+ * Rows the chat surface actually gets once the status bar, prompt and
+ * hint strip have taken theirs. Both `ChatLog` (scroll viewport) and
+ * `SplashBanner` (fit budget) read the same number so the splash can
+ * never plan for more rows than the surface it is rendered into.
+ *
+ * `columns` is optional so existing callers keep the wide-terminal
+ * behaviour; pass it to get the narrow-terminal correction.
+ */
+export function computeChatViewportRows(
+  rows: number,
+  columns = Number.POSITIVE_INFINITY,
+): number {
+  const chrome =
+    CHROME_ROWS + (columns < NARROW_COLUMNS ? NARROW_CHROME_EXTRA : 0);
+  return Math.max(MIN_VIEWPORT_ROWS, rows - chrome);
+}

--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -30,12 +30,35 @@ export const SIDEBAR_MAX_WIDTH = 34;
 const SIDEBAR_WIDTH_RATIO = 0.25;
 
 /**
- * Rows the rail spends on its own chrome before a single list row is
- * drawn: the status bar above it, the two section headers, the blank
- * row between the panes, a "↓ N more" footer per pane and one row of
- * slack.
+ * Rows the rail itself spends before a single list row is drawn: the
+ * two section headers, the blank row between the panes and a "↓ N
+ * more" footer per pane. Counted off the rendered component rather
+ * than estimated — the left border costs no rows because `sidebar.tsx`
+ * turns the top and bottom edges off — and pinned by
+ * `sidebar-fit.test.tsx`, which renders the rail at a budget and
+ * asserts it comes to exactly `sessions + tasks + SIDEBAR_CHROME_ROWS`
+ * rows.
  */
-const SIDEBAR_CHROME_ROWS = 7;
+export const SIDEBAR_CHROME_ROWS = 5;
+
+/**
+ * Rows the rail costs outside its own frame: the status bar above it
+ * (one row at any width that carries the rail) plus one row of slack,
+ * so the frame lands short of the terminal height rather than exactly
+ * on it.
+ */
+const SIDEBAR_OUTER_ROWS = 2;
+
+/** Everything the row budget has to leave alone. */
+const SIDEBAR_RESERVED_ROWS = SIDEBAR_CHROME_ROWS + SIDEBAR_OUTER_ROWS;
+
+/**
+ * Shortest terminal that still fits the reserved rows plus one list
+ * row in each pane. Below this the rail is not drawn at all: Ink 7
+ * overlaps rather than clips (see `row-window.ts`), so a rail that
+ * does not fit garbles the whole frame instead of losing its tail.
+ */
+export const SIDEBAR_MIN_ROWS = SIDEBAR_RESERVED_ROWS + 2;
 
 /**
  * Rows of "chrome" outside the chat surface: status bar + prompt
@@ -73,9 +96,14 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
-/** Whether the terminal is wide enough to carry the right rail. */
-export function isSidebarVisible(columns: number): boolean {
-  return columns >= SIDEBAR_MIN_COLUMNS;
+/**
+ * Whether the terminal is both wide and tall enough to carry the right
+ * rail. Height matters as much as width: a 100×8 split pane is wide
+ * enough for the rail and far too short for it, and an over-tall rail
+ * garbles the frame rather than being clipped.
+ */
+export function isSidebarVisible(columns: number, rows: number): boolean {
+  return columns >= SIDEBAR_MIN_COLUMNS && rows >= SIDEBAR_MIN_ROWS;
 }
 
 /**
@@ -96,29 +124,37 @@ export function computeSidebarWidth(columns: number): number {
  * Columns available to the chat column (and therefore to the splash)
  * once the root padding and the rail have taken their share.
  */
-export function computeChatWidth(columns: number): number {
-  const rail = isSidebarVisible(columns) ? computeSidebarWidth(columns) : 0;
+export function computeChatWidth(columns: number, rows: number): number {
+  const rail = isSidebarVisible(columns, rows)
+    ? computeSidebarWidth(columns)
+    : 0;
   return Math.max(0, columns - ROOT_PADDING_LEFT - rail);
 }
 
 /**
  * Split the rail's usable height between the Sessions and Tasks panes,
- * roughly 2:1 in favour of sessions. Both panes keep at least one row
- * so neither header is ever left dangling over an empty pane, and both
- * stay under the caps that used to be hard-coded in `sidebar.tsx`.
+ * roughly 2:1 in favour of sessions, and stay under the caps that used
+ * to be hard-coded in `sidebar.tsx`.
  *
  * Ink 7 does not clip a frame taller than the terminal — it overlaps
  * earlier lines (see `row-window.ts`) — so this budget is what keeps a
- * short window from garbling the rail.
+ * short window from garbling the rail. Nothing here floors the split
+ * above what is actually available: `sessions + tasks` never exceeds
+ * `usable`, and a window too short to seat one row in each pane is
+ * handled by `isSidebarVisible` hiding the rail outright, not by
+ * handing back a budget that does not fit.
  */
 export function computeSidebarRowBudget(rows: number): SidebarRowBudget {
-  const usable = Math.max(2, rows - SIDEBAR_CHROME_ROWS);
+  const usable = Math.max(0, rows - SIDEBAR_RESERVED_ROWS);
+  // Capping at `usable - 1` leaves the last row to Tasks, so its
+  // header is never left dangling over an empty pane while sessions
+  // still take the larger share of anything above two rows.
   const sessions = clamp(
-    Math.ceil((usable * 2) / 3),
-    1,
+    Math.min(Math.ceil((usable * 2) / 3), Math.max(1, usable - 1)),
+    0,
     SIDEBAR_MAX_SESSION_ROWS,
   );
-  const tasks = clamp(usable - sessions, 1, SIDEBAR_MAX_TASK_ROWS);
+  const tasks = clamp(usable - sessions, 0, SIDEBAR_MAX_TASK_ROWS);
   return { sessions, tasks };
 }
 

--- a/src/tui/theme/theme-palettes.ts
+++ b/src/tui/theme/theme-palettes.ts
@@ -41,6 +41,7 @@ export const GITHUB_DARK_COLORS: TuiColors = {
   warnStrong: "#db6d28",
   success: "#3fb950",
   info: "#4493f8",
+  brandMark: "#a5c9ff",
 };
 
 // GitHub Primer "light (default)" — @primer/primitives functional tokens
@@ -62,6 +63,7 @@ export const GITHUB_LIGHT_COLORS: TuiColors = {
   warnStrong: "#bc4c00",
   success: "#1a7f37",
   info: "#0969da",
+  brandMark: "#54a3ff",
 };
 
 // Catppuccin Mocha — official palette (catppuccin/palette palette.json).
@@ -84,6 +86,7 @@ export const CATPPUCCIN_MOCHA_COLORS: TuiColors = {
   warnStrong: "#fab387",
   success: "#a6e3a1",
   info: "#89b4fa",
+  brandMark: "#b4cffa",
 };
 
 // Catppuccin Latte — official palette (light flavour).
@@ -104,6 +107,7 @@ export const CATPPUCCIN_LATTE_COLORS: TuiColors = {
   warnStrong: "#fe640b",
   success: "#40a02b",
   info: "#1e66f5",
+  brandMark: "#5f9bf5",
 };
 
 // Dracula — official spec (draculatheme.com). accent=purple, green,
@@ -126,6 +130,7 @@ export const DRACULA_COLORS: TuiColors = {
   warnStrong: "#ffb86c",
   success: "#50fa7b",
   info: "#bd93f9",
+  brandMark: "#b9c9ff",
 };
 
 // Nord — official spec (nordtheme.com). accent=nord8 frost, nord14 green,
@@ -148,6 +153,7 @@ export const NORD_COLORS: TuiColors = {
   warnStrong: "#d08770",
   success: "#a3be8c",
   info: "#88c0d0",
+  brandMark: "#b3ccec",
 };
 
 // Tokyo Night ("Night" variant) — official spec
@@ -170,6 +176,7 @@ export const TOKYO_NIGHT_COLORS: TuiColors = {
   warnStrong: "#ff9e64",
   success: "#9ece6a",
   info: "#7aa2f7",
+  brandMark: "#a9c7ff",
 };
 
 // Gruvbox Dark — official "bright" palette (morhetz/gruvbox). accent=blue,
@@ -192,6 +199,7 @@ export const GRUVBOX_DARK_COLORS: TuiColors = {
   warnStrong: "#fe8019",
   success: "#b8bb26",
   info: "#83a598",
+  brandMark: "#b3d1e6",
 };
 
 // Gruvbox Light — official "faded" palette on light bg (morhetz/gruvbox).
@@ -212,6 +220,7 @@ export const GRUVBOX_LIGHT_COLORS: TuiColors = {
   warnStrong: "#af3a03",
   success: "#79740e",
   info: "#076678",
+  brandMark: "#5a9ec9",
 };
 
 // Solarized Dark — official spec (Ethan Schoonover). Accents are shared
@@ -234,6 +243,7 @@ export const SOLARIZED_DARK_COLORS: TuiColors = {
   warnStrong: "#cb4b16",
   success: "#859900",
   info: "#268bd2",
+  brandMark: "#9fc7e8",
 };
 
 // Solarized Light — same accent set, light base. base1(muted), base2(border).
@@ -254,4 +264,5 @@ export const SOLARIZED_LIGHT_COLORS: TuiColors = {
   warnStrong: "#cb4b16",
   success: "#859900",
   info: "#268bd2",
+  brandMark: "#4a95c9",
 };

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -42,6 +42,13 @@ export interface TuiColors {
   readonly toolError: string;
   readonly accent: string;
   readonly accentSoft: string;
+  /**
+   * The brand mark's own blue — deliberately lighter and whiter than
+   * `accent`. The mark is not a control, and painting it in the same
+   * blue as every accented control made the start page read as one big
+   * highlighted widget.
+   */
+  readonly brandMark: string;
   readonly border: string;
   readonly muted: string;
   readonly error: string;
@@ -210,11 +217,69 @@ export function getActiveThemeName(): ThemeName {
 }
 
 /**
+ * Backdrop dimming. While the operator menu is open the whole app behind it
+ * fades, so the popup reads as the foreground rather than as one more panel
+ * competing with the chat log.
+ *
+ * Implemented here rather than by threading a `dimmed` prop through every
+ * component because {@link theme} is already a read-at-render proxy — the
+ * same machinery that makes `/theme` live-preview repaint the whole UI. One
+ * flag flips every colour; the menu itself reads {@link chromeTheme}, which
+ * ignores the flag, so it stays at full contrast.
+ *
+ * Every colour collapses to the active theme's `muted`: a real terminal has
+ * no alpha channel, so "faded" has to mean "one low-contrast tone" rather
+ * than "the same colours, weaker".
+ */
+let backdropDimmed = false;
+let dimmedColorsFor: TuiColors | null = null;
+let dimmedColorsCache: TuiColors | null = null;
+
+export function setBackdropDimmed(next: boolean): void {
+  backdropDimmed = next;
+}
+
+export function isBackdropDimmed(): boolean {
+  return backdropDimmed;
+}
+
+function dimColors(colors: TuiColors): TuiColors {
+  if (dimmedColorsFor === colors && dimmedColorsCache) return dimmedColorsCache;
+  const flat = Object.fromEntries(
+    Object.keys(colors).map((key) => [key, colors.muted]),
+  ) as unknown as TuiColors;
+  dimmedColorsFor = colors;
+  dimmedColorsCache = flat;
+  return flat;
+}
+
+/**
  * The themed palette consumed across the TUI. A `Proxy` that always forwards
  * to the current {@link activeTheme}, so `theme.colors.X` reflects the active
  * theme at read time even after a `setActiveTheme` swap.
  */
 export const theme: TuiTheme = new Proxy({} as TuiTheme, {
+  get(_target, prop: string | symbol): unknown {
+    if (prop === "colors" && backdropDimmed) return dimColors(activeTheme.colors);
+    return activeTheme[prop as keyof TuiTheme];
+  },
+  has(_target, prop: string | symbol): boolean {
+    return prop in activeTheme;
+  },
+  ownKeys(): ArrayLike<string | symbol> {
+    return Reflect.ownKeys(activeTheme);
+  },
+  getOwnPropertyDescriptor(_target, prop: string | symbol) {
+    return Reflect.getOwnPropertyDescriptor(activeTheme, prop);
+  },
+});
+
+/**
+ * The palette for chrome that must stay legible while the backdrop is dimmed —
+ * i.e. the operator menu. Identical to {@link theme} except that it ignores
+ * {@link setBackdropDimmed}.
+ */
+export const chromeTheme: TuiTheme = new Proxy({} as TuiTheme, {
   get(_target, prop: string | symbol): unknown {
     return activeTheme[prop as keyof TuiTheme];
   },

--- a/src/tui/tui-app.test.tsx
+++ b/src/tui/tui-app.test.tsx
@@ -44,7 +44,11 @@ describe("TuiApp (smoke)", () => {
     expect(text).toContain("Run");
     expect(text).toContain("Observe");
     expect(text).toContain("Manage");
-    expect(text).toContain("Local AI-First Agent");
+    // The splash mark scales with the window; ink-testing-library's
+    // 100-column stdout reports no rows, so the fallback 80x24 surface
+    // gets the compact mark rather than the wordmark + tagline. Assert
+    // on what every size keeps. See `components/splash-fit.render.test.tsx`.
+    expect(text).toContain(":::");
     expect(text).toContain("commands");
     unmount();
   });

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -478,11 +478,13 @@ export function TuiApp({
     state.uiMode === "debug" && state.activeTab === "privacy";
   const terminalSize = useTerminalSize();
   const sidebarVisible =
-    state.uiMode === "chat" && isSidebarVisible(terminalSize.columns);
+    state.uiMode === "chat" &&
+    isSidebarVisible(terminalSize.columns, terminalSize.rows);
   // The rail takes a share of the terminal rather than a flat 30
   // columns, and its two panes get a row budget cut from the terminal
   // height — Ink 7 overlaps rather than clips an over-tall frame, so
-  // an unbudgeted rail garbles short windows.
+  // an unbudgeted rail garbles short windows. A window too short for
+  // even one row per pane drops the rail entirely.
   const sidebarWidth = computeSidebarWidth(terminalSize.columns);
   const sidebarRows = computeSidebarRowBudget(terminalSize.rows);
   const sidebarFocused = sidebarVisible && state.chatFocus === "sidebar";
@@ -515,9 +517,9 @@ export function TuiApp({
             state.localModelsPanel.removeConfirmId !== null)
         )));
 
-  // When the sidebar collapses below the width threshold (terminal
-  // resized smaller), focus must follow back to the editor so Tab does
-  // not strand the operator on an invisible surface.
+  // When the sidebar collapses below the width or height threshold
+  // (terminal resized smaller), focus must follow back to the editor so
+  // Tab does not strand the operator on an invisible surface.
   useEffect(() => {
     if (!sidebarVisible && state.chatFocus === "sidebar") {
       dispatch({ type: "chat_focus_set", focus: "editor" });

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -35,6 +35,11 @@ import { UpdateModal } from "./components/update-modal.js";
 import { UpdateIndicator } from "./components/update-indicator.js";
 import { UpdateRestartPrompt } from "./components/update-restart-prompt.js";
 import { useTerminalSize } from "./hooks/use-terminal-size.js";
+import {
+  computeSidebarRowBudget,
+  computeSidebarWidth,
+  isSidebarVisible,
+} from "./layout.js";
 import { filterSlashCommands } from "./commands/slash-commands.js";
 import { slashPrefix } from "./commands/slash-command-parser.js";
 import { handleEditorSubmit } from "./submit-handler.js";
@@ -346,15 +351,6 @@ const DEFAULT_MAX_VISIBLE_ROWS = 14;
 const CTRL_C_WINDOW_MS = 1500;
 
 /**
- * Minimum terminal width (in columns) at which the right-rail sidebar
- * is rendered. Narrower terminals collapse the layout back to the
- * single-column form so cramped sessions over SSH stay usable. Picked
- * to match opencode's threshold.
- */
-const SIDEBAR_MIN_COLUMNS = 100;
-const SIDEBAR_WIDTH = 30;
-
-/**
  * Rotating placeholder pool shown in the prompt's empty state. Phrasing
  * intentionally nudges the operator toward concrete actions the agent
  * can execute locally — file ops, browser automation, codebase Q&A —
@@ -482,7 +478,13 @@ export function TuiApp({
     state.uiMode === "debug" && state.activeTab === "privacy";
   const terminalSize = useTerminalSize();
   const sidebarVisible =
-    state.uiMode === "chat" && terminalSize.columns >= SIDEBAR_MIN_COLUMNS;
+    state.uiMode === "chat" && isSidebarVisible(terminalSize.columns);
+  // The rail takes a share of the terminal rather than a flat 30
+  // columns, and its two panes get a row budget cut from the terminal
+  // height — Ink 7 overlaps rather than clips an over-tall frame, so
+  // an unbudgeted rail garbles short windows.
+  const sidebarWidth = computeSidebarWidth(terminalSize.columns);
+  const sidebarRows = computeSidebarRowBudget(terminalSize.rows);
   const sidebarFocused = sidebarVisible && state.chatFocus === "sidebar";
   const editorFocus =
     !state.pendingApproval &&
@@ -817,7 +819,9 @@ export function TuiApp({
         </Box>
         {sidebarVisible ? (
           <Sidebar
-            width={SIDEBAR_WIDTH}
+            width={sidebarWidth}
+            maxSessionRows={sidebarRows.sessions}
+            maxTaskRows={sidebarRows.tasks}
             sessions={state.recentSessions}
             sessionsCursor={state.sidebarCursor}
             currentSessionId={state.session.sessionId}


### PR DESCRIPTION
## Problem

The TUI start page was built from three pieces that never looked at the terminal:

| Piece | Hard-coded size |
|---|---|
| Brand mark + `ATOMIC AGENT` wordmark (`logo.tsx`) | 34 cols art + 3 gap + 46 cols wordmark = **83 cols**, **20 rows** |
| Tip list (`splash-banner.tsx`) | 8 fixed rows, `padEnd(24)` + descriptions up to 62 chars ≈ **90 cols** |
| Right rail (`sidebar.tsx`) | `width={30}` flat, `MAX_SESSION_ROWS=10`, `MAX_TASK_ROWS=5`, height never consulted |

So the splash needed ~90 columns and ~29 rows, plus the 8 rows of prompt chrome — **37 rows** — before it could render honestly. Anything smaller broke, and as `row-window.ts` already notes, Ink 7 does not clip an over-tall frame: it overlaps earlier lines.

Two extra details made it worse than the raw numbers suggest:

- The rail appeared at ≥100 columns and took a flat 30, leaving **70** columns for a splash that wanted 87 — so the artwork wrapped at *every* width from 100 up to ~118.
- The rail had no `flexShrink={0}`, so Yoga let the chat column claw columns back out of it. On a 100-column terminal the rail rendered ~18 wide instead of 30 and truncated `(no sessions yet)` to `(no sessions ye…`.

`Logo` already had a `compact` prop; `SplashBanner` never passed it. `useTerminalSize()` already existed and was already used by `ChatLog` and `TuiApp`.

### Before — real `atomic-agent tui`, 80×24

```
  atomic-agent v0.2.2  |  ▸ Run  ·    Observe  ·    Manage
       -:::::::::::::-
    -::::::::::::::::-
  :::::::::::::::::::::::::::::::-
  ::::::::::::::::::::::::::::::::   ▄▀█ ▀█▀ █▀█ █▀▄▀█ █ █▀▀   ▄▀█ █▀▀ █▀▀ █▄ █
  ::::::::::::::::::::::::::::::::   █▀█  █  █▄█ █ ▀ █ █ █▄▄   █▀█ █▄█ ██▄ █ ▀█
  ::::::::::::::::::::::::::::::::
  -----------:::::::::::::::::---=   Local AI-First Agent
  @@@@@@@@@@*-::::::::::::-=+#%%@
            -:::::::::::-+#@
            -::::::::::=#@
      • /sessions               switch to a previous thread
      • /model                  change the chat model
      • /tasks                  jump to the Tasks tab (Option 4 cron + ingress
      • /import                 open the Import tab (one-shot Hermes ->
      • Ctrl+C ×2               quit (once aborts a running turn)
```

Top of the mark cut off, wordmark clipped mid-glyph, the `Enter` / `/help` / `/new` tips gone, two descriptions sliced mid-word.

### Before — 60×20

```
  atomic-agent v0.2.2  |  ▸ Run  ·    Observe  ·    Manage
  :::::::::::::::::::::-
  ::::::::::::::::::::::   ▄▀█ ▀█▀ █▀█ █▀▄▀█ █ █▀▀   ▄▀█ █▀▀
  ::::::::::::::::::::::   █▀█  █  █▄█ █ ▀ █ █ █▄▄   █▀█ █▄█
  ::::::::::::::::::::::
  -:::::::::::::::::---=   Local AI-First Agent
  *-::::::::::::-=+#%%@
  -:::  • /sessions               switch to a previous ds
  -:::  • /tasks                  jump to the Tasks tab
  -:::  • /import                 open the Import tab
  -:::  • Ctrl+C ×2               quit (once aborts a
```

Here the overlap is unmistakable — tip rows are painted straight over the artwork.

## What this does

Everything on the start page is now sized against the live terminal.

**`src/tui/layout.ts` (new)** — the shared geometry, React-free:

- `isSidebarVisible(columns)` / `computeSidebarWidth(columns)` — the rail is `clamp(24, 25% of columns, 34)` instead of a flat 30. The ≥100-column visibility gate is unchanged.
- `computeChatWidth(columns)` — what is left for the chat column once the root padding and the rail have taken theirs. `TuiApp` and `SplashBanner` read the same number, so the splash can no longer disagree with the rail about where the boundary is.
- `computeChatViewportRows(rows, columns?)` — the old `CHROME_ROWS` constant from `chat-log.tsx`, now shared, plus a correction for narrow terminals where the status bar, the hint strip and the prompt placeholder each wrap onto extra lines.
- `computeSidebarRowBudget(rows)` — splits the rail's usable height ~2:1 between Sessions and Tasks, both with a floor of 1 and the old 10 / 5 as caps.

**`src/tui/components/splash-fit.ts` (new)** — pure breakpoint maths. Takes the surface size, returns which mark to draw, whether the wordmark and tagline fit, how many tips survive, the tip-label column width, and whether descriptions are full, terse or dropped. Being React-free, it is unit-tested as a table rather than through rendered frames.

**`logo.tsx`** — the mark now comes in three sizes: `full` (the original 34×20 drawing, untouched), `small` (17×10) and `mini` (a single 14-column line). The artwork moved into an exported `LOGO_ART` record so a test can measure it. `compact` still works for existing callers.

**`splash-banner.tsx`** — measures the terminal, applies the fit plan. Tips live in one priority-ordered array with a long and a short description each; the tail is dropped first when rows run out, and descriptions collapse to the terse form before any tip disappears. Takes an optional explicit `size` so tests are deterministic.

**`sidebar.tsx`** — stays purely presentational: `width`, `maxSessionRows` and `maxTaskRows` arrive as props from `TuiApp`, which owns the measurement. Preview truncation is derived from the rail width instead of the hard-coded 28 / 24. Both panes now use the shared `computeRowWindow` from `row-window.ts` (replacing a private copy), so the Tasks pane finally scrolls to keep its cursor visible instead of silently slicing the first five rows. Added `flexShrink={0}` so the rail keeps the width it was given.

The mark has priority over the tip list: a window that grows tall enough for a bigger mark spends its new rows on the artwork, so the tip count can legitimately drop across a variant change. Within one variant the list only ever grows. That trade-off is documented and pinned by a test.

### After — 120×40

```
  atomic-agent v0.2.2  |  ▸ Run  ·    Observe  ·    Manage
                                                                                          │ Sessions
                 -:::::::--                                                               │ (no sessions yet)
                 -::::::::-                                                               │
                -:::::::::-                                                               │ Tasks
               -::::::::::-                                                               │ (no active tasks)
              -:::::::::::-                                                               │
            -:::::::::::::-                                                               │
         -::::::::::::::::-                                                               │
     -::::::::::::::::::::::::::::::::-                                                   │
     ::::::::::::::::::::::::::::::::::   ▄▀█ ▀█▀ █▀█ █▀▄▀█ █ █▀▀   ▄▀█ █▀▀ █▀▀ █▄ █ ▀█▀  │
     ::::::::::::::::::::::::::::::::::   █▀█  █  █▄█ █ ▀ █ █ █▄▄   █▀█ █▄█ ██▄ █ ▀█  █   │
     -:::::::::::::::::::::::::::::::::                                                   │
     =------------:::::::::::::::::---=   Local AI-First Agent                            │
      @@@@@@@@@@@*-::::::::::::-=+#%%@                                                    │
                 -:::::::::::-+#@                                                         │
                 -::::::::::=#@                                                           │
                 -:::::::::=#                                                             │
                 -::::::::-*                                                              │
                 -::::::::=                                                               │
                 +--------*                                                               │
                   %%%%%%                                                                 │
                                                                                          │
              • Enter                   submit message to the agent                       │
              • /help                   list all slash commands                           │
              • /sessions               switch to a previous thread                       │
              • /new                    start a fresh session                             │
              • /model                  change the chat model                             │
              • /tasks                  jump to the Tasks tab (cron + ingress UI)         │
              • /import                 open the Import tab (Hermes migration)            │
              • Ctrl+C ×2               quit (once aborts a running turn)                 │
                                                                                          │
                                                                                          │
  │                                                                                       │
  │ ❯  Type a message or `/` for commands…                                                │
  │                                                                                       │
  │ llama.cpp                                                                             │
  ╹                                                                                       │
  [enter] send [alt+enter] newline [tab] sidebar  [fn+↑↓] scroll [/] commands  [ctrl+c]   │
```

### After — 100×30

The rail border now sits exactly where `computeChatWidth(100)` says it should — column 75 — and `(no sessions yet)` is no longer truncated.

```
  atomic-agent v0.2.2  |  ▸ Run  ·    Observe  ·    Manage
                                                                           │ Sessions
                                    -:::--                                 │ (no sessions yet)
                                    -::::-                                 │
                                   -:::::-                                 │ Tasks
                                 -:::::::-                                 │ (no active tasks)
                              -:::::::::::::::-                            │
                              :::::::::::::::::                            │
                              =-----:::::::::-=                            │
                               @@@@@*-::::-=#%                             │
                                    -::::-*                                │
                                    +----*                                 │
                                                                           │
      • Enter                   submit message to the agent                │
      • /help                   list all slash commands                    │
      • /sessions               switch to a previous thread                │
      • /new                    start a fresh session                      │
      • /model                  change the chat model                      │
      • /tasks                  jump to the Tasks tab (cron + ingress UI)  │
      • /import                 open the Import tab (Hermes migration)     │
      • Ctrl+C ×2               quit (once aborts a running turn)          │
                                                                           │
  │                                                                        │
  │ ❯  Ask anything about your codebase…                                   │
  │                                                                        │
  │ llama.cpp                                                              │
  ╹                                                                        │
  [enter] sen[alt+enter]     [tab] sideba[fn+↑↓] scrol[/] commands[ctrl+c] │
```

### After — 60×20

```
  atomic-agent v0.2.2  |  ▸ Run  ·    Observe  ·    Manage
                        + ATOMIC AGENT

                    • Enter     send message
                    • /help     all commands
                    • /sessions past threads
                    • /new      new session
                    • /model    pick model
                    • /tasks    Tasks tab
                    • /import   Hermes import
                    • Ctrl+C ×2 quit

  │
  │ ❯  Ask anything about your codebase…
  │
  │ llama.cpp
  ╹
  [enter]  [alt+enter]  [tab]    [fn+↑↓]   [/]       [ctrl+c
  send  ·  newline  ·   sidebar  scroll  · commands  ] quit
```

### After — 50×18

```
  atomic-age        | ▸ Run  ·    Observe  ·
  t         v0.2.2    Manage
                   + ATOMIC AGENT

        • Enter     submit message to the agent
        • /help     list all slash commands
        • /sessions switch to a previous thread
        • /new      start a fresh session

  │
  │ ❯  Ask anything about your codebase…
  │
  │ llama.cpp
  ╹
```

## Tests

- `src/tui/layout.test.ts` — rail width clamps, chat-width monotonicity, row-budget floors and caps, viewport chrome.
- `src/tui/components/splash-fit.test.ts` — breakpoint table plus invariants swept over 10–200 columns × 2–60 rows: the planned layout always fits its surface, the mark never shrinks as the terminal widens, the tip list never shrinks within a variant.
- `src/tui/components/splash-fit.render.test.tsx` — renders the real component at 40×12, 60×20, 80×24, 100×30 and 100×50 and asserts no line exceeds the surface width and the frame never exceeds its rows, in the style of `manage-panel-fit.test.tsx`.
- `src/tui/components/logo-fit.test.ts` — measures the actual artwork rows against the `LOGO_METRICS` the breakpoints are built on, so the two can never drift apart silently.
- `src/tui/components/sidebar.test.tsx` — per-pane row budget, the Tasks pane scrolling to its cursor, and previews narrowing with the rail.

Two tests that were already failing on `main` are fixed on the way past: `splash-banner.test.tsx` asserted `/observe`, `/manage` and `/run` (the tips changed in #97), and `chat-log.test.tsx` asserted the banner text `Local-First AI Agent` when the component renders `Local AI-First Agent`.

## Verification

Node 25, `npm run build` clean. `npx vitest run src/tui`: the only remaining failures are the ones already failing on `main` in the same environment (`tui-app.test.tsx` nav-flakes under parallel load, `llm-health-poller`, `persist-embedding-hybrid-recall`). Frames above are real captures of `atomic-agent tui` driven through a PTY at each exact size and replayed through a terminal emulator.

Known limit: at 45×16 — narrower than any of the sizes above — Ink can still leave a stray character behind when the rotating prompt placeholder wraps and shifts the vertically-centred splash by a row. The frame no longer overlaps itself, which was the actual bug, but that size is past the point where the chrome alone fills the window.
