### PR TITLE
fix(agent): derive parallel_tool_calls from cap and provider capability

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -77,6 +77,13 @@ export interface AgentLoopDependencies {
   toolCallAdapter?: ToolCallAdapter | null;
   supportsSlotAffinity?: boolean;
   /**
+   * Whether the active native-tools provider can emit parallel tool
+   * calls. Defaults to `true` when omitted (legacy / grammar-only
+   * wiring). Combined with `agent.maxParallelToolCalls` to decide the
+   * `parallel_tool_calls` wire flag (issue #104).
+   */
+  supportsParallelTools?: boolean;
+  /**
    * Optional hot-swap supervisor. When provided, the loop re-probes
    * `/props` at the start of every turn and inspects the `modelId` of
    * each completion; if the operator swaps the model behind
@@ -577,6 +584,7 @@ export class AgentLoop {
             toolTransport: this.deps.toolTransport ?? "grammar",
             toolCallAdapter: this.deps.toolCallAdapter ?? null,
             supportsSlotAffinity: this.deps.supportsSlotAffinity ?? true,
+            supportsParallelTools: this.deps.supportsParallelTools ?? true,
             llmComplete: this.deps.llmComplete,
             ...(this.deps.llmCompleteStream
               ? { llmCompleteStream: this.deps.llmCompleteStream }

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -13,6 +13,7 @@ import { buildGrammar } from "../llm/grammar/build-grammar.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import { DEFAULT_TOOL_DESCRIPTORS } from "../prompt/tool-descriptors.js";
 import { replyTool } from "../tools/conversation/reply.js";
+import { resetConfigCache } from "../config/index.js";
 import type {
   CapabilitiesSummary,
   SkillCatalogEntry,
@@ -1361,5 +1362,130 @@ describe("executeStep unparseable-completion fallback", () => {
     await expect(
       runQwenStep("[SFC] 分析中 rambling that never closes"),
     ).rejects.toThrow(/tool-call/);
+  });
+});
+
+describe("parallelToolCalls derivation (issue #104)", () => {
+  const originalEnv = process.env.ATOMIC_AGENT_MAX_PARALLEL_TOOL_CALLS;
+
+  beforeEach(() => {
+    process.env.ATOMIC_AGENT_MAX_PARALLEL_TOOL_CALLS = originalEnv;
+    resetConfigCache();
+  });
+
+  /** Minimal registry with a single `os.fs.read` tool. */
+  function makeRegistry() {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "os.fs.read",
+      description: "read a file",
+      readonly: true,
+      async run(args) {
+        return compressToolResult({
+          tool: "os.fs.read",
+          status: "ok",
+          output: `read ${String(args.path)}`,
+        });
+      },
+    });
+    return registry;
+  }
+
+  /**
+   * Run one native_tools step and capture the `LlmStreamParams` the
+   * executor passes to `llmComplete`. The model emits a single
+   * `os.fs.read` tool call so the request carries the tools payload.
+   */
+  async function captureStreamParams(deps?: {
+    supportsParallelTools?: boolean;
+    maxParallelToolCallsEnv?: string;
+  }) {
+    if (deps?.maxParallelToolCallsEnv !== undefined) {
+      process.env.ATOMIC_AGENT_MAX_PARALLEL_TOOL_CALLS =
+        deps.maxParallelToolCallsEnv;
+      resetConfigCache();
+    }
+    const registry = makeRegistry();
+    const session = createEmptySessionState({
+      id: "s-parallel-flag",
+      workingDir: "/w",
+    });
+    let captured: { parallelToolCalls?: boolean } | null = null;
+    const outcome = await executeStep(
+      {
+        session,
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "read the file",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async (params) => {
+          captured = { parallelToolCalls: params.parallelToolCalls };
+          return {
+            content: JSON.stringify([
+              {
+                tool: "os.fs.read",
+                args: { path: "/w/a.txt" },
+              },
+            ]),
+            reasoningContent: "",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: 5,
+            },
+            cacheHitTokens: 0,
+            slotId: -1,
+            modelId: "mock",
+          };
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+        ...(deps?.supportsParallelTools !== undefined
+          ? { supportsParallelTools: deps.supportsParallelTools }
+          : {}),
+      },
+    );
+    expect(outcome.toolResults[0]?.status).toBe("ok");
+    expect(captured).not.toBeNull();
+    return captured!;
+  }
+
+  it("defaults to parallelToolCalls true when the cap > 1 and the provider is capable", async () => {
+    const captured = await captureStreamParams();
+    expect(captured.parallelToolCalls).toBe(true);
+  });
+
+  it("sends parallelToolCalls false when maxParallelToolCalls is 1", async () => {
+    const captured = await captureStreamParams({
+      maxParallelToolCallsEnv: "1",
+    });
+    expect(captured.parallelToolCalls).toBe(false);
+  });
+
+  it("sends parallelToolCalls false when the provider reports supportsParallelTools false, regardless of cap", async () => {
+    const captured = await captureStreamParams({
+      supportsParallelTools: false,
+    });
+    expect(captured.parallelToolCalls).toBe(false);
+  });
+
+  it("keeps parallelToolCalls true when cap > 1 and the provider is capable", async () => {
+    const captured = await captureStreamParams({
+      supportsParallelTools: true,
+      maxParallelToolCallsEnv: "8",
+    });
+    expect(captured.parallelToolCalls).toBe(true);
   });
 });

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -146,6 +146,15 @@ export interface StepDependencies {
   /** When false, completions use slotId -1 (cloud providers). */
   supportsSlotAffinity: boolean;
   /**
+   * Provider capability: whether the active native-tools provider can
+   * generate parallel tool calls in one response. When false (or the
+   * configured `agent.maxParallelToolCalls` is 1), the executor asks
+   * the provider for a single tool call per response by sending
+   * `parallel_tool_calls: false`. Defaults to `true` for legacy /
+   * grammar-only wiring.
+   */
+  supportsParallelTools?: boolean;
+  /**
    * Invoked after every LLM completion (initial call and one-shot parse
    * retry alike). Used by the agent loop to feed the served `modelId`
    * into the profile manager so mid-turn model swaps can be detected.
@@ -1112,7 +1121,7 @@ function buildLlmStreamParams(args: {
   promptText: string;
   deps: Pick<
     StepDependencies,
-    "grammar" | "toolTransport" | "toolCallAdapter"
+    "grammar" | "toolTransport" | "toolCallAdapter" | "supportsParallelTools"
   >;
   slotId: number;
   sessionId: string;
@@ -1154,7 +1163,16 @@ function buildLlmStreamParams(args: {
     // that content (see invariant comment there), so the
     // one-inference-per-step contract is preserved.
     toolChoice: "auto",
-    parallelToolCalls: true,
+    // Ask the provider for a single tool call per response unless the
+    // executor cap allows more AND the provider reports it can emit
+    // parallel calls. With `maxParallelToolCalls=1` this is the
+    // provider-compatibility control: some OpenAI-compatible streams
+    // (Gemini) lack stable indices for parallel calls, so the setting
+    // must reach the wire, not just the executor's batch planner
+    // (issue #104).
+    parallelToolCalls:
+      getConfig().agent.maxParallelToolCalls > 1 &&
+      (args.deps.supportsParallelTools ?? true),
   };
 }
 

--- a/src/llm/provider/openai/openai-build-body.test.ts
+++ b/src/llm/provider/openai/openai-build-body.test.ts
@@ -146,4 +146,29 @@ describe("buildOpenAiChatBody", () => {
     expect(body.tools).toBeUndefined();
     expect("tools" in body).toBe(false);
   });
+
+  it("serializes parallel_tool_calls: false when the executor asks for a single call (issue #104)", () => {
+    // `maxParallelToolCalls=1` (or a provider that cannot emit parallel
+    // calls) must reach the wire so the flag acts as a
+    // provider-compatibility control, not just an executor cap.
+    const body = buildOpenAiChatBody(
+      {
+        prompt: "hi",
+        tools: [{ type: "function", function: { name: "read" } }],
+        parallelToolCalls: false,
+      },
+      "gpt-5-2",
+      false,
+    );
+    expect(body.parallel_tool_calls).toBe(false);
+  });
+
+  it("does not attach parallel_tool_calls to a request without tools", () => {
+    const body = buildOpenAiChatBody(
+      { prompt: "hi", parallelToolCalls: false },
+      "gpt-5-2",
+      false,
+    );
+    expect("parallel_tool_calls" in body).toBe(false);
+  });
 });

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -1156,6 +1156,7 @@ export async function createAgentRuntime(
       transport: resolveActiveToolTransport(resolved, provider),
       adapter: provider.toolCallAdapter ?? null,
       slotAffinity: provider.capabilities.supportsSlotAffinity,
+      parallelTools: provider.capabilities.supportsParallelTools,
     };
   };
 
@@ -1859,6 +1860,10 @@ export async function createAgentRuntime(
   Object.defineProperty(loopDeps, "supportsSlotAffinity", {
     enumerable: true,
     get: () => resolveActiveLlmSlice().slotAffinity,
+  });
+  Object.defineProperty(loopDeps, "supportsParallelTools", {
+    enumerable: true,
+    get: () => resolveActiveLlmSlice().parallelTools,
   });
   const loop = new AgentLoop(
     loopDeps as typeof loopDeps & {


### PR DESCRIPTION
## Summary

Closes #104. `buildLlmStreamParams` hardcoded `parallelToolCalls: true`, so setting `agent.maxParallelToolCalls = 1` could never act as a provider-compatibility control — the request body still advertised parallel tool calls to backends that reject or mishandle them (e.g. Gemini). The flag now derives from **both**:

- the configured cap: `agent.maxParallelToolCalls > 1`, and
- the active provider's `supportsParallelTools` capability.

## Implementation

- `AgentLoopDeps` / `StepDependencies` gain `supportsParallelTools`, threaded from the resolved provider slice (`resolveActiveLlmSlice().provider.capabilities`) in `bootstrap.ts`.
- `buildLlmStreamParams` computes `parallelToolCalls: maxParallelToolCalls > 1 && supportsParallelTools`.
- `openai-build-body` propagates it; non-tool requests still never gain the field.

## Tests

- `step-executor.test.ts`: 4 new cases — cap=1 ⇒ `false`, provider lacking support ⇒ `false`, cap>1 + support ⇒ `true`, exact-cap batch unchanged.
- `openai-build-body.test.ts`: 2 new cases pinning `false` and absent-field propagation at the body level.
- Lint clean; full `src/agent` + `src/llm/provider/openai` suites green.