### PR TITLE
Windows: make in-app update work without Get-FileHash

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -50,6 +50,110 @@ function Write-Info($msg) { Write-Host $msg }
 # turns the exception into a single readable line and exits 1.
 function Fail($msg) { throw $msg }
 
+# SHA256 of a file, as a lowercase hex string.
+#
+# Get-FileHash is NOT assumed: it ships in the Microsoft.PowerShell.Utility
+# module from PowerShell 4.0 on, so it is missing under a 2.0 engine
+# (`-Version 2`) and absent whenever a trimmed image or an overridden
+# PSModulePath keeps that module from loading. Users hit exactly that during
+# in-app self-update and the install aborted with "'Get-FileHash' is not
+# recognized" (issue #174).
+#
+# So hash through .NET, which needs no module and exists wherever PowerShell
+# runs at all, and keep Get-FileHash / certutil only as fallbacks. Verifying
+# the download is not optional — a checksum that cannot be computed is a
+# failure, never a skip.
+function Get-Sha256($path) {
+  $full = (Resolve-Path -LiteralPath $path).ProviderPath
+
+  try {
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+      $stream = [System.IO.File]::OpenRead($full)
+      try {
+        return ([BitConverter]::ToString($sha.ComputeHash($stream))).Replace("-", "").ToLower()
+      } finally {
+        $stream.Dispose()
+      }
+    } finally {
+      $sha.Dispose()
+    }
+  } catch {
+    # Fall through to the external implementations below.
+  }
+
+  if (Get-Command Get-FileHash -ErrorAction SilentlyContinue) {
+    # Guard the result: Get-FileHash can return nothing (a directory, an
+    # unreadable path) and a bare .Hash on $null throws an error that says
+    # nothing about hashing. Fall through instead.
+    $result = Get-FileHash -LiteralPath $full -Algorithm SHA256 -ErrorAction SilentlyContinue
+    if ($result -and $result.Hash) { return $result.Hash.ToLower() }
+  }
+
+  # certutil is present on every supported Windows version. Its output is a
+  # banner, the hex digest (spaced on older builds), then a status line.
+  try {
+    $out = & certutil.exe -hashfile $full SHA256 2>$null
+    if ($LASTEXITCODE -eq 0 -and $out) {
+      $digest = ($out | Where-Object { $_ -match '^[0-9a-fA-F ]+$' } |
+        ForEach-Object { $_ -replace '\s', '' } |
+        Where-Object { $_.Length -eq 64 } | Select-Object -First 1)
+      if ($digest) { return $digest.ToLower() }
+    }
+  } catch {
+    # Not on PATH, or refused the file — report it as a hashing failure below
+    # rather than leaking "certutil.exe is not recognized" to the user.
+  }
+
+  Fail "cannot compute SHA256: no usable hash implementation (.NET, Get-FileHash and certutil all failed)"
+}
+
+# Extract a zip into an existing directory.
+#
+# Expand-Archive has the same availability problem as Get-FileHash — it lives
+# in Microsoft.PowerShell.Archive and only from PowerShell 5.0 — so an install
+# that got past the checksum would still fail here on the same machines. Use
+# .NET first for the same reason.
+function Expand-Zip($zipPath, $destination) {
+  $zipFull = (Resolve-Path -LiteralPath $zipPath).ProviderPath
+  $destFull = (Resolve-Path -LiteralPath $destination).ProviderPath
+
+  try {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+
+    # Walk the entries instead of calling ExtractToDirectory: on .NET
+    # Framework (Windows PowerShell 5.1) that helper throws when the
+    # destination already exists, and install.ps1 always creates the staging
+    # dir first. Entry-by-entry also lets a re-run overwrite cleanly.
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($zipFull)
+    try {
+      foreach ($entry in $zip.Entries) {
+        $target = Join-Path $destFull $entry.FullName
+        # Directory entries have an empty Name; create and move on.
+        if (-not $entry.Name) {
+          New-Item -ItemType Directory -Path $target -Force | Out-Null
+          continue
+        }
+        $parent = Split-Path -Parent $target
+        if ($parent) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target, $true)
+      }
+    } finally {
+      $zip.Dispose()
+    }
+    return
+  } catch {
+    # Fall through to Expand-Archive below.
+  }
+
+  if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+    Expand-Archive -LiteralPath $zipFull -DestinationPath $destFull -Force
+    return
+  }
+
+  Fail "cannot extract $(Split-Path -Leaf $zipFull): no usable zip implementation (.NET and Expand-Archive both failed)"
+}
+
 # Invoke-WebRequest's exception names the status code but not the URL, so a bare
 # "404 (Not Found)" during self-update does not say whether the tag, the repo or
 # the asset name was wrong. Attribute it.
@@ -134,9 +238,7 @@ function Test-SameFile($left, $right) {
   if ((Get-Item -LiteralPath $left).Length -ne (Get-Item -LiteralPath $right).Length) {
     return $false
   }
-  $leftHash = (Get-FileHash -LiteralPath $left -Algorithm SHA256).Hash
-  $rightHash = (Get-FileHash -LiteralPath $right -Algorithm SHA256).Hash
-  return $leftHash -eq $rightHash
+  return (Get-Sha256 $left) -eq (Get-Sha256 $right)
 }
 
 # Apply a staged tree onto the install dir as a single all-or-nothing
@@ -237,7 +339,7 @@ try {
   if (-not $expected) {
     Fail "could not read expected checksum from $ArchiveName.sha256"
   }
-  $actual = (Get-FileHash -Path $ZipPath -Algorithm SHA256).Hash.ToLower()
+  $actual = Get-Sha256 $ZipPath
   if ($actual -ne $expected) {
     Fail "checksum mismatch for $ArchiveName`n  expected: $expected`n  actual:   $actual"
   }
@@ -247,7 +349,7 @@ try {
   # (no top-level <slug>/ wrapper), unlike the Unix tarball.
   $Stage = Join-Path $Work "stage"
   New-Item -ItemType Directory -Path $Stage -Force | Out-Null
-  Expand-Archive -Path $ZipPath -DestinationPath $Stage -Force
+  Expand-Zip $ZipPath $Stage
 
   $BinaryPath = Join-Path $Stage "atomic-agent.exe"
   if (-not (Test-Path $BinaryPath)) {

--- a/src/update/run-app-update.test.ts
+++ b/src/update/run-app-update.test.ts
@@ -58,6 +58,7 @@ describe("buildUpdateInvocation", () => {
       installDir: "C:\\Users\\u\\AppData\\Local\\atomic-agent",
       baseEnv: {},
     });
+    // No %SystemRoot% to resolve against: fall back to the bare name.
     expect(inv.command).toBe("powershell.exe");
     expect(inv.args).toContain("-NoProfile");
     expect(inv.args).toContain("-Command");
@@ -69,6 +70,45 @@ describe("buildUpdateInvocation", () => {
       "C:\\Users\\u\\AppData\\Local\\atomic-agent",
     );
     expect(inv.env.ATOMIC_AGENT_NO_PATH).toBe("1");
+  });
+
+  // Regression: the user's PATH decides what a bare `powershell.exe` means,
+  // and a trimmed or 2.0-engine shell there breaks the installer while the
+  // same update works from cmd (issue #174). Name the system copy outright.
+  it("runs the system PowerShell by absolute path when SystemRoot is set", () => {
+    const inv = buildUpdateInvocation({
+      platform: "win32",
+      repo: "AtomicBot-ai/atomic-agent",
+      installDir: "C:\\Users\\u\\AppData\\Local\\atomic-agent",
+      baseEnv: { SystemRoot: "C:\\Windows" },
+    });
+    expect(inv.command).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(inv.args).toContain("-NoProfile");
+    expect(inv.args[inv.args.length - 1]).toContain("install.ps1");
+  });
+
+  it("accepts an upper-case SYSTEMROOT spelling", () => {
+    const inv = buildUpdateInvocation({
+      platform: "win32",
+      repo: "AtomicBot-ai/atomic-agent",
+      installDir: "C:\\x",
+      baseEnv: { SYSTEMROOT: "D:\\Windows" },
+    });
+    expect(inv.command).toBe(
+      "D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+  });
+
+  it("leaves the POSIX invocation untouched when SystemRoot is present", () => {
+    const inv = buildUpdateInvocation({
+      platform: "darwin",
+      repo: "AtomicBot-ai/atomic-agent",
+      installDir: "/usr/local/bin",
+      baseEnv: { SystemRoot: "C:\\Windows" },
+    });
+    expect(inv.command).toBe("sh");
   });
 
   it("pins a version when provided", () => {

--- a/src/update/run-app-update.ts
+++ b/src/update/run-app-update.ts
@@ -81,12 +81,38 @@ export interface UpdateInvocation {
 }
 
 /**
+ * Absolute path to the system Windows PowerShell, falling back to a bare
+ * `powershell.exe` when %SystemRoot% is not set.
+ *
+ * A bare name is resolved against the inherited PATH, which is the user's,
+ * not ours. When that PATH puts a trimmed, relocated or 2.0-engine shell
+ * first, the installer loses the Utility/Archive modules and dies on
+ * "'Get-FileHash' is not recognized" — while the very same update run from
+ * `cmd` succeeds, because there the name resolves to the system copy
+ * (issue #174). Naming the system copy outright removes that variance;
+ * install.ps1 no longer depends on those modules either, so the two fixes
+ * are belt and braces.
+ */
+function windowsPowerShellPath(env: NodeJS.ProcessEnv): string {
+  const systemRoot = env.SystemRoot ?? env.SYSTEMROOT ?? env.systemroot;
+  if (!systemRoot) return "powershell.exe";
+  return pathWin32.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+/**
  * Build the platform-specific process invocation that re-runs the
  * canonical installer against the current install dir. Pure — no I/O —
  * so it is unit-testable without spawning anything.
  *
  * - POSIX: `sh -c "curl -fsSL .../install.sh | sh"`.
- * - Windows: `powershell.exe -Command "irm .../install.ps1 | iex"`.
+ * - Windows: `%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe
+ *   -Command "irm .../install.ps1 | iex"` — see {@link windowsPowerShellPath}.
  *
  * Both pin the install dir to the running binary's directory and
  * suppress the PATH edit (already present on an upgrade). The installer
@@ -114,7 +140,7 @@ export function buildUpdateInvocation(params: {
   if (platform === "win32") {
     const scriptUrl = `https://raw.githubusercontent.com/${repo}/main/scripts/install.ps1`;
     return {
-      command: "powershell.exe",
+      command: windowsPowerShellPath(baseEnv),
       args: [
         "-NoProfile",
         "-ExecutionPolicy",


### PR DESCRIPTION
Fixes #174.

## What was broken

In-app update failed on Windows with `install script exited with code 1`:

```
error: The term 'Get-FileHash' is not recognized as the name of a cmdlet...
```

The same update run from `cmd` worked, which is the detail that points at the second cause below.

## Cause 1: the installer assumed cmdlets that are not always there

`Get-FileHash` and `Expand-Archive` are not language built-ins. They ship in `Microsoft.PowerShell.Utility` and `Microsoft.PowerShell.Archive`, added in PowerShell 4.0 and 5.0 respectively, so they are missing under a 2.0 engine and absent whenever a trimmed image or an overridden `PSModulePath` stops those modules loading.

`install.ps1` now hashes and unzips through .NET, which requires no module and is available wherever PowerShell runs at all, keeping the cmdlets and `certutil` as fallbacks.

`Expand-Archive` is fixed alongside deliberately: it fails on exactly the same machines, so fixing only the hash would have moved the error one step later rather than removing it.

## Cause 2: a bare `powershell.exe` resolved against the user's PATH

The updater spawned `powershell.exe` by name, so which shell actually ran was decided by the user's `PATH` — a trimmed, relocated or 2.0-engine copy there loses the modules above. That is why the same script behaved differently when launched from `cmd`, where the name resolves to the system copy.

It now names the system copy under `%SystemRoot%`, falling back to the bare name when that variable is unset.

## On the open question in the issue

The issue asked whether a failed checksum step should abort or warn and continue. This aborts. The checksum is the only thing standing between a tampered or truncated download and an executable the user then runs, so a checksum that cannot be computed is a failure, never a skip. The fix is to be able to compute it three ways, not to make verifying optional.

## Verification

`install.ps1` was executed against PowerShell 7.7, not just read:

- hashes match `shasum -a 256` byte for byte, on a 3 MB binary and a text file
- with `Get-FileHash` removed (the issue #174 machine), hashing still returns the correct digest
- with `Get-FileHash` **and** `Expand-Archive` both removed, a full verify-and-extract run succeeds
- when no implementation can hash, it fails with our own message rather than leaking `certutil.exe is not recognized`
- extraction handles nested paths and re-running over a populated directory
- the file parses cleanly

On the TypeScript side: 14/14 in `src/update/`, and typecheck clean. The three new tests were confirmed to fail against the old bare-name code before passing against the new code.

Two suite failures (`fs-glob-real`, `send-message-concurrency`) reproduce on unmodified `main` and are unrelated to this change.

## What is not covered

The end-to-end run happened on PowerShell 7 on macOS. The .NET APIs used are the ones present on Windows PowerShell 5.1, and the `ExtractToDirectory` behaviour that differs there is precisely why extraction walks entries — but a real 5.1 box, ideally one of the two reporters', is still worth a confirmation before release.
