### PR TITLE
config: parse userModels, promptCache and providerPreferences on llm providers

### DIFF
--- a/src/config/llm-config.test.ts
+++ b/src/config/llm-config.test.ts
@@ -231,6 +231,160 @@ describe("llm-config", () => {
     });
   });
 
+  const withProviderField = (extra: Record<string, unknown>) => ({
+    version: USER_CONFIG_VERSION,
+    llm: {
+      activeTextProvider: "openrouter",
+      activeEmbeddingProvider: "local-llama",
+      toolTransport: "auto" as const,
+      providers: [
+        { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:19091" },
+        { id: "openrouter", kind: "openrouter", defaultChatModel: "gpt", ...extra },
+      ],
+    },
+  });
+
+  it("round-trips promptCache and providerPreferences on a provider entry", () => {
+    const parsed = parseUserConfigFile(
+      withProviderField({
+        promptCache: "explicit-markers",
+        providerPreferences: { order: ["anthropic"], allow_fallbacks: false },
+      }),
+    );
+    expect(parsed.llm?.providers[1]).toMatchObject({
+      promptCache: "explicit-markers",
+      providerPreferences: { order: ["anthropic"], allow_fallbacks: false },
+    });
+  });
+
+  it("rejects an unknown promptCache mode", () => {
+    expect(() =>
+      parseUserConfigFile(withProviderField({ promptCache: "always" })),
+    ).toThrow(/llm\.providers\[1\]\.promptCache/);
+  });
+
+  it("rejects a non-object providerPreferences", () => {
+    expect(() =>
+      parseUserConfigFile(withProviderField({ providerPreferences: ["anthropic"] })),
+    ).toThrow(/llm\.providers\[1\]\.providerPreferences/);
+  });
+
+  const withUserModels = (userModels: unknown) => ({
+    version: USER_CONFIG_VERSION,
+    llm: {
+      activeTextProvider: "model-studio",
+      activeEmbeddingProvider: "local-llama",
+      toolTransport: "auto" as const,
+      providers: [
+        { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:19091" },
+        {
+          id: "model-studio",
+          kind: "qwen-openai-compatible",
+          baseUrl: "https://example.invalid/compatible-mode",
+          defaultChatModel: "qwen3.8-27b",
+          userModels,
+        },
+      ],
+    },
+  });
+
+  it("round-trips userModels on a provider entry", () => {
+    const parsed = parseUserConfigFile(
+      withUserModels([
+        {
+          id: "qwen3.8-27b",
+          kind: "chat",
+          contextWindow: 262144,
+          supportsVision: true,
+          supportsTools: "strict",
+          supportsPromptCache: true,
+          reasoningFormat: "delta_reasoning_content",
+          pricing: { input: 0.0004, output: 0.0012, cacheRead: 0 },
+        },
+        { id: "text-embedding-v4", kind: "embedding", dim: 1024 },
+      ]),
+    );
+
+    // resolveModel reads userModels as its highest-priority source, so
+    // the parser dropping these rows is the difference between a
+    // hand-configured model and the 128k/no-pricing defaults.
+    expect(parsed.llm?.providers[1]?.userModels).toEqual([
+      {
+        id: "qwen3.8-27b",
+        kind: "chat",
+        contextWindow: 262144,
+        dim: undefined,
+        supportsVision: true,
+        supportsTools: "strict",
+        supportsPromptCache: true,
+        reasoningFormat: "delta_reasoning_content",
+        pricing: { input: 0.0004, output: 0.0012, cacheRead: 0 },
+      },
+      {
+        id: "text-embedding-v4",
+        kind: "embedding",
+        contextWindow: undefined,
+        dim: 1024,
+        supportsVision: undefined,
+        supportsTools: undefined,
+        supportsPromptCache: undefined,
+        reasoningFormat: undefined,
+        pricing: undefined,
+      },
+    ]);
+  });
+
+  it("omits userModels when the entry does not configure any", () => {
+    const parsed = parseUserConfigFile(withUserModels(undefined));
+    expect(parsed.llm?.providers[1]?.userModels).toBeUndefined();
+  });
+
+  it("rejects a userModels row with an unknown kind", () => {
+    expect(() =>
+      parseUserConfigFile(
+        withUserModels([{ id: "qwen3.8-27b", kind: "completion" }]),
+      ),
+    ).toThrow(/llm\.providers\[1\]\.userModels\[0\]\.kind/);
+  });
+
+  it("rejects a userModels row with a malformed contextWindow", () => {
+    expect(() =>
+      parseUserConfigFile(
+        withUserModels([
+          { id: "a", kind: "chat" },
+          { id: "b", kind: "chat", contextWindow: "262144" },
+        ]),
+      ),
+    ).toThrow(/llm\.providers\[1\]\.userModels\[1\]\.contextWindow/);
+  });
+
+  it("rejects userModels pricing that is missing a rate", () => {
+    expect(() =>
+      parseUserConfigFile(
+        withUserModels([
+          { id: "a", kind: "chat", pricing: { input: 0.0004 } },
+        ]),
+      ),
+    ).toThrow(/llm\.providers\[1\]\.userModels\[0\]\.pricing\.output/);
+  });
+
+  it("rejects duplicate model ids within one provider's userModels", () => {
+    expect(() =>
+      parseUserConfigFile(
+        withUserModels([
+          { id: "a", kind: "chat" },
+          { id: "a", kind: "chat" },
+        ]),
+      ),
+    ).toThrow(/userModels\[1\]\.id/);
+  });
+
+  it("rejects a non-array userModels", () => {
+    expect(() =>
+      parseUserConfigFile(withUserModels({ "qwen3.8-27b": { kind: "chat" } })),
+    ).toThrow(/userModels/);
+  });
+
   it("rejects a non-object extraBody", () => {
     expect(() =>
       parseUserConfigFile({

--- a/src/config/llm-config.ts
+++ b/src/config/llm-config.ts
@@ -23,6 +23,18 @@ export type UserLlmProviderEntry = {
   supportsVision?: boolean;
   requestTimeoutMs?: number;
   /**
+   * Prompt-caching policy for this provider. Declared in the config
+   * schema and on `LlmProviderConfigEntry`; no provider reads it yet,
+   * so today it only has to survive the round-trip through config.
+   */
+  promptCache?: "auto" | "off" | "explicit-markers";
+  /**
+   * Vendor routing preferences (e.g. OpenRouter's `provider` block).
+   * Same status as `promptCache`: carried through config, not yet read
+   * by any provider.
+   */
+  providerPreferences?: Record<string, unknown>;
+  /**
    * Vendor-specific fields merged into the OpenAI-compatible chat body
    * for `openai-compatible` / `qwen-openai-compatible` providers. Lets a
    * deployment reach vendor extensions outside the OpenAI schema, e.g.
@@ -36,6 +48,44 @@ export type UserLlmProviderEntry = {
    * after the merge and cannot be overridden from config.
    */
   extraBody?: Record<string, unknown>;
+  /**
+   * Hand-written model metadata for this provider. `resolveModel`
+   * reads it as its highest-priority source (userModels > bundled
+   * catalog > defaults), so it is the documented way to teach the
+   * runtime about a model the bundled catalog does not know: context
+   * window, capabilities and pricing.
+   */
+  userModels?: ReadonlyArray<UserModelEntry>;
+};
+
+/**
+ * One hand-configured model on a provider entry. Mirrors
+ * `UserModelConfigEntry` in the provider registry — the shape
+ * `resolveModel` merges over the bundled catalog.
+ *
+ * Note `supportsTools` here is a support *level*, not the boolean of
+ * the same name on the provider entry: a model can advertise strict or
+ * parallel tool calling independently of whether the transport does.
+ */
+export type UserModelEntry = {
+  id: string;
+  kind: "chat" | "embedding";
+  contextWindow?: number;
+  dim?: number;
+  supportsVision?: boolean;
+  supportsTools?: "none" | "basic" | "parallel" | "strict";
+  supportsPromptCache?: boolean;
+  reasoningFormat?:
+    | "none"
+    | "delta_reasoning"
+    | "delta_thinking"
+    | "delta_reasoning_content";
+  pricing?: {
+    input: number;
+    output: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
 };
 
 export type UserLlmFallbackConfig = {
@@ -172,11 +222,19 @@ export function parseLlmProviderEntry(
                 "expected positive number",
               );
             })(),
-    extraBody: parseOptionalExtraBody(obj.extraBody, `${field}.extraBody`),
+    promptCache: parseOptionalEnum<
+      NonNullable<UserLlmProviderEntry["promptCache"]>
+    >(obj.promptCache, `${field}.promptCache`, PROMPT_CACHE_MODES),
+    providerPreferences: parseOptionalPlainObject(
+      obj.providerPreferences,
+      `${field}.providerPreferences`,
+    ),
+    extraBody: parseOptionalPlainObject(obj.extraBody, `${field}.extraBody`),
+    userModels: parseOptionalUserModels(obj.userModels, `${field}.userModels`),
   };
 }
 
-function parseOptionalExtraBody(
+function parseOptionalPlainObject(
   raw: unknown,
   field: string,
 ): Record<string, unknown> | undefined {
@@ -185,6 +243,139 @@ function parseOptionalExtraBody(
     throw new ConfigValidationError(field, "expected object");
   }
   return { ...(raw as Record<string, unknown>) };
+}
+
+const PROMPT_CACHE_MODES = new Set(["auto", "off", "explicit-markers"]);
+const TOOLS_SUPPORT_LEVELS = new Set(["none", "basic", "parallel", "strict"]);
+const REASONING_FORMATS = new Set([
+  "none",
+  "delta_reasoning",
+  "delta_thinking",
+  "delta_reasoning_content",
+]);
+
+function parseOptionalBoolean(
+  raw: unknown,
+  field: string,
+): boolean | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "boolean") {
+    throw new ConfigValidationError(field, "expected boolean");
+  }
+  return raw;
+}
+
+function parseOptionalEnum<T extends string>(
+  raw: unknown,
+  field: string,
+  allowed: ReadonlySet<string>,
+): T | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "string" || !allowed.has(raw)) {
+    throw new ConfigValidationError(field, `expected ${[...allowed].join("|")}`);
+  }
+  return raw as T;
+}
+
+/**
+ * Prices are per-token rates, so 0 is legal (free tiers) but negative
+ * or non-finite is not — a NaN rate would poison every cost estimate
+ * downstream rather than fail loudly.
+ */
+function parseRate(raw: unknown, field: string): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) {
+    throw new ConfigValidationError(field, "expected a non-negative number");
+  }
+  return raw;
+}
+
+function parseUserModelPricing(
+  raw: unknown,
+  field: string,
+): UserModelEntry["pricing"] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(field, "expected object");
+  }
+  const obj = raw as Record<string, unknown>;
+  const pricing: NonNullable<UserModelEntry["pricing"]> = {
+    input: parseRate(obj.input, `${field}.input`),
+    output: parseRate(obj.output, `${field}.output`),
+  };
+  if (obj.cacheRead !== undefined && obj.cacheRead !== null) {
+    pricing.cacheRead = parseRate(obj.cacheRead, `${field}.cacheRead`);
+  }
+  if (obj.cacheWrite !== undefined && obj.cacheWrite !== null) {
+    pricing.cacheWrite = parseRate(obj.cacheWrite, `${field}.cacheWrite`);
+  }
+  return pricing;
+}
+
+function parseUserModelEntry(raw: unknown, field: string): UserModelEntry {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(field, "expected object");
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "string" || obj.id.length === 0) {
+    throw new ConfigValidationError(`${field}.id`, "expected non-empty string");
+  }
+  if (obj.kind !== "chat" && obj.kind !== "embedding") {
+    throw new ConfigValidationError(`${field}.kind`, "expected chat|embedding");
+  }
+  return {
+    id: obj.id,
+    kind: obj.kind,
+    contextWindow:
+      obj.contextWindow === undefined || obj.contextWindow === null
+        ? undefined
+        : parsePositiveInt(obj.contextWindow, `${field}.contextWindow`),
+    dim:
+      obj.dim === undefined || obj.dim === null
+        ? undefined
+        : parsePositiveInt(obj.dim, `${field}.dim`),
+    supportsVision: parseOptionalBoolean(
+      obj.supportsVision,
+      `${field}.supportsVision`,
+    ),
+    supportsTools: parseOptionalEnum<
+      NonNullable<UserModelEntry["supportsTools"]>
+    >(obj.supportsTools, `${field}.supportsTools`, TOOLS_SUPPORT_LEVELS),
+    supportsPromptCache: parseOptionalBoolean(
+      obj.supportsPromptCache,
+      `${field}.supportsPromptCache`,
+    ),
+    reasoningFormat: parseOptionalEnum<
+      NonNullable<UserModelEntry["reasoningFormat"]>
+    >(obj.reasoningFormat, `${field}.reasoningFormat`, REASONING_FORMATS),
+    pricing: parseUserModelPricing(obj.pricing, `${field}.pricing`),
+  };
+}
+
+function parseOptionalUserModels(
+  raw: unknown,
+  field: string,
+): UserModelEntry[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) {
+    throw new ConfigValidationError(field, "expected array");
+  }
+  // `resolveModel` looks a model up by id with `.find`, so a duplicate
+  // id would silently shadow the later row. Reject it at parse time
+  // instead of serving whichever copy happens to come first.
+  const seen = new Set<string>();
+  const out: UserModelEntry[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const entry = parseUserModelEntry(raw[i], `${field}[${i}]`);
+    if (seen.has(entry.id)) {
+      throw new ConfigValidationError(
+        `${field}[${i}].id`,
+        `duplicate model id ${JSON.stringify(entry.id)}`,
+      );
+    }
+    seen.add(entry.id);
+    out.push(entry);
+  }
+  return out;
 }
 
 export function parseLlmProviders(


### PR DESCRIPTION
## Problem

`parseLlmProviderEntry` in `src/config/llm-config.ts` builds its returned object field by field, and three fields that are documented in the config schema (`src/config/config-schema.ts` ~L704-746) and typed on `LlmProviderConfigEntry` (`src/llm/provider/registry/provider-types.ts`) were never read off the raw object. Anything a user wrote into `<stateDir>/config.json` under them was silently discarded at parse time:

- **`userModels`** — the one with teeth today. `resolveModel` (`src/llm/provider/model-resolver.ts:44`) reads it as its highest-priority source (`userModels > bundled catalog > defaults`), so it is the documented way to hand-configure a model the bundled catalog does not know. With the field dropped, such a model silently resolved to the `DEFAULT_CHAT` fallback instead: 128k context, `supportsVision: false`, no pricing — which also means cost tracking quietly reported nothing for it.
- **`promptCache`**, **`providerPreferences`** — same silent-discard bug, but no provider reads either field yet. Parsing them only makes them survive the round-trip so a future consumer can read them; nothing changes at runtime today.

## Change

- `UserLlmProviderEntry` gains `userModels?: ReadonlyArray<UserModelEntry>`, `promptCache?: "auto" | "off" | "explicit-markers"` and `providerPreferences?: Record<string, unknown>`, plus a new exported `UserModelEntry` type mirroring `UserModelConfigEntry` in the provider registry. `userModels` is readonly to match `LlmProviderConfigEntry` — a mutable array fails `npm run lint` at the TUI wizard call sites that pass one type into the other.
- New `parseOptionalUserModels` / `parseUserModelEntry` / `parseUserModelPricing`, in the style of the surrounding parsers: `ConfigValidationError` with a `llm.providers[1].userModels[0].pricing.output`-shaped path. `id` non-empty string and `kind` `chat|embedding` required; `contextWindow`/`dim` through the existing `parsePositiveInt`; booleans for `supportsVision`/`supportsPromptCache`; enum checks for `supportsTools` (a support *level* here — `none|basic|parallel|strict` — not the provider-level boolean of the same name) and `reasoningFormat`; pricing rates finite and `>= 0`, so a free tier's `0` stays legal but `NaN` cannot reach cost tracking.
- Duplicate model ids within one provider are rejected: `resolveModel` looks up with `.find`, so a duplicate would silently shadow the later row — the same class of bug this PR fixes.
- `parseOptionalExtraBody` is generalized to `parseOptionalPlainObject` and reused for `providerPreferences`; `extraBody` behavior is unchanged.

## Tests

10 new cases in the colocated `src/config/llm-config.test.ts`, all driven through `parseUserConfigFile` so they cover the real round-trip, not just the leaf parser: a full `userModels` round-trip (chat row with context window, capabilities and pricing; embedding row with `dim`), a `promptCache`/`providerPreferences` round-trip, and rejections for a bad `kind`, a non-numeric `contextWindow`, pricing missing `output`, duplicate ids, a non-array `userModels`, an unknown `promptCache` mode and a non-object `providerPreferences` — each asserting on the field path.

Reverting just the parser change fails 9 of the 10; the tenth ("omits `userModels` when absent") passes either way by design.

## Verification

- `npm run lint` (`tsc --noEmit`): clean.
- `npx vitest run src/config`: 186 passed. `src/llm/provider` also green.
- Full `npx vitest run`: 4074 passed, 8 failed in 7 files — all pre-existing timing/parallelism-sensitive TUI and sidecar tests (`tui-app`, `chat-log`, `splash-banner`, `send-message-concurrency`, `persist-embedding-hybrid-recall`, `fs-glob-real`, `llm-health-poller`), which fail the same way on unmodified `main` and none of which touch config.
- `tsc -p tsconfig.test.json` has 466 pre-existing errors on this commit, identical before and after, none in the touched files.
