### PR TITLE
fix(tools): seven tool-reliability defects from the GAIA validation campaign

### DIFF
--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -556,6 +556,54 @@ describe("executeBatch", () => {
     expect(body).not.toContain("undefined");
   });
 
+  // The wandering spread is a property of the history window, so it stays
+  // above the threshold once the model stops varying its argument. Reporting
+  // a verbatim repeat as "N different attempts" is the same false statement
+  // the wandering wording exists to avoid, in the mirror case.
+  it("stops claiming different attempts once a wandering model settles on one url", async () => {
+    const registry = buildRegistry({
+      "os.web.fetch": async () => okResult("os.web.fetch"),
+    });
+    const tracker = new ToolLoopTracker({
+      warningThreshold: 2,
+      criticalThreshold: 3,
+      wanderingThreshold: 3,
+      wanderingEscalation: 4,
+    });
+    // Wander first: four distinct URLs on one host crosses the escalation.
+    for (const path of ["a", "b", "c", "d"]) {
+      const wandered = { url: `https://web.archive.org/${path}` };
+      tracker.check("os.web.fetch", wandered);
+      tracker.recordCall("os.web.fetch", wandered);
+      tracker.recordOutcome(
+        "os.web.fetch",
+        wandered,
+        okResult("os.web.fetch", path),
+      );
+    }
+    // Then settle: the same URL, twice, so the second call is a repeat.
+    const settled = { url: "https://web.archive.org/same" };
+    tracker.check("os.web.fetch", settled);
+    tracker.recordCall("os.web.fetch", settled);
+    tracker.recordOutcome(
+      "os.web.fetch",
+      settled,
+      okResult("os.web.fetch", "same"),
+    );
+
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.web.fetch", args: settled }]),
+      registry,
+      { ...ctx(new AbortController().signal), tracker },
+    );
+    const body = out.results[0]!.compressed!.summary;
+    expect(body).toContain("BLOCKED");
+    expect(body).toContain("web.archive.org");
+    expect(body).not.toContain("different attempts");
+    // A count the verdict cannot substantiate must not be quoted either.
+    expect(body).not.toContain("0 consecutive");
+  });
+
   it("does not throw and stays generic when args are malformed", async () => {
     const registry = buildRegistry({ "os.web.fetch": async () => okResult("os.web.fetch") });
     const tracker = new ToolLoopTracker({

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -497,6 +497,83 @@ describe("executeBatch", () => {
     expect(out.loopSignals[0]!.detector).toBe("wandering");
   });
 
+  // Issue #186: the veto body must name the invariant that held across
+  // the blocked attempts and offer a concrete alternative.
+  it("veto body names the repeated host and offers the search-first alternative", async () => {
+    const registry = buildRegistry({ "os.web.fetch": async () => okResult("os.web.fetch") });
+    const tracker = new ToolLoopTracker({
+      warningThreshold: 2,
+      criticalThreshold: 2,
+    });
+    const args = { url: "https://web.archive.org/web/2020/https://x.test/a?k=SECRET" };
+    seedCriticalStreak(tracker, "os.web.fetch", args, 2);
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.web.fetch", args }]),
+      registry,
+      { ...ctx(new AbortController().signal), tracker },
+    );
+    const body = out.results[0]!.compressed!.summary;
+    expect(body).toContain("web.archive.org");
+    expect(body).toContain("`os.web.search`");
+    // The full URL — path, query, secret — must NOT reach model context.
+    expect(body).not.toContain("SECRET");
+    expect(body).not.toContain("/web/2020/");
+  });
+
+  it("veto body names the command for a shell loop", async () => {
+    const registry = buildRegistry({ "os.shell.run": async () => okResult("os.shell.run") });
+    const tracker = new ToolLoopTracker({
+      warningThreshold: 2,
+      criticalThreshold: 2,
+    });
+    const args = { command: "curl -s https://x.test --header 'Authorization: Bearer SECRET'" };
+    seedCriticalStreak(tracker, "os.shell.run", args, 2);
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.shell.run", args }]),
+      registry,
+      { ...ctx(new AbortController().signal), tracker },
+    );
+    const body = out.results[0]!.compressed!.summary;
+    expect(body).toContain("`curl`");
+    expect(body).not.toContain("SECRET");
+  });
+
+  it("veto body degrades to generic wording when args carry no extractable target", async () => {
+    const registry = buildRegistry({ "os.fs.read": async () => okResult("os.fs.read") });
+    const tracker = new ToolLoopTracker({
+      warningThreshold: 2,
+      criticalThreshold: 2,
+    });
+    seedCriticalStreak(tracker, "os.fs.read", { path: "a" }, 2);
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.fs.read", args: { path: "a" } }]),
+      registry,
+      { ...ctx(new AbortController().signal), tracker },
+    );
+    const body = out.results[0]!.compressed!.summary;
+    expect(body).toContain("BLOCKED");
+    expect(body).toContain("2 consecutive calls returned the same no-progress outcome");
+    expect(body).not.toContain("undefined");
+  });
+
+  it("does not throw and stays generic when args are malformed", async () => {
+    const registry = buildRegistry({ "os.web.fetch": async () => okResult("os.web.fetch") });
+    const tracker = new ToolLoopTracker({
+      warningThreshold: 2,
+      criticalThreshold: 2,
+    });
+    const args = { url: "://not a url" };
+    seedCriticalStreak(tracker, "os.web.fetch", args, 2);
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.web.fetch", args }]),
+      registry,
+      { ...ctx(new AbortController().signal), tracker },
+    );
+    const body = out.results[0]!.compressed!.summary;
+    expect(body).toContain("BLOCKED");
+    expect(body).not.toContain("undefined");
+  });
+
   it("marks tail calls as cancelled when the signal aborts mid-serialised-group", async () => {
     const ctrl = new AbortController();
     const registry = new ToolRegistry();

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -11,6 +11,7 @@ import {
   type ResourceClass,
 } from "./tool-resource-class.js";
 import {
+  extractLoopTarget,
   formatVetoInstruction,
   LOOP_VETO_DENIED_REASON,
   type LoopCheckVerdict,
@@ -456,14 +457,25 @@ function runSyncLoopGate(
     const count = breakerTripped
       ? Math.max(verdict.count, ctx.tracker.breakerThreshold)
       : verdict.count;
+    // Name the invariant that held across the blocked attempts (host for
+    // web/HTTP, command name for shell) so the message says WHAT stayed
+    // the same instead of only that something did.
+    const target = extractLoopTarget(tool, args);
+    // A wandering escalation rides this same veto path but its `count` is
+    // a spread of DISTINCT arguments; pass the detector so the wording
+    // does not claim they were identical.
+    const detector =
+      wanderingEscalated && verdict.detector !== "no_progress"
+        ? "wandering"
+        : verdict.detector;
     const vetoResult = compressToolResult({
       tool,
       status: "error",
-      output: formatVetoInstruction({ tool, count }),
+      output: formatVetoInstruction({ tool, count, target, detector }),
       details: {
         deniedReason: LOOP_VETO_DENIED_REASON,
         loopCount: count,
-        detector: verdict.detector,
+        detector,
       },
     });
     ctx.tracker.recordOutcome(tool, args, vetoResult);
@@ -471,7 +483,7 @@ function runSyncLoopGate(
       kind: forceBreaker ? "breaker" : "critical",
       tool,
       count,
-      detector: verdict.detector,
+      detector,
       warningKey: verdict.warningKey,
     });
     return { proceed: false, vetoResult };

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -464,8 +464,14 @@ function runSyncLoopGate(
     // A wandering escalation rides this same veto path but its `count` is
     // a spread of DISTINCT arguments; pass the detector so the wording
     // does not claim they were identical.
+    //
+    // The verdict decides, not the escalation flag. `isWanderingEscalated`
+    // answers for the whole history window, so it stays true after the model
+    // stops wandering and settles on repeating one argument -- and borrowing
+    // it there would announce "N different attempts" about a verbatim
+    // repeat, quoting a count the verdict never established.
     const detector =
-      wanderingEscalated && verdict.detector !== "no_progress"
+      wanderingEscalated && verdict.detector === "wandering"
         ? "wandering"
         : verdict.detector;
     const vetoResult = compressToolResult({

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -21,6 +21,7 @@ export {
   formatRepeatNotice,
   formatVetoInstruction,
   formatForcedLoopReply,
+  extractLoopTarget,
   BATCH_LOOP_LABEL,
   LOOP_VETO_DENIED_REASON,
   LOOP_WARNING_BUCKET_SIZE,

--- a/src/agent/loop-detector.test.ts
+++ b/src/agent/loop-detector.test.ts
@@ -4,6 +4,7 @@ import {
   BATCH_LOOP_LABEL,
   LOOP_VETO_DENIED_REASON,
   ToolLoopTracker,
+  extractLoopTarget,
   formatForcedLoopReply,
   formatRepeatNotice,
   formatVetoInstruction,
@@ -309,6 +310,155 @@ describe("loop notice formatters", () => {
     expect(note).toContain("7 different arguments");
     expect(note.toLowerCase()).toContain("wandering loop");
     expect(note.toLowerCase()).toContain("search");
+  });
+});
+
+describe("extractLoopTarget", () => {
+  it("reduces a web fetch URL to its host, dropping path and query", () => {
+    expect(
+      extractLoopTarget("os.web.fetch", {
+        url: "https://web.archive.org/web/2020/https://x.test/a?token=SECRET",
+      }),
+    ).toBe("web.archive.org");
+  });
+
+  it("handles os.http.request and schemeless URLs", () => {
+    expect(
+      extractLoopTarget("os.http.request", {
+        url: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed",
+      }),
+    ).toBe("eutils.ncbi.nlm.nih.gov");
+    expect(extractLoopTarget("os.web.fetch", { url: "en.wikipedia.org/wiki/X" })).toBe(
+      "en.wikipedia.org",
+    );
+  });
+
+  it("reduces a shell command to the executable name only", () => {
+    expect(
+      extractLoopTarget("os.shell.run", {
+        command: "curl -s https://x.test/a --header 'Authorization: Bearer SECRET'",
+      }),
+    ).toBe("curl");
+  });
+
+  it("returns undefined for unextractable or malformed args", () => {
+    expect(extractLoopTarget("os.web.fetch", {})).toBeUndefined();
+    expect(extractLoopTarget("os.web.fetch", { url: "" })).toBeUndefined();
+    expect(extractLoopTarget("os.web.fetch", { url: 42 })).toBeUndefined();
+    expect(extractLoopTarget("os.web.fetch", null)).toBeUndefined();
+    expect(extractLoopTarget("os.web.fetch", undefined)).toBeUndefined();
+    expect(extractLoopTarget("os.web.fetch", "not-an-object")).toBeUndefined();
+    expect(extractLoopTarget("os.shell.run", { command: "   " })).toBeUndefined();
+    expect(extractLoopTarget("browser.click", { selector: "#a" })).toBeUndefined();
+  });
+
+  it("never throws on hostile or malformed URL values", () => {
+    for (const url of ["http://", "://", "%%%", "h ttp://a b", " "]) {
+      expect(() => extractLoopTarget("os.web.fetch", { url })).not.toThrow();
+    }
+  });
+});
+
+describe("veto message names the invariant and an alternative (issue #186)", () => {
+  it("names the repeated host for a fetch loop", () => {
+    const veto = formatVetoInstruction({
+      tool: "os.web.fetch",
+      count: 5,
+      target: "web.archive.org",
+      detector: "no_progress",
+    });
+    expect(veto).toContain("BLOCKED");
+    expect(veto).toContain("web.archive.org");
+    expect(veto).toContain("5 consecutive calls");
+    expect(veto).toContain("same no-progress outcome");
+  });
+
+  it("offers the search-first alternative naming a different host", () => {
+    const veto = formatVetoInstruction({
+      tool: "os.web.fetch",
+      count: 5,
+      target: "web.archive.org",
+      detector: "no_progress",
+    });
+    expect(veto).toContain("`os.web.search`");
+    expect(veto).toContain("DIFFERENT host");
+    expect(veto.toLowerCase()).toContain("do not repeat");
+  });
+
+  it("names the command for a shell loop", () => {
+    const veto = formatVetoInstruction({
+      tool: "os.shell.run",
+      count: 5,
+      target: "curl",
+      detector: "no_progress",
+    });
+    expect(veto).toContain("`curl`");
+    expect(veto).toContain("5 consecutive calls");
+    expect(veto).toContain("change the arguments or path");
+  });
+
+  it("does not claim identical outcomes on a wandering escalation", () => {
+    const veto = formatVetoInstruction({
+      tool: "os.web.fetch",
+      count: 13,
+      target: "web.archive.org",
+      detector: "wandering",
+    });
+    expect(veto).toContain("13 different attempts");
+    expect(veto).toContain("web.archive.org");
+    expect(veto).not.toContain("identical");
+    expect(veto).not.toContain("consecutive calls");
+    // Wandering means many DIFFERENT URLs, so the hint says stop guessing
+    // rather than "stop retrying" (which would imply identical calls).
+    expect(veto).toContain("Stop guessing URLs");
+    expect(veto).toContain("`os.web.search`");
+    expect(veto).not.toContain("stop retrying");
+  });
+
+  it("degrades to the generic wording when no target can be extracted", () => {
+    const veto = formatVetoInstruction({ tool: "noop", count: 5 });
+    expect(veto).toContain("BLOCKED");
+    expect(veto).toContain("`noop`");
+    expect(veto).toContain("5 consecutive calls returned the same no-progress outcome");
+    expect(veto).not.toContain("undefined");
+    expect(veto.toLowerCase()).toContain("do not repeat");
+  });
+
+  it("sanitizes a hostile target: no backticks or newlines leak through", () => {
+    const veto = formatVetoInstruction({
+      tool: "os.web.fetch",
+      count: 5,
+      target: "evil`\n## injected heading\n`x",
+      detector: "no_progress",
+    });
+    expect(veto).not.toContain("## injected heading\n");
+    expect(veto.split("\n")[0]).toContain("evil");
+    // Header stays a single line.
+    expect(veto.split("\n")[0]).not.toContain("injected heading\n");
+  });
+
+  it("truncates an over-long target", () => {
+    const veto = formatVetoInstruction({
+      tool: "os.web.fetch",
+      count: 5,
+      target: "a".repeat(200),
+      detector: "no_progress",
+    });
+    expect(veto).toContain("...");
+    // The 200-char target is capped at 60 chars, not echoed in full.
+    expect(veto).not.toContain("a".repeat(61));
+    expect(veto.split("\n")[0]!.length).toBeLessThan(160);
+  });
+
+  it("stays short — the message is injected on every veto", () => {
+    const veto = formatVetoInstruction({
+      tool: "os.web.fetch",
+      count: 5,
+      target: "web.archive.org",
+      detector: "no_progress",
+    });
+    expect(veto.split("\n").length).toBeLessThanOrEqual(5);
+    expect(veto.length).toBeLessThan(600);
   });
 });
 

--- a/src/agent/loop-detector.ts
+++ b/src/agent/loop-detector.ts
@@ -168,7 +168,16 @@ export class ToolLoopTracker {
     }
     if (isWanderingProneTool(tool)) {
       const spread = this.effectiveSpread(tool, argsHash);
-      if (spread >= this.wanderingThreshold) {
+      // The spread is a property of the whole window, so it stays above the
+      // threshold after the model stops varying its argument and settles on
+      // repeating one. Classifying THIS call as wandering would then tell it
+      // "N different attempts" about a call that is a verbatim repeat -- the
+      // same kind of false statement the wandering wording exists to avoid.
+      // A repeat falls through to the repeat detector, which describes it
+      // accurately.
+      const repeatsEarlierCall =
+        getRepeatCount(this.history, tool, argsHash) > 0;
+      if (spread >= this.wanderingThreshold && !repeatsEarlierCall) {
         return {
           level: "warn",
           count: spread,
@@ -654,10 +663,18 @@ function formatLoopGuidance(
     header = target
       ? `BLOCKED: \`${tool}\` — ${count} different attempts against \`${target}\` and still no answer.`
       : `BLOCKED: \`${tool}\` — ${count} different attempts and still no answer.`;
-  } else if (mode === "veto") {
+  } else if (mode === "veto" && count > 1) {
     header = target
       ? `BLOCKED: \`${tool}\` — ${count} consecutive calls to \`${target}\` returned the same no-progress outcome.`
       : `BLOCKED: \`${tool}\` — ${count} consecutive calls returned the same no-progress outcome.`;
+  } else if (mode === "veto") {
+    // The breaker can fire on a verdict that carries no streak of its own
+    // (a wandering episode the model ended by settling on one argument).
+    // State only what is certainly true rather than quoting a count that
+    // would read as "0 consecutive calls".
+    header = target
+      ? `BLOCKED: \`${tool}\` — repeated calls to \`${target}\` are not making progress.`
+      : `BLOCKED: \`${tool}\` — repeated calls are not making progress.`;
   } else {
     header = target
       ? `You called \`${tool}\` on \`${target}\` ${count} times with the same arguments and neither the result nor the world snapshot changed.`

--- a/src/agent/loop-detector.ts
+++ b/src/agent/loop-detector.ts
@@ -571,19 +571,29 @@ function canonicalJson(value: unknown): string {
 export function formatRepeatNotice(verdict: {
   count: number;
   tool: string;
+  target?: string;
 }): string {
-  return formatLoopGuidance(verdict.tool, verdict.count, "notice");
+  return formatLoopGuidance(verdict.tool, verdict.count, "notice", verdict);
 }
 
 /**
  * Body of the synthetic veto tool result (critical). Same class-aware
  * guidance as the notice, plus an explicit "do not repeat" instruction.
+ *
+ * `target` names the invariant that stayed the same across the blocked
+ * attempts (host for web/HTTP calls, command name for shell). `detector`
+ * distinguishes a true no-progress repeat from a `wandering` escalation
+ * riding the same veto path — the two need opposite wording, because a
+ * wandering `count` is a spread of DISTINCT arguments, not a run of
+ * identical outcomes.
  */
 export function formatVetoInstruction(verdict: {
   count: number;
   tool: string;
+  target?: string;
+  detector?: LoopCheckVerdict["detector"];
 }): string {
-  return formatLoopGuidance(verdict.tool, verdict.count, "veto");
+  return formatLoopGuidance(verdict.tool, verdict.count, "veto", verdict);
 }
 
 /**
@@ -629,27 +639,57 @@ function formatLoopGuidance(
   tool: string,
   count: number,
   mode: "notice" | "veto",
+  context: {
+    target?: string;
+    detector?: LoopCheckVerdict["detector"];
+  } = {},
 ): string {
-  const header =
-    mode === "veto"
-      ? `BLOCKED: \`${tool}\` was vetoed as a no-progress loop (${count} identical no-progress outcomes).`
-      : `You called \`${tool}\` with the same arguments ${count} times and neither the result nor the world snapshot changed.`;
+  const target = sanitizeLoopTarget(context.target);
+  const wandering = context.detector === "wandering";
 
-  const webHint =
-    tool === "os.web.fetch" || tool === "os.http.request"
-      ? "- The URL may be dead or returning an HTTP error — read the status in the tool result and try a different source, endpoint, or search query."
-      : null;
+  let header: string;
+  if (mode === "veto" && wandering) {
+    // Wandering: `count` is a spread of DISTINCT arguments, so calling
+    // these "identical outcomes" would be flatly wrong.
+    header = target
+      ? `BLOCKED: \`${tool}\` — ${count} different attempts against \`${target}\` and still no answer.`
+      : `BLOCKED: \`${tool}\` — ${count} different attempts and still no answer.`;
+  } else if (mode === "veto") {
+    header = target
+      ? `BLOCKED: \`${tool}\` — ${count} consecutive calls to \`${target}\` returned the same no-progress outcome.`
+      : `BLOCKED: \`${tool}\` — ${count} consecutive calls returned the same no-progress outcome.`;
+  } else {
+    header = target
+      ? `You called \`${tool}\` on \`${target}\` ${count} times with the same arguments and neither the result nor the world snapshot changed.`
+      : `You called \`${tool}\` with the same arguments ${count} times and neither the result nor the world snapshot changed.`;
+  }
+
+  // Actionable alternative, modelled on the wandering redirect: name the
+  // next move, do not restate the failure mode.
+  let webHint: string | null = null;
+  if (tool === "os.web.fetch" || tool === "os.http.request") {
+    if (wandering && target) {
+      webHint = `- Stop guessing URLs on \`${target}\`. Run \`os.web.search\` for the fact you need and fetch a result from a DIFFERENT host.`;
+    } else if (target) {
+      webHint = `- Run \`os.web.search\` for the fact you need and fetch a result from a DIFFERENT host — stop retrying \`${target}\`. The URL may be dead or returning an HTTP error; read the status in the tool result.`;
+    } else {
+      webHint =
+        "- Run `os.web.search` for the fact you need, then fetch one URL from the results — do not keep guessing URLs. The URL may be dead or returning an HTTP error; read the status in the tool result.";
+    }
+  }
   const browserHint = tool.startsWith("browser.")
     ? "- Re-read `### world` — the answer may already be on the page. Try `browser.scroll`, a different element, or `browser.navigate` to a more direct URL. An `[expanded]` element is already open."
     : null;
   const shellHint =
     tool.startsWith("os.shell.") || tool.startsWith("os.fs.")
-      ? "- Change the command, path, or arguments — repeating the same invocation will not produce a different result."
+      ? target
+        ? `- \`${target}\` will not behave differently on a re-run — change the arguments or path, or use a different command entirely.`
+        : "- Change the command, path, or arguments — repeating the same invocation will not produce a different result."
       : null;
 
   const lines = [
     header,
-    "This is a no-progress loop. Change strategy BEFORE calling any tool again:",
+    "Change strategy BEFORE calling any tool again:",
     webHint,
     browserHint,
     shellHint,
@@ -660,4 +700,60 @@ function formatLoopGuidance(
   ].filter((line): line is string => line !== null);
 
   return lines.join("\n");
+}
+
+/**
+ * Defensive cleanup for a caller-supplied invariant label before it is
+ * echoed into model context: single line, no backticks (they would break
+ * the surrounding code span), length-capped. Returns `undefined` for
+ * anything empty so callers degrade to the generic wording.
+ */
+function sanitizeLoopTarget(raw: string | undefined): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const cleaned = raw.replace(/[`\r\n]+/g, " ").trim();
+  if (cleaned.length === 0) return undefined;
+  return cleaned.length > 60 ? `${cleaned.slice(0, 57)}...` : cleaned;
+}
+
+/**
+ * Extract the invariant that stayed the same across a loop's blocked
+ * attempts, for use as the `target` label in guidance messages.
+ *
+ * Deliberately coarse: web/HTTP calls collapse to the URL's HOST and
+ * shell calls to the leading command word, so no query parameters,
+ * credentials, paths, or other potentially sensitive argument content
+ * reaches the model context. Returns `undefined` when nothing meaningful
+ * can be extracted, so the caller falls back to the generic wording.
+ * Never throws on malformed args.
+ */
+export function extractLoopTarget(
+  tool: string,
+  args: unknown,
+): string | undefined {
+  if (args === null || typeof args !== "object") return undefined;
+  const record = args as Record<string, unknown>;
+
+  if (tool === "os.web.fetch" || tool === "os.http.request") {
+    const raw = record.url ?? record.uri ?? record.endpoint;
+    if (typeof raw !== "string" || raw.length === 0) return undefined;
+    const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)
+      ? raw
+      : `https://${raw}`;
+    try {
+      const host = new URL(candidate).hostname;
+      return host.length > 0 ? host : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (tool === "os.shell.run") {
+    const raw = record.command ?? record.cmd;
+    if (typeof raw !== "string") return undefined;
+    // Leading word only: the executable name, never the full argv.
+    const name = raw.trim().split(/\s+/)[0];
+    return name !== undefined && name.length > 0 ? name : undefined;
+  }
+
+  return undefined;
 }

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -159,6 +159,27 @@ describe("parseUserConfigFile", () => {
     expect(parsed.tui.theme).toBe("auto");
   });
 
+  it("fills web.fetch defaults when migrating from v37", () => {
+    const parsed = parseUserConfigFile({
+      version: 37,
+      web: { search: { provider: "exa", timeoutMs: 15_000 } },
+    });
+    expect(parsed.version).toBe(USER_CONFIG_VERSION);
+    expect(parsed.web.fetch.timeoutMs).toBe(30_000);
+    expect(parsed.web.fetch.connectTimeoutMs).toBe(10_000);
+    expect(parsed.web.fetch.maxRetries).toBe(2);
+    // The version bump must not drop the settings a v37 file already carried.
+    expect(parsed.web.search.timeoutMs).toBe(15_000);
+  });
+
+  it("accepts every version between the oldest supported and the current one", () => {
+    // A bump that forgets to append the outgoing version to the supported
+    // list locks out everyone whose config is still on it.
+    for (let version = 5; version <= USER_CONFIG_VERSION; version += 1) {
+      expect(() => parseUserConfigFile({ version })).not.toThrow();
+    }
+  });
+
   it("preserves an explicit tui.theme name", () => {
     const parsed = parseUserConfigFile({
       version: USER_CONFIG_VERSION,

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -31,6 +31,50 @@ export type BrowserChannel = "chrome" | "msedge" | "chromium";
 
 export type WebSearchProviderName = "duckduckgo" | "searxng" | "exa" | "brave";
 
+/**
+ * Tunables for `os.web.fetch` (config v38). Before v38 the tool hard-coded a
+ * 30s overall budget with no connect timeout and no retries, so a single
+ * unreachable host burned 30s of the task budget and a transient 503 (the
+ * bulk of them from `web.archive.org`, which serves the same URL seconds
+ * later) ended the fetch outright.
+ */
+export interface WebFetchConfig {
+  /**
+   * Overall per-attempt budget in milliseconds, passed to curl `--max-time`.
+   * Kept at the historical 30_000 so unconfigured installs behave exactly as
+   * before. A per-call `timeoutMs` tool argument overrides it.
+   */
+  timeoutMs: number;
+  /**
+   * TCP/TLS connect budget in milliseconds, passed to curl `--connect-timeout`.
+   * Much smaller than `timeoutMs` because a host that has not completed a
+   * handshake in 10s is almost never merely slow — it is firewalled, dead, or
+   * blackholing packets, and waiting the full overall budget for it is pure
+   * loss. A slow but reachable server still gets the whole `timeoutMs` to
+   * stream its body, since `--connect-timeout` only covers the handshake.
+   */
+  connectTimeoutMs: number;
+  /**
+   * Extra attempts after the first for retryable failures (429/502/503/504 and
+   * curl exit 28 "operation timed out"). `0` disables retrying. Deliberately
+   * small: `os.web.fetch` is GET-only, so retries are always safe, but each one
+   * spends task budget.
+   */
+  maxRetries: number;
+  /**
+   * Base delay in milliseconds for exponential backoff between retries
+   * (attempt N waits `retryBaseDelayMs * 2^(N-1)`). A server-sent `Retry-After`
+   * header wins over the computed delay when it is shorter than the cap.
+   */
+  retryBaseDelayMs: number;
+  /**
+   * Upper bound in milliseconds on any single backoff wait, including one
+   * derived from `Retry-After`. Stops a hostile or overloaded origin from
+   * parking the agent for minutes on a header value.
+   */
+  retryMaxDelayMs: number;
+}
+
 export interface WebSearchConfig {
   enabled: boolean;
   provider: WebSearchProviderName;
@@ -293,6 +337,7 @@ export interface AtomicAgentConfig {
   };
   web: {
     search: WebSearchConfig;
+    fetch: WebFetchConfig;
   };
   /**
    * User-declared project root directories consumed by
@@ -941,6 +986,7 @@ export interface UserConfigFile {
   };
   web: {
     search: WebSearchConfig;
+    fetch: WebFetchConfig;
   };
   /**
    * Project path resolution (config v36). `roots` lists directories
@@ -1419,7 +1465,12 @@ export interface UserConfigFile {
 // is absent, a legacy `approvalRequired: false` maps to level 5 and
 // `true`/absent maps to level 1 — both preserve the old behaviour
 // exactly. The legacy key is never written back.
-export const USER_CONFIG_VERSION = 38 as const;
+// v39: new `web.fetch` block (`timeoutMs`, `connectTimeoutMs`, `maxRetries`,
+// `retryBaseDelayMs`, `retryMaxDelayMs`) making `os.web.fetch` timeouts and
+// retry/backoff configurable. Older files transparently inherit the defaults,
+// and `timeoutMs` keeps its historical 30_000 value, so the migration does not
+// change behaviour for anyone who does not opt in.
+export const USER_CONFIG_VERSION = 39 as const;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1537,6 +1588,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   35,
   36,
   37,
+  38,
   USER_CONFIG_VERSION,
 ];
 
@@ -1597,6 +1649,13 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       brave: {
         apiKeyEnv: "BRAVE_SEARCH_API_KEY",
       },
+    },
+    fetch: {
+      timeoutMs: 30_000,
+      connectTimeoutMs: 10_000,
+      maxRetries: 2,
+      retryBaseDelayMs: 500,
+      retryMaxDelayMs: 5_000,
     },
   },
   projects: {
@@ -2673,6 +2732,7 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
   const web = (obj.web as Record<string, unknown> | undefined) ?? {};
   const projects = (obj.projects as Record<string, unknown> | undefined) ?? {};
   const webSearch = (web.search as Record<string, unknown> | undefined) ?? {};
+  const webFetch = (web.fetch as Record<string, unknown> | undefined) ?? {};
   const webSearchProvider = parseWebSearchProviderName(
     webSearch.provider ?? USER_CONFIG_DEFAULTS.web.search.provider,
     "web.search.provider",
@@ -2960,6 +3020,33 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
             "web.search.brave.apiKeyEnv",
           ),
         },
+      },
+      fetch: {
+        timeoutMs: parsePositiveInt(
+          webFetch.timeoutMs ?? USER_CONFIG_DEFAULTS.web.fetch.timeoutMs,
+          "web.fetch.timeoutMs",
+        ),
+        connectTimeoutMs: parsePositiveInt(
+          webFetch.connectTimeoutMs ??
+            USER_CONFIG_DEFAULTS.web.fetch.connectTimeoutMs,
+          "web.fetch.connectTimeoutMs",
+        ),
+        maxRetries: parseNonNegativeBoundedInt(
+          webFetch.maxRetries ?? USER_CONFIG_DEFAULTS.web.fetch.maxRetries,
+          "web.fetch.maxRetries",
+          0,
+          5,
+        ),
+        retryBaseDelayMs: parsePositiveInt(
+          webFetch.retryBaseDelayMs ??
+            USER_CONFIG_DEFAULTS.web.fetch.retryBaseDelayMs,
+          "web.fetch.retryBaseDelayMs",
+        ),
+        retryMaxDelayMs: parsePositiveInt(
+          webFetch.retryMaxDelayMs ??
+            USER_CONFIG_DEFAULTS.web.fetch.retryMaxDelayMs,
+          "web.fetch.retryMaxDelayMs",
+        ),
       },
     },
     projects: {

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -1536,6 +1536,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   34,
   35,
   36,
+  37,
   USER_CONFIG_VERSION,
 ];
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,7 @@ export type {
   TelegramParseMode,
   UserConfigFile,
   UserManagedLocalLlmConfig,
+  WebFetchConfig,
   WebSearchConfig,
   WebSearchProviderName,
   WebhookConfig,

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -303,6 +303,7 @@ export function loadConfig(): AtomicAgentConfig {
     },
     web: {
       search: { ...user.web.search },
+      fetch: { ...user.web.fetch },
     },
     projects: {
       roots: [...user.projects.roots],

--- a/src/prompt/default-tool-args-schemas.test.ts
+++ b/src/prompt/default-tool-args-schemas.test.ts
@@ -69,6 +69,45 @@ describe("default tool argsJsonSchema map", () => {
     });
   });
 
+  // Issue #185: `paths` was a bare string[] with no upper bound, so
+  // neither cloud schema validation nor grammar-constrained decoding
+  // could hint the 4-image cap and the model learned it by failing.
+  it("pins vision.describe schema (paths capped at maxItems 4)", () => {
+    const schema = getDefaultArgsJsonSchema("vision.describe");
+    expect(schema).toMatchObject({
+      type: "object",
+      required: ["prompt"],
+      additionalProperties: false,
+    });
+    const properties = (schema as { properties: Record<string, unknown> }).properties;
+    expect(properties.paths).toEqual({
+      type: "array",
+      items: { type: "string" },
+      maxItems: 4,
+    });
+  });
+
+  it("does not leak vision.describe's maxItems onto other string[] schemas", () => {
+    const properties = (
+      getDefaultArgsJsonSchema("os.shell.run") as {
+        properties: Record<string, unknown>;
+      }
+    ).properties;
+    expect(properties.args).not.toHaveProperty("maxItems");
+  });
+
+  it("documents the vision.describe image cap in the stable-prefix descriptor", () => {
+    const descriptor = DEFAULT_TOOL_DESCRIPTORS.find(
+      (d) => d.name === "vision.describe",
+    );
+    expect(descriptor).toBeDefined();
+    // The descriptor array is static and cannot read config, so it
+    // documents the DEFAULT with wording that stays true if someone
+    // raises `vision.maxImagesPerCall`.
+    expect(descriptor!.summary).toContain("at most 4 images per call by default");
+    expect(descriptor!.argsSchema).toContain("at most 4 by default");
+  });
+
   it("attachDefaultArgsJsonSchema preserves an explicit override (MCP inputSchema path)", () => {
     const override = {
       type: "object" as const,

--- a/src/prompt/default-tool-args-schemas.ts
+++ b/src/prompt/default-tool-args-schemas.ts
@@ -462,6 +462,7 @@ const DEFAULT_TOOL_ARGS_SCHEMAS: ReadonlyMap<string, Schema> = new Map<
         url: stringSchema,
         extractMode: { type: "string", enum: ["markdown", "text"] },
         maxChars: numberSchema,
+        timeoutMs: numberSchema,
       },
       ["url"],
     ),
@@ -587,7 +588,12 @@ const DEFAULT_TOOL_ARGS_SCHEMAS: ReadonlyMap<string, Schema> = new Map<
       {
         prompt: stringSchema,
         path: stringSchema,
-        paths: stringArraySchema,
+        // `maxItems` mirrors the DEFAULT of `config.vision.maxImagesPerCall`
+        // (4). The runtime check in `buildVisionDescribeTool` reads the live
+        // config and stays authoritative; this bound is a hint so cloud
+        // providers and grammar-constrained decoding stop the model from
+        // emitting a 20-image call it can only discover is invalid by failing.
+        paths: { ...stringArraySchema, maxItems: 4 },
       },
       ["prompt"],
     ),

--- a/src/prompt/default-tool-descriptors-a.ts
+++ b/src/prompt/default-tool-descriptors-a.ts
@@ -213,7 +213,7 @@ export const DEFAULT_TOOL_DESCRIPTORS_A: readonly ToolDescriptor[] = [
     name: "os.web.fetch",
     summary:
       "Read a web page as readable markdown/text (cf-markdown → Readability → basic). GET only, no JS, no auth; SSRF-guarded; read-only. For raw API/JSON or POST, use os.http.request.",
-    argsSchema: `{ url: string, extractMode?: "markdown" | "text", maxChars?: number }`,
+    argsSchema: `{ url: string, extractMode?: "markdown" | "text", maxChars?: number, timeoutMs?: number }`,
     examples: [
       '{"url":"https://example.com/article"}',
       '{"url":"https://docs.example.com/guide","extractMode":"text","maxChars":20000}',

--- a/src/prompt/default-tool-descriptors-b.ts
+++ b/src/prompt/default-tool-descriptors-b.ts
@@ -162,9 +162,9 @@ export const DEFAULT_TOOL_DESCRIPTORS_B: readonly ToolDescriptor[] = [
     // `{paths: [...]}` without `prompt` and burning a step on the
     // schema error before retrying with the right shape.
     name: "vision.describe",
-    summary: "Describe one or more images via the configured vision LLM. Only available when the active model + provider support multimodal input.",
+    summary: "Describe one or more images via the configured vision LLM. Only available when the active model + provider support multimodal input. Accepts at most 4 images per call by default (`vision.maxImagesPerCall`); to cover more images, split them across several calls.",
     argsSchema:
-      "{ prompt: string, path?: string, paths?: string[] /* png|jpg|jpeg|webp|gif */ }",
+      "{ prompt: string, path?: string, paths?: string[] /* png|jpg|jpeg|webp|gif; at most 4 by default */ }",
     examples: [
       '{"path":"./screenshot.png","prompt":"What error is shown?"}',
       '{"paths":["a.png","b.png"],"prompt":"Compare these two diagrams"}',

--- a/src/tools/coerce-tool-args.test.ts
+++ b/src/tools/coerce-tool-args.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import { ToolRegistry, type ToolContext, type ToolDefinition } from "./tool-registry.js";
+import { coerceToolArgs } from "./coerce-tool-args.js";
+
+const ctx: ToolContext = {
+  workingDir: "/w",
+  sessionId: "s1",
+  stepIndex: 0,
+  signal: new AbortController().signal,
+};
+
+/** Records the args a tool actually received after registry coercion. */
+function spyTool(name: string): { definition: ToolDefinition; seen: () => Record<string, unknown> } {
+  let received: Record<string, unknown> = {};
+  return {
+    seen: () => received,
+    definition: {
+      name,
+      description: name,
+      readonly: true,
+      run: async (args) => {
+        received = args;
+        return { status: "ok", summary: "", details: {} } as never;
+      },
+    },
+  };
+}
+
+async function invokeWith(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const registry = new ToolRegistry();
+  const spy = spyTool(name);
+  registry.register(spy.definition);
+  await registry.invoke(name, args, ctx);
+  return spy.seen();
+}
+
+describe("coerceToolArgs — real failing calls from the campaign", () => {
+  it("unwraps a stringified string[] for vision.describe (26 occurrences)", async () => {
+    const seen = await invokeWith("vision.describe", {
+      prompt: "read the numbers",
+      paths: '["/var/crops/num_04.png", "/var/crops/num_05.png"]',
+    });
+    expect(seen.paths).toEqual(["/var/crops/num_04.png", "/var/crops/num_05.png"]);
+    expect(seen.prompt).toBe("read the numbers");
+  });
+
+  it("unwraps stringified numbers for os.fs.read_document (15 occurrences)", async () => {
+    const seen = await invokeWith("os.fs.read_document", {
+      path: "census2011final_en.pdf",
+      maxBytes: "200000",
+      pagesFrom: "4",
+      pagesTo: "12",
+    });
+    expect(seen).toEqual({
+      path: "census2011final_en.pdf",
+      maxBytes: 200000,
+      pagesFrom: 4,
+      pagesTo: 12,
+    });
+  });
+
+  it("unwraps a stringified header object for os.http.request (3 occurrences)", async () => {
+    const seen = await invokeWith("os.http.request", {
+      url: "https://example.com",
+      headers: '{"User-Agent": "Mozilla/5.0 (Macintosh)"}',
+    });
+    expect(seen.headers).toEqual({ "User-Agent": "Mozilla/5.0 (Macintosh)" });
+    expect(seen.url).toBe("https://example.com");
+  });
+
+  it("unwraps a stringified number for browser.scroll (1 occurrence)", async () => {
+    const seen = await invokeWith("browser.scroll", { direction: "down", amount: "3000" });
+    expect(seen).toEqual({ direction: "down", amount: 3000 });
+  });
+});
+
+describe("coerceToolArgs — the union case (browser.scroll `amount`)", () => {
+  // `amount` is anyOf: ["page" | "half"] | number. The enum strings are
+  // legal values as written and must survive; a numeric string is not.
+  it("leaves the enum string \"page\" untouched", () => {
+    expect(coerceToolArgs("browser.scroll", { direction: "down", amount: "page" })).toEqual({
+      direction: "down",
+      amount: "page",
+    });
+  });
+
+  it("leaves the enum string \"half\" untouched", () => {
+    expect(coerceToolArgs("browser.scroll", { direction: "up", amount: "half" })).toEqual({
+      direction: "up",
+      amount: "half",
+    });
+  });
+
+  it("converts a numeric string on the same union field", () => {
+    expect(coerceToolArgs("browser.scroll", { direction: "down", amount: "3000" })).toEqual({
+      direction: "down",
+      amount: 3000,
+    });
+  });
+
+  it("passes an off-schema string through for the tool to reject", () => {
+    expect(coerceToolArgs("browser.scroll", { direction: "down", amount: "lots" })).toEqual({
+      direction: "down",
+      amount: "lots",
+    });
+  });
+
+  it("leaves a JSON-looking string on a string|object field alone", () => {
+    // os.http.request.body accepts a raw string, so `{"a":1}` is a
+    // legitimate body rather than an over-encoded object.
+    const args = { url: "https://example.com", method: "POST", body: '{"a":1}' };
+    expect(coerceToolArgs("os.http.request", args).body).toBe('{"a":1}');
+  });
+});
+
+describe("coerceToolArgs — do no harm", () => {
+  it("leaves a string value for a string-typed field alone", () => {
+    const args = { path: "1234", format: "5" };
+    expect(coerceToolArgs("os.fs.read_document", args)).toEqual(args);
+  });
+
+  it("passes an uncoercible number string through unchanged", () => {
+    const args = { path: "a.pdf", maxBytes: "not-a-number" };
+    expect(coerceToolArgs("os.fs.read_document", args)).toEqual(args);
+    expect(coerceToolArgs("os.fs.read_document", args).maxBytes).toBe("not-a-number");
+  });
+
+  it("passes malformed JSON for an array field through without throwing", () => {
+    const args = { prompt: "p", paths: "[broken" };
+    expect(() => coerceToolArgs("vision.describe", args)).not.toThrow();
+    expect(coerceToolArgs("vision.describe", args)).toEqual(args);
+  });
+
+  it("passes malformed JSON for an object field through without throwing", () => {
+    const args = { url: "https://example.com", headers: "{not json" };
+    expect(() => coerceToolArgs("os.http.request", args)).not.toThrow();
+    expect(coerceToolArgs("os.http.request", args).headers).toBe("{not json");
+  });
+
+  it("does not coerce a JSON array of the wrong item type", () => {
+    // vision.describe.paths is string[]; numbers must not slip through.
+    const args = { prompt: "p", paths: "[1, 2, 3]" };
+    expect(coerceToolArgs("vision.describe", args)).toEqual(args);
+  });
+
+  it("leaves an already-correct array untouched (no double parsing)", () => {
+    const paths = ["/a.png", "/b.png"];
+    const result = coerceToolArgs("vision.describe", { prompt: "p", paths });
+    expect(result.paths).toBe(paths);
+  });
+
+  it("leaves already-correct numbers and objects untouched", () => {
+    const args = { path: "a.pdf", maxBytes: 200000, pageSeparators: true };
+    expect(coerceToolArgs("os.fs.read_document", args)).toEqual(args);
+  });
+
+  it("passes a tool with no registered schema through completely unchanged", () => {
+    const args = { anything: "[1,2,3]", other: "500" };
+    expect(coerceToolArgs("mcp.some.unregistered.tool", args)).toBe(args);
+  });
+
+  it("ignores unknown keys not present in the schema properties", () => {
+    const args = { path: "a.pdf", bogusKey: "[1,2,3]" };
+    expect(coerceToolArgs("os.fs.read_document", args)).toEqual(args);
+  });
+
+  it("does not mutate the caller's object", () => {
+    const args = { prompt: "p", paths: '["/a.png"]' };
+    const snapshot = { ...args };
+    coerceToolArgs("vision.describe", args);
+    expect(args).toEqual(snapshot);
+    expect(args.paths).toBe('["/a.png"]');
+  });
+
+  it("returns the same reference when nothing needed coercing", () => {
+    const args = { path: "a.pdf", maxBytes: 200 };
+    expect(coerceToolArgs("os.fs.read_document", args)).toBe(args);
+  });
+
+  it("handles an empty args object", () => {
+    expect(coerceToolArgs("vision.describe", {})).toEqual({});
+  });
+
+  it("leaves non-string values of the wrong type alone for the tool to reject", () => {
+    // Only strings are candidates for unwrapping; a bad number stays bad.
+    const args = { prompt: "p", paths: 42 };
+    expect(coerceToolArgs("vision.describe", args)).toEqual(args);
+  });
+});
+
+describe("ToolRegistry.invoke integration", () => {
+  it("still dispatches to the right tool and returns its result", async () => {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "vision.describe",
+      description: "d",
+      readonly: true,
+      run: async (args) => ({ status: "ok", summary: String(args.paths), details: {} }) as never,
+    });
+    const result = await registry.invoke(
+      "vision.describe",
+      { prompt: "p", paths: '["/a.png"]' },
+      ctx,
+    );
+    expect(result.status).toBe("ok");
+  });
+
+  it("still throws ToolNotFoundError before any coercion", async () => {
+    const registry = new ToolRegistry();
+    await expect(registry.invoke("nope.missing", { a: "1" }, ctx)).rejects.toThrow(
+      /tool not registered/,
+    );
+  });
+});

--- a/src/tools/coerce-tool-args.ts
+++ b/src/tools/coerce-tool-args.ts
@@ -1,0 +1,83 @@
+import {
+  coerceJsonSchemaValue,
+  validateJsonSchemaValue,
+} from "../llm/provider/openai/coerce-json-schema-value.js";
+import { getDefaultArgsJsonSchema } from "../prompt/default-tool-args-schemas.js";
+
+type Schema = Record<string, unknown>;
+
+/**
+ * Repairs tool arguments that arrived one level over-encoded.
+ *
+ * Models routinely emit a JSON value wrapped in a string: a number as
+ * `"200000"`, an array as `"[\"a.png\"]"`, an object as
+ * `"{\"User-Agent\":\"...\"}"`. The payload is valid JSON of the right
+ * shape, but the tools' strict `typeof` checks reject it and the step
+ * is wasted. This runs on every dispatch (see `ToolRegistry.invoke`)
+ * and unwraps exactly that case.
+ *
+ * The rule is do-no-harm. A string is left alone whenever the declared
+ * schema already accepts it as written, and any coercion failure keeps
+ * the original value so the tool's own validation produces its normal
+ * error. A tool with no registered schema passes through unchanged.
+ */
+export function coerceToolArgs(
+  name: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const properties = argsProperties(name);
+  if (!properties) return args;
+
+  let coerced: Record<string, unknown> | null = null;
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value !== "string") continue;
+    const schema = asSchema(properties[key]);
+    if (!schema) continue;
+
+    const candidate = tryCoerce(value, schema);
+    if (candidate === undefined) continue;
+
+    coerced ??= { ...args };
+    coerced[key] = candidate;
+  }
+  return coerced ?? args;
+}
+
+/**
+ * Returns the unwrapped value, or `undefined` when the string must be
+ * left exactly as it is.
+ *
+ * The guard that matters is the first one. `browser.scroll`'s `amount`
+ * is declared `anyOf: ["page" | "half", number]`, so the field accepts
+ * both strings and numbers: `"page"` validates as written and must stay
+ * a string, while `"3000"` does not and becomes `3000`. Checking the
+ * concrete value against the schema — rather than asking whether the
+ * schema mentions `string` anywhere — gets both halves right, and it
+ * covers `os.http.request`'s `body` (`string | object`) too, where a
+ * JSON-looking string is a legitimate value rather than an encoding
+ * mistake.
+ */
+function tryCoerce(value: string, schema: Schema): unknown {
+  try {
+    if (validateJsonSchemaValue(value, schema)) return undefined;
+    const candidate = coerceJsonSchemaValue(value, schema);
+    // A coercion that yields another string changed nothing worth
+    // rewriting; treat it as a no-op.
+    return typeof candidate === "string" ? undefined : candidate;
+  } catch {
+    // Unsupported schema, or the value does not fit the declared shape.
+    return undefined;
+  }
+}
+
+/** The `properties` map of a default tool's args schema, when registered. */
+function argsProperties(name: string): Schema | null {
+  const schema = getDefaultArgsJsonSchema(name);
+  return schema ? asSchema(schema.properties) : null;
+}
+
+function asSchema(value: unknown): Schema | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Schema)
+    : null;
+}

--- a/src/tools/os/fs-grep.test.ts
+++ b/src/tools/os/fs-grep.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { afterAll, beforeAll, describe, it, expect } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type {
   CommandOptions,
   CommandResult,
@@ -6,11 +9,23 @@ import type {
 import type { ToolContext } from "../tool-registry.js";
 import { buildOsFsGrepTool, parseRipgrepJson } from "./fs-grep.js";
 
-// A platform-native absolute root: the grep runner is mocked in these tests
-// so the path is never touched on disk, but it must be a valid absolute path
-// for the host so `resolveUserPath` does not reject a Unix path on Windows.
-const FIXTURE_ROOT =
-  process.platform === "win32" ? "C:\\tmp\\fixture" : "/tmp/fixture";
+// The grep runner is mocked in these tests, but the tool now stats the
+// requested path to decide the child process cwd, so the fixture must exist
+// on disk. A real temp directory also keeps the paths platform-native, so
+// `resolveUserPath` does not reject a Unix path on Windows.
+let FIXTURE_ROOT: string;
+let FIXTURE_FILE: string;
+const FIXTURE_FILE_NAME = "darktrace.txt";
+
+beforeAll(async () => {
+  FIXTURE_ROOT = await mkdtemp(join(tmpdir(), "fs-grep-test-"));
+  FIXTURE_FILE = join(FIXTURE_ROOT, FIXTURE_FILE_NAME);
+  await writeFile(FIXTURE_FILE, "endopsychic\n", "utf8");
+});
+
+afterAll(async () => {
+  await rm(FIXTURE_ROOT, { recursive: true, force: true });
+});
 
 function makeCtx(): ToolContext {
   return {
@@ -308,5 +323,93 @@ describe("os.fs.grep", () => {
     expect(after).toBeGreaterThan(-1);
     expect(capturedArgs[before + 1]).toBe("2");
     expect(capturedArgs[after + 1]).toBe("2");
+  });
+
+  // Regression coverage for #183: an absolute file path used to be passed
+  // through as the child process cwd, which `spawn` rejects with ENOTDIR.
+  it("searches an absolute file path from its parent directory", async () => {
+    let capturedArgs: string[] = [];
+    let capturedCwd: string | undefined;
+    const tool = buildOsFsGrepTool({
+      resolveRgPath: () => "/fake/rg",
+      runCommand: async (_cmd, args, opts: CommandOptions) => {
+        capturedArgs = args;
+        capturedCwd = opts.cwd;
+        return makeCommandResult({ stdout: "" });
+      },
+    });
+    const result = await tool.run(
+      {
+        pattern: "endopsychic",
+        path: FIXTURE_FILE,
+        outputMode: "content",
+        contextAround: 3,
+        caseInsensitive: true,
+      },
+      makeCtx(),
+    );
+    expect(result.status).toBe("ok");
+    expect(capturedCwd).toBe(FIXTURE_ROOT);
+    expect(capturedArgs[capturedArgs.length - 1]).toBe(FIXTURE_FILE_NAME);
+    expect(capturedArgs[capturedArgs.length - 2]).toBe("endopsychic");
+  });
+
+  it("searches a relative file path from its parent directory", async () => {
+    let capturedArgs: string[] = [];
+    let capturedCwd: string | undefined;
+    const tool = buildOsFsGrepTool({
+      resolveRgPath: () => "/fake/rg",
+      runCommand: async (_cmd, args, opts: CommandOptions) => {
+        capturedArgs = args;
+        capturedCwd = opts.cwd;
+        return makeCommandResult({ stdout: "" });
+      },
+    });
+    const result = await tool.run(
+      { pattern: "endopsychic", path: FIXTURE_FILE_NAME },
+      makeCtx(),
+    );
+    expect(result.status).toBe("ok");
+    expect(capturedCwd).toBe(FIXTURE_ROOT);
+    expect(capturedArgs[capturedArgs.length - 1]).toBe(FIXTURE_FILE_NAME);
+  });
+
+  it("still searches a directory path with '.' as the target", async () => {
+    let capturedArgs: string[] = [];
+    let capturedCwd: string | undefined;
+    const tool = buildOsFsGrepTool({
+      resolveRgPath: () => "/fake/rg",
+      runCommand: async (_cmd, args, opts: CommandOptions) => {
+        capturedArgs = args;
+        capturedCwd = opts.cwd;
+        return makeCommandResult({ stdout: "" });
+      },
+    });
+    const result = await tool.run(
+      { pattern: "endopsychic", path: FIXTURE_ROOT },
+      makeCtx(),
+    );
+    expect(result.status).toBe("ok");
+    expect(capturedCwd).toBe(FIXTURE_ROOT);
+    expect(capturedArgs[capturedArgs.length - 1]).toBe(".");
+  });
+
+  it("reports a clear error for a path that does not exist", async () => {
+    let ran = false;
+    const tool = buildOsFsGrepTool({
+      resolveRgPath: () => "/fake/rg",
+      runCommand: async () => {
+        ran = true;
+        return makeCommandResult({ stdout: "" });
+      },
+    });
+    const result = await tool.run(
+      { pattern: "foo", path: join(FIXTURE_ROOT, "no-such-file.txt") },
+      makeCtx(),
+    );
+    expect(result.status).toBe("error");
+    expect(result.summary).toContain("does not exist");
+    expect(result.summary).not.toContain("ENOTDIR");
+    expect(ran).toBe(false);
   });
 });

--- a/src/tools/os/fs-grep.ts
+++ b/src/tools/os/fs-grep.ts
@@ -1,3 +1,5 @@
+import { stat } from "node:fs/promises";
+import { basename, dirname } from "node:path";
 import { compressToolResult } from "../../compressor/result-compressor.js";
 import { resolveUserPath } from "./expand-home.js";
 import {
@@ -72,9 +74,22 @@ export function buildOsFsGrepTool(
         });
       }
 
-      const rgArgs = buildRgArgs(args);
+      let target: SearchTarget;
+      try {
+        target = await resolveSearchTarget(args.path, ctx.workingDir);
+      } catch (err) {
+        const reason = (err as Error).message;
+        return compressToolResult({
+          tool: "os.fs.grep",
+          status: "error",
+          output: reason,
+          details: { path: args.path, hint: reason },
+        });
+      }
+
+      const rgArgs = buildRgArgs(args, target.searchTarget);
       const result = await runCommand(rgPath, rgArgs, {
-        cwd: args.path,
+        cwd: target.cwd,
         timeoutMs: args.timeoutMs,
         signal: ctx.signal,
       });
@@ -194,7 +209,49 @@ function parseArgs(
   };
 }
 
-function buildRgArgs(args: GrepArgs): string[] {
+interface SearchTarget {
+  /** Directory the ripgrep child process is spawned in. Always a directory. */
+  cwd: string;
+  /** Positional target handed to ripgrep, relative to `cwd`. */
+  searchTarget: string;
+}
+
+/**
+ * Work out where to spawn ripgrep and what to point it at.
+ *
+ * `spawn` requires `cwd` to be a directory, so passing a file path straight
+ * through fails with `ENOTDIR` before ripgrep ever runs. A file is therefore
+ * searched from its parent directory, with the file name as the positional
+ * target; a directory keeps the previous behaviour (`cwd` = the directory,
+ * target = `.`) so glob and type filters resolve the same way as before.
+ */
+async function resolveSearchTarget(
+  path: string,
+  workingDir: string,
+): Promise<SearchTarget> {
+  let info;
+  try {
+    info = await stat(path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      throw new Error(`os.fs.grep: path does not exist: ${path}`);
+    }
+    throw new Error(
+      `os.fs.grep: cannot access path ${path}: ${(err as Error).message}`,
+    );
+  }
+  if (info.isDirectory()) {
+    return { cwd: path, searchTarget: "." };
+  }
+  const parent = dirname(path);
+  // `dirname` of a filesystem root returns the root itself; fall back to the
+  // working directory only when the parent is somehow unusable.
+  const cwd = parent.length > 0 ? parent : workingDir;
+  return { cwd, searchTarget: basename(path) };
+}
+
+function buildRgArgs(args: GrepArgs, searchTarget: string): string[] {
   const rg: string[] = ["--json"];
   if (args.caseInsensitive) rg.push("-i");
   if (args.multiline) {
@@ -207,7 +264,7 @@ function buildRgArgs(args: GrepArgs): string[] {
     rg.push("--glob", g);
   }
   if (args.type) rg.push("--type", args.type);
-  rg.push("--", args.pattern, ".");
+  rg.push("--", args.pattern, searchTarget);
   return rg;
 }
 

--- a/src/tools/os/http-request-fetch.ts
+++ b/src/tools/os/http-request-fetch.ts
@@ -181,6 +181,9 @@ function buildPinnedCurlArgs(input: BuildPinnedCurlArgs): string[] {
     : input.pinnedIp;
   const argv: string[] = [
     "-sS",
+    // Send `[`, `]`, `{`, `}` in URLs literally. Without this curl reads them
+    // as its own range/set glob syntax and fails with "bad range in URL".
+    "--globoff",
     "--max-time",
     String(Math.ceil(input.timeoutMs / 1000)),
     // Hop-by-hop follow is owned by executeGuardedHttpRequest so each

--- a/src/tools/os/http-request.test.ts
+++ b/src/tools/os/http-request.test.ts
@@ -633,6 +633,28 @@ describe("os.http.request", () => {
     expect(capture.args).not.toContain("-L");
   });
 
+  it("passes --globoff so bracketed URLs are not read as curl ranges", async () => {
+    // Real failure from the field: without --globoff curl rejects the
+    // `[Dd]` character set with "curl: (3) bad range in URL position 158".
+    const url =
+      "http://web.archive.org/cdx/search/cdx?url=base-search.net" +
+      "&matchType=domain&filter=original:.*[Dd]ewey.*&collapse=urlkey";
+    const capture: { cmd?: string; args?: string[] } = {};
+    const tool = buildOsHttpRequestTool({
+      lookup: publicLookup,
+      approvals: approveAll(),
+      approvalRequired: false,
+      config: makeHttpConfig({ approvalMode: "never" }),
+      runCommand: fakeRun(capture, {
+        stdout: "ok\n" + meta(200, "text/plain", 2),
+      }),
+    });
+    await tool.run({ url }, makeCtx());
+    expect(capture.args).toContain("--globoff");
+    // The bracketed URL still reaches curl verbatim as the final operand.
+    expect(capture.args![capture.args!.length - 1]).toContain("[Dd]ewey");
+  });
+
   it("re-validates redirect hops and blocks a private Location target", async () => {
     const calls: string[][] = [];
     const runCommand = async (

--- a/src/tools/os/index.ts
+++ b/src/tools/os/index.ts
@@ -132,7 +132,7 @@ export function registerOsTools(
     }),
   );
   registry.register(buildOsWebSearchTool({ config: options.config }));
-  registry.register(buildOsWebFetchTool());
+  registry.register(buildOsWebFetchTool({ config: options.config }));
   registry.register(osClipboardReadTool);
   registry.register(osClipboardWriteTool);
   registry.register(osWindowListTool);

--- a/src/tools/os/web-fetch.test.ts
+++ b/src/tools/os/web-fetch.test.ts
@@ -3,6 +3,7 @@ import { buildOsWebFetchTool, parseCurlMeta } from "./web-fetch.js";
 import type { runCommand as RunCommandType } from "../../sandbox/command-runner.js";
 import type { HostLookup } from "./web-fetch-ssrf-guard.js";
 import type { ToolContext } from "../tool-registry.js";
+import { USER_CONFIG_DEFAULTS } from "../../config/index.js";
 
 const MARKER = "__ATOMIC_WEBFETCH_META__";
 
@@ -19,8 +20,32 @@ function curlStdout(opts: {
   status: number;
   contentType: string;
   redirectUrl?: string;
+  /** Response headers rendered the way curl's `%{header_json}` emits them. */
+  headers?: Record<string, string>;
 }): string {
-  return `${opts.body}\n${MARKER}${opts.status}|${opts.contentType}|${opts.redirectUrl ?? ""}|${opts.body.length}`;
+  const headerJson =
+    opts.headers === undefined
+      ? ""
+      : JSON.stringify(
+          Object.fromEntries(
+            Object.entries(opts.headers).map(([k, v]) => [k, [v]]),
+          ),
+        );
+  return `${opts.body}\n${MARKER}${opts.status}|${opts.contentType}|${opts.redirectUrl ?? ""}|${opts.body.length}|${headerJson}`;
+}
+
+/** Collects backoff waits instead of sleeping, so retry tests run instantly. */
+function fakeSleep(): {
+  sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+  waits: number[];
+} {
+  const waits: number[] = [];
+  return {
+    waits,
+    sleep: async (ms: number) => {
+      waits.push(ms);
+    },
+  };
 }
 
 function makeRunCommand(
@@ -65,6 +90,28 @@ describe("parseCurlMeta", () => {
     expect(parsed.status).toBe(200);
     expect(parsed.contentType).toBe("text/html; charset=utf-8");
     expect(parsed.redirectUrl).toBe("https://x/redir");
+  });
+
+  it("parses Retry-After out of the header_json field", () => {
+    const parsed = parseCurlMeta(
+      `body\n${MARKER}503|text/html|| 5|{"retry-after":["7"],"server":["x"]}`,
+    );
+    expect(parsed.status).toBe(503);
+    expect(parsed.retryAfterMs).toBe(7_000);
+  });
+
+  it("keeps header_json containing pipes out of the fixed fields", () => {
+    const parsed = parseCurlMeta(
+      `body\n${MARKER}200|text/html||4|{"x-thing":["a|b"],"retry-after":["3"]}`,
+    );
+    expect(parsed.contentType).toBe("text/html");
+    expect(parsed.retryAfterMs).toBe(3_000);
+  });
+
+  it("yields no Retry-After when header_json is absent (older curl)", () => {
+    const parsed = parseCurlMeta(`body\n${MARKER}503|text/html||4|%{header_json}`);
+    expect(parsed.status).toBe(503);
+    expect(parsed.retryAfterMs).toBeNull();
   });
 });
 
@@ -189,6 +236,7 @@ describe("os.web.fetch tool", () => {
     expect(result.summary).toContain("HTTP 500");
     expect(result.details.status).toBe(500);
   });
+
   it("passes --globoff so bracketed URLs are not read as curl ranges", async () => {
     // Real failure from the field: without --globoff curl rejects the
     // `[... TO ...]` date range with "curl: (3) bad range in URL position 124".
@@ -211,5 +259,291 @@ describe("os.web.fetch tool", () => {
     expect(args).toContain("--globoff");
     // The bracketed URL still reaches curl verbatim as the final operand.
     expect(args[args.length - 1]).toContain("[202102010000");
+  });
+});
+
+// Issue #181 — 236 timeout failures each burned a fixed 30s of the task
+// budget, with no connect timeout and no way to shorten the wait.
+describe("os.web.fetch timeouts (#181)", () => {
+  function cfg(fetch: Partial<{
+    timeoutMs: number;
+    connectTimeoutMs: number;
+    maxRetries: number;
+    retryBaseDelayMs: number;
+    retryMaxDelayMs: number;
+  }>) {
+    return {
+      web: {
+        search: USER_CONFIG_DEFAULTS.web.search,
+        fetch: { ...USER_CONFIG_DEFAULTS.web.fetch, ...fetch },
+      },
+    };
+  }
+
+  it("passes --connect-timeout so dead hosts fail fast", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({ body: ARTICLE, status: 200, contentType: "text/html" }),
+      })),
+    );
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup });
+    await tool.run({ url: "https://example.com/doc" }, ctx());
+    const args = run.mock.calls[0]![1] as string[];
+    // Default connect budget is 10s, well below the 30s overall budget.
+    expect(args[args.indexOf("--connect-timeout") + 1]).toBe("10");
+  });
+
+  it("uses the configured timeoutMs for --max-time", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({ body: ARTICLE, status: 200, contentType: "text/html" }),
+      })),
+    );
+    const tool = buildOsWebFetchTool({
+      runCommand: run,
+      lookup: publicLookup,
+      config: cfg({ timeoutMs: 8_000, connectTimeoutMs: 3_000 }),
+    });
+    await tool.run({ url: "https://example.com/doc" }, ctx());
+    const args = run.mock.calls[0]![1] as string[];
+    expect(args[args.indexOf("--max-time") + 1]).toBe("8");
+    expect(args[args.indexOf("--connect-timeout") + 1]).toBe("3");
+  });
+
+  it("lets a per-call timeoutMs override the configured default", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({ body: ARTICLE, status: 200, contentType: "text/html" }),
+      })),
+    );
+    const tool = buildOsWebFetchTool({
+      runCommand: run,
+      lookup: publicLookup,
+      config: cfg({ timeoutMs: 30_000 }),
+    });
+    await tool.run({ url: "https://example.com/doc", timeoutMs: 5_000 }, ctx());
+    const args = run.mock.calls[0]![1] as string[];
+    expect(args[args.indexOf("--max-time") + 1]).toBe("5");
+  });
+
+  it("never lets the connect budget exceed a smaller per-call timeout", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({ body: ARTICLE, status: 200, contentType: "text/html" }),
+      })),
+    );
+    const tool = buildOsWebFetchTool({
+      runCommand: run,
+      lookup: publicLookup,
+      config: cfg({ timeoutMs: 30_000, connectTimeoutMs: 10_000 }),
+    });
+    await tool.run({ url: "https://example.com/doc", timeoutMs: 2_000 }, ctx());
+    const args = run.mock.calls[0]![1] as string[];
+    expect(args[args.indexOf("--max-time") + 1]).toBe("2");
+    expect(args[args.indexOf("--connect-timeout") + 1]).toBe("2");
+  });
+});
+
+// Issue #180 — os.web.fetch never retried. 128 of 130 real 503s came from
+// web.archive.org, which serves the very same URL seconds later.
+describe("os.web.fetch retries (#180)", () => {
+  const ARCHIVE_URL = "https://web.archive.org/web/2023/https://example.com";
+
+  it("retries a 503 from web.archive.org and succeeds on the second attempt", async () => {
+    let attempts = 0;
+    const run = vi.fn(
+      makeRunCommand(() => {
+        attempts += 1;
+        if (attempts === 1) {
+          return {
+            stdout: curlStdout({
+              body: "<html><body>slow down</body></html>",
+              status: 503,
+              contentType: "text/html",
+            }),
+          };
+        }
+        return {
+          stdout: curlStdout({ body: ARTICLE, status: 200, contentType: "text/html" }),
+        };
+      }),
+    );
+    const { sleep, waits } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    const result = await tool.run({ url: ARCHIVE_URL }, ctx());
+    expect(result.status).toBe("ok");
+    expect(result.details.status).toBe(200);
+    expect(run).toHaveBeenCalledTimes(2);
+    // First backoff is the base delay.
+    expect(waits).toEqual([500]);
+  });
+
+  it("returns the error once the retry budget is exhausted", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({
+          body: "<html><body>still down</body></html>",
+          status: 503,
+          contentType: "text/html",
+        }),
+      })),
+    );
+    const { sleep, waits } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    const result = await tool.run({ url: ARCHIVE_URL }, ctx());
+    expect(result.status).toBe("error");
+    expect(result.details.status).toBe(503);
+    // Default maxRetries: 2 → 3 attempts total, exponential 500ms then 1000ms.
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([500, 1_000]);
+  });
+
+  it("does NOT retry a 404", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({
+          body: "<html><body>not found</body></html>",
+          status: 404,
+          contentType: "text/html",
+        }),
+      })),
+    );
+    const { sleep, waits } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    const result = await tool.run({ url: "https://example.com/missing" }, ctx());
+    expect(result.status).toBe("error");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(waits).toEqual([]);
+  });
+
+  it("retries a curl timeout (exit 28)", async () => {
+    let attempts = 0;
+    const run = vi.fn(
+      makeRunCommand(() => {
+        attempts += 1;
+        if (attempts === 1) {
+          return {
+            stdout: "",
+            exitCode: 28,
+            stderr: "curl: (28) Connection timed out after 30006 milliseconds",
+          };
+        }
+        return {
+          stdout: curlStdout({ body: ARTICLE, status: 200, contentType: "text/html" }),
+        };
+      }),
+    );
+    const { sleep } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    const result = await tool.run({ url: "https://example.com/slow" }, ctx());
+    expect(result.status).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a non-timeout curl failure", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: "",
+        exitCode: 6,
+        stderr: "curl: (6) Could not resolve host: nope.invalid",
+      })),
+    );
+    const { sleep } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    const result = await tool.run({ url: "https://nope.invalid/x" }, ctx());
+    expect(result.status).toBe("error");
+    expect(result.summary).toContain("Could not resolve host");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours a Retry-After header over the computed backoff", async () => {
+    let attempts = 0;
+    const run = vi.fn(
+      makeRunCommand(() => {
+        attempts += 1;
+        if (attempts === 1) {
+          return {
+            stdout: curlStdout({
+              body: "",
+              status: 429,
+              contentType: "text/html",
+              headers: { "retry-after": "2" },
+            }),
+          };
+        }
+        return {
+          stdout: curlStdout({ body: ARTICLE, status: 200, contentType: "text/html" }),
+        };
+      }),
+    );
+    const { sleep, waits } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    const result = await tool.run({ url: "https://example.com/limited" }, ctx());
+    expect(result.status).toBe("ok");
+    // 2s from the header, not the 500ms base delay.
+    expect(waits).toEqual([2_000]);
+  });
+
+  it("clamps an oversized Retry-After to retryMaxDelayMs", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({
+          body: "",
+          status: 503,
+          contentType: "text/html",
+          headers: { "retry-after": "3600" },
+        }),
+      })),
+    );
+    const { sleep, waits } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    await tool.run({ url: ARCHIVE_URL }, ctx());
+    // Never parks the agent for an hour — capped at the 5s default.
+    expect(waits).toEqual([5_000, 5_000]);
+  });
+
+  it("respects maxRetries: 0 (retrying disabled)", async () => {
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({ body: "", status: 503, contentType: "text/html" }),
+      })),
+    );
+    const { sleep } = fakeSleep();
+    const tool = buildOsWebFetchTool({
+      runCommand: run,
+      lookup: publicLookup,
+      sleep,
+      config: {
+        web: {
+          search: USER_CONFIG_DEFAULTS.web.search,
+          fetch: { ...USER_CONFIG_DEFAULTS.web.fetch, maxRetries: 0 },
+        },
+      },
+    });
+    const result = await tool.run({ url: ARCHIVE_URL }, ctx());
+    expect(result.status).toBe("error");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying once the abort signal fires", async () => {
+    const controller = new AbortController();
+    const run = vi.fn(
+      makeRunCommand(() => {
+        // The task is cancelled while the first attempt is in flight.
+        controller.abort();
+        return {
+          stdout: curlStdout({ body: "", status: 503, contentType: "text/html" }),
+        };
+      }),
+    );
+    const { sleep, waits } = fakeSleep();
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup, sleep });
+    const result = await tool.run(
+      { url: ARCHIVE_URL },
+      { ...ctx(), signal: controller.signal },
+    );
+    expect(result.status).toBe("error");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(waits).toEqual([]);
   });
 });

--- a/src/tools/os/web-fetch.test.ts
+++ b/src/tools/os/web-fetch.test.ts
@@ -189,4 +189,27 @@ describe("os.web.fetch tool", () => {
     expect(result.summary).toContain("HTTP 500");
     expect(result.details.status).toBe(500);
   });
+  it("passes --globoff so bracketed URLs are not read as curl ranges", async () => {
+    // Real failure from the field: without --globoff curl rejects the
+    // `[... TO ...]` date range with "curl: (3) bad range in URL position 124".
+    const url =
+      "http://export.arxiv.org/api/query?search_query=all:%22multiwavelength%22" +
+      "+AND+submittedDate:[202102010000+TO+202104300000]&start=0&max_results=30";
+    const run = vi.fn(
+      makeRunCommand(() => ({
+        stdout: curlStdout({
+          body: "<feed></feed>",
+          status: 200,
+          contentType: "application/atom+xml",
+        }),
+      })),
+    );
+    const tool = buildOsWebFetchTool({ runCommand: run, lookup: publicLookup });
+    await tool.run({ url }, ctx());
+    expect(run).toHaveBeenCalledTimes(1);
+    const args = run.mock.calls[0]![1] as string[];
+    expect(args).toContain("--globoff");
+    // The bracketed URL still reaches curl verbatim as the final operand.
+    expect(args[args.length - 1]).toContain("[202102010000");
+  });
 });

--- a/src/tools/os/web-fetch.ts
+++ b/src/tools/os/web-fetch.ts
@@ -243,6 +243,7 @@ function buildCurlArgs(url: URL, pinnedIp: string): string[] {
   const resolveTarget = pinnedIp.includes(":") ? `[${pinnedIp}]` : pinnedIp;
   return [
     "-sS",
+    "--globoff",
     "--max-time",
     String(Math.ceil(DEFAULT_TIMEOUT_MS / 1000)),
     "--max-redirs",

--- a/src/tools/os/web-fetch.ts
+++ b/src/tools/os/web-fetch.ts
@@ -4,6 +4,7 @@ import {
   type CommandResult,
 } from "../../sandbox/command-runner.js";
 import type { ToolDefinition } from "../tool-registry.js";
+import type { AtomicAgentConfig, WebFetchConfig } from "../../config/index.js";
 import { extractWebContent, type ExtractMode } from "./web-fetch-extract.js";
 import { CurlUnavailableError, isCurlMissingError } from "./ensure-curl.js";
 import {
@@ -21,6 +22,30 @@ const MAX_REDIRECTS = 3;
 const DEFAULT_MAX_CHARS = 50_000;
 const MAX_CHARS_CAP = 50_000;
 
+/**
+ * Fallback `web.fetch` settings for callers that construct the tool without a
+ * config (tests, embedders). Mirrors `USER_CONFIG_DEFAULTS.web.fetch`.
+ */
+const DEFAULT_FETCH_CONFIG: WebFetchConfig = {
+  timeoutMs: DEFAULT_TIMEOUT_MS,
+  connectTimeoutMs: 10_000,
+  maxRetries: 2,
+  retryBaseDelayMs: 500,
+  retryMaxDelayMs: 5_000,
+};
+
+/**
+ * HTTP statuses worth a second attempt. 503 dominates the field data (and is
+ * overwhelmingly `web.archive.org` shedding load, which serves the very same
+ * URL seconds later); 429/502/504 are the other transient-by-contract codes.
+ * Everything else — notably 4xx like 404/403 — is a stable answer that would
+ * only burn budget on a repeat.
+ */
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+
+/** curl's "operation timed out" exit. The other exits are not transient. */
+const CURL_EXIT_TIMEOUT = 28;
+
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
   "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
@@ -37,12 +62,21 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 export interface OsWebFetchOptions {
   runCommand?: typeof defaultRunCommand;
   lookup?: HostLookup;
+  /**
+   * Timeout / retry tunables. Optional so existing callers and tests keep
+   * working — when absent `DEFAULT_FETCH_CONFIG` applies, which reproduces the
+   * pre-v38 30s budget.
+   */
+  config?: Pick<AtomicAgentConfig, "web">;
+  /** Injectable sleep so retry-backoff tests do not wait in real time. */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
 }
 
 interface WebFetchArgs {
   url: string;
   mode: ExtractMode;
   maxChars: number;
+  timeoutMs: number;
 }
 
 interface CurlResponse {
@@ -51,6 +85,8 @@ interface CurlResponse {
   redirectUrl: string;
   body: string;
   truncated: boolean;
+  /** Seconds parsed from a `Retry-After` response header, when present. */
+  retryAfterMs: number | null;
 }
 
 interface FetchOutcome {
@@ -66,6 +102,8 @@ export function buildOsWebFetchTool(
   options: OsWebFetchOptions = {},
 ): ToolDefinition {
   const runCommand = options.runCommand ?? defaultRunCommand;
+  const fetchCfg = options.config?.web.fetch ?? DEFAULT_FETCH_CONFIG;
+  const sleep = options.sleep ?? defaultSleep;
   return {
     name: TOOL_NAME,
     description:
@@ -74,12 +112,14 @@ export function buildOsWebFetchTool(
       "(Accept: text/markdown), then Mozilla Readability, then a basic " +
       "tag-stripping fallback. GET only, no auth headers, no JavaScript " +
       "(use browser.* for JS-heavy pages). Blocks private/internal " +
-      "addresses (SSRF) and re-validates each redirect hop. For raw " +
-      "API/JSON responses, custom headers, auth, or POST, use " +
-      "os.http.request instead.",
+      "addresses (SSRF) and re-validates each redirect hop. Retries " +
+      "transient failures (429/502/503/504, connection timeouts) with " +
+      "exponential backoff. Optional `timeoutMs` overrides the configured " +
+      "per-attempt budget. For raw API/JSON responses, custom headers, " +
+      "auth, or POST, use os.http.request instead.",
     readonly: true,
     async run(rawArgs, ctx) {
-      const args = parseArgs(rawArgs);
+      const args = parseArgs(rawArgs, fetchCfg.timeoutMs);
       let outcome: FetchOutcome;
       try {
         outcome = await fetchWithGuard(args.url, {
@@ -87,6 +127,9 @@ export function buildOsWebFetchTool(
           lookup: options.lookup,
           cwd: ctx.workingDir,
           signal: ctx.signal,
+          fetchCfg,
+          timeoutMs: args.timeoutMs,
+          sleep,
         });
       } catch (err) {
         return compressToolResult({
@@ -149,7 +192,10 @@ export function buildOsWebFetchTool(
   };
 }
 
-function parseArgs(rawArgs: Record<string, unknown>): WebFetchArgs {
+function parseArgs(
+  rawArgs: Record<string, unknown>,
+  defaultTimeoutMs: number,
+): WebFetchArgs {
   const url = rawArgs.url;
   if (typeof url !== "string" || url.length === 0) {
     throw new Error(`${TOOL_NAME}: \`url\` must be a non-empty string`);
@@ -168,7 +214,14 @@ function parseArgs(rawArgs: Record<string, unknown>): WebFetchArgs {
   if (typeof rawArgs.maxChars === "number" && Number.isFinite(rawArgs.maxChars)) {
     maxChars = Math.min(MAX_CHARS_CAP, Math.max(1, Math.trunc(rawArgs.maxChars)));
   }
-  return { url, mode, maxChars };
+  // Mirrors os.http.request: a per-call `timeoutMs` overrides the configured
+  // default so the model can shorten the budget for a host it expects to be
+  // slow, instead of losing the full default on every attempt.
+  const timeoutMs =
+    typeof rawArgs.timeoutMs === "number" && Number.isFinite(rawArgs.timeoutMs)
+      ? Math.max(1, Math.trunc(rawArgs.timeoutMs))
+      : defaultTimeoutMs;
+  return { url, mode, maxChars, timeoutMs };
 }
 
 interface FetchWithGuardOptions {
@@ -176,12 +229,32 @@ interface FetchWithGuardOptions {
   lookup?: HostLookup;
   cwd: string;
   signal: AbortSignal;
+  fetchCfg: WebFetchConfig;
+  /** Effective per-attempt budget (per-call arg, else `fetchCfg.timeoutMs`). */
+  timeoutMs: number;
+  sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+/** Thrown by `curlOnce` when curl itself failed (non-zero exit). */
+class CurlFailedError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+  ) {
+    super(message);
+    this.name = "CurlFailedError";
+  }
 }
 
 /**
  * Fetch `rawUrl`, following redirects manually (curl `--max-redirs 0`) so the
  * SSRF guard can re-validate every hop and pin curl to a verified IP via
  * `--resolve`, closing the DNS-rebinding window.
+ *
+ * Each hop is retried independently for transient failures. `os.web.fetch` is
+ * GET-only (no method argument exists, and curl is invoked without `-X`/`-d`),
+ * so every request is idempotent and safe to repeat — there is no
+ * non-idempotent case to exclude here.
  */
 async function fetchWithGuard(
   rawUrl: string,
@@ -190,8 +263,7 @@ async function fetchWithGuard(
   let currentUrl = parseHttpUrl(rawUrl);
   const chain: string[] = [];
   for (let hop = 0; ; hop++) {
-    const pinnedIp = await assertHostAllowed(currentUrl, { lookup: opts.lookup });
-    const res = await curlOnce(currentUrl, pinnedIp, opts);
+    const res = await fetchHopWithRetry(currentUrl, opts);
     chain.push(currentUrl.toString());
     if (REDIRECT_STATUSES.has(res.status) && res.redirectUrl.length > 0) {
       if (hop >= MAX_REDIRECTS) {
@@ -213,17 +285,106 @@ async function fetchWithGuard(
   }
 }
 
+/**
+ * One redirect hop, retried on transient failure with exponential backoff.
+ *
+ * Retryable: HTTP 429/502/503/504, and curl exit 28 (`--max-time` /
+ * `--connect-timeout` expiry). Everything else — a 404, a DNS failure, a TLS
+ * error — is returned or thrown on the first attempt, because repeating it only
+ * spends task budget for the same answer.
+ *
+ * The budget is deliberately small (`maxRetries`, default 2). Worst case adds
+ * two attempts plus backoff on top of the first, which is bounded by
+ * `retryMaxDelayMs` per wait rather than growing without limit. `ctx.signal` is
+ * honoured both during the sleep and by `runCommand`, so an aborted task stops
+ * immediately instead of finishing its retry ladder.
+ */
+async function fetchHopWithRetry(
+  url: URL,
+  opts: FetchWithGuardOptions,
+): Promise<CurlResponse> {
+  const { maxRetries } = opts.fetchCfg;
+  for (let attempt = 0; ; attempt++) {
+    // Re-resolve on every attempt: the guard must pin a freshly verified IP
+    // rather than trusting one resolved before an arbitrary backoff wait.
+    const pinnedIp = await assertHostAllowed(url, { lookup: opts.lookup });
+
+    let res: CurlResponse | null = null;
+    let failure: unknown = null;
+    try {
+      res = await curlOnce(url, pinnedIp, opts);
+    } catch (err) {
+      // Only a curl timeout is worth another attempt; a missing curl binary or
+      // an aborted run must surface immediately.
+      if (
+        !(err instanceof CurlFailedError) ||
+        err.exitCode !== CURL_EXIT_TIMEOUT
+      ) {
+        throw err;
+      }
+      failure = err;
+    }
+
+    const retryable =
+      failure !== null || (res !== null && RETRYABLE_STATUSES.has(res.status));
+    if (!retryable || attempt >= maxRetries || opts.signal.aborted) {
+      if (res !== null) return res;
+      throw failure;
+    }
+
+    await opts.sleep(
+      backoffDelayMs(attempt, res?.retryAfterMs ?? null, opts.fetchCfg),
+      opts.signal,
+    );
+  }
+}
+
+/**
+ * Delay before retry `attempt` (0-based): `retryBaseDelayMs * 2^attempt`,
+ * clamped to `retryMaxDelayMs`. Defaults give 500ms then 1000ms — long enough
+ * for a load-shedding origin like `web.archive.org` to recover, short enough
+ * that two retries cost ~1.5s against a 25-minute task budget.
+ *
+ * A `Retry-After` sent by the server wins over the computed delay, since the
+ * origin knows its own recovery window, but is still clamped to
+ * `retryMaxDelayMs` so a large or hostile value cannot park the agent.
+ */
+function backoffDelayMs(
+  attempt: number,
+  retryAfterMs: number | null,
+  cfg: WebFetchConfig,
+): number {
+  const backoff = cfg.retryBaseDelayMs * 2 ** attempt;
+  const chosen = retryAfterMs !== null ? retryAfterMs : backoff;
+  return Math.min(cfg.retryMaxDelayMs, Math.max(0, chosen));
+}
+
+function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(finish, ms);
+    function finish(): void {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    }
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}
+
 async function curlOnce(
   url: URL,
   pinnedIp: string,
   opts: FetchWithGuardOptions,
 ): Promise<CurlResponse> {
-  const curlArgs = buildCurlArgs(url, pinnedIp);
+  const curlArgs = buildCurlArgs(url, pinnedIp, opts);
   let result: CommandResult;
   try {
     result = await opts.runCommand("curl", curlArgs, {
       cwd: opts.cwd,
-      timeoutMs: DEFAULT_TIMEOUT_MS + 2_000,
+      // Outer guard sits just above curl's own `--max-time` so curl reports the
+      // timeout itself (exit 28) instead of being killed by the runner.
+      timeoutMs: opts.timeoutMs + 2_000,
       signal: opts.signal,
       maxOutputBytes: MAX_RESPONSE_BYTES + 1024,
     });
@@ -232,20 +393,40 @@ async function curlOnce(
     throw err;
   }
   if (result.exitCode !== 0) {
-    throw new Error(`${TOOL_NAME}: ${formatCurlError(result)}`);
+    throw new CurlFailedError(
+      `${TOOL_NAME}: ${formatCurlError(result)}`,
+      result.exitCode ?? -1,
+    );
   }
   return { ...parseCurlMeta(result.stdout), truncated: result.truncated };
 }
 
-function buildCurlArgs(url: URL, pinnedIp: string): string[] {
+function buildCurlArgs(
+  url: URL,
+  pinnedIp: string,
+  opts: Pick<FetchWithGuardOptions, "fetchCfg" | "timeoutMs">,
+): string[] {
   const host = url.hostname.replace(/^\[|\]$/g, "");
   const port = url.port || (url.protocol === "https:" ? "443" : "80");
   const resolveTarget = pinnedIp.includes(":") ? `[${pinnedIp}]` : pinnedIp;
+  // Never let the connect budget exceed the overall one — a per-call
+  // `timeoutMs` smaller than the configured connect timeout must still cap the
+  // handshake.
+  const connectTimeoutMs = Math.min(
+    opts.fetchCfg.connectTimeoutMs,
+    opts.timeoutMs,
+  );
   return [
     "-sS",
+    // Send `[`, `]`, `{`, `}` in URLs literally. Without this curl reads them
+    // as its own range/set glob syntax and fails with "bad range in URL".
     "--globoff",
     "--max-time",
-    String(Math.ceil(DEFAULT_TIMEOUT_MS / 1000)),
+    String(Math.ceil(opts.timeoutMs / 1000)),
+    // Fail fast on hosts that never complete a handshake instead of holding
+    // the whole `--max-time` budget open for them.
+    "--connect-timeout",
+    String(Math.ceil(connectTimeoutMs / 1000)),
     "--max-redirs",
     "0",
     "--resolve",
@@ -257,7 +438,11 @@ function buildCurlArgs(url: URL, pinnedIp: string): string[] {
     "-H",
     "Accept-Language: en-US,en;q=0.9",
     "-w",
-    `\n${CURL_META_MARKER}%{http_code}|%{content_type}|%{redirect_url}|%{size_download}`,
+    // `%{header_json}` is last on purpose: it is multi-line JSON that can
+    // itself contain `|`, so every pipe-delimited field must precede it.
+    // Requires curl >= 7.83; older curl emits the literal token, which
+    // `parseCurlMeta` tolerates by yielding no Retry-After.
+    `\n${CURL_META_MARKER}%{http_code}|%{content_type}|%{redirect_url}|%{size_download}|%{header_json}`,
     "--",
     url.toString(),
   ];
@@ -268,18 +453,67 @@ export function parseCurlMeta(
 ): Omit<CurlResponse, "truncated"> {
   const markerIdx = stdout.lastIndexOf(CURL_META_MARKER);
   if (markerIdx === -1) {
-    return { status: 0, contentType: "", redirectUrl: "", body: stdout };
+    return {
+      status: 0,
+      contentType: "",
+      redirectUrl: "",
+      body: stdout,
+      retryAfterMs: null,
+    };
   }
   const body = stdout.slice(0, markerIdx).replace(/\n$/, "");
   const meta = stdout.slice(markerIdx + CURL_META_MARKER.length).trim();
-  const [statusStr = "", contentType = "", redirectUrl = ""] = meta.split("|");
+  // Split off exactly the four fixed fields; whatever follows is
+  // `%{header_json}`, which may itself contain `|` and newlines.
+  const parts = meta.split("|");
+  const [statusStr = "", contentType = "", redirectUrl = ""] = parts;
+  const headerJson = parts.slice(4).join("|");
   const status = Number.parseInt(statusStr, 10);
   return {
     status: Number.isFinite(status) ? status : 0,
     contentType: contentType.trim(),
     redirectUrl: redirectUrl.trim(),
     body,
+    retryAfterMs: parseRetryAfterMs(headerJson),
   };
+}
+
+/**
+ * Pull `Retry-After` out of curl's `%{header_json}` blob and normalise it to
+ * milliseconds. Handles both RFC 9110 forms — delta-seconds and an HTTP-date —
+ * and returns `null` for anything unparseable (including older curl builds that
+ * do not support `%{header_json}` and emit the literal token instead), so a
+ * missing or malformed header simply falls back to plain exponential backoff.
+ */
+function parseRetryAfterMs(headerJson: string): number | null {
+  const trimmed = headerJson.trim();
+  if (trimmed.length === 0 || !trimmed.startsWith("{")) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  // curl lowercases header names, but match case-insensitively regardless.
+  const entry = Object.entries(parsed as Record<string, unknown>).find(
+    ([key]) => key.toLowerCase() === "retry-after",
+  );
+  const rawValue = entry?.[1];
+  const value = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (text.length === 0) return null;
+
+  if (/^\d+$/.test(text)) {
+    return Number.parseInt(text, 10) * 1000;
+  }
+  const dateMs = Date.parse(text);
+  if (!Number.isNaN(dateMs)) {
+    // Past dates clamp to 0 — retry immediately rather than not at all.
+    return Math.max(0, dateMs - Date.now());
+  }
+  return null;
 }
 
 function formatCurlError(result: CommandResult): string {

--- a/src/tools/os/web-search/transport/search-http.test.ts
+++ b/src/tools/os/web-search/transport/search-http.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { searchHttp } from "./search-http.js";
+import type { runCommand as RunCommandType } from "../../../../sandbox/command-runner.js";
+import type { HostLookup } from "../../web-fetch-ssrf-guard.js";
+
+const publicLookup: HostLookup = async () => [
+  { address: "93.184.216.34", family: 4 },
+];
+
+/**
+ * Builds the curl stdout envelope that `parseCurlMeta` expects: the response
+ * body followed by the trailing `__ATOMIC_WEB_SEARCH_META__status|ct|redir|size`
+ * block that searchHttp appends via `curl -w`.
+ */
+function stubCurlStdout(body: string): string {
+  return `${body}\n__ATOMIC_WEB_SEARCH_META__200|text/html||${body.length}`;
+}
+
+function capturingRunCommand(calls: string[][]): typeof RunCommandType {
+  return (async (_command: string, args: string[]) => {
+    calls.push(args);
+    return {
+      command: "curl",
+      args,
+      exitCode: 0,
+      signal: null,
+      stdout: stubCurlStdout("<html></html>"),
+      stderr: "",
+      durationMs: 1,
+      timedOut: false,
+      truncated: false,
+    };
+  }) as unknown as typeof RunCommandType;
+}
+
+describe("searchHttp curl argv", () => {
+  it("passes --globoff so bracketed URLs are not read as curl ranges", async () => {
+    // Search queries routinely carry `[`/`]`/`{`/`}`. Without --globoff curl
+    // reads them as its own range/set syntax and fails with "bad range in URL".
+    const calls: string[][] = [];
+    const url =
+      "https://search.example/search?q=filter:original:.*[Dd]ewey.*" +
+      "&range=[202102010000+TO+202104300000]";
+    await searchHttp({
+      url,
+      timeoutMs: 1000,
+      cwd: "/tmp",
+      signal: new AbortController().signal,
+      runCommand: capturingRunCommand(calls),
+      lookup: publicLookup,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("--globoff");
+    // The bracketed URL still reaches curl verbatim as the final operand.
+    expect(calls[0]![calls[0]!.length - 1]).toContain("[Dd]ewey");
+  });
+});

--- a/src/tools/os/web-search/transport/search-http.ts
+++ b/src/tools/os/web-search/transport/search-http.ts
@@ -125,6 +125,9 @@ function buildCurlArgs(input: {
     : input.pinnedIp;
   const args = [
     "-sS",
+    // Send `[`, `]`, `{`, `}` in URLs literally. Without this curl reads them
+    // as its own range/set glob syntax and fails with "bad range in URL".
+    "--globoff",
     "--max-time",
     String(Math.ceil(input.timeoutMs / 1000)),
     "--max-redirs",

--- a/src/tools/tool-registry.ts
+++ b/src/tools/tool-registry.ts
@@ -1,4 +1,5 @@
 import type { CompressedToolResult } from "../compressor/result-compressor.js";
+import { coerceToolArgs } from "./coerce-tool-args.js";
 
 export interface ToolContext {
   /** Working directory for OS tools and relative path resolution. */
@@ -64,6 +65,10 @@ export class ToolRegistry {
     ctx: ToolContext,
   ): Promise<CompressedToolResult> {
     const tool = this.get(name);
-    return tool.run(args, ctx);
+    // Models sometimes emit a JSON value one level over-encoded (a
+    // number as "200000", an array as "[\"a.png\"]"). Unwrap those
+    // before dispatch; anything that cannot be coerced is passed
+    // through untouched so the tool reports its own error.
+    return tool.run(coerceToolArgs(name, args), ctx);
   }
 }

--- a/src/tools/vision/describe.test.ts
+++ b/src/tools/vision/describe.test.ts
@@ -127,6 +127,88 @@ describe("buildVisionDescribeTool", () => {
     expect(call.images[0]!.mimeType).toBe("image/png");
   });
 
+  // Issue #185: the per-call image cap was enforced but documented
+  // nowhere the model could read, so it discovered the limit only by
+  // burning a step on a failed 8/12/20-image call. The cap now appears
+  // in the tool description, and the error names the remedy.
+  it("documents the image cap in the tool description", () => {
+    const tool = buildVisionDescribeTool({
+      provider: fakeProvider(),
+      maxImagesPerCall: 4,
+      maxImageBytes: 1024,
+    });
+    expect(tool.description).toContain("At most 4 images per call");
+    expect(tool.description).toMatch(/split/i);
+  });
+
+  it("reflects a reconfigured cap in the tool description", () => {
+    const tool = buildVisionDescribeTool({
+      provider: fakeProvider(),
+      maxImagesPerCall: 7,
+      maxImageBytes: 1024,
+    });
+    expect(tool.description).toContain("At most 7 images per call");
+  });
+
+  it("rejects more images than the cap and names the split remedy", async () => {
+    const tool = buildVisionDescribeTool({
+      provider: fakeProvider(),
+      maxImagesPerCall: 4,
+      maxImageBytes: 1024,
+    });
+    const result = await tool.run(
+      {
+        prompt: "describe",
+        paths: Array.from({ length: 12 }, (_, i) => `img-${i}.png`),
+      },
+      ctx(process.cwd()),
+    );
+    expect(result.status).toBe("error");
+    expect(result.summary).toContain("at most 4 images per call (got 12)");
+    // 12 / 4 = 3 calls. The remedy is the point: the model should not
+    // have to guess how to recover from the cap.
+    expect(result.summary).toContain("split into 3 calls of at most 4");
+  });
+
+  it("rounds the suggested call count up for a partial final batch", async () => {
+    const tool = buildVisionDescribeTool({
+      provider: fakeProvider(),
+      maxImagesPerCall: 4,
+      maxImageBytes: 1024,
+    });
+    const result = await tool.run(
+      {
+        prompt: "describe",
+        paths: Array.from({ length: 13 }, (_, i) => `img-${i}.png`),
+      },
+      ctx(process.cwd()),
+    );
+    expect(result.status).toBe("error");
+    // Math.ceil(13 / 4) === 4, not 3.
+    expect(result.summary).toContain("split into 4 calls of at most 4");
+  });
+
+  it("accepts exactly the cap without erroring", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "vision-tool-"));
+    const paths: string[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      const path = join(tmp, `image-${i}.png`);
+      await writeFile(path, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      paths.push(path);
+    }
+    const provider = fakeProvider();
+    const tool = buildVisionDescribeTool({
+      provider,
+      maxImagesPerCall: 4,
+      maxImageBytes: 1024,
+    });
+    const result = await tool.run({ prompt: "describe", paths }, ctx(tmp));
+    expect(result.status).toBe("ok");
+    const call = (provider.describeImage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as VisionRequest;
+    expect(call.images).toHaveLength(4);
+  });
+
   it("rejects images that exceed maxImageBytes", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "vision-tool-"));
     const path = join(tmp, "big.png");

--- a/src/tools/vision/describe.ts
+++ b/src/tools/vision/describe.ts
@@ -55,8 +55,7 @@ export function buildVisionDescribeTool(
 ): ToolDefinition {
   return {
     name: "vision.describe",
-    description:
-      "Describe one or more images via the configured vision LLM. Use when the user attaches an image or asks what is on a screenshot.",
+    description: `Describe one or more images via the configured vision LLM. Use when the user attaches an image or asks what is on a screenshot. At most ${options.maxImagesPerCall} images per call; to cover more, split them across several calls.`,
     readonly: true,
     async run(rawArgs, ctx) {
       let parsed: ParsedArgs;
@@ -66,8 +65,10 @@ export function buildVisionDescribeTool(
         return errorResult((error as Error).message);
       }
       if (parsed.paths.length > options.maxImagesPerCall) {
+        const calls = Math.ceil(parsed.paths.length / options.maxImagesPerCall);
         return errorResult(
-          `at most ${options.maxImagesPerCall} images per call (got ${parsed.paths.length})`,
+          `at most ${options.maxImagesPerCall} images per call (got ${parsed.paths.length})` +
+            ` — split into ${calls} calls of at most ${options.maxImagesPerCall}`,
         );
       }
       if (!options.provider.capabilities.vision) {


### PR DESCRIPTION
Eight commits: seven defects surfaced by the `gaia-tool-reliability-2026-08` campaign, plus one config bug found while reviewing them. Together the campaign fixes account for 1,036 of the 3,039 tool failures in that run. Every test added uses arguments taken verbatim from the campaign's own records rather than invented ones.

| Commit | Issue | Failures |
|---|---|---|
| `--globoff` for bracketed URLs | #184 | 30 |
| `os.fs.grep` on a file path | #183 | 23 |
| `vision.describe` image cap documented | #185 | 13 |
| Over-encoded JSON args coerced | #182 | 45 |
| `os.web.fetch` retry + configurable timeout | #180, #181 | 830 |
| Loop veto names the invariant | #186 | 95 |
| Veto stops claiming variety on repeats | #186 | — |
| Grandfather the outgoing config version | — | — |

## Findings the issues did not contain

- **`--globoff` was missing from a third curl argv builder.** The issue named `os.web.fetch` and `os.http.request`; the shared web-search transport has the identical defect. The flag also does more than fix an error message: a URL whose brackets form a *valid* range made curl issue one request per value, silently multiplying rate-limit consumption.
- **The arg-coercion defect also hit `browser.scroll`** (`amount: "3000"`), which no issue mentioned. A per-tool fix would have missed it, so coercion is applied once at dispatch. The decision asks whether the schema accepts the value *as written*, so `browser.scroll`'s `"page" | "half" | number` union keeps `"page"` intact while converting `"3000"`.
- **The veto message was inverted, in both directions.** Thirteen fetches to thirteen *different* URLs were reported as "13 identical no-progress outcomes". Fixing that introduced the mirror bug — a model that stopped wandering and settled on repeating one URL was still told "13 different attempts", and on the escalation path "0 different attempts", a count nothing had established. Both directions are now covered, with a test for each.
- **Bumping the config version locked out every installed user.** The supported-input list ends with `USER_CONFIG_VERSION`, so raising that constant drops the version it replaces. This was reachable in review (`unsupported config version 37`) and would have recurred on the next bump; a test now walks every version from the oldest supported to the current one.

## Notes for review

- **Config bumps to v39**, additively, for the new `web.fetch` block. `timeoutMs` keeps its 30s default, so behaviour is unchanged for anyone who does not opt in. (v38 was taken by the approval-ladder work while this branch was in review.)
- **`stringArraySchema` is shared by fourteen tools.** `vision.describe`'s `maxItems` is applied to a copy; mutating the shared const would have silently capped `os.shell.run` args at four elements. A test pins the isolation.
- **Only the host reaches the veto message**, never the full URL — a query string or an `Authorization` header would otherwise be copied into the model's context. Backticks and newlines are stripped so a crafted URL cannot inject markup into the prompt.
- **`Retry-After` needs curl >= 7.83** for `%{header_json}`. Older curl degrades to plain exponential backoff rather than breaking; a test pins that fallback.
- **#186's third sub-point was already done** — the veto threshold is 5, not the 13 the issue inferred. No threshold or default was changed.

## Known limitations, not addressed here

Surfaced by review and left for follow-ups rather than widened into this branch:

- `vision.describe`'s JSON schema hardcodes `maxItems: 4` while the runtime cap is configurable, so raising `vision.maxImagesPerCall` above 4 would have structured decoding reject a call the runtime accepts. Making the static descriptor config-aware is a larger refactor.
- `os.fs.grep` on a FIFO or device path blocks until the tool timeout (~30s) rather than being rejected up front.
- A pipe character in a redirect URL desyncs the curl meta field split, truncating the redirect target and dropping `Retry-After`.

## Testing

4,593 passing. Every remaining failure is present on `main` at the same commit and was verified side by side, file by file: `tui-app.test.tsx` fails 5/21 identically on both, and `sidecar` + `fs-glob-real` fail 2/2 identically on both. `npx tsc -p tsconfig.json --noEmit` is clean.

Each fix was ablated — reverted individually to confirm its tests fail without it, so none of the new coverage is vacuous. `os.fs.grep` was additionally verified end-to-end against real ripgrep, since the existing suite stubbed `runCommand` against a fixture root that never existed on disk, which is precisely why it could not see the bug.

Closes #180
Closes #181
Closes #182
Closes #183
Closes #184
Closes #185
Closes #186
