### PR TITLE
fix(tui): stop arrow keys from discarding the typed draft

### DIFF
--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -113,12 +113,20 @@ export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
       return { ...state, activeTab: action.tab };
     case "abort_requested":
       return { ...state, aborting: true };
-    case "input_changed":
+    case "input_changed": {
+      // Moving the caret re-emits the buffer unchanged (the editor owns
+      // the cursor and reports it through `onChange`). That is not an
+      // edit, so it must not knock us out of history recall — otherwise
+      // a single Left/Right after Up dropped the recall position and the
+      // parked draft with it.
+      if (action.value === state.inputValue) return state;
       return {
         ...state,
         inputValue: action.value,
         inputHistoryCursor: null,
+        inputHistoryDraft: null,
       };
+    }
     case "message_submitted":
       return startNewRun(state);
     case "quit_requested":

--- a/src/tui/input-history-keys.test.tsx
+++ b/src/tui/input-history-keys.test.tsx
@@ -1,0 +1,104 @@
+import { render } from "ink-testing-library";
+import { createElement, useReducer, type ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { reduceTuiState } from "./agent-event-reducer.js";
+import { MultiLineEditor } from "./components/multi-line-editor.js";
+import { createInitialTuiState, type TuiSessionInfo } from "./tui-state.js";
+
+const SESSION: TuiSessionInfo = {
+  sessionId: "s1",
+  workingDir: "/tmp",
+  llamaUrl: "http://127.0.0.1:19091",
+  browserChannel: "chromium",
+  browserHeadless: true,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+const UP = "\u001b[A";
+const DOWN = "\u001b[B";
+const LEFT = "\u001b[D";
+const RIGHT = "\u001b[C";
+
+/**
+ * Renders the real editor against the real reducer, wired exactly as
+ * `tui-app` wires them, so these assertions exercise the true keystroke
+ * path rather than a hand-rolled stand-in.
+ */
+function Harness(): ReactElement {
+  const [state, dispatch] = useReducer(reduceTuiState, undefined, () => ({
+    ...createInitialTuiState(SESSION),
+    inputHistory: ["first", "second"],
+  }));
+  return createElement(MultiLineEditor, {
+    value: state.inputValue,
+    focus: true,
+    onChange: (next: string) => dispatch({ type: "input_changed", value: next }),
+    onSubmit: () => {},
+    onHistoryPrev: () => dispatch({ type: "input_history_navigated", delta: -1 }),
+    onHistoryNext: () => dispatch({ type: "input_history_navigated", delta: 1 }),
+  });
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+describe("editor arrow keys vs input history", () => {
+  it("restores the typed draft after Up then Down", async () => {
+    const { stdin, lastFrame } = render(createElement(Harness));
+    await settle();
+    stdin.write("hello draft");
+    await settle();
+    expect(lastFrame()).toContain("hello draft");
+
+    stdin.write(UP);
+    await settle();
+    expect(lastFrame()).toContain("second");
+
+    stdin.write(DOWN);
+    await settle();
+    expect(lastFrame()).toContain("hello draft");
+  });
+
+  it("does not wipe the draft when Left/Right move the caret", async () => {
+    const { stdin, lastFrame } = render(createElement(Harness));
+    await settle();
+    stdin.write("keep me");
+    await settle();
+
+    stdin.write(LEFT);
+    await settle();
+    expect(lastFrame()).toContain("keep me");
+
+    stdin.write(RIGHT);
+    await settle();
+    expect(lastFrame()).toContain("keep me");
+  });
+
+  it("keeps walking further back when Left is pressed mid-recall", async () => {
+    const { stdin, lastFrame } = render(createElement(Harness));
+    await settle();
+    stdin.write("draft");
+    await settle();
+
+    stdin.write(UP);
+    await settle();
+    expect(lastFrame()).toContain("second");
+
+    // Caret movement must not drop the recall position.
+    stdin.write(LEFT);
+    await settle();
+    stdin.write(UP);
+    await settle();
+    expect(lastFrame()).toContain("first");
+
+    stdin.write(DOWN);
+    await settle();
+    expect(lastFrame()).toContain("second");
+    stdin.write(DOWN);
+    await settle();
+    expect(lastFrame()).toContain("draft");
+  });
+});

--- a/src/tui/reduce-ui-actions.test.ts
+++ b/src/tui/reduce-ui-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { reduceTuiState } from "./agent-event-reducer.js";
 import { reduceUiAction } from "./reduce-ui-actions.js";
 import { THEME_NAMES } from "./theme/theme.js";
 import { createInitialTuiState, type TuiSessionInfo } from "./tui-state.js";
@@ -83,5 +84,40 @@ describe("reduceUiAction theme picker", () => {
     const closed = reduceUiAction(open, { type: "theme_picker_closed" });
     expect(closed?.themePickerOpen).toBe(false);
     expect(closed?.themePickerOriginal).toBe("");
+  });
+});
+
+describe("input history navigation", () => {
+  const withHistory = (draft: string) => ({
+    ...createInitialTuiState(SESSION),
+    inputHistory: ["first", "second"],
+    inputValue: draft,
+  });
+
+  it("preserves the in-progress draft when Up recalls history", () => {
+    const state = withHistory("draft I am typing");
+    const up = reduceTuiState(state, { type: "input_history_navigated", delta: -1 });
+    expect(up.inputValue).toBe("second");
+    const back = reduceTuiState(up, { type: "input_history_navigated", delta: 1 });
+    expect(back.inputValue).toBe("draft I am typing");
+  });
+
+  it("keeps the history cursor when the caret moves without editing", () => {
+    const state = withHistory("draft");
+    const up = reduceTuiState(state, { type: "input_history_navigated", delta: -1 });
+    expect(up.inputHistoryCursor).toBe(1);
+    const caret = reduceTuiState(up, { type: "input_changed", value: "second" });
+    expect(caret.inputHistoryCursor).toBe(1);
+    const older = reduceTuiState(caret, { type: "input_history_navigated", delta: -1 });
+    expect(older.inputValue).toBe("first");
+  });
+
+  it("drops the stashed draft once the recalled entry is edited", () => {
+    const state = withHistory("draft");
+    const up = reduceTuiState(state, { type: "input_history_navigated", delta: -1 });
+    const edited = reduceTuiState(up, { type: "input_changed", value: "second!" });
+    expect(edited.inputHistoryCursor).toBeNull();
+    const down = reduceTuiState(edited, { type: "input_history_navigated", delta: 1 });
+    expect(down.inputValue).toBe("second!");
   });
 });

--- a/src/tui/reduce-ui-actions.ts
+++ b/src/tui/reduce-ui-actions.ts
@@ -92,8 +92,6 @@ export function reduceUiAction(
     }
     case "input_history_navigated":
       return navigateInputHistory(state, action.delta);
-    case "input_history_reset":
-      return { ...state, inputHistoryCursor: null, inputHistoryDraft: null };
     case "chat_cleared":
       return {
         ...state,

--- a/src/tui/reduce-ui-actions.ts
+++ b/src/tui/reduce-ui-actions.ts
@@ -93,7 +93,7 @@ export function reduceUiAction(
     case "input_history_navigated":
       return navigateInputHistory(state, action.delta);
     case "input_history_reset":
-      return { ...state, inputHistoryCursor: null };
+      return { ...state, inputHistoryCursor: null, inputHistoryDraft: null };
     case "chat_cleared":
       return {
         ...state,
@@ -224,13 +224,23 @@ function navigateInputHistory(state: TuiState, delta: 1 | -1): TuiState {
   // buffer (Down). Cursor value equals the history index shown.
   let cursor: number | null;
   if (state.inputHistoryCursor === null) {
-    cursor = delta === -1 ? max : null;
+    // Down on the live buffer has nowhere to go — leave the draft alone.
+    if (delta === 1) return state;
+    cursor = max;
   } else {
     const candidate = state.inputHistoryCursor + delta;
     if (candidate < 0) return state;
     if (candidate > max) cursor = null;
     else cursor = candidate;
   }
-  const value = cursor === null ? "" : (history[cursor] ?? "");
-  return { ...state, inputHistoryCursor: cursor, inputValue: value };
+  // Entering recall parks the live draft; stepping back past the newest
+  // entry hands it back verbatim instead of clearing the editor.
+  const draft = state.inputHistoryCursor === null ? state.inputValue : state.inputHistoryDraft;
+  const value = cursor === null ? (draft ?? "") : (history[cursor] ?? "");
+  return {
+    ...state,
+    inputHistoryCursor: cursor,
+    inputHistoryDraft: cursor === null ? null : draft,
+    inputValue: value,
+  };
 }

--- a/src/tui/reducer-helpers.ts
+++ b/src/tui/reducer-helpers.ts
@@ -128,6 +128,7 @@ export function appendUserMessage(state: TuiState, text: string): TuiState {
     ...withMessage,
     inputHistory: history,
     inputHistoryCursor: null,
+    inputHistoryDraft: null,
   };
 }
 
@@ -176,6 +177,7 @@ export function startNewRun(state: TuiState): TuiState {
     lastRunStatus: null,
     inputValue: "",
     inputHistoryCursor: null,
+    inputHistoryDraft: null,
     slashPaletteOpen: false,
     slashQuery: "",
     slashPaletteCursor: 0,

--- a/src/tui/tui-action.ts
+++ b/src/tui/tui-action.ts
@@ -99,8 +99,6 @@ export type TuiAction =
   | { type: "slash_palette_cursor_set"; row: number }
   /** Navigate input history by delta (up = older, down = newer). */
   | { type: "input_history_navigated"; delta: 1 | -1 }
-  /** Restore the live editor buffer, exiting history navigation. */
-  | { type: "input_history_reset" }
   /** Clear the chat transcript (slash `/clear`). */
   | { type: "chat_cleared" }
   /** Populate + show the session picker overlay. */

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -303,6 +303,13 @@ export interface TuiState {
    * the newest entry at the end.
    */
   inputHistoryCursor: number | null;
+  /**
+   * The half-written draft that was in the editor when history recall
+   * started, parked so Down can hand it back. `null` whenever the editor
+   * is showing the live buffer — recall always stashes before it
+   * overwrites, and any real edit to a recalled entry drops the stash.
+   */
+  inputHistoryDraft: string | null;
   /** Is the slash-command overlay currently visible below the editor? */
   slashPaletteOpen: boolean;
   /** Current slash prefix (characters typed after the leading `/`). */
@@ -486,6 +493,7 @@ export function createInitialTuiState(
     inputValue: "",
     inputHistory: [],
     inputHistoryCursor: null,
+    inputHistoryDraft: null,
     slashPaletteOpen: false,
     slashQuery: "",
     slashPaletteCursor: 0,


### PR DESCRIPTION
## What's broken

Two defects made the editor lose in-progress text on arrow keys. They compound, which is why it reads as "any arrow wipes the draft".

**Up discarded the draft.** Recall overwrote `inputValue` with a history entry without saving what was already typed, and Down walked back past the newest entry to a hardcoded `""`. Press Up by reflex mid-message and the text was unrecoverable.

**Left/Right silently broke recall.** The editor owns the caret and reports every move through `onChange`, so a caret-only keystroke re-emits the buffer unchanged — and `input_changed` reset `inputHistoryCursor` on every emit. One Left after Up dropped the recall position, so the next Up jumped back to the newest entry instead of stepping further back.

## The fix

- Park the draft in `inputHistoryDraft` when recall starts; hand it back when Down leaves history.
- Treat an `input_changed` whose value equals the current buffer as the no-op it is.
- Editing a recalled entry still drops the stash; submit/reset clear it so a stale draft cannot resurface.

## Testing

Reducer tests plus an end-to-end test that drives the real editor with real arrow-key escape sequences rather than a stand-in. Reverting the fix fails 2 of the 3 end-to-end cases, so they genuinely pin the behavior.

Full suite: 3989 pass. The 8–9 failures are the pre-existing `main` baseline (splash-banner, llm-health, sidecar) and are timing-flaky under parallel load — verified identical against clean `main`. All 93 tests in touched files pass; `tsc --noEmit` clean.

## Scope

TUI input handling only. No changes to the agent loop, providers, or eval tooling.


## Scope note (AGENTS.md 300-line rule)

`agent-event-reducer.ts` (504 -> 512), `tui-state.ts` (527 -> 535) and `reducer-helpers.ts` (339 -> 341) were already over the cap; the additions are load-bearing lines at the exact sites of the fix, not new surface area. Flagging rather than bundling a split into a bug-fix PR.

Also removed: the `input_history_reset` action (type-union member + reducer case). It had zero dispatchers anywhere in src or tests, and Down-leaving-history now restores the parked draft — the behavior that action existed to approximate.
