### PR TITLE
fix(tui): Esc returns to Run from Observe tabs instead of quitting the agent

### DIFF
--- a/src/tui/escape-observe-tabs.test.tsx
+++ b/src/tui/escape-observe-tabs.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "./tui-app.js";
+import { OBSERVE_TABS } from "./section.js";
+import type { TuiSessionInfo } from "./tui-state.js";
+
+const SESSION: TuiSessionInfo = {
+  sessionId: null,
+  workingDir: "/tmp/smoke",
+  llamaUrl: "http://127.0.0.1:8080",
+  browserChannel: "chrome",
+  browserHeadless: false,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+/**
+ * A lone Esc byte is held back by Ink's input parser for
+ * `pendingInputFlushDelayMilliseconds` (20ms) so it can be disambiguated
+ * from the start of a longer escape sequence. Every assertion therefore
+ * has to wait past that flush window before reading the frame.
+ */
+const ESC = String.fromCharCode(27);
+const FLUSH_MS = 60;
+
+const strip = (value: string): string =>
+  value
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .replace(/\u001b\]8;;[^\u0007]*\u0007/g, "");
+
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, FLUSH_MS));
+
+function trackingCallbacks(counts: { quit: number; abort: number }): TuiAppCallbacks {
+  return {
+    onApprovalDecision: () => {},
+    onAbort: () => {
+      counts.abort++;
+    },
+    onQuit: () => {
+      counts.quit++;
+    },
+    onMessageSubmitted: () => {},
+  };
+}
+
+describe("Esc on the Observe tabs", () => {
+  for (const tab of OBSERVE_TABS) {
+    it(`returns to Run from "${tab}" instead of quitting the agent`, async () => {
+      const counts = { quit: 0, abort: 0 };
+      const bus = makeTuiEventBus();
+      const { lastFrame, stdin, unmount } = render(
+        <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+      );
+      await settle();
+      bus.emit({ type: "ui_mode_set", mode: "debug" });
+      bus.emit({ type: "tab_changed", tab });
+      await settle();
+      expect(strip(lastFrame() ?? "")).toContain("▸ Observe");
+
+      stdin.write(ESC);
+      await settle();
+
+      // The hint strip promises "[esc] back to Run" on every debug tab.
+      // These five have no panel key layer, so before the fix the keypress
+      // reached the still-focused chat editor and quit the process.
+      expect(counts.quit).toBe(0);
+      expect(counts.abort).toBe(0);
+      expect(strip(lastFrame() ?? "")).toContain("▸ Run");
+      unmount();
+    });
+  }
+
+  it("does not quit when Esc is pressed twice from an Observe tab", async () => {
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+    bus.emit({ type: "ui_mode_set", mode: "debug" });
+    bus.emit({ type: "tab_changed", tab: "logs" });
+    await settle();
+
+    stdin.write(ESC);
+    await settle();
+    expect(counts.quit).toBe(0);
+    unmount();
+  });
+});

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -613,6 +613,16 @@ export function TuiApp({
       dispatch({ type: "chat_scroll_reset" });
       return;
     }
+    // A debug panel is open: Esc is the way back to Run, exactly as the
+    // hint strip advertises. The Observe tabs (Feed / World / Reasoning /
+    // Logs / LLM logs) have no key layer of their own, so `handlePanelEscape`
+    // never sees the keypress and the editor — which stays focused there so
+    // the operator can keep typing while watching the feed — used to fall
+    // through to the quit branch below and kill the agent instead.
+    if (state.uiMode === "debug") {
+      dispatch({ type: "ui_mode_set", mode: "chat" });
+      return;
+    }
     if (canAcceptMessage(state)) {
       callbacks.onQuit();
       dispatch({ type: "quit_requested" });


### PR DESCRIPTION
## Symptom

Pressing <kbd>Esc</kbd> on any **Observe** tab terminates the agent. One keypress, no confirmation — on a surface whose own hint strip promises `[esc] back to Run`.

Fastest repro:

```
/model        →  L        →  Esc      →  agent exits
(LLM panel)      (Local LLM logs)
```

`/logs`, `/feed`, `/observe` and Tab-cycling into Observe all reach the same place. All five tabs are affected: Feed, World, Reasoning, Logs, LLM logs.

## Cause

The TUI runs **two independent Ink `useInput` subscriptions** — the global one in `TuiApp` and the chat editor's own inside `MultiLineEditor`. Which one gets Esc is decided by `editorFocus` (`src/tui/tui-app.tsx`), a hand-maintained allow-list of tabs that unfocus the editor.

The Observe tabs are deliberately *not* on that list: the editor stays live there so you can keep typing while watching the feed. But they also have no panel key layer, so the `if/else` chain in `TuiApp`'s `useInput` leaves `panelHandled === null` and `handlePanelEscape` — the "Esc goes home to Run" layer added in #148 — is never reached. The keypress lands in the editor's `onEscape`, whose final branch is `onQuit()` whenever the session is idle.

So #148 fixed the Manage tabs and could not, by construction, fix these five.

## Fix

`onEscape` resolves debug mode to "back to Run" before it can reach the quit branch, dispatching the same `ui_mode_set` action that `handlePanelEscape` and `applyNavSlot` already use — one definition of "back to Run".

Manage tabs are untouched: they unfocus the editor, so their own panel layer still owns Esc and the existing *"Esc from an idle Manage panel returns to the Run screen"* test still passes.

## Evidence

Driving the real `TuiApp` through `ink-testing-library` and counting `onQuit` calls:

| tab | before | after |
|---|---|---|
| feed / world / reasoning / logs / llm-logs | `quit=2`, app gone | `→ Run`, `quit=0` |

## Tests

`src/tui/escape-observe-tabs.test.tsx` — one case per Observe tab plus a repeat-press case. Verified red before the change (`expected 2 to be +0` on all six) and green after.

`npx tsc --noEmit` clean. `npx vitest run src/tui`: same 5 pre-existing failures as `main @ 667dae1`, no new ones.

> Note for reviewers: a lone Esc byte is held by Ink's parser for 20 ms (`pendingInputFlushDelayMilliseconds`) to disambiguate it from a longer escape sequence, so the tests wait past that window before asserting. A shorter wait silently drops the keypress and the test passes vacuously.
