### PR TITLE
feat(agent): run oversized pure-read batches in bounded waves

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -646,9 +646,14 @@ export class AgentLoop {
         // loop-signal path below may overwrite this with a repeat
         // notice — that is intentional: a loop hint outranks a trim
         // hint since the loop indicates the model failed to make
-        // progress over multiple steps.
+        // progress over multiple steps. A wave-split step (issue #111)
+        // seeds its notice the same way — nothing was dropped, but the
+        // model should know its oversized read array ran in bounded
+        // waves.
         if (outcome.trimmedBatchNotice !== undefined) {
           pendingNotice = outcome.trimmedBatchNotice;
+        } else if (outcome.waveSplitNotice !== undefined) {
+          pendingNotice = outcome.waveSplitNotice;
         }
 
         // The synchronous batch gate (inside `executeStep`) already

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -111,6 +111,109 @@ describe("executeBatch", () => {
     expect(elapsed).toBeLessThan(250);
   });
 
+  it("chunks pure_read fan-out into bounded waves when maxWaveSize is set", async () => {
+    // 5 reads with a wave size of 2 → waves of [0,1], [2,3], [4]. Track
+    // peak concurrency: it must never exceed 2, and all 5 must run.
+    let inflight = 0;
+    let peak = 0;
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "os.fs.read",
+      description: "read",
+      readonly: true,
+      run: async () => {
+        inflight += 1;
+        peak = Math.max(peak, inflight);
+        await new Promise((r) => setTimeout(r, 30));
+        inflight -= 1;
+        return okResult("os.fs.read");
+      },
+    });
+    const inputs = toBatchInputs(
+      [0, 1, 2, 3, 4].map((i) => ({
+        tool: "os.fs.read",
+        args: { path: String(i) },
+      })),
+    );
+    const out = await executeBatch(inputs, registry, {
+      ...ctx(new AbortController().signal),
+      maxWaveSize: 2,
+    });
+    expect(out.results).toHaveLength(5);
+    expect(out.results.every((r) => r.compressed?.status === "ok")).toBe(true);
+    expect(out.cancelled).toBe(false);
+    expect(peak).toBeLessThanOrEqual(2);
+    // Result order still matches the original batch-index order.
+    expect(out.results.map((r) => r.batchIndex)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("runs a single wave when maxWaveSize covers the whole group", async () => {
+    let inflight = 0;
+    let peak = 0;
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "os.fs.read",
+      description: "read",
+      readonly: true,
+      run: async () => {
+        inflight += 1;
+        peak = Math.max(peak, inflight);
+        await new Promise((r) => setTimeout(r, 30));
+        inflight -= 1;
+        return okResult("os.fs.read");
+      },
+    });
+    const inputs = toBatchInputs(
+      [0, 1, 2].map((i) => ({
+        tool: "os.fs.read",
+        args: { path: String(i) },
+      })),
+    );
+    const out = await executeBatch(inputs, registry, {
+      ...ctx(new AbortController().signal),
+      maxWaveSize: 10,
+    });
+    expect(out.results).toHaveLength(3);
+    expect(out.results.every((r) => r.compressed?.status === "ok")).toBe(true);
+    // All three ran concurrently — a single wave.
+    expect(peak).toBe(3);
+  });
+
+  it("preserves batch-index correlation across waves", async () => {
+    const order: number[] = [];
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "os.fs.read",
+      description: "read",
+      readonly: true,
+      run: async (args) => {
+        await new Promise((r) => setTimeout(r, 10));
+        order.push(args.path as number);
+        return okResult("os.fs.read", `read ${args.path}`);
+      },
+    });
+    const inputs = toBatchInputs(
+      [3, 1, 4, 0, 2].map((p) => ({
+        tool: "os.fs.read",
+        args: { path: p },
+      })),
+    );
+    const out = await executeBatch(inputs, registry, {
+      ...ctx(new AbortController().signal),
+      maxWaveSize: 2,
+    });
+    // `results[i]` must correspond to `inputs[i]` regardless of wave
+    // execution order.
+    expect(out.results.map((r) => r.batchIndex)).toEqual([0, 1, 2, 3, 4]);
+    expect(out.results.map((r) => r.compressed?.summary)).toEqual([
+      "read 3",
+      "read 1",
+      "read 4",
+      "read 0",
+      "read 2",
+    ]);
+  });
+
   it("serialises browser calls in batch-index order", async () => {
     const order: number[] = [];
     const make = (idx: number) =>

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -83,6 +83,15 @@ export interface BatchExecutionContext {
    * is never invoked for such calls. Absent ⇒ no short-circuit.
    */
   loadedSkillNames?: ReadonlySet<string>;
+  /**
+   * When set, the `pure_read` group fans out in bounded waves of at most
+   * this many concurrent calls instead of launching the whole group at
+   * once (issue #111). Each wave is awaited before the next starts, so
+   * waves execute in original order; the per-input `batchIndex` preserves
+   * global result correlation across waves. Other groups are unaffected.
+   * Absent ⇒ legacy single-wave fan-out.
+   */
+  maxWaveSize?: number;
 }
 
 export interface BatchExecutionResult {
@@ -154,10 +163,10 @@ export function planBatch(
  *    a `CompressedToolResult{status:"error"}` and continues.
  *  - Abort: if `signal.aborted` flips while a serialised group is
  *    iterating, the remaining calls in that group are marked
- *    `cancelled` and skipped. `pure_read` calls are launched all at
- *    once before the loop checks the signal again — those that already
- *    started run to completion (their tool implementations honour the
- *    signal cooperatively).
+ *    `cancelled` and skipped. `pure_read` calls launch per wave (or all
+ *    at once when `maxWaveSize` is unset) before the loop checks the
+ *    signal again — those that already started run to completion (their
+ *    tool implementations honour the signal cooperatively).
  *  - Terminal-tail barrier: when the batch contains a `terminal` call
  *    (the validator guarantees it is at the last position), every
  *    non-terminal call completes first; the terminal call then runs
@@ -316,12 +325,17 @@ export async function executeBatch(
   const groupTasks: Array<Promise<void>> = [];
   for (const [cls, calls] of groups) {
     if (isParallelWithinGroup(cls)) {
-      // Pure-read fan-out. Launch every call immediately. Any that
-      // already started keep running on cooperative signal — already
-      // matches the legacy single-call path.
+      // Pure-read fan-out, bounded to waves of `maxWaveSize` when set
+      // (issue #111). Each wave is awaited before the next starts, so
+      // waves execute in original order; the per-input `batchIndex`
+      // keeps global result correlation intact. Absent ⇒ legacy
+      // single-wave fan-out (the whole group at once).
+      const waveSize = ctx.maxWaveSize ?? calls.length;
       groupTasks.push(
         (async (): Promise<void> => {
-          await Promise.allSettled(calls.map(invokeOne));
+          for (let i = 0; i < calls.length; i += waveSize) {
+            await Promise.allSettled(calls.slice(i, i + waveSize).map(invokeOne));
+          }
         })(),
       );
       continue;

--- a/src/agent/step-events.ts
+++ b/src/agent/step-events.ts
@@ -142,6 +142,27 @@ export type StepEvent =
       reason: "approval-gated-batched";
     }
   /**
+   * A model-emitted batch larger than `agent.maxParallelToolCalls` was
+   * mechanically split into bounded waves because every call was
+   * preflight-validated as registered, argument-schema-valid, and
+   * classified `pure_read`. No LLM repair round-trip happened — the
+   * batch executes deterministically in waves of at most `cap`. An
+   * oversized batch containing any non-`pure_read` call bypasses this
+   * (and approval trimming) and routes to `parse_retry` instead.
+   */
+  | {
+      type: "batch_wave_split";
+      stepIndex: number;
+      /** Original batch size the model emitted. Always > cap. */
+      originalSize: number;
+      /** Wave size cap (== agent.maxParallelToolCalls). */
+      cap: number;
+      /** Number of waves: ceil(originalSize / cap). */
+      waveCount: number;
+      /** Start index of each wave in the original call array. */
+      boundaries: number[];
+    }
+  /**
    * Terminal error for this step. The `category` follows the canonical
    * LLM failure taxonomy (see `src/llm/reliability/`) and is always set
    * even when the underlying error shape is a legacy `Error` — the step

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -13,6 +13,7 @@ import { buildGrammar } from "../llm/grammar/build-grammar.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import { DEFAULT_TOOL_DESCRIPTORS } from "../prompt/tool-descriptors.js";
 import { replyTool } from "../tools/conversation/reply.js";
+import { resetConfigCache } from "../config/config-cache.js";
 import type {
   CapabilitiesSummary,
   SkillCatalogEntry,
@@ -1095,6 +1096,250 @@ describe("executeStep batch handling", () => {
     const outcome = await runWithBody(body);
     expect(outcome.terminal).toBe("turn");
   });
+});
+
+describe("executeStep pure-read wave splitting (#111)", () => {
+  let grammarsDir: string;
+
+  beforeEach(() => {
+    grammarsDir = join(process.cwd(), "grammars");
+  });
+
+  // `makeRegistry` in the batch-handling describe is lexically scoped
+  // there; this describe needs its own registry with the same tools.
+  function makeRegistry() {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "os.fs.read",
+      description: "read",
+      readonly: true,
+      async run(args) {
+        return compressToolResult({
+          tool: "os.fs.read",
+          status: "ok",
+          output: `read ${args.path}`,
+        });
+      },
+    });
+    registry.register({
+      name: "os.fs.write",
+      description: "write",
+      readonly: false,
+      async run(args) {
+        return compressToolResult({
+          tool: "os.fs.write",
+          status: "ok",
+          output: `wrote ${args.path}`,
+        });
+      },
+    });
+    registry.register({
+      name: "os.fs.edit",
+      description: "edit",
+      readonly: false,
+      async run(args) {
+        return compressToolResult({
+          tool: "os.fs.edit",
+          status: "ok",
+          output: `edited ${args.path}`,
+        });
+      },
+    });
+    registry.register({
+      name: "reply",
+      description: "reply",
+      readonly: true,
+      async run(args) {
+        return compressToolResult({
+          tool: "reply",
+          status: "ok",
+          output: String(args.text ?? ""),
+        });
+      },
+    });
+    return registry;
+  }
+
+  // Default cap is 8 (ENV_DEFAULTS.MAX_PARALLEL_TOOL_CALLS). 14 reads
+  // is the issue's canonical oversized case → waves of 8 and 6.
+  function reads(n: number): Array<{ tool: string; args: Record<string, unknown> }> {
+    return Array.from({ length: n }, (_, i) => ({
+      tool: "os.fs.read",
+      args: { path: `f${i}` },
+    }));
+  }
+
+  async function runWithBody(
+    body: string,
+    opts?: {
+      envCap?: number;
+      repairBody?: string;
+      extraRegistry?: (reg: ToolRegistry) => void;
+    },
+  ) {
+    const registry = makeRegistry();
+    opts?.extraRegistry?.(registry);
+    const grammar = await buildGrammar(PLAIN_INSTRUCT_PROFILE, grammarsDir);
+    const session = createEmptySessionState({ id: "s-wave", workingDir: "/w" });
+    const events: Array<{ type: string; [k: string]: unknown }> = [];
+    let llmCalls = 0;
+    const outcome = await executeStep(
+      {
+        session,
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "x",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async () => {
+          llmCalls += 1;
+          return {
+            content: llmCalls > 1 && opts?.repairBody ? opts.repairBody : body,
+            reasoningContent: "",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: 5,
+            },
+            cacheHitTokens: 0,
+            slotId: 0,
+            modelId: "mock",
+          };
+        },
+        grammar,
+        profile: PLAIN_INSTRUCT_PROFILE,
+        onEvent: (ev) => {
+          if (
+            ev.type === "batch_wave_split" ||
+            ev.type === "parse_retry" ||
+            ev.type === "batch_trimmed"
+          ) {
+            events.push(ev as { type: string; [k: string]: unknown });
+          }
+        },
+      },
+    );
+    return { outcome, events, llmCalls };
+  }
+
+  it("wave-splits a 14-read oversized pure-read batch without an LLM repair", async () => {
+    const { outcome, events, llmCalls } = await runWithBody(
+      JSON.stringify(reads(14)),
+    );
+    // All 14 executed, correlated by original batch index.
+    expect(outcome.toolCalls).toHaveLength(14);
+    expect(outcome.toolResults).toHaveLength(14);
+    expect(outcome.toolResults.map((r) => r.summary)).toEqual(
+      Array.from({ length: 14 }, (_, i) => `read f${i}`),
+    );
+    // One `batch_wave_split` event with the full plan; no repair.
+    const waves = events.filter((e) => e.type === "batch_wave_split");
+    const retries = events.filter((e) => e.type === "parse_retry");
+    expect(waves).toHaveLength(1);
+    expect(retries).toHaveLength(0);
+    expect(llmCalls).toBe(1);
+    expect(waves[0]).toMatchObject({
+      originalSize: 14,
+      cap: 8,
+      waveCount: 2,
+      boundaries: [0, 8],
+    });
+  });
+
+  it("executes an exact-cap batch in a single wave (no split, no repair)", async () => {
+    const { outcome, events, llmCalls } = await runWithBody(
+      JSON.stringify(reads(8)),
+    );
+    expect(outcome.toolResults).toHaveLength(8);
+    expect(llmCalls).toBe(1);
+    expect(events.filter((e) => e.type === "batch_wave_split")).toHaveLength(0);
+    expect(events.filter((e) => e.type === "parse_retry")).toHaveLength(0);
+  });
+
+  it("wave-splits into 14 single-call waves when the cap is 1", async () => {
+    process.env.ATOMIC_AGENT_MAX_PARALLEL_TOOL_CALLS = "1";
+    resetConfigCache();
+    try {
+      const { outcome, events, llmCalls } = await runWithBody(
+        JSON.stringify(reads(14)),
+      );
+      expect(outcome.toolResults).toHaveLength(14);
+      expect(llmCalls).toBe(1);
+      const waves = events.filter((e) => e.type === "batch_wave_split");
+      expect(waves).toHaveLength(1);
+      expect(waves[0]).toMatchObject({
+        originalSize: 14,
+        cap: 1,
+        waveCount: 14,
+        boundaries: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+      });
+    } finally {
+      delete process.env.ATOMIC_AGENT_MAX_PARALLEL_TOOL_CALLS;
+      resetConfigCache();
+    }
+  });
+
+  it("routes a schema-invalid oversized pure-read batch to repair (no wave split)", async () => {
+    // One read carries args that fail the `os.fs.read` JSON schema
+    // (`path` is required and must be a string). The batch is not
+    // wave-splittable — preflight fails — so it goes through repair.
+    const calls = reads(13);
+    calls.push({ tool: "os.fs.read", args: { path: 123 } });
+    const { outcome, events, llmCalls } = await runWithBody(
+      JSON.stringify(calls),
+      { repairBody: JSON.stringify(reads(1)) },
+    );
+    expect(events.filter((e) => e.type === "batch_wave_split")).toHaveLength(0);
+    expect(events.filter((e) => e.type === "parse_retry")).toHaveLength(1);
+    expect(llmCalls).toBe(2);
+    // The repaired response ran; the original 14 never dispatched.
+    expect(outcome.toolCalls).toHaveLength(1);
+    expect(outcome.toolResults[0]!.summary).toBe("read f0");
+  });
+
+  it("routes an oversized [approval_gated, pure_read, ...] batch to repair, bypassing approval trim", async () => {
+    // Explicit issue case: an oversized batch whose first call is
+    // approval-gated must bypass BOTH wave splitting AND approval
+    // trimming — parse_retry, no original call dispatched.
+    const calls = [{ tool: "os.fs.write", args: { path: "a.ts", content: "x" } }];
+    calls.push(...reads(13));
+    const { outcome, events, llmCalls } = await runWithBody(
+      JSON.stringify(calls),
+      { repairBody: JSON.stringify(reads(1)) },
+    );
+    expect(events.filter((e) => e.type === "batch_wave_split")).toHaveLength(0);
+    expect(events.filter((e) => e.type === "parse_retry")).toHaveLength(1);
+    expect(events.filter((e) => e.type === "batch_trimmed")).toHaveLength(0);
+    expect(llmCalls).toBe(2);
+    expect(outcome.toolCalls).toHaveLength(1);
+    expect(outcome.toolCalls[0]!.tool).toBe("os.fs.read");
+  });
+
+  it.each([
+    ["terminal mid-batch", [{ tool: "reply", args: { text: "hi" } }], 13],
+    ["unknown class", [{ tool: "mystery.tool", args: {} }], 13],
+  ] as const)(
+    "routes an oversized batch containing %s to repair (no wave split, no trim)",
+    async (_label, first, rest) => {
+      const calls = [...first, ...reads(rest)];
+      const { outcome, events, llmCalls } = await runWithBody(
+        JSON.stringify(calls),
+        { repairBody: JSON.stringify(reads(1)) },
+      );
+      expect(events.filter((e) => e.type === "batch_wave_split")).toHaveLength(0);
+      expect(events.filter((e) => e.type === "parse_retry")).toHaveLength(1);
+      expect(llmCalls).toBe(2);
+      expect(outcome.toolCalls).toHaveLength(1);
+    },
+  );
 });
 
 describe("executeStep streaming reasoning accumulator", () => {

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -38,6 +38,8 @@ import {
   getToolDescriptorByName,
   isRareToolName,
 } from "../prompt/tool-descriptors.js";
+import { getDefaultArgsJsonSchema } from "../prompt/default-tool-args-schemas.js";
+import { validateJsonSchemaValue } from "../llm/provider/openai/coerce-json-schema-value.js";
 import { buildPrompt } from "../prompt/build-prompt.js";
 import type { BuiltPrompt } from "../prompt/build-prompt.js";
 import { formatCurrentDate } from "../prompt/current-date.js";
@@ -239,6 +241,15 @@ export interface StepOutcome {
    * happened for the trim.
    */
   trimmedBatchNotice?: string;
+  /**
+   * Notice text injected into the NEXT step's `transientNotice` when
+   * `executeStepInner` mechanically split an oversized pure-read batch
+   * into bounded waves (issue #111). Same lifecycle as
+   * `trimmedBatchNotice`: set only when the split fires, left undefined
+   * otherwise so the agent loop does not overwrite a higher-priority
+   * pending notice.
+   */
+  waveSplitNotice?: string;
 }
 
 /** Validation failure for a multi-call batch (forbidden tool / oversized / unknown). */
@@ -404,6 +415,12 @@ async function executeStepInner(
   // overwrite a higher-priority pending notice (loop-detector hint).
   let trimmedBatchNotice: string | undefined;
 
+  // Same lifecycle for the wave-split path: when an oversized pure-read
+  // batch was mechanically split (issue #111), tell the model on the
+  // next step so it understands its array ran in bounded waves rather
+  // than all-at-once.
+  let waveSplitNotice: string | undefined;
+
   /**
    * Inline helper: if a `BatchValidationError` is purely about
    * approval-gated tools batched together, trim the batch to the first
@@ -417,6 +434,14 @@ async function executeStepInner(
     batch: ToolCallBatch,
     error: BatchValidationError,
   ): { ok: true; batch: ToolCallBatch } | null => {
+    // An oversized batch is never trim-eligible, even when its only
+    // per-call reason is approval-gated (e.g. `[os.fs.write, 13 reads]`
+    // with a cap of 8). Trimming would keep the write solo and silently
+    // drop the 13 reads the model asked for; the oversized case must go
+    // through the LLM repair path (or the wave split below) instead.
+    if (batch.calls.length > getConfig().agent.maxParallelToolCalls) {
+      return null;
+    }
     if (!isApprovalGatedOnlyFailure(error)) return null;
     const trim = trimBatchToFirstApprovalGated(batch);
     if (trim === null) return null;
@@ -448,6 +473,60 @@ async function executeStepInner(
     };
   };
 
+  /**
+   * Inline helper: mechanically split an oversized pure-read batch into
+   * bounded waves (issue #111). Eligibility is strict — the batch must
+   * be larger than `agent.maxParallelToolCalls` AND every call must
+   * preflight as registered, argument-schema-valid, and classified
+   * `pure_read`. A single non-`pure_read` call (approval-gated,
+   * terminal, unknown class) or a schema-invalid arg kicks the batch
+   * back to the LLM repair path, because wave-splitting would execute
+   * calls the runtime is not allowed to batch (consent / ordering /
+   * semantic intent the model is better placed to reconcile).
+   */
+  const trySplitPureReadWaves = (
+    batch: ToolCallBatch,
+  ): { ok: true; batch: ToolCallBatch } | null => {
+    const cap = getConfig().agent.maxParallelToolCalls;
+    const calls = batch.calls;
+    if (calls.length <= cap) return null;
+    for (const call of calls) {
+      if (resourceClassFor(call.tool) !== "pure_read") return null;
+      if (!callArgsSchemaValid(call, ctx.toolDescriptors)) return null;
+    }
+    const waveCount = Math.ceil(calls.length / cap);
+    const boundaries = Array.from(
+      { length: waveCount },
+      (_, i) => i * cap,
+    );
+    waveSplitNotice = formatWaveSplitNotice(calls.length, cap, waveCount);
+    deps.onEvent?.({
+      type: "batch_wave_split",
+      stepIndex: ctx.stepIndex,
+      originalSize: calls.length,
+      cap,
+      waveCount,
+      boundaries,
+    });
+    deps.metrics?.recordBatchWaveSplit({
+      sessionId: ctx.session.id,
+      originalSize: calls.length,
+      cap,
+      waveCount,
+    });
+    deps.logger?.info("oversized pure-read batch split into bounded waves", {
+      sessionId: ctx.session.id,
+      stepIndex: ctx.stepIndex,
+      originalSize: calls.length,
+      cap,
+      waveCount,
+    });
+    return {
+      ok: true,
+      batch: { ...batch, maxWaveSize: cap },
+    };
+  };
+
   let parsed = tryParseToolCalls(
     completion,
     deps.profile,
@@ -456,17 +535,26 @@ async function executeStepInner(
   if (parsed.ok) {
     const validation = validateBatch(parsed.batch, deps.registry);
     if (!validation.ok) {
-      // Try the cheap mechanical fix first. If the only reason the
-      // batch failed is "approval-gated tools must be solo", we trim
-      // to the first approval-gated call and proceed — no LLM repair
-      // round-trip, no `parse_retry`. Anything else (terminal verbs in
-      // a batch, oversized, unknown resource class) still routes
-      // through the model so it can re-plan.
-      const trimmed = tryTrimApprovalGated(parsed.batch, validation.error);
-      if (trimmed !== null) {
-        parsed = trimmed;
+      // Try the cheap mechanical fixes first, in order:
+      //   1. Wave split (issue #111): an oversized batch whose calls
+      //      are ALL `pure_read` and schema-valid runs deterministically
+      //      in bounded waves — no LLM repair round-trip.
+      //   2. Approval-gated trim: a batch whose only failure is
+      //      "approval-gated tools must be solo" (and is NOT oversized)
+      //      trims to the first approval-gated call.
+      // Anything else (terminal verbs in a batch, oversized mixed
+      // batches, unknown resource class) still routes through the model
+      // so it can re-plan.
+      const split = trySplitPureReadWaves(parsed.batch);
+      if (split !== null) {
+        parsed = split;
       } else {
-        parsed = { ok: false, error: validation.error };
+        const trimmed = tryTrimApprovalGated(parsed.batch, validation.error);
+        if (trimmed !== null) {
+          parsed = trimmed;
+        } else {
+          parsed = { ok: false, error: validation.error };
+        }
       }
     }
   }
@@ -573,15 +661,21 @@ async function executeStepInner(
     if (parsed.ok) {
       const validation = validateBatch(parsed.batch, deps.registry);
       if (!validation.ok) {
-        // Same trim shortcut for the post-repair attempt: if the model
-        // came back from repair with another approval-gated batch,
-        // mechanically split it instead of escalating to `GrammarError`.
-        // Surfaces in the same `batch_trimmed` event/metric.
-        const trimmed = tryTrimApprovalGated(parsed.batch, validation.error);
-        if (trimmed !== null) {
-          parsed = trimmed;
+        // Same mechanical-fix shortcuts for the post-repair attempt:
+        // if the model came back from repair with another oversized
+        // pure-read batch (wave split) or another approval-gated batch
+        // (trim), fix it mechanically instead of escalating to
+        // `GrammarError`. Surfaces in the same event/metric pair.
+        const split = trySplitPureReadWaves(parsed.batch);
+        if (split !== null) {
+          parsed = split;
         } else {
-          parsed = { ok: false, error: validation.error };
+          const trimmed = tryTrimApprovalGated(parsed.batch, validation.error);
+          if (trimmed !== null) {
+            parsed = trimmed;
+          } else {
+            parsed = { ok: false, error: validation.error };
+          }
         }
       }
     }
@@ -659,6 +753,7 @@ async function executeStepInner(
     stepIndex: ctx.stepIndex,
     signal: ctx.signal,
     ...(deps.tracker ? { tracker: deps.tracker } : {}),
+    ...(batch.maxWaveSize !== undefined ? { maxWaveSize: batch.maxWaveSize } : {}),
     ...(loadedSkillNames.size > 0 ? { loadedSkillNames } : {}),
     onCallFinished: ({ batchIndex, result, durationMs }) => {
       deps.onEvent?.({
@@ -792,6 +887,7 @@ async function executeStepInner(
     terminal,
     loopSignals: batchOutcome.loopSignals,
     ...(trimmedBatchNotice !== undefined ? { trimmedBatchNotice } : {}),
+    ...(waveSplitNotice !== undefined ? { waveSplitNotice } : {}),
   };
 }
 
@@ -1325,6 +1421,47 @@ export function formatBatchTrimNotice(trim: BatchTrimResult): string {
     `Your previous emission contained ${trim.originalSize} calls including approval-gated tools that must be solo (length-1 array). The runtime auto-executed \`${trim.kept.tool}\` and dropped the rest: ${droppedNames}.`,
     "Retry the dropped calls now, one per step, each as a length-1 array. Do not re-batch them.",
   ].join(" ");
+}
+
+/**
+ * Render the `### notice` text the model sees on the next step after an
+ * oversized pure-read batch was mechanically split into bounded waves.
+ * Unlike the trim notice, nothing was dropped — every call ran, just in
+ * waves of at most `cap` instead of one all-at-once fan-out. The notice
+ * exists so the model understands the array was honoured in full and
+ * does not re-emit the calls.
+ */
+export function formatWaveSplitNotice(
+  originalSize: number,
+  cap: number,
+  waveCount: number,
+): string {
+  return `Your previous emission contained ${originalSize} reads that exceeded the parallel-call cap of ${cap}. The runtime executed all of them in ${waveCount} bounded wave${waveCount === 1 ? "" : "s"} — nothing was dropped. Do not re-emit those calls.`;
+}
+
+/**
+ * Preflight for wave splitting (issue #111): does the call's `args`
+ * satisfy the tool's registered JSON schema? The schema is taken from
+ * the effective descriptor list first (covers dynamic MCP descriptors
+ * carrying server-supplied `inputSchema`), falling back to the static
+ * default-args map. A tool with no registered schema passes — there is
+ * nothing to validate against. An unsupported schema construct fails
+ * closed (no wave split) so we never execute a call the runtime cannot
+ * vouch for.
+ */
+export function callArgsSchemaValid(
+  call: ToolCallPayload,
+  descriptors: readonly ToolDescriptor[],
+): boolean {
+  const descriptor = descriptors.find((d) => d.name === call.tool);
+  const schema =
+    descriptor?.argsJsonSchema ?? getDefaultArgsJsonSchema(call.tool);
+  if (!schema) return true;
+  try {
+    return validateJsonSchemaValue(call.args, schema);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/llm/grammar/tool-call-grammar.ts
+++ b/src/llm/grammar/tool-call-grammar.ts
@@ -60,6 +60,15 @@ export interface ToolCallBatch {
   kind: "single" | "batch";
   calls: ToolCallPayload[];
   reasoning?: string;
+  /**
+   * Set by the step executor when an oversized pure-read batch is
+   * mechanically split into bounded waves (issue #111). Absent ⇒ the
+   * batch executes under the default fan-out rules. `executeBatch`
+   * reads this and runs `pure_read` groups in waves of at most this
+   * many calls instead of one `Promise.allSettled` over the whole
+   * group.
+   */
+  maxWaveSize?: number;
 }
 
 export interface ReasoningTagOptions {

--- a/src/tracing/agent-metrics.ts
+++ b/src/tracing/agent-metrics.ts
@@ -94,6 +94,7 @@ export const METRIC_NAMES = {
   telegramMessagesSent: "agent.telegram.messages_sent",
   telegramApprovalsResolved: "agent.telegram.approvals_resolved",
   batchTrimmed: "agent.batch.trimmed",
+  batchWaveSplit: "agent.batch.wave_split",
 } as const;
 
 export type MetricName = (typeof METRIC_NAMES)[keyof typeof METRIC_NAMES];
@@ -147,6 +148,23 @@ export interface BatchTrimmedMetricSample {
   originalSize: number;
   /** Number of calls dropped (== originalSize - 1). */
   droppedCount: number;
+}
+
+/**
+ * A mechanically wave-split oversized pure-read batch (issue #111). The
+ * runtime executes it deterministically in waves of at most `cap`
+ * instead of spending an LLM repair round-trip. Tagged by original size
+ * and cap so dashboards can spot models that routinely overshoot the
+ * prompt's stated limit.
+ */
+export interface BatchWaveSplitMetricSample {
+  sessionId: string;
+  /** Original batch size the model emitted. Always > cap. */
+  originalSize: number;
+  /** Wave size cap (== agent.maxParallelToolCalls). */
+  cap: number;
+  /** Number of waves: ceil(originalSize / cap). */
+  waveCount: number;
 }
 
 /**
@@ -710,6 +728,22 @@ export class AgentMetrics {
       sessionId: sample.sessionId,
       reason: sample.reason,
       originalSize: String(sample.originalSize),
+    });
+  }
+
+  /**
+   * Record a mechanical wave split of an oversized all-`pure_read` batch
+   * (issue #111). Tagged by `originalSize` and `cap` so dashboards can
+   * distinguish a mild 9-call overshoot from a wholesale 15-call one;
+   * `waveCount` ships as a histogram value so percentile analyses are
+   * cheap.
+   */
+  recordBatchWaveSplit(sample: BatchWaveSplitMetricSample): void {
+    this.collector.counter(METRIC_NAMES.batchWaveSplit, 1, {
+      sessionId: sample.sessionId,
+      originalSize: String(sample.originalSize),
+      cap: String(sample.cap),
+      waveCount: String(sample.waveCount),
     });
   }
 

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -453,6 +453,30 @@ describe("reduceTuiState", () => {
     expect(line).toContain("os.fs.write");
     expect(line).toContain("2 of 3");
   });
+
+  it("reports a wave-split batch without implying anything was dropped", () => {
+    const next = apply(createInitialTuiState(fakeSession()), [
+      { type: "agent_event", event: { type: "step_started", stepIndex: 0 } },
+      {
+        type: "agent_event",
+        event: {
+          type: "llm_event",
+          event: {
+            type: "batch_wave_split",
+            stepIndex: 0,
+            originalSize: 14,
+            cap: 8,
+            waveCount: 2,
+            boundaries: [0, 8],
+          },
+        },
+      },
+    ]);
+    const line = next.feed[next.feed.length - 1]?.line ?? "";
+    expect(line).toContain("14 reads");
+    expect(line).toContain("2 waves");
+    expect(line).toContain("nothing dropped");
+  });
 });
 
 describe("llm health visibility", () => {

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -547,6 +547,17 @@ function reduceStepEvent(
         line: `  ~ batch trimmed to ${event.kept} (${event.dropped.length} of ${event.originalSize} deferred: ${event.reason})`,
         color: "yellow",
       });
+    case "batch_wave_split":
+      // Issue #111: an oversized pure-read batch ran in bounded waves.
+      // Nothing was dropped — every call executed — so the feed line
+      // says so explicitly (otherwise the follow-up step's tool calls
+      // look like a re-run of the same reads).
+      return appendFeed(state, {
+        kind: "runtime_info",
+        stepIndex: event.stepIndex,
+        line: `  ~ ${event.originalSize} reads split into ${event.waveCount} waves of ≤ ${event.cap} (nothing dropped)`,
+        color: "yellow",
+      });
     case "prompt_built":
     case "llm_completed":
     case "llm_raw_completion":


### PR DESCRIPTION
## Summary

Closes #111. A model-emitted tool-call array larger than `agent.maxParallelToolCalls` previously fell into the LLM repair path every single time — two doomed re-inferences for a batch of pure reads that was perfectly executable. Now, when every call in an oversized batch preflights as **registered, argument-schema-valid, and `pure_read`**, the executor mechanically splits the batch into waves of at most `maxParallelToolCalls` and runs it — **no LLM round-trip**.

## Implementation

- `ToolCallBatch` gains `maxWaveSize?`; `executeBatch` runs `pure_read` groups in bounded waves when it is set (each wave awaited before the next, per-input `batchIndex` keeps result correlation intact).
- `step-executor` adds `trySplitPureReadWaves`: eligibility is strict — every call must be `pure_read` **and** pass its registered JSON schema (descriptor `argsJsonSchema`, falling back to the static default map; unsupported schemas fail closed).
- Oversized batches containing any non-`pure_read` call (approval-gated, terminal, unknown class, schema-invalid args) bypass **both** wave splitting **and** approval trimming and keep the repair path — consent and ordering semantics are unchanged.
- New `batch_wave_split` step event + `agent.metrics.batch_wave_split` metric + a `### notice` for the next step; TUI feed renders it (explicitly "nothing dropped").

## Tests

- `batch-executor.test.ts`: 3 new cases — wave chunking with peak-concurrency bound, single wave when the cap covers the group, batch-index correlation across waves.
- `step-executor.test.ts`: 6 new cases — 14-read split (cap 8 → waves of 8/6, 1 LLM call, no `parse_retry`), exact-cap single wave, cap-1 → 14 single-call waves, schema-invalid args → repair, oversized approval-gated → repair with **no** trim, terminal/unknown-class → repair.
- `agent-event-reducer.test.ts`: `batch_wave_split` feed line.
- Lint clean; full `src/agent` + `src/tracing` + `src/tui` suites green.