### PR TITLE
feat(providers): add Sarvam preset to the provider wizard

### DIFF
--- a/src/tui/providers/provider-presets.ts
+++ b/src/tui/providers/provider-presets.ts
@@ -222,6 +222,14 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
     note: "open-weight models on custom silicon; models listed without a key",
   },
   {
+    id: "sarvam",
+    label: "Sarvam",
+    baseUrl: "https://api.sarvam.ai",
+    envVar: "SARVAM_API_KEY",
+    listsModelsWithoutKey: true,
+    note: "Sarvam AI models, OpenAI-compatible; models listed without a key",
+  },
+  {
     id: "together",
     label: "Together AI",
     baseUrl: "https://api.together.xyz",


### PR DESCRIPTION
Follow-up to the closed #129, per the maintainer's guidance: this is a preset-only addition — no new provider kind.

**Change**: one `PROVIDER_PRESETS` entry between SambaNova and Together AI, resolving to the existing `openai-compatible` kind like every other preset.

**`/v1/models` confirmation** (probed live 2026-08-20, per the file's admission bar):

- `GET https://api.sarvam.ai/v1/models` → **200** with a `data` array, keyless: `sarvam-105b`, `sarvam-105b-conversations`
- `GET https://api.sarvam.ai/v1/definitely-not-a-route` → **404** (the host actually routes `/v1/models`)

Because the list answers keyless (same as SambaNova / Ollama Cloud / Novita / Nous), the entry sets `listsModelsWithoutKey: true`, so the wizard skips the key screen. The `SARVAM_API_KEY` env var is still wired for chat requests that need it.

Verified: `tsc --noEmit` clean, preset tests (sort order, keyless marking) pass.