### PR TITLE
feat(cli): install `atag` as a short alias for atomic-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ The installer downloads the release archive, verifies the checksum, and installs
 atomic-agent
 ```
 
+Both installers also drop a short alias next to the binary, so this is the same thing:
+
+```bash
+atag
+```
+
 > [!TIP]
 > Need a second agent? Press **Ctrl+N** (or run `/window`) inside the TUI — it opens a new terminal window with a fresh atomic-agent in the same directory.
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "dist/sidecar/index.js",
   "bin": {
     "atomic-agent": "dist/cli/index.js",
+    "atag": "dist/cli/index.js",
     "atomic-agent-sidecar": "dist/sidecar/main.js"
   },
   "files": [

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -264,8 +264,20 @@ try {
   Remove-StaleBackups $InstallDir
   Copy-TreeTransactional $Stage $InstallDir
 
+  # Short alias: `atag` is the same CLI under a shorter name. A .cmd shim
+  # rather than a copy of the (large) SEA binary, and rather than a symlink,
+  # which needs an elevated shell or Developer Mode. %~dp0 resolves to the
+  # directory of the shim, so it always launches the atomic-agent.exe sitting
+  # next to it and asset resolution is unaffected. Rewritten on every install,
+  # so it self-heals and needs no place in the transactional copy.
+  Set-Content -LiteralPath (Join-Path $InstallDir "atag.cmd") -Encoding ASCII -Value @(
+    "@echo off",
+    "`"%~dp0atomic-agent.exe`" %*"
+  )
+
   Write-Info ""
   Write-Info "installed atomic-agent to $InstallDir\atomic-agent.exe"
+  Write-Info "(plus the short alias 'atag' next to it)"
 }
 catch {
   # A bare PowerShell error record is unreadable when the in-app updater
@@ -313,15 +325,18 @@ switch ($script:PathStatus) {
   "present" {
     Write-Info "to run:"
     Write-Info "  atomic-agent"
+    Write-Info "  atag           # same thing, shorter"
   }
   "manual" {
     Write-Info "atomic-agent is NOT on your PATH yet."
     Write-Info "add $InstallDir to your PATH, then run:"
     Write-Info "  atomic-agent"
+    Write-Info "  atag           # same thing, shorter"
   }
   default {
     Write-Info "atomic-agent was added to your PATH."
     Write-Info "it works in THIS terminal now; open a NEW terminal elsewhere, then run:"
     Write-Info "  atomic-agent"
+    Write-Info "  atag           # same thing, shorter"
   }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -333,6 +333,23 @@ else
   exit 1
 fi
 
+# Short alias: `atag` is the same binary under a shorter name. A relative
+# symlink keeps the install dir movable, and because it points at a sibling
+# the runtime still resolves grammars/, starter-skills/, vendor/ and
+# node_modules/ next to the binary (dirname(process.execPath)) — execPath
+# reports the resolved target, not the link. Falls back to a copy on
+# filesystems without symlinks.
+link_alias() {
+  # $1 target file name (sibling), $2 alias path
+  ln -sfn "$1" "$2" 2>/dev/null || cp -f "$INSTALL_DIR/$1" "$2"
+}
+
+if [ -f "$INSTALL_DIR/atomic-agent" ]; then
+  link_alias atomic-agent "$INSTALL_DIR/atag"
+elif [ -f "$INSTALL_DIR/atomic-agent.exe" ]; then
+  link_alias atomic-agent.exe "$INSTALL_DIR/atag.exe"
+fi
+
 replace_dir "$STAGE/grammars" "$INSTALL_DIR/grammars"
 # Built-in starter skills. The runtime resolves them next to the binary
 # (see resolveStarterSkillsSourceDir / seedStarterSkillsIfMissing) and
@@ -429,20 +446,24 @@ fi
 
 echo
 echo "installed atomic-agent to ${INSTALL_DIR}/atomic-agent"
+echo "(plus the short alias 'atag' next to it)"
 case "${PATH_STATUS:-added}" in
   present)
     echo "to run:"
     echo "  atomic-agent"
+    echo "  atag           # same thing, shorter"
     ;;
   manual)
     echo "atomic-agent is NOT on your PATH yet."
     echo "add ${INSTALL_DIR} to your PATH, then run:"
     echo "  atomic-agent"
+    echo "  atag           # same thing, shorter"
     ;;
   *)
     echo "atomic-agent was added to your PATH."
     echo "open a NEW terminal, then run:"
     echo "  atomic-agent"
+    echo "  atag           # same thing, shorter"
     if [ -n "${RC_FILE:-}" ]; then
       echo "(to use it in THIS terminal, first reload your shell config: ${RC_FILE})"
     fi

--- a/src/cli/bin-alias.test.ts
+++ b/src/cli/bin-alias.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * `atag` is the short alias for the CLI. It has to be created by every
+ * install channel, and each channel owns its own file — so dropping it from
+ * one while editing another is an easy mistake. These assertions are the
+ * guard against a partially-installed alias.
+ */
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function read(relative: string): string {
+  return readFileSync(resolve(repoRoot, relative), "utf8");
+}
+
+describe("atag alias", () => {
+  it("npm exposes it as a bin entry pointing at the CLI entrypoint", () => {
+    const manifest = JSON.parse(read("package.json")) as {
+      bin: Record<string, string>;
+    };
+    expect(manifest.bin.atag).toBe(manifest.bin["atomic-agent"]);
+  });
+
+  it("the POSIX installer links it next to the binary", () => {
+    const script = read("scripts/install.sh");
+    expect(script).toContain('link_alias atomic-agent "$INSTALL_DIR/atag"');
+    // Relative link target, so moving the install dir does not break it.
+    expect(script).toContain('ln -sfn "$1" "$2"');
+  });
+
+  it("the Windows installer writes an atag.cmd shim", () => {
+    const script = read("scripts/install.ps1");
+    expect(script).toContain('Join-Path $InstallDir "atag.cmd"');
+    // %~dp0 keeps the shim pointed at the binary beside it.
+    expect(script).toContain('"`"%~dp0atomic-agent.exe`" %*"');
+  });
+
+  it("is documented in the CLI help", () => {
+    expect(read("src/cli/index.ts")).toContain("atag <command> [options]");
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,6 +113,7 @@ function printHelp(): void {
     "",
     "Usage:",
     "  atomic-agent <command> [options]",
+    "  atag <command> [options]       (short alias, same binary)",
     "",
     "Commands:",
     ...COMMANDS.filter((c) => !c.hidden).map(


### PR DESCRIPTION
`atomic-agent` is 12 characters you type dozens of times a day (`atomic-agent tui --cwd …`, `atomic-agent models list`). This ships `atag` as an official short alias — the same binary, same argv, same behaviour, including bare `atag` opening the TUI.

## What changed

| Channel | Mechanism |
|---|---|
| npm / `npm link` | extra `bin` entry → `dist/cli/index.js` |
| macOS + Linux installer | relative symlink `atag → atomic-agent` next to the binary |
| Windows installer | `atag.cmd` shim next to `atomic-agent.exe` |

Plus one `Usage:` line in `--help` and a line in the README's Run section.

**Why a symlink on POSIX:** relative, so the install dir stays movable, and `process.execPath` reports the *resolved* target — verified below — so `resolveAssetDir`'s `dirname(process.execPath)` lookup for `grammars/`, `starter-skills/`, `vendor/rg` and `node_modules/` is unaffected. Falls back to a copy where symlinks are unavailable.

**Why a `.cmd` shim on Windows:** a copy would duplicate a ~135 MB binary, and `New-Item -ItemType SymbolicLink` needs an elevated shell or Developer Mode. `%~dp0` keeps the shim pointed at the `atomic-agent.exe` beside it, so asset resolution is likewise unaffected. It is rewritten on every install, so it self-heals and needs no slot in the transactional copy.

**Existing installs get it for free:** `runAppUpdate` re-runs `scripts/install.sh` from `main` against the current install dir, so the alias appears on the next update.

`scripts/package-bundle.ts` is deliberately untouched — the alias is an install-time artifact, and putting `atag` in the archive would imply that a manual `tar -xzf` gets it too (it would not; the installer copies the binary explicitly).

## Verification

- `npm run lint` clean; `npx vitest run src/cli/` → 86 passed, including the new `src/cli/bin-alias.test.ts`, which fails if the alias is dropped from any one channel.
- `sh -n scripts/install.sh` parses.
- End-to-end with the **modified** installer into a throwaway dir (`ATOMIC_AGENT_INSTALL_DIR=… ATOMIC_AGENT_NO_PATH=1 sh scripts/install.sh`, darwin-arm64, v0.3.1):
  - `atag -> atomic-agent` (relative symlink),
  - `./atag --version` → `atomic-agent 0.3.1`, `./atag skill list` runs,
  - `ATOMIC_AGENT_DEBUG_ARGV=1 ./atag --version` → `execPath=<dir>/atomic-agent`, i.e. the alias resolves to the real binary and assets resolve from the install dir.
- `node dist/cli/index.js --version` for the npm path.

**Caveat:** the Windows path is reviewed but not executed — no PowerShell on the machine I built this on, so `install.ps1` was not run and `atag.cmd` was not exercised on Windows.
