### PR TITLE
fix(tui): Esc leaves the Import tab instead of being swallowed by the form

### DIFF
--- a/src/tui/escape-import-tab.test.tsx
+++ b/src/tui/escape-import-tab.test.tsx
@@ -1,0 +1,64 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "./tui-app.js";
+import type { TuiSessionInfo } from "./tui-state.js";
+
+const SESSION: TuiSessionInfo = {
+  sessionId: null,
+  workingDir: "/tmp/smoke",
+  llamaUrl: "http://127.0.0.1:8080",
+  browserChannel: "chrome",
+  browserHeadless: false,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+/**
+ * Ink holds a lone Esc byte for `pendingInputFlushDelayMilliseconds`
+ * (20ms) to disambiguate it from a longer escape sequence, so every
+ * assertion waits past that flush window before reading the frame.
+ */
+const ESC = String.fromCharCode(27);
+const FLUSH_MS = 60;
+
+const strip = (value: string): string =>
+  value
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .replace(/\u001b\]8;;[^\u0007]*\u0007/g, "");
+
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, FLUSH_MS));
+
+describe("Esc on the Import tab", () => {
+  it("returns to Run instead of being swallowed by the form", async () => {
+    let quit = 0;
+    const callbacks: TuiAppCallbacks = {
+      onApprovalDecision: () => {},
+      onAbort: () => {},
+      onQuit: () => {
+        quit++;
+      },
+      onMessageSubmitted: () => {},
+    };
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={callbacks} />,
+    );
+    await settle();
+    bus.emit({ type: "ui_mode_set", mode: "debug" });
+    bus.emit({ type: "tab_changed", tab: "import" });
+    await settle();
+    expect(strip(lastFrame() ?? "")).toContain("▸ Manage");
+
+    stdin.write(ESC);
+    await settle();
+
+    // The configure-mode handler ends in a catch-all `return true` that
+    // swallows stray letters; before the fix it swallowed Esc too, so the
+    // operator was stuck on the tab with no "back" gesture at all.
+    expect(strip(lastFrame() ?? "")).toContain("▸ Run");
+    expect(quit).toBe(0);
+    unmount();
+  });
+});

--- a/src/tui/import/import-key-bindings.ts
+++ b/src/tui/import/import-key-bindings.ts
@@ -48,6 +48,12 @@ function handleConfigureKey(
   form: ImportFormState,
 ): boolean {
   const { dispatch, callbacks } = ctx;
+  // Decline Esc so `handlePanelEscape` can turn it into "back to Run" —
+  // the gesture the hint strip advertises on every debug tab. The
+  // catch-all `return true` at the bottom of this handler (which swallows
+  // stray letters so they cannot leak into the form) would otherwise eat
+  // it and leave the operator with no way off the Import tab.
+  if (key.escape) return false;
   if (key.ctrl && key.return) {
     callbacks.onImportPreview?.(form);
     return true;


### PR DESCRIPTION
## Symptom

<kbd>Esc</kbd> does nothing at all on the **Import** tab. Pressing it repeatedly leaves you parked on the form with no way back to Run, while the hint strip advertises `[esc] back to Run`.

```
/import  →  Esc  →  (nothing)  →  Esc  →  (nothing)  →  Esc  →  (nothing)
```

Tab still cycles out, so it is a trap only for the documented gesture — which is the one the footer tells you to use.

## Cause

`handleConfigureKey` ends in a catch-all `return true`. That is deliberate and correct for letters: the form has text fields, and stray keystrokes must not leak into the global hotkey layer.

But it also claims Esc. `TuiApp` then sees `panelHandled === true` and skips `handlePanelEscape`, the layer that turns a *declined* Esc into "back to Run".

## Fix

Configure mode declines Esc explicitly — the same one-liner the local-models panel already uses for exactly this reason — so the panel-escape layer can act on it.

Letter swallowing is unchanged. `preview` and `done` modes keep their own Esc meaning (reset the form one level); `running` still swallows everything while the import is in flight.

## Evidence

Driving the real `TuiApp`, three consecutive Esc presses on the Import tab:

| | before | after |
|---|---|---|
| esc ×3 | stays on `▸ Manage` every time | `→ ▸ Run` on the first press |

## Tests

`src/tui/escape-import-tab.test.tsx`. Verified red before the change (`expected '… Run …' to contain '▸ Run'`) and green after.

`npx tsc --noEmit` clean; no new failures in `npx vitest run src/tui` against `main @ 667dae1`.
