### PR TITLE
docs: cover what happens when the local Ollama server is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ In the TUI, open the LLM tab, add a provider, and pick **Ollama (local)** (or **
 
 Model ids are the tags the server reports, `qwen2.5:0.5b` or `llama3.2:latest` for Ollama, so use the same name you passed to `ollama pull`. The list comes from the server's own `/v1/models`, which means anything you have pulled shows up without a restart.
 
+The preset is a fixed `http://localhost:11434` endpoint — it does not probe for a running server. If `ollama serve` isn't up when you reach the model step, the list fails to load (`could not list models from Ollama (local)`), and the wizard falls back to letting you type a model id by hand; in the LLM panel the list shows `model list unavailable` and only the current model. Start the server (`ollama serve`, then `ollama pull <model>` for anything you want) and re-open the preset.
+
 | Preset | Endpoint |
 | --- | --- |
 | Ollama (local) | `http://localhost:11434` |


### PR DESCRIPTION
Follow-up to the closed #128. That PR added a "New in v0.2.1 / auto-detects" note that was rightly rejected:

- the preset is a fixed `http://localhost:11434` endpoint, not a detector (see `src/tui/providers/provider-presets.ts`)
- the section already covered the setup flow two paragraphs above
- the repo keeps no "New in vX" version badges

This change drops that note and instead documents the gap @sosidudku1 pointed out: what happens when the Ollama server isn't running.

Verified against the code:

- **Wizard** (`src/tui/components/providers-wizard.tsx`): when the fetch to `http://localhost:11434/v1/models` fails, the hint reads `could not list models from Ollama (local)` and falls back to typing a model id by hand.
- **LLM panel** (`src/tui/components/llm-mode-rows.tsx`): the model list shows `model list unavailable` and only the current model.
- **Preset** (`src/tui/providers/provider-presets.ts`): fixed `http://localhost:11434`, no probe — so the "auto-detects" wording was never accurate.

The new sentence tells the reader to start `ollama serve` (and pull the model) and re-open the preset.