### PR TITLE
Suppress pdfjs Canvas/DOM warnings in text-only PDF extraction

### DIFF
--- a/src/tools/os/read-document/extractors/pdf-extractor.canvas-warnings.test.ts
+++ b/src/tools/os/read-document/extractors/pdf-extractor.canvas-warnings.test.ts
@@ -1,0 +1,247 @@
+import { execFile } from "node:child_process";
+import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Regression test for issue #117.
+ *
+ * pdfjs-dist warns at *import time* when its optional `@napi-rs/canvas`
+ * dependency is missing. Those warnings look like extraction failures even
+ * though text-only extraction is unaffected. They cannot be reproduced inside
+ * the vitest process: pdfjs is very likely already imported (module cache), and
+ * a normal dev install has `@napi-rs/canvas` present, which hides the symptom
+ * entirely.
+ *
+ * So this test builds a throwaway package tree that resolves `pdfjs-dist` but
+ * *not* `@napi-rs/canvas` — the shape produced by `npm ci --omit=optional` and
+ * by our SEA bundle — and runs the extractor in a fresh child process.
+ */
+
+const KNOWN_CANVAS_WARNINGS = [
+  'Cannot load "@napi-rs/canvas" package',
+  "Cannot polyfill `DOMMatrix`",
+  "Cannot polyfill `ImageData`",
+  "Cannot polyfill `Path2D`",
+];
+
+const TEXT_MARKER = "ATOMIC_PDF_MARKER";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../../../..");
+
+/** A tiny single-page PDF with uncompressed, extractable text. */
+function buildPdf(): string {
+  const content = `BT /F1 24 Tf 72 700 Td (${TEXT_MARKER}) Tj ET`;
+  const objs = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " +
+      "/Resources << /Font << /F1 5 0 R >> >> >>",
+    `<< /Length ${content.length} >>\nstream\n${content}\nendstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ];
+  let pdf = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  objs.forEach((obj, i) => {
+    offsets.push(pdf.length);
+    pdf += `${i + 1} 0 obj\n${obj}\nendobj\n`;
+  });
+  const xref = pdf.length;
+  pdf += `xref\n0 ${objs.length + 1}\n0000000000 65535 f \n`;
+  for (const off of offsets) {
+    pdf += `${String(off).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf +=
+    `trailer\n<< /Size ${objs.length + 1} /Root 1 0 R >>\n` +
+    `startxref\n${xref}\n%%EOF\n`;
+  return pdf;
+}
+
+/**
+ * Build a sandbox whose `node_modules` contains only `pdfjs-dist`, with
+ * `@napi-rs/canvas` deliberately absent — the shape of `npm ci --omit=optional`
+ * and of our SEA bundle.
+ *
+ * pdfjs must be *copied*, not symlinked. It resolves the optional canvas
+ * package via `createRequire(import.meta.url)`, and `import.meta.url` points at
+ * the module's real path — Node resolves symlinks by default. A symlinked
+ * pdfjs would therefore walk up the *real* `node_modules` and find the canvas
+ * package that a dev machine has installed, silently defeating the isolation.
+ */
+async function makeCanvasFreeSandbox(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "atomic-pdf-nocanvas-"));
+  const nodeModules = join(dir, "node_modules");
+  const require = createRequire(import.meta.url);
+  const pdfjsRoot = dirname(require.resolve("pdfjs-dist/package.json"));
+
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "sandbox", private: true, type: "module" }),
+  );
+  await mkdir(nodeModules, { recursive: true });
+  // Skip pdfjs's own nested deps and the browser-only `web/` viewer. The
+  // filter receives absolute *source* paths, so compare against the portion
+  // below `pdfjsRoot` — matching on the absolute path would reject the copy
+  // root itself (it already sits inside a `node_modules` directory).
+  await cp(pdfjsRoot, join(nodeModules, "pdfjs-dist"), {
+    recursive: true,
+    dereference: true,
+    filter: (src) => {
+      const rel = src.slice(pdfjsRoot.length);
+      return !rel.startsWith(`${sep}node_modules`) && !rel.startsWith(`${sep}web`);
+    },
+  });
+  return dir;
+}
+
+/**
+ * The extractor's loading strategy, mirrored as standalone source so it can run
+ * in the sandbox without pulling in the whole TypeScript build. `applyFix`
+ * toggles the fix, which lets the same harness prove the test actually detects
+ * the bug (ablation) rather than passing vacuously.
+ */
+function sandboxScript(pdfPath: string, applyFix: boolean): string {
+  return `
+import Module from "node:module";
+import fs from "node:fs";
+
+const CANVAS_PACKAGE = "@napi-rs/canvas";
+const CANVAS_STUB = {
+  DOMMatrix: class {}, ImageData: class {}, Path2D: class {},
+};
+
+async function load() {
+  return import("pdfjs-dist/legacy/build/pdf.mjs");
+}
+
+let pdfjs;
+if (${applyFix ? "true" : "false"}) {
+  const original = Module._load;
+  Module._load = function (...args) {
+    if (args[0] === CANVAS_PACKAGE) return CANVAS_STUB;
+    return original.apply(this, args);
+  };
+  try { pdfjs = await load(); } finally { Module._load = original; }
+} else {
+  pdfjs = await load();
+}
+
+globalThis.pdfjsWorker = await import("pdfjs-dist/legacy/build/pdf.worker.mjs");
+
+const doc = await pdfjs.getDocument({
+  data: new Uint8Array(fs.readFileSync(${JSON.stringify(pdfPath)})),
+  disableFontFace: true,
+  useSystemFonts: false,
+  isEvalSupported: false,
+  verbosity: 0,
+}).promise;
+
+let text = "";
+for (let p = 1; p <= doc.numPages; p++) {
+  const c = await (await doc.getPage(p)).getTextContent();
+  text += c.items.map((i) => i.str).join("");
+}
+await doc.destroy();
+process.stdout.write("EXTRACTED:" + text + "\\n");
+`;
+}
+
+async function runInSandbox(
+  applyFix: boolean,
+): Promise<{ stdout: string; stderr: string }> {
+  const dir = await makeCanvasFreeSandbox();
+  try {
+    const pdfPath = join(dir, "sample.pdf");
+    await writeFile(pdfPath, buildPdf(), "latin1");
+    const scriptPath = join(dir, "run.mjs");
+    await writeFile(scriptPath, sandboxScript(pdfPath, applyFix));
+    return await execFileAsync(process.execPath, [scriptPath], {
+      cwd: dir,
+      encoding: "utf8",
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("pdf extractor: optional canvas warnings (issue #117)", () => {
+  it("sanity-checks that the sandbox really lacks @napi-rs/canvas", async () => {
+    const dir = await makeCanvasFreeSandbox();
+    try {
+      // Probe from inside the copied pdfjs build — that is where pdfjs itself
+      // resolves the optional package from. Probing at the sandbox root would
+      // pass even if a symlinked pdfjs could still reach the real install.
+      const probe = join(
+        dir,
+        "node_modules",
+        "pdfjs-dist",
+        "legacy",
+        "build",
+        "probe.mjs",
+      );
+      await writeFile(
+        probe,
+        'import { createRequire } from "node:module";\n' +
+          "try {\n" +
+          '  createRequire(import.meta.url).resolve("@napi-rs/canvas");\n' +
+          '  process.stdout.write("RESOLVED");\n' +
+          '} catch { process.stdout.write("ABSENT"); }\n',
+      );
+      const { stdout } = await execFileAsync(process.execPath, [probe], {
+        cwd: dir,
+        encoding: "utf8",
+      });
+      expect(stdout).toBe("ABSENT");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it("emits the canvas warnings without the fix (ablation)", async () => {
+    const { stdout, stderr } = await runInSandbox(false);
+    // Guard against a vacuous pass: the ablation must still extract text.
+    expect(stdout).toContain(`EXTRACTED:${TEXT_MARKER}`);
+    const combined = stdout + stderr;
+    for (const warning of KNOWN_CANVAS_WARNINGS) {
+      expect(combined).toContain(warning);
+    }
+  }, 60_000);
+
+  it("emits no canvas warnings with the fix, and still extracts text", async () => {
+    const { stdout, stderr } = await runInSandbox(true);
+    expect(stdout).toContain(`EXTRACTED:${TEXT_MARKER}`);
+    const combined = stdout + stderr;
+    for (const warning of KNOWN_CANVAS_WARNINGS) {
+      expect(combined).not.toContain(warning);
+    }
+  }, 60_000);
+
+  it("does not intercept console anywhere in the extractor", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const source = await readFile(join(here, "pdf-extractor.ts"), "utf8");
+    expect(source).not.toMatch(/console\s*\.\s*(log|warn|error)\s*=/);
+  });
+
+  it("leaves Module._load restored after loading pdfjs", async () => {
+    const Module = (await import("node:module")).default as unknown as {
+      _load: unknown;
+    };
+    const before = Module._load;
+    const { pdfExtractor } = await import("./pdf-extractor.js");
+    const data = Buffer.from(buildPdf(), "latin1");
+    const result = await pdfExtractor({
+      data,
+      path: join(repoRoot, "sample.pdf"),
+    } as Parameters<typeof pdfExtractor>[0]);
+    expect(result.text).toContain(TEXT_MARKER);
+    expect(Module._load).toBe(before);
+  }, 60_000);
+});

--- a/src/tools/os/read-document/extractors/pdf-extractor.ts
+++ b/src/tools/os/read-document/extractors/pdf-extractor.ts
@@ -1,3 +1,5 @@
+import Module, { createRequire } from "node:module";
+
 import type { Extractor, ExtractResult } from "./extractor-types.js";
 
 /**
@@ -22,6 +24,8 @@ export const pdfExtractor: Extractor = async (input) => {
     isEvalSupported: false,
     // 0 = ERRORS only. Suppresses the cosmetic "standardFontDataUrl not
     // provided" warning — we don't render fonts, just extract glyph runs.
+    // Note this only governs per-document warnings; import-time warnings are
+    // handled by `withQuietCanvasResolution` below.
     verbosity: 0,
   }).promise;
 
@@ -143,16 +147,106 @@ function clampPageRange(
  * resolver handles it from `node_modules` in dev — and stash the namespace
  * on `globalThis.pdfjsWorker`, which works identically in both runtimes.
  */
-let pdfJsModule: typeof import("pdfjs-dist/legacy/build/pdf.mjs") | undefined;
-async function loadPdfJs(): Promise<
+let pdfJsPromise:
+  | Promise<typeof import("pdfjs-dist/legacy/build/pdf.mjs")>
+  | undefined;
+function loadPdfJs(): Promise<
   typeof import("pdfjs-dist/legacy/build/pdf.mjs")
 > {
-  if (!pdfJsModule) {
-    const mod = await import("pdfjs-dist/legacy/build/pdf.mjs");
+  // Memoize the *promise*, not the resolved module. Two concurrent
+  // read_document calls must share one import — otherwise both could enter
+  // the canvas shim below and the second would restore `Module._load` while
+  // the first is still importing.
+  pdfJsPromise ??= (async () => {
+    const mod = await withQuietCanvasResolution(
+      () => import("pdfjs-dist/legacy/build/pdf.mjs"),
+    );
     await ensurePdfWorkerOnMainThread();
-    pdfJsModule = mod;
+    return mod;
+  })();
+  return pdfJsPromise;
+}
+
+/**
+ * pdfjs's `node_utils` module tries to `require("@napi-rs/canvas")` at import
+ * time to polyfill `DOMMatrix`/`ImageData`/`Path2D`. That package is an
+ * *optional* dependency of pdfjs-dist and is deliberately not shipped in our
+ * SEA bundle, nor installed by `npm ci --omit=optional`. When it is absent
+ * pdfjs prints four warnings straight to stdout:
+ *
+ *   Warning: Cannot load "@napi-rs/canvas" package: ...
+ *   Warning: Cannot polyfill `DOMMatrix`, rendering may be broken.
+ *   Warning: Cannot polyfill `ImageData`, rendering may be broken.
+ *   Warning: Cannot polyfill `Path2D`, rendering may be broken.
+ *
+ * They are non-actionable for us: those three globals only matter when
+ * *rendering* pages to a canvas, and this extractor only ever reads glyph
+ * runs via `getTextContent()`. But they read like extraction failures.
+ *
+ * `verbosity: 0` on `getDocument` cannot suppress them — pdfjs keeps
+ * verbosity in a module-level variable, and the warnings above are emitted by
+ * top-level code while the module is still being imported, long before any
+ * per-document option applies. `setVerbosityLevel` is not exported, so there
+ * is no public API to mute it ahead of the import either.
+ *
+ * So we satisfy the require instead of silencing the complaint: hand pdfjs a
+ * stub carrying the three constructors it looks for. Scoped deliberately:
+ *
+ *   - Only the exact `@napi-rs/canvas` specifier is intercepted; every other
+ *     request falls through to the real loader untouched.
+ *   - `Module._load` is restored in a `finally`, so a failed import cannot
+ *     leave the hook installed.
+ *   - We never touch `console` — global console interception would hide
+ *     unrelated diagnostics and is unsafe under concurrent reads.
+ *
+ * If the real `@napi-rs/canvas` *is* installed we leave it alone, so a normal
+ * npm install keeps genuine canvas support.
+ */
+async function withQuietCanvasResolution<T>(load: () => Promise<T>): Promise<T> {
+  if (canvasPackageIsInstalled()) return load();
+
+  // `Module._load` is a private Node API, but it is the only interception
+  // point for the `createRequire(...)` call pdfjs makes internally. It has
+  // been stable across Node's entire CJS lifetime; if it ever disappears we
+  // fall back to loading normally (noisy, but never broken).
+  const nodeModule = Module as unknown as {
+    _load?: (...args: unknown[]) => unknown;
+  };
+  const originalLoad = nodeModule._load;
+  if (typeof originalLoad !== "function") return load();
+
+  nodeModule._load = function patchedLoad(...args: unknown[]) {
+    if (args[0] === CANVAS_PACKAGE) return CANVAS_STUB;
+    return originalLoad.apply(this, args);
+  };
+  try {
+    return await load();
+  } finally {
+    nodeModule._load = originalLoad;
   }
-  return pdfJsModule;
+}
+
+const CANVAS_PACKAGE = "@napi-rs/canvas";
+
+/**
+ * Minimal stand-ins for the three constructors pdfjs copies onto `globalThis`.
+ * Text extraction never instantiates them — pdfjs only reaches for them on
+ * rendering paths we do not use. They exist so the polyfill block finds
+ * something and stays quiet.
+ */
+const CANVAS_STUB = {
+  DOMMatrix: class DOMMatrixStub {},
+  ImageData: class ImageDataStub {},
+  Path2D: class Path2DStub {},
+};
+
+function canvasPackageIsInstalled(): boolean {
+  try {
+    createRequire(import.meta.url).resolve(CANVAS_PACKAGE);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // pdfjs-dist does not ship `.d.ts` declarations for the worker entry point


### PR DESCRIPTION
Fixes #117.

## Problem

`os.fs.read_document` extracts PDF text correctly, but when pdfjs-dist's optional `@napi-rs/canvas` dependency is missing it prints four warnings that look like extraction failures:

```text
Warning: Cannot load "@napi-rs/canvas" package: ...
Warning: Cannot polyfill `DOMMatrix`, rendering may be broken.
Warning: Cannot polyfill `ImageData`, rendering may be broken.
Warning: Cannot polyfill `Path2D`, rendering may be broken.
```

Those three globals only matter when *rendering* pages to a canvas. This extractor only reads glyph runs via `getTextContent()`, so the warnings are non-actionable — but a user seeing "rendering may be broken" on a successful read reasonably files a bug.

`@napi-rs/canvas` is an **optional** dependency of pdfjs-dist, so a normal dev install hides the symptom. It reproduces under `npm ci --omit=optional` and in the SEA bundle, which does not ship the package (`scripts/bundle-sea.ts` externalizes only `better-sqlite3` and `playwright-core`).

## Why `verbosity: 0` did not already fix it

Two reasons, both worth recording:

1. pdfjs keeps verbosity in a **module-level** variable, and these warnings are emitted by **top-level code while the module is still importing** — before any per-document option can apply. `verbosity: 0` on `getDocument` is simply too late.
2. `setVerbosityLevel` is **not exported** from the module, so there is no public API to mute it ahead of the import either.

## Fix

Rather than silencing the complaint, satisfy the require: hand pdfjs a stub carrying the three constructors, for the duration of its import only.

Scoping, per the issue's constraints:

- Only the exact `@napi-rs/canvas` specifier is intercepted; every other request falls through untouched.
- `Module._load` is restored in a `finally`, so a failed import cannot leave the hook installed.
- **`console` is never touched** — global console interception would hide unrelated diagnostics and is unsafe under concurrent reads.
- If the real `@napi-rs/canvas` *is* installed, the shim is skipped entirely, so a normal npm install keeps genuine canvas support.
- The module **promise** is memoized (previously the resolved module was), so two overlapping `read_document` calls share one import instead of racing the hook.

## Verification

Reproduced and verified in a sandbox where `@napi-rs/canvas` is genuinely unresolvable:

- **Text is byte-identical** with and without the real canvas package — same SHA-256 over extracted text, 12 pages / 2634 chars on `eval/fixtures/gaia/compliance-handbook.pdf`.
- The **real compiled extractor** (`dist/`) emits zero warnings and returns `warnings: []` in that environment.
- 5 concurrent reads all succeed; `Module._load` is restored; `console` is untouched.
- A corrupt PDF still throws `InvalidPDFException` — genuine errors are not masked.

## Tests

New `pdf-extractor.canvas-warnings.test.ts` (5 cases), which runs pdfjs in a **fresh child process**, not the test runner's module cache:

- A sanity check asserting the sandbox really cannot resolve `@napi-rs/canvas` — probing from *inside the copied pdfjs build*, since pdfjs resolves via `createRequire(import.meta.url)` and Node resolves symlinks by default. (A symlinked pdfjs silently reaches the real install; pdfjs must be copied.)
- An **ablation** case asserting the warnings *do* appear without the fix, so the test cannot pass vacuously. It also asserts text still extracts, so the ablation is not passing for the wrong reason.
- The main case: no known warnings, text still extracted.
- A guard asserting the extractor never assigns to `console.log/warn/error`.
- A check that `Module._load` is restored after a real extraction.

`npx vitest run src/tools/os/read-document/` → 47 passed. `tsc --noEmit` clean.

## Acceptance criteria

- [x] Regression test runs the import in a fresh child process
- [x] Reproduces a deployment without `@napi-rs/canvas` and fails on the current warning strings
- [x] Successful text-only read emits none of the known warnings to stdout/stderr
- [x] Missing graphics support does not require installing `@napi-rs/canvas`
- [x] Corrupt PDFs and page-level failures remain visible via errors / `details.warnings`
- [x] Warning handling scoped to the loading strategy; no global `console` interception
- [x] Concurrent reads cannot interfere with process-wide logging

One item is left for a maintainer: **CI coverage of an optional-dependency-absent target**. The new test simulates that environment in-process rather than changing the CI matrix, since adding an `--omit=optional` job is a workflow decision. Happy to add it if you want it in this PR.

## Note on `Module._load`

This is a private Node API — it is the only interception point for the `createRequire(...)` call pdfjs makes internally. It has been stable across Node's entire CJS lifetime, and the code degrades safely: if it is ever absent, we fall back to loading normally (noisy, never broken). Called out here so the trade-off is explicit rather than buried.
