### PR TITLE
fix(tui): Esc in the chat editor clears the draft instead of quitting the agent

### DIFF
--- a/src/tui/components/hotkey-hint.test.tsx
+++ b/src/tui/components/hotkey-hint.test.tsx
@@ -1,3 +1,4 @@
+import { Box } from "ink";
 import { render } from "ink-testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import React from "react";
@@ -16,8 +17,24 @@ const MAC_SCROLL_KEY = "fn+↑↓";
 const OTHER_SCROLL_KEY = "pgup/pgdn";
 const SCROLL_KEY_PATTERN = /fn\+↑↓|pgup\/pgdn/;
 
-function renderHint(state: TuiState): string {
-  const { lastFrame, unmount } = render(<HotkeyHint state={state} />);
+/**
+ * Wide enough that no chip is shed — these cases assert *which* chips a
+ * state offers, not how the row degrades. Narrow behaviour has its own
+ * describe block below.
+ */
+const WIDE = 200;
+
+/**
+ * The strip is rendered inside a column-direction Box exactly as
+ * `TuiApp` renders it, so Ink resolves the same width and the frame we
+ * assert on is the frame the operator sees at `columns`.
+ */
+function renderHint(state: TuiState, columns: number = WIDE): string {
+  const { lastFrame, unmount } = render(
+    <Box width={columns} flexDirection="column">
+      <HotkeyHint state={state} width={columns} />
+    </Box>,
+  );
   const out = (lastFrame() ?? "").replace(ANSI, "");
   unmount();
   return out;
@@ -29,6 +46,15 @@ function chatState(overrides: Partial<TuiState> = {}): TuiState {
     uiMode: "chat" as const,
     ...overrides,
   };
+}
+
+/** Chips are `[key] label`; counting the brackets counts the chips. */
+function chipCount(frame: string): number {
+  return (frame.match(/\[/g) ?? []).length;
+}
+
+function widest(frame: string): number {
+  return Math.max(0, ...frame.split("\n").map((line) => line.length));
 }
 
 function fakeApproval(): ApprovalRequest {
@@ -71,6 +97,92 @@ describe("HotkeyHint scroll chip", () => {
   });
 });
 
+// Renders are the expensive part of this file (~2s each under Ink), so
+// each case below is one render and asserts everything it can from it.
+describe("HotkeyHint draft chips", () => {
+  it("swaps the inert / chip for esc / clear draft once a draft exists", () => {
+    // With a non-empty buffer `/` no longer opens the palette
+    // (`slashPrefix` only fires on a leading slash), so the chip being
+    // replaced costs the operator nothing — and the row stays six wide
+    // instead of growing a seventh chip.
+    const out = renderHint(chatState({ inputValue: "half a thought" }));
+    expect(out).toContain("[esc]");
+    expect(out).toContain("clear draft");
+    expect(out).not.toContain("commands");
+    expect(chipCount(out)).toBe(6);
+  });
+
+  it("keeps the empty idle footer free of the clear-draft chip", () => {
+    const out = renderHint(chatState());
+    expect(out).not.toContain("clear draft");
+    expect(out).toContain("[/]");
+    expect(out).toContain("commands");
+    expect(chipCount(out)).toBe(6);
+  });
+
+  it("tells the operator the draft survives an abort mid-turn", () => {
+    const out = renderHint(
+      chatState({ status: "running", inputValue: "half a thought" }),
+    );
+    expect(out).toContain("[esc]");
+    expect(out).toContain("abort, draft kept");
+    // Clearing is not on offer while a turn is in flight — abort wins.
+    expect(out).not.toContain("clear draft");
+  });
+
+  it("leaves the running label plain when there is no draft to keep", () => {
+    const out = renderHint(chatState({ status: "running" }));
+    expect(out).toContain("[esc]");
+    expect(out).toContain("abort");
+    expect(out).not.toContain("draft");
+  });
+});
+
+/**
+ * Ink wraps an over-wide row instead of clipping it, which both costs a
+ * row `debug-pane` budgeted away (`APP_CHROME_ROWS` counts the strip as
+ * 1) and smears chips across two lines with their separators stranded.
+ * The strip must therefore stay exactly one row, shedding whole chips
+ * rather than letting Yoga chop them.
+ */
+describe("HotkeyHint narrow-width degradation", () => {
+  it("sheds the scroll hint before send / clear-draft / quit at 80 columns", () => {
+    const out = renderHint(chatState({ inputValue: "half a thought" }), 80);
+    expect(out.split("\n")).toHaveLength(1);
+    expect(widest(out)).toBeLessThanOrEqual(80);
+    expect(out).not.toMatch(SCROLL_KEY_PATTERN);
+    expect(out).toContain("send");
+    expect(out).toContain("clear draft");
+    expect(out).toContain("quit");
+  });
+
+  it("keeps the running strip and its abort label on one row at 80 columns", () => {
+    const out = renderHint(
+      chatState({ status: "running", inputValue: "half a thought" }),
+      80,
+    );
+    expect(out.split("\n")).toHaveLength(1);
+    expect(widest(out)).toBeLessThanOrEqual(80);
+    expect(out).toContain("abort, draft kept");
+  });
+
+  it("keeps the debug footer on one row at 80 columns", () => {
+    const out = renderHint(chatState({ uiMode: "debug" }), 80);
+    expect(out.split("\n")).toHaveLength(1);
+    expect(widest(out)).toBeLessThanOrEqual(80);
+    expect(out).toContain("back to Run");
+  });
+
+  it("clips instead of wrapping once only essential chips are left", () => {
+    // 40 columns cannot hold even the essentials; `truncate-end` must
+    // take the overflow rather than Ink adding a second row.
+    const out = renderHint(chatState({ inputValue: "half a thought" }), 40);
+    expect(out.split("\n")).toHaveLength(1);
+    expect(widest(out)).toBeLessThanOrEqual(40);
+    expect(out).toContain("[enter]");
+  });
+});
+
 describe("HotkeyHint debug footer", () => {
   it("advertises the way back to Run and drops the duplicate ctrl+b chip", () => {
     const out = renderHint(chatState({ uiMode: "debug" }));
@@ -98,7 +210,11 @@ describe("HotkeyHint scroll key spelling per platform", () => {
     Object.defineProperty(process, "platform", { value: platform });
     vi.resetModules();
     const fresh = await import("./hotkey-hint.js");
-    const { lastFrame, unmount } = render(<fresh.HotkeyHint state={chatState()} />);
+    const { lastFrame, unmount } = render(
+      <Box width={WIDE} flexDirection="column">
+        <fresh.HotkeyHint state={chatState()} width={WIDE} />
+      </Box>,
+    );
     const out = (lastFrame() ?? "").replace(ANSI, "");
     unmount();
     return out;

--- a/src/tui/components/hotkey-hint.tsx
+++ b/src/tui/components/hotkey-hint.tsx
@@ -7,11 +7,25 @@ interface HotkeyHintProps {
   state: TuiState;
   /** Whether a Ctrl+C was recently pressed and is armed for exit. */
   ctrlCArmed?: boolean;
+  /**
+   * Columns the strip may occupy. This is the **chat column**, not the
+   * terminal: the caller subtracts the root gutter and the sidebar,
+   * because the strip shares a flex row with them. Required so a new
+   * call site cannot forget it and silently reintroduce the wrap.
+   */
+  width: number;
 }
 
 interface HotkeyChip {
   readonly key: string;
   readonly label: string;
+  /**
+   * Position in the shedding queue when the row does not fit `width`:
+   * chip `1` is dropped first, then `2`, and so on. A chip with no rank
+   * is essential — it stays even if the row still overflows (and is then
+   * clipped by `truncate-end` rather than wrapped).
+   */
+  readonly shed?: number;
 }
 
 /**
@@ -23,34 +37,46 @@ const SCROLL_KEY = process.platform === "darwin" ? "fn+\u2191\u2193" : "pgup/pgd
 
 /**
  * Bottom hint strip: surfaces the keybindings that are meaningful in
- * the current state so the user never has to guess. We cap to ~6 chips
- * to fit one terminal row and let slash commands take care of the long
- * tail.
+ * the current state so the user never has to guess.
+ *
+ * The strip is budgeted to **one row**. Ink does not clip an over-wide
+ * row, it wraps it — and a wrapped strip both costs a row the debug
+ * pane already budgeted away (`APP_CHROME_ROWS`) and splits chips from
+ * their separators into an unreadable two-line smear. So chips are shed
+ * in a declared order until the row fits, and `truncate-end` clips the
+ * essential remainder on a terminal too narrow even for those.
  */
-export function HotkeyHint({ state, ctrlCArmed }: HotkeyHintProps): ReactElement {
-  const chips = resolveChips(state, ctrlCArmed ?? false);
+export function HotkeyHint({
+  state,
+  ctrlCArmed,
+  width,
+}: HotkeyHintProps): ReactElement {
+  const chips = fitChips(resolveChips(state, ctrlCArmed ?? false), width);
   return (
     <Box flexShrink={0}>
-      {chips.map((chip, idx) => (
-        <Text key={chip.key}>
-          <Text color={theme.colors.accentSoft} bold>
-            [{chip.key}]
-          </Text>
-          <Text color={theme.colors.muted}> {chip.label}</Text>
-          {idx < chips.length - 1 ? (
-            <Text color={theme.colors.muted}>
-              {"  "}
-              {theme.glyphs.dotSeparator}
-              {"  "}
+      <Text wrap="truncate-end">
+        {chips.map((chip, idx) => (
+          <Text key={chip.key}>
+            <Text color={theme.colors.accentSoft} bold>
+              [{chip.key}]
             </Text>
-          ) : null}
-        </Text>
-      ))}
+            <Text color={theme.colors.muted}> {chip.label}</Text>
+            {idx < chips.length - 1 ? (
+              <Text color={theme.colors.muted}>
+                {"  "}
+                {theme.glyphs.dotSeparator}
+                {"  "}
+              </Text>
+            ) : null}
+          </Text>
+        ))}
+      </Text>
     </Box>
   );
 }
 
 function resolveChips(state: TuiState, ctrlCArmed: boolean): HotkeyChip[] {
+  const hasDraft = state.inputValue.length > 0;
   if (state.pendingApproval) {
     return [
       { key: "y", label: "approve" },
@@ -66,11 +92,16 @@ function resolveChips(state: TuiState, ctrlCArmed: boolean): HotkeyChip[] {
     ];
   }
   if (state.status === "running") {
-    // A long streaming answer is exactly when the operator wants to
-    // scroll back, so the hint rides along with abort.
+    // Esc has exactly one meaning during a turn — abort — because abort
+    // deliberately wins over clear-draft (see `onEscape` in
+    // `tui-app.tsx`). Say so when a draft exists: an operator who typed
+    // while the agent worked otherwise has nothing on screen telling him
+    // whether Esc also eats what he typed. A long streaming answer is
+    // also exactly when he wants to scroll back, so that hint rides
+    // along until the row runs out of room.
     return [
-      { key: SCROLL_KEY, label: "scroll" },
-      { key: "esc", label: "abort" },
+      { key: SCROLL_KEY, label: "scroll", shed: 1 },
+      { key: "esc", label: hasDraft ? "abort, draft kept" : "abort" },
       {
         key: "ctrl+c",
         label: ctrlCArmed ? "press again to quit" : "abort",
@@ -80,12 +111,13 @@ function resolveChips(state: TuiState, ctrlCArmed: boolean): HotkeyChip[] {
   if (state.uiMode === "debug") {
     // Ctrl+B still cycles panels but is unadvertised: it duplicated the
     // Tab chip word-for-word, and the freed slot pays for the one hint
-    // panels actually lacked — the way back to Run.
+    // panels actually lacked — the way back to Run. Shift+Tab sheds
+    // first because "prev panel" is guessable from "next panel".
     return [
       { key: "tab", label: "next panel" },
-      { key: "shift+tab", label: "prev panel" },
+      { key: "shift+tab", label: "prev panel", shed: 1 },
       { key: "esc", label: "back to Run" },
-      { key: "/", label: "commands" },
+      { key: "/", label: "commands", shed: 2 },
       {
         key: "ctrl+c",
         label: ctrlCArmed ? "press again to quit" : "quit",
@@ -94,9 +126,9 @@ function resolveChips(state: TuiState, ctrlCArmed: boolean): HotkeyChip[] {
   }
   if (state.chatFocus === "sidebar") {
     return [
-      { key: "↑↓", label: "select" },
+      { key: "↑↓", label: "select", shed: 2 },
       { key: "enter", label: "open" },
-      { key: "tab", label: "next pane" },
+      { key: "tab", label: "next pane", shed: 1 },
       { key: "esc", label: "back to editor" },
       {
         key: "ctrl+c",
@@ -104,18 +136,70 @@ function resolveChips(state: TuiState, ctrlCArmed: boolean): HotkeyChip[] {
       },
     ];
   }
-  // Six chips is the cap for one row on narrow terminals. The scroll
+  // Six chips is the cap for one row on a wide terminal. The scroll
   // hint replaces ctrl+b: Observe stays reachable via /observe, while
-  // scrolling had no visible entry point at all.
+  // scrolling had no visible entry point at all. Shedding order: scroll
+  // (the wheel already does it), then the sidebar (which the same
+  // narrow terminals collapse anyway — see `SIDEBAR_MIN_COLUMNS`), then
+  // the newline key.
   return [
     { key: "enter", label: "send" },
-    { key: "alt+enter", label: "newline" },
-    { key: "tab", label: "sidebar" },
-    { key: SCROLL_KEY, label: "scroll" },
-    { key: "/", label: "commands" },
+    { key: "alt+enter", label: "newline", shed: 3 },
+    { key: "tab", label: "sidebar", shed: 2 },
+    { key: SCROLL_KEY, label: "scroll", shed: 1 },
+    // A draft **swaps** the `/` chip instead of adding a seventh one:
+    // with a non-empty buffer `/` no longer opens the palette
+    // (`slashPrefix` only fires on a leading slash), so the chip being
+    // replaced is inert in exactly the state that needs the new one.
+    hasDraft
+      ? { key: "esc", label: "clear draft" }
+      : { key: "/", label: "commands" },
     {
       key: "ctrl+c",
       label: ctrlCArmed ? "press again to quit" : "quit",
     },
   ];
+}
+
+/**
+ * Drop chips — lowest `shed` rank first — until the row fits `width`.
+ * Stops once only essential (rank-less) chips remain; those overflow
+ * into `truncate-end` rather than silently disappearing.
+ */
+function fitChips(chips: HotkeyChip[], width: number): HotkeyChip[] {
+  let kept = chips;
+  while (stripWidth(kept) > width) {
+    const next = nextToShed(kept);
+    if (next < 0) break;
+    kept = kept.filter((_, idx) => idx !== next);
+  }
+  return kept;
+}
+
+function nextToShed(chips: readonly HotkeyChip[]): number {
+  let best = -1;
+  let bestRank = Number.POSITIVE_INFINITY;
+  chips.forEach((chip, idx) => {
+    if (chip.shed === undefined || chip.shed >= bestRank) return;
+    best = idx;
+    bestRank = chip.shed;
+  });
+  return best;
+}
+
+/**
+ * Rendered columns of the whole strip. Every key and label we ship is
+ * single-width (ASCII plus `↑`, `↓`, `·`), so `String.length` is the
+ * rendered width and we do not need a `string-width` dependency here —
+ * keep new chips inside that alphabet.
+ */
+function stripWidth(chips: readonly HotkeyChip[]): number {
+  if (chips.length === 0) return 0;
+  const separator = 4 + theme.glyphs.dotSeparator.length;
+  const chipWidths = chips.reduce(
+    // "[" + key + "] " + label
+    (acc, chip) => acc + chip.key.length + chip.label.length + 3,
+    0,
+  );
+  return chipWidths + (chips.length - 1) * separator;
 }

--- a/src/tui/components/multi-line-editor.tsx
+++ b/src/tui/components/multi-line-editor.tsx
@@ -115,13 +115,24 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
   // the callback checks the *current* focus, not the focus the subscription
   // was created with. (Render-phase write is safe: the value is derived
   // from props, never from state updated here.)
-  const activeRef = useRef(focus && !disabled);
-  activeRef.current = focus && !disabled;
+  const activeRef = useRef(focus);
+  activeRef.current = focus;
 
   useInput(
     (input, key) => {
       if (!activeRef.current) return;
-      if (disabled) return;
+      // A disabled editor rejects every key that could touch the buffer.
+      // Esc is not one of those: it is the surface-level cancel, and
+      // while the chat editor holds focus this hook owns the *only* Esc
+      // subscription — `handlePanelEscape` bows out on `editorFocus` and
+      // `handleAppKey` has no chat-mode Esc branch. Dropping it here is
+      // why the running hint strip advertised an `esc / abort` that
+      // never fired once the editor went disabled for the turn. Forward
+      // Esc, swallow the rest.
+      if (disabled) {
+        if (key.escape) onEscape?.();
+        return;
+      }
       handleKey({
         input,
         key,
@@ -138,7 +149,7 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
         onHistoryNext,
       });
     },
-    { isActive: focus && !disabled },
+    { isActive: focus },
   );
 
   const cursor = cursorToRowCol(value, cursorPos);

--- a/src/tui/escape-chat-editor.test.tsx
+++ b/src/tui/escape-chat-editor.test.tsx
@@ -79,6 +79,50 @@ describe("Esc in the chat editor", () => {
     unmount();
   });
 
+  it("aborts the turn and keeps the draft when both are on the table", async () => {
+    // The precedence this branch commits to: while a turn is in flight
+    // Esc aborts and leaves the buffer alone; the *next* Esc, now idle,
+    // clears it. Abort is the destructive, time-critical action and a
+    // draft is cheap to keep, so it wins.
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+    stdin.write("draft message");
+    await settle();
+    bus.emitAgentEvent({ type: "turn_started", turnIndex: 0 });
+    await settle();
+    expect(strip(lastFrame() ?? "")).toContain("draft message");
+
+    stdin.write(ESC);
+    await settle();
+
+    expect(counts.abort).toBe(1);
+    expect(counts.quit).toBe(0);
+    // Untouched: the run stopped, the half-typed message did not.
+    expect(strip(lastFrame() ?? "")).toContain("draft message");
+
+    bus.emitAgentEvent({
+      type: "turn_finished",
+      turnIndex: 0,
+      reason: "cancelled",
+      stepCount: 0,
+      durationMs: 1,
+    });
+    await settle();
+
+    stdin.write(ESC);
+    await settle();
+
+    // Second Esc, this time idle: now the draft goes and nothing else.
+    expect(strip(lastFrame() ?? "")).not.toContain("draft message");
+    expect(counts.abort).toBe(1);
+    expect(counts.quit).toBe(0);
+    unmount();
+  });
+
   it("survives leaving a Manage panel and pressing Esc again", async () => {
     // The reported trap: Esc walks back from the panel to Run, and the
     // next Esc — the natural "and back out of here too" press — used to

--- a/src/tui/escape-chat-editor.test.tsx
+++ b/src/tui/escape-chat-editor.test.tsx
@@ -1,0 +1,110 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "./tui-app.js";
+import type { TuiSessionInfo } from "./tui-state.js";
+
+const SESSION: TuiSessionInfo = {
+  sessionId: null,
+  workingDir: "/tmp/smoke",
+  llamaUrl: "http://127.0.0.1:8080",
+  browserChannel: "chrome",
+  browserHeadless: false,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+/**
+ * Ink holds a lone Esc byte for `pendingInputFlushDelayMilliseconds`
+ * (20ms) to disambiguate it from a longer escape sequence, so every
+ * assertion waits past that flush window before reading the frame.
+ */
+const ESC = String.fromCharCode(27);
+const FLUSH_MS = 60;
+
+const strip = (value: string): string =>
+  value
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .replace(/\u001b\]8;;[^\u0007]*\u0007/g, "");
+
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, FLUSH_MS));
+
+function trackingCallbacks(counts: { quit: number; abort: number }): TuiAppCallbacks {
+  return {
+    onApprovalDecision: () => {},
+    onAbort: () => {
+      counts.abort++;
+    },
+    onQuit: () => {
+      counts.quit++;
+    },
+    onMessageSubmitted: () => {},
+  };
+}
+
+describe("Esc in the chat editor", () => {
+  it("does not quit an idle agent", async () => {
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+
+    stdin.write(ESC);
+    await settle();
+
+    expect(counts.quit).toBe(0);
+    expect(counts.abort).toBe(0);
+    unmount();
+  });
+
+  it("clears a half-typed draft instead of killing the agent", async () => {
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+    stdin.write("draft message");
+    await settle();
+    expect(strip(lastFrame() ?? "")).toContain("draft message");
+
+    stdin.write(ESC);
+    await settle();
+
+    expect(strip(lastFrame() ?? "")).not.toContain("draft message");
+    expect(counts.quit).toBe(0);
+    unmount();
+  });
+
+  it("survives leaving a Manage panel and pressing Esc again", async () => {
+    // The reported trap: Esc walks back from the panel to Run, and the
+    // next Esc — the natural "and back out of here too" press — used to
+    // terminate the agent.
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+    bus.emit({ type: "ui_mode_set", mode: "debug" });
+    bus.emit({ type: "tab_changed", tab: "skills" });
+    await settle();
+
+    stdin.write(ESC);
+    await settle();
+    expect(strip(lastFrame() ?? "")).toContain("▸ Run");
+    expect(counts.quit).toBe(0);
+
+    stdin.write(ESC);
+    await settle();
+    expect(counts.quit).toBe(0);
+
+    stdin.write(ESC);
+    await settle();
+    expect(counts.quit).toBe(0);
+    unmount();
+  });
+});

--- a/src/tui/escape-observe-tabs.test.tsx
+++ b/src/tui/escape-observe-tabs.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "./tui-app.js";
+import { OBSERVE_TABS } from "./section.js";
+import type { TuiSessionInfo } from "./tui-state.js";
+
+const SESSION: TuiSessionInfo = {
+  sessionId: null,
+  workingDir: "/tmp/smoke",
+  llamaUrl: "http://127.0.0.1:8080",
+  browserChannel: "chrome",
+  browserHeadless: false,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+/**
+ * A lone Esc byte is held back by Ink's input parser for
+ * `pendingInputFlushDelayMilliseconds` (20ms) so it can be disambiguated
+ * from the start of a longer escape sequence. Every assertion therefore
+ * has to wait past that flush window before reading the frame.
+ */
+const ESC = String.fromCharCode(27);
+const FLUSH_MS = 60;
+
+const strip = (value: string): string =>
+  value
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .replace(/\u001b\]8;;[^\u0007]*\u0007/g, "");
+
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, FLUSH_MS));
+
+function trackingCallbacks(counts: { quit: number; abort: number }): TuiAppCallbacks {
+  return {
+    onApprovalDecision: () => {},
+    onAbort: () => {
+      counts.abort++;
+    },
+    onQuit: () => {
+      counts.quit++;
+    },
+    onMessageSubmitted: () => {},
+  };
+}
+
+describe("Esc on the Observe tabs", () => {
+  for (const tab of OBSERVE_TABS) {
+    it(`returns to Run from "${tab}" instead of quitting the agent`, async () => {
+      const counts = { quit: 0, abort: 0 };
+      const bus = makeTuiEventBus();
+      const { lastFrame, stdin, unmount } = render(
+        <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+      );
+      await settle();
+      bus.emit({ type: "ui_mode_set", mode: "debug" });
+      bus.emit({ type: "tab_changed", tab });
+      await settle();
+      expect(strip(lastFrame() ?? "")).toContain("▸ Observe");
+
+      stdin.write(ESC);
+      await settle();
+
+      // The hint strip promises "[esc] back to Run" on every debug tab.
+      // These five have no panel key layer, so before the fix the keypress
+      // reached the still-focused chat editor and quit the process.
+      expect(counts.quit).toBe(0);
+      expect(counts.abort).toBe(0);
+      expect(strip(lastFrame() ?? "")).toContain("▸ Run");
+      unmount();
+    });
+  }
+
+  it("does not quit when Esc is pressed twice from an Observe tab", async () => {
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+    bus.emit({ type: "ui_mode_set", mode: "debug" });
+    bus.emit({ type: "tab_changed", tab: "logs" });
+    await settle();
+
+    stdin.write(ESC);
+    await settle();
+    expect(counts.quit).toBe(0);
+    unmount();
+  });
+});

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -613,6 +613,16 @@ export function TuiApp({
       dispatch({ type: "chat_scroll_reset" });
       return;
     }
+    // A debug panel is open: Esc is the way back to Run, exactly as the
+    // hint strip advertises. The Observe tabs (Feed / World / Reasoning /
+    // Logs / LLM logs) have no key layer of their own, so `handlePanelEscape`
+    // never sees the keypress and the editor — which stays focused there so
+    // the operator can keep typing while watching the feed — used to fall
+    // through to the quit branch below and kill the agent instead.
+    if (state.uiMode === "debug") {
+      dispatch({ type: "ui_mode_set", mode: "chat" });
+      return;
+    }
     if (canAcceptMessage(state)) {
       callbacks.onQuit();
       dispatch({ type: "quit_requested" });

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -353,6 +353,8 @@ const CTRL_C_WINDOW_MS = 1500;
  */
 const SIDEBAR_MIN_COLUMNS = 100;
 const SIDEBAR_WIDTH = 30;
+/** Left gutter of the whole app frame — see the root `paddingLeft`. */
+const ROOT_PADDING_COLUMNS = 2;
 
 /**
  * Rotating placeholder pool shown in the prompt's empty state. Phrasing
@@ -483,6 +485,15 @@ export function TuiApp({
   const terminalSize = useTerminalSize();
   const sidebarVisible =
     state.uiMode === "chat" && terminalSize.columns >= SIDEBAR_MIN_COLUMNS;
+  // Columns left for the main column once the frame gutter and the
+  // right rail have taken their cut — what the one-row hint strip has
+  // to fit inside.
+  const mainColumnWidth = Math.max(
+    0,
+    terminalSize.columns -
+      ROOT_PADDING_COLUMNS -
+      (sidebarVisible ? SIDEBAR_WIDTH : 0),
+  );
   const sidebarFocused = sidebarVisible && state.chatFocus === "sidebar";
   const editorFocus =
     !state.pendingApproval &&
@@ -623,19 +634,32 @@ export function TuiApp({
       dispatch({ type: "ui_mode_set", mode: "chat" });
       return;
     }
-    // Esc never quits. Everywhere else in the TUI it means cancel / back
-    // one level, so a single unannounced press killing the agent — and
-    // the half-typed message with it — was a trap: no hint strip ever
-    // advertised it, while Ctrl+C deliberately asks twice. Quitting stays
-    // on Ctrl+C twice and `/quit`; Esc just clears the draft.
-    if (canAcceptMessage(state)) {
-      if (state.inputValue.length > 0) {
-        dispatch({ type: "input_changed", value: "" });
-      }
+    // `canAcceptMessage` is `status === "idle"`, so its negation reads
+    // "a turn is in flight" — running, awaiting approval, or quitting.
+    const turnInFlight = !canAcceptMessage(state);
+    // PRECEDENCE, decided rather than inherited from branch order: while
+    // a turn is in flight **abort wins and the draft is left alone**.
+    // Abort is the destructive, time-critical action — the operator who
+    // hits Esc mid-run wants the agent stopped now — whereas a draft is
+    // cheap to keep: one more Esc, this time idle, clears it. The other
+    // order would silently eat the message while the run it was meant to
+    // stop kept going. Nothing on screen could disambiguate the two, so
+    // the running hint strip labels Esc `abort, draft kept` whenever
+    // there is a draft to keep (see `hotkey-hint.tsx`).
+    if (turnInFlight) {
+      callbacks.onAbort();
+      dispatch({ type: "abort_requested" });
       return;
     }
-    callbacks.onAbort();
-    dispatch({ type: "abort_requested" });
+    // Idle: Esc never quits. Everywhere else in the TUI it means cancel /
+    // back one level, so a single unannounced press killing the agent —
+    // and the half-typed message with it — was a trap: no hint strip ever
+    // advertised it, while Ctrl+C deliberately asks twice. Quitting stays
+    // on Ctrl+C twice and `/quit`; Esc clears the draft and no-ops on an
+    // empty buffer.
+    if (state.inputValue.length > 0) {
+      dispatch({ type: "input_changed", value: "" });
+    }
   }, [state, callbacks]);
 
   // Tab in the editor is reserved for slash-palette completion. Section
@@ -733,7 +757,7 @@ export function TuiApp({
   return (
     <Box
       flexDirection="column"
-      paddingLeft={2}
+      paddingLeft={ROOT_PADDING_COLUMNS}
       {...(rootHeight ? { height: rootHeight } : {})}
     >
       <Box flexShrink={0}>
@@ -829,7 +853,11 @@ export function TuiApp({
             onHistoryPrev={onHistoryPrev}
             onHistoryNext={onHistoryNext}
           />
-          <HotkeyHint state={state} ctrlCArmed={ctrlCArmed} />
+          <HotkeyHint
+            state={state}
+            ctrlCArmed={ctrlCArmed}
+            width={mainColumnWidth}
+          />
         </Box>
         {sidebarVisible ? (
           <Sidebar

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -623,13 +623,19 @@ export function TuiApp({
       dispatch({ type: "ui_mode_set", mode: "chat" });
       return;
     }
+    // Esc never quits. Everywhere else in the TUI it means cancel / back
+    // one level, so a single unannounced press killing the agent — and
+    // the half-typed message with it — was a trap: no hint strip ever
+    // advertised it, while Ctrl+C deliberately asks twice. Quitting stays
+    // on Ctrl+C twice and `/quit`; Esc just clears the draft.
     if (canAcceptMessage(state)) {
-      callbacks.onQuit();
-      dispatch({ type: "quit_requested" });
-    } else {
-      callbacks.onAbort();
-      dispatch({ type: "abort_requested" });
+      if (state.inputValue.length > 0) {
+        dispatch({ type: "input_changed", value: "" });
+      }
+      return;
     }
+    callbacks.onAbort();
+    dispatch({ type: "abort_requested" });
   }, [state, callbacks]);
 
   // Tab in the editor is reserved for slash-palette completion. Section


### PR DESCRIPTION
> **Stacked on #153 ("Esc returns to Run from Observe tabs").** Both touch `onEscape`. Merge that one first; this branch is built on it.

## Symptom

A single <kbd>Esc</kbd> on the Run screen terminates the agent as soon as the session is idle — no confirmation, and no hint strip anywhere advertises it. <kbd>Ctrl</kbd>+<kbd>C</kbd> deliberately asks twice before it kills anything; Esc did it on the first press, and took any half-typed message with it.

It is reachable straight out of ordinary navigation, which is how I hit it:

```
/skill  →  Esc  →  back to Run   (correct)
        →  Esc  →  agent exits   (the natural "and out of here too")
```

Same from `/model`, and from every overlay: closing the slash palette, theme picker, session picker or sidebar focus with Esc leaves you one press away from an unannounced exit.

## Cause

`onEscape` ends in:

```ts
if (canAcceptMessage(state)) {
  callbacks.onQuit();
  dispatch({ type: "quit_requested" });
}
```

Esc means *cancel / back one level* on every other surface of this TUI. The one place it meant "exit" was the one place nothing said so.

## Fix

Esc on an idle Run screen clears the draft and no-ops on an empty buffer, reusing the same `input_changed` reset the submit handler dispatches — which also clears the input-history cursor.

Quitting stays on <kbd>Ctrl</kbd>+<kbd>C</kbd> twice and `/quit`. The abort path for a non-idle session is unchanged.

No hint-strip change: the chat row is already at its six-chip cap and still correctly shows `[ctrl+c] quit`.

## Evidence

Counting `onQuit` calls while driving the real `TuiApp`:

| scenario | before | after |
|---|---|---|
| Esc, idle Run screen | `quit=2`, app gone | `quit=0` |
| Esc with a draft typed | `quit=2`, draft lost | `quit=0`, draft cleared |
| `/skill` → Esc → Esc | 2nd press exits | stays on Run |
| Esc ×2 from slash palette / theme picker / session picker / sidebar | 2nd press exits | stays on Run |

## Tests

`src/tui/escape-chat-editor.test.tsx` — idle no-quit, draft-clearing, and the reported panel → Run → Esc → Esc sequence. Verified red before the change (3 of 3 failing) and green after.

`npx tsc --noEmit` clean; no new failures in `npx vitest run src/tui` against `main @ 667dae1`.
