### PR TITLE
feat(tui): reskin the terminal UI to the retro design

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ atomic-agent trace list --limit 10
 
 Handy slash commands: `/help` lists every command, `/tools` lists the built-in tool families, `/model` jumps to the LLM panel and reopens the model picker for the active cloud provider, `/privacy` shows what leaves the machine (`/privacy analytics off` turns analytics off). The chat log scrolls with PgUp / PgDn (fn+arrows on macOS).
 
+**Look.** The TUI ships with the `atomic-retro` palette: an indigo rail, raised `+ new` / `≡ Menu` / `send →` controls, a `RUN` badge and session title in the top bar, `AGENT` / `YOU` labels on the transcript, and green tool results. Eleven other palettes are still there — `/theme` lists them, `/theme github-dark` restores the previous look, and the choice persists.
+
 **Mouse.** The TUI is clickable: the breadcrumb (which opens the menu, the same as `ctrl+p`), sidebar sessions and tasks, every list row (skills, tasks, memory, MCP, models, providers), the session / theme / slash pickers, approval buttons, tool cards, and the prompt itself — clicking in the input places the caret. A click selects a row, a second click on the selected row opens it, and the wheel scrolls the chat or walks the focused panel.
 
 While mouse reporting is on the terminal hands clicks to the app, which means its own drag-to-select is unavailable (iTerm2, GNOME Terminal and Windows Terminal let you hold Shift to bypass; Apple Terminal does not). Turn it off whenever you want to select text: `/mouse off` in the app, `atomic-agent tui --no-mouse` for one run, or `"tui": { "mouse": false }` in `<stateDir>/config.json`. With mouse off, wheel scrolling still works through the terminal's alternate-scroll mode, exactly as before.

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -109,6 +109,9 @@ export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
     case "approval_resolved":
       if (state.pendingApproval?.approvalId !== action.approvalId) return state;
       return { ...state, pendingApproval: null, status: "running" };
+    case "composer_selection_changed":
+      if (state.composerHasSelection === action.hasSelection) return state;
+      return { ...state, composerHasSelection: action.hasSelection };
     case "metric":
       return applyMetric(state, action.sample);
     case "log":

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -109,6 +109,9 @@ export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
     case "approval_resolved":
       if (state.pendingApproval?.approvalId !== action.approvalId) return state;
       return { ...state, pendingApproval: null, status: "running" };
+    case "composer_notice":
+      if (state.composerNotice === action.text) return state;
+      return { ...state, composerNotice: action.text };
     case "composer_selection_changed":
       if (state.composerHasSelection === action.hasSelection) return state;
       return { ...state, composerHasSelection: action.hasSelection };

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -82,6 +82,24 @@ export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
       };
     case "agent_event":
       return reduceAgentEvent(state, action.event);
+    case "session_delete_requested":
+      return {
+        ...state,
+        sessionDelete: {
+          sessionId: action.sessionId,
+          preview: action.preview,
+          // Destructive default: the dialog opens on Cancel.
+          cursor: "cancel",
+        },
+      };
+    case "session_delete_cursor_set":
+      if (!state.sessionDelete) return state;
+      return {
+        ...state,
+        sessionDelete: { ...state.sessionDelete, cursor: action.cursor },
+      };
+    case "session_delete_closed":
+      return { ...state, sessionDelete: null };
     case "approval_requested":
       return {
         ...state,

--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -36,6 +36,8 @@ export interface AppKeyCallbacks {
    * request's whole category, `"shape"` (`a`, shell only) silences the
    * request's command binary. Absent = this call only (`y`).
    */
+  /** The operator confirmed "delete the session?" for this thread. */
+  onSessionDeleteConfirmed?(sessionId: string): void;
   onApprovalDecision(
     approvalId: string,
     approved: boolean,
@@ -182,6 +184,9 @@ export function handleAppKey(
   ctx: AppKeyContext,
 ): boolean {
   const { state, dispatch, callbacks, ctrlCArmed, setCtrlCArmed } = ctx;
+  if (state.sessionDelete) {
+    return handleSessionDeleteKey(input, key, ctx);
+  }
   if (state.pendingApproval) {
     return handleApprovalKey(input, key, state.pendingApproval, ctx);
   }
@@ -598,6 +603,52 @@ export function decideApproval(
       text: grantConfirmation(request, grant),
     });
   }
+}
+
+/**
+ * Keys for the "delete the session?" dialog. `y` deletes, `n` / Esc
+ * cancels, ←/→ and Tab move between the two controls, Enter runs the
+ * focused one — which starts on Cancel, so a reflexive Enter is a
+ * no-op rather than a lost thread.
+ *
+ * Every other key is swallowed: while a destructive confirmation is up,
+ * a stray letter must not reach the rail or the composer behind it.
+ */
+function handleSessionDeleteKey(
+  input: string,
+  key: Key,
+  ctx: AppKeyContext,
+): boolean {
+  const { state, dispatch, callbacks } = ctx;
+  const confirm = state.sessionDelete;
+  if (!confirm) return false;
+  if (key.ctrl || key.meta) return false;
+  const lower = input.toLowerCase();
+  const close = (): void => dispatch({ type: "session_delete_closed" });
+  if (key.escape || lower === "n") {
+    close();
+    return true;
+  }
+  if (lower === "y") {
+    callbacks.onSessionDeleteConfirmed?.(confirm.sessionId);
+    close();
+    return true;
+  }
+  if (key.leftArrow || key.rightArrow || key.tab) {
+    dispatch({
+      type: "session_delete_cursor_set",
+      cursor: confirm.cursor === "yes" ? "cancel" : "yes",
+    });
+    return true;
+  }
+  if (key.return) {
+    if (confirm.cursor === "yes") {
+      callbacks.onSessionDeleteConfirmed?.(confirm.sessionId);
+    }
+    close();
+    return true;
+  }
+  return true;
 }
 
 function handleApprovalKey(

--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -238,6 +238,11 @@ export function handleAppKey(
     if (handleSidebarKey(input, key, ctx)) return true;
   }
   if (key.ctrl && input === "c") {
+    // With text selected in the composer, Ctrl+C copies it — the
+    // convention every terminal-adjacent editor follows. The editor owns
+    // that; arming the quit chord here would make the same keystroke
+    // mean two things at once.
+    if (state.composerHasSelection) return false;
     if (ctrlCArmed) {
       callbacks.onAbort();
       callbacks.onQuit();

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -287,6 +287,40 @@ export class ChatOrchestrator {
     this.bus.emit({ type: "recent_sessions_updated", sessions });
   }
 
+  /**
+   * Remove a session for good, from the rail's `x` (confirmed).
+   *
+   * Deleting the thread the operator is *in* would leave the app
+   * pointed at a row that no longer exists, so that case rolls straight
+   * into a fresh session — the same landing `/new` gives. Deleting any
+   * other thread only refreshes the list.
+   *
+   * Refused mid-turn for the same reason switching is: the running turn
+   * writes its transcript back to the store when it finishes, which
+   * would resurrect the row that was just deleted.
+   */
+  deleteSession(sessionId: string): void {
+    if (this.quitting) return;
+    if (this.currentController) {
+      this.bus.emit({
+        type: "runtime_info",
+        line: "cannot delete a session while a turn is running — press Ctrl+C first",
+      });
+      return;
+    }
+    const deletingCurrent = this.session?.id === sessionId;
+    this.runtime.sessionStore.delete(sessionId);
+    this.bus.emit({
+      type: "system_message",
+      text: `session deleted${deletingCurrent ? " — started a fresh one" : ""}`,
+    });
+    if (deletingCurrent) {
+      this.newSession();
+      return;
+    }
+    this.refreshRecentSessions();
+  }
+
   switchSession(sessionId: string): void {
     if (this.quitting) return;
     if (this.currentController) {

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -269,22 +269,76 @@ export class ChatOrchestrator {
   }
 
   openSessionPicker(): void {
-    const sessions = this.runtime.sessionStore
-      .listRecent(25)
-      .map((s) => toPickerEntry(s));
-    this.bus.emit({ type: "session_picker_opened", sessions });
+    // Same list the rail shows. The menu's `N recent` badge counts the
+    // rail's entries, so a picker with its own idea of the set would
+    // open contradicting the number that advertised it.
+    this.bus.emit({
+      type: "session_picker_opened",
+      sessions: this.railSessions(),
+    });
   }
 
   /**
-   * Refreshes the always-on sidebar's session list. Called on TUI
-   * mount + after `session_created` / `session_switched` so the rail
-   * stays in sync without the user having to open the modal picker.
+   * The rail lists threads, not allocations. A session exists the moment
+   * `+ new` mints it — `runtime.createSession` persists it immediately,
+   * and scheduled tasks, webhooks and Telegram all depend on that — but
+   * an unnamed row is noise: it says "(empty)" until someone types, and
+   * two of them are indistinguishable.
+   *
+   * So the list shows sessions that have been *spoken to*. The catch is
+   * timing: the first user turn only reaches SQLite when the whole turn
+   * finishes (`executeTurn` saves after the loop returns), so a
+   * store-backed refresh at prompt time still sees nothing. `pendingRow`
+   * bridges that window with an entry built from the submitted text, and
+   * retires itself as soon as the store can answer for the same id.
    */
+  private pendingRow: SessionPickerEntry | null = null;
+
   refreshRecentSessions(): void {
-    const sessions = this.runtime.sessionStore
+    this.bus.emit({
+      type: "recent_sessions_updated",
+      sessions: this.railSessions(),
+    });
+  }
+
+  /** Stored threads that have a first prompt, plus the pending one. */
+  private railSessions(): SessionPickerEntry[] {
+    const stored = this.runtime.sessionStore
       .listRecent(25)
+      .filter((state) => hasFirstPrompt(state))
       .map((s) => toPickerEntry(s));
-    this.bus.emit({ type: "recent_sessions_updated", sessions });
+    const pending = this.pendingRow;
+    if (!pending) return stored;
+    // The store caught up: drop the stand-in rather than render the
+    // same session twice (the rail keys rows by session id).
+    if (stored.some((entry) => entry.sessionId === pending.sessionId)) {
+      this.pendingRow = null;
+      return stored;
+    }
+    return [pending, ...stored];
+  }
+
+  /**
+   * Put the current session on the rail the instant its first prompt is
+   * sent, named by that prompt. Called from `runOneTurn`, which is the
+   * one funnel every first turn passes through — `sendMessage` and
+   * `steerMessage` both land there, and hooking either alone would miss
+   * `/steer <text>` as an opening prompt.
+   */
+  private noteFirstPrompt(text: string): void {
+    const session = this.session;
+    if (!session) return;
+    if (this.pendingRow?.sessionId === session.id) return;
+    if (hasFirstPrompt(session)) return;
+    this.pendingRow = {
+      sessionId: session.id,
+      workingDir: session.workingDir,
+      turnCount: 1,
+      stepCount: 0,
+      updatedAt: Date.now(),
+      preview: text,
+    };
+    this.refreshRecentSessions();
   }
 
   /**
@@ -309,6 +363,7 @@ export class ChatOrchestrator {
       return;
     }
     const deletingCurrent = this.session?.id === sessionId;
+    if (this.pendingRow?.sessionId === sessionId) this.pendingRow = null;
     this.runtime.sessionStore.delete(sessionId);
     this.bus.emit({
       type: "system_message",
@@ -601,6 +656,7 @@ export class ChatOrchestrator {
 
   private async runOneTurn(text: string): Promise<void> {
     if (!this.session) return;
+    this.noteFirstPrompt(text);
     const controller = new AbortController();
     this.currentController = controller;
     // A new turn is in flight: whatever is still queued was aimed at an
@@ -643,6 +699,9 @@ export class ChatOrchestrator {
       this.exitCode = 1;
     } finally {
       if (this.currentController === controller) this.currentController = null;
+      // The turn wrote the session back, so the stored row can now
+      // answer for itself and the stand-in retires.
+      this.refreshRecentSessions();
     }
     const next = this.queue.shift();
     // Unconditional: the idle boundary re-syncs the strip even when
@@ -775,6 +834,16 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes}B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+/**
+ * Has anyone spoken to this session? The rail and the picker list only
+ * threads that have a first user turn — that turn is what gives a
+ * session its name, and an unnamed row is indistinguishable from every
+ * other unnamed row.
+ */
+function hasFirstPrompt(state: SessionState): boolean {
+  return state.turns.some((turn) => turn.kind === "user");
 }
 
 function toPickerEntry(state: SessionState): SessionPickerEntry {

--- a/src/tui/components/assistant-bubble.tsx
+++ b/src/tui/components/assistant-bubble.tsx
@@ -12,12 +12,14 @@ interface AssistantBubbleProps {
 }
 
 /**
- * opencode-style assistant reply bubble. Mirrors `UserBubble` (left
- * coloured border + vertical padding + `marginTop=1`) so the chat
- * surface reads as a two-colour ribbon instead of a labelled list.
- * Tool-step count and a final `●` glyph land in a meta-row **below**
- * the bubble (outside the border), again copied from opencode — the
- * label is the colour, not the inline text.
+ * The assistant reply. Mirrors `UserBubble`: an `AGENT` label over a
+ * coloured left border, with the tool-step count and a final `●` glyph
+ * in a meta-row **below** the bubble, outside the border.
+ *
+ * The label is the word AND the colour. Colour on its own carries
+ * nothing under NO_COLOR or in a pipe, and a reply that is only
+ * distinguishable by hue from the message that prompted it is a
+ * transcript nobody can skim.
  *
  * Markdown rendering is gated on `!streaming`: partial markdown
  * (half-opened `**`, fenced block missing its closing ```, dangling
@@ -32,6 +34,9 @@ export function AssistantBubble({
   const showFooter = !streaming && toolSteps !== undefined && toolSteps > 0;
   return (
     <Box flexDirection="column" marginTop={1}>
+      <Text color={theme.colors.assistant} bold>
+        {"  AGENT"}
+      </Text>
       <Box
         borderStyle="single"
         borderTop={false}
@@ -39,7 +44,6 @@ export function AssistantBubble({
         borderBottom={false}
         borderLeft
         borderColor={theme.colors.assistant}
-        paddingTop={1}
         paddingBottom={1}
         paddingLeft={2}
         paddingRight={1}

--- a/src/tui/components/chip.tsx
+++ b/src/tui/components/chip.tsx
@@ -1,0 +1,67 @@
+import { Text } from "ink";
+import type { ReactElement } from "react";
+import { theme } from "../theme/theme.js";
+
+/**
+ * A raised control: `+ new`, `≡ Menu`, `send →`.
+ *
+ * The design draws these as DOS-style buttons — a near-white face, dark
+ * text, a light bevel on the top/left and a dark one on the bottom/right.
+ * A terminal cell has no sub-cell bevel to draw, so the raised look falls
+ * back to what raised meant before bevels existed: a light face under
+ * dark text. `chipBackground` / `chipForeground` carry that pair per
+ * palette, so a chip stays legible on all twelve — including this one,
+ * where the rail it sits on is itself a colour.
+ *
+ * The padding spaces are part of the control: a chip with no ground
+ * either side of its label reads as highlighted text rather than as a
+ * button.
+ */
+export function Chip({
+  label,
+  tone = "raised",
+}: {
+  label: string;
+  /**
+   * `raised` is the button face. `badge` is the flatter, accent-tinted
+   * variant used for status — the `RUN` pill — which the design tints
+   * rather than raises.
+   */
+  tone?: "raised" | "badge";
+}): ReactElement {
+  if (tone === "badge") {
+    return (
+      <Text
+        color={theme.colors.accent}
+        backgroundColor={theme.colors.badgeBackground}
+        bold
+      >
+        {` ${label} `}
+      </Text>
+    );
+  }
+  return (
+    <Text
+      color={theme.colors.chipForeground}
+      backgroundColor={theme.colors.chipBackground}
+      bold
+    >
+      {` ${label} `}
+    </Text>
+  );
+}
+
+/**
+ * The design letter-spaces the `RUN` badge. A terminal grid cannot do
+ * fractional tracking, so the one honest approximation is a full space
+ * between letters — which doubles the word's width. That is affordable
+ * for a three-letter status word and absurd for `OBSERVE`, so anything
+ * longer than four characters is only upper-cased.
+ */
+const MAX_TRACKED_LENGTH = 4;
+
+export function tracked(label: string): string {
+  const upper = label.toUpperCase();
+  if (upper.length > MAX_TRACKED_LENGTH) return upper;
+  return upper.split("").join(" ");
+}

--- a/src/tui/components/debug-pane.tsx
+++ b/src/tui/components/debug-pane.tsx
@@ -32,6 +32,12 @@ import { ProvidersPanel } from "./providers-panel.js";
 interface DebugPaneProps {
   state: TuiState;
   maxVisible: number;
+  /**
+   * Whether the composer is on screen below the pane. It is not, on the
+   * Manage tabs — so those panels really do have six more rows to spend,
+   * and budgeting as if it were there leaves them dead.
+   */
+  composerVisible: boolean;
   onMcpAddJsonChange?: (json: string) => void;
   onMcpAddSubmit?: (json: string) => void;
   onMcpAddCancel?: () => void;
@@ -49,6 +55,7 @@ interface DebugPaneProps {
 export function DebugPane({
   state,
   maxVisible,
+  composerVisible,
   onMcpAddJsonChange,
   onMcpAddSubmit,
   onMcpAddCancel,
@@ -61,6 +68,7 @@ export function DebugPane({
       <ActiveDebugTab
         state={state}
         maxVisible={maxVisible}
+        composerVisible={composerVisible}
         onMcpAddJsonChange={onMcpAddJsonChange}
         onMcpAddSubmit={onMcpAddSubmit}
         onMcpAddCancel={onMcpAddCancel}
@@ -162,15 +170,31 @@ function buildManageTabs(state: TuiState): SubTab[] {
 }
 
 /**
- * Height consumed by the always-on app frame OUTSIDE the debug pane:
- * the top `StatusBar` (1 row) + the `PromptShell` (≈6 rows: top margin,
- * the rounded frame's two border rows, the editor line and the action
- * bar) + the
- * `HotkeyHint` (1 row). Ink 7 does NOT clip a frame taller than the
- * terminal — it overlaps/garbles earlier lines instead (verified) — so
- * the per-tab budget must subtract this accurately and err generous.
+ * Height consumed by the always-on app frame OUTSIDE the debug pane
+ * when the composer is NOT on screen: the top `StatusBar` (1 row), the
+ * hairline under it (1) and the `HotkeyHint` (1).
  */
-export const APP_CHROME_ROWS = 9;
+export const APP_CHROME_ROWS_BASE = 3;
+/**
+ * Rows the `PromptShell` costs when it is mounted: a top margin, the
+ * rounded frame's two border rows, the editor line and the action bar.
+ */
+export const COMPOSER_ROWS = 6;
+/**
+ * Height consumed by the always-on app frame OUTSIDE the debug pane.
+ * Ink 7 does NOT clip a frame taller than the terminal — it overlaps /
+ * garbles earlier lines instead (verified) — so the per-tab budget must
+ * subtract this accurately and err generous.
+ *
+ * The composer is only on screen on the Run screen, so its rows are
+ * conditional: a Manage tab really does have six more rows to spend, and
+ * budgeting as if the composer were still there leaves them dead.
+ */
+export function appChromeRows(composerVisible: boolean): number {
+  return APP_CHROME_ROWS_BASE + (composerVisible ? COMPOSER_ROWS : 0);
+}
+/** Back-compat alias: the chat-screen total. */
+export const APP_CHROME_ROWS = APP_CHROME_ROWS_BASE + COMPOSER_ROWS;
 /**
  * Height consumed INSIDE the debug pane above the active tab: the
  * `SubTabBar` (1 row) + the `DebugDiagnosticsLine`. The diagnostics line
@@ -201,28 +225,33 @@ const MIN_LIST_ROWS = 3;
  * Total number of rows available for an active tab's own content
  * (panel chrome + its list), derived from the live terminal height.
  */
-function tabContentBudget(terminalRows: number): number {
+function tabContentBudget(terminalRows: number, composerVisible: boolean): number {
   return Math.max(
     MIN_LIST_ROWS,
-    terminalRows - APP_CHROME_ROWS - DEBUG_TAB_CHROME_ROWS - RENDER_SAFETY_ROWS,
+    terminalRows -
+      appChromeRows(composerVisible) -
+      DEBUG_TAB_CHROME_ROWS -
+      RENDER_SAFETY_ROWS,
   );
 }
 
 function ActiveDebugTab({
   state,
   maxVisible,
+  composerVisible,
   onMcpAddJsonChange,
   onMcpAddSubmit,
   onMcpAddCancel,
 }: {
   state: TuiState;
   maxVisible: number;
+  composerVisible: boolean;
   onMcpAddJsonChange?: (json: string) => void;
   onMcpAddSubmit?: (json: string) => void;
   onMcpAddCancel?: () => void;
 }): ReactElement {
   const { rows: terminalRows } = useTerminalSize();
-  const tabBudget = tabContentBudget(terminalRows);
+  const tabBudget = tabContentBudget(terminalRows, composerVisible);
   // Compact panels have a tiny fixed header, so they get the list slice
   // directly. LLM / Models own large fixed chrome (RouteCard / status
   // footer) that they collapse themselves, so they receive the full

--- a/src/tui/components/hotkey-hint.test.tsx
+++ b/src/tui/components/hotkey-hint.test.tsx
@@ -117,7 +117,10 @@ describe("HotkeyHint draft chips", () => {
     expect(out).not.toContain("clear draft");
     expect(out).toContain("[ctrl+p]");
     expect(out).toContain("menu");
-    expect(chipCount(out)).toBe(6);
+    // On an empty buffer Esc opens the menu, so the strip says so — the
+    // same slot that carries `clear draft` once there is a draft.
+    expect(out).toContain("[esc]");
+    expect(chipCount(out)).toBe(7);
   });
 
   it("tells the operator the draft survives an abort mid-turn", () => {

--- a/src/tui/components/hotkey-hint.tsx
+++ b/src/tui/components/hotkey-hint.tsx
@@ -9,6 +9,7 @@ import {
 } from "../mouse/mouse-context.js";
 import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { cycleNavSlot } from "../section.js";
+import { hasShiftEnterNewline } from "../shift-enter-support.js";
 import { theme } from "../theme/theme.js";
 import type { TuiState } from "../tui-state.js";
 
@@ -251,7 +252,15 @@ function resolveChips(
   // with a non-empty buffer, so nothing usable is displaced.
   return [
     { key: "enter", label: "send" },
-    { key: "alt+enter", label: "newline", shed: 3 },
+    // Shift+Enter only exists as a keystroke where the terminal speaks
+    // the kitty keyboard protocol; everywhere else it is byte-identical
+    // to Enter and would submit. Alt+Enter works in both worlds, so it
+    // is what the strip promises when the protocol is absent.
+    {
+      key: hasShiftEnterNewline() ? "shift+enter" : "alt+enter",
+      label: "newline",
+      shed: 3,
+    },
     {
       key: "tab",
       label: "sidebar",

--- a/src/tui/components/hotkey-hint.tsx
+++ b/src/tui/components/hotkey-hint.tsx
@@ -260,8 +260,13 @@ function resolveChips(
         mouse.dispatch({ type: "chat_focus_set", focus: "sidebar" }),
     },
     { key: SCROLL_KEY, label: "scroll", shed: 1 },
+    // Esc opens the menu only on an empty buffer — with a draft it
+    // clears the draft — so the strip advertises whichever one the next
+    // press will actually do.
+    ...(hasDraft
+      ? [{ key: "esc", label: "clear draft" }]
+      : [{ key: "esc", label: "menu", shed: 5 }]),
     { key: "ctrl+p", label: "menu", shed: 4 },
-    ...(hasDraft ? [{ key: "esc", label: "clear draft" }] : []),
     {
       key: "ctrl+c",
       label: ctrlCArmed ? "press again to quit" : "quit",

--- a/src/tui/components/multi-line-editor-body.tsx
+++ b/src/tui/components/multi-line-editor-body.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
-import { useMouseTarget } from "../mouse/mouse-context.js";
+import { useMouseCommands, useMouseTarget } from "../mouse/mouse-context.js";
 import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { theme } from "../theme/theme.js";
 import type { Cursor } from "./multi-line-editor-cursor.js";
@@ -13,6 +13,17 @@ export interface EditorBodyProps {
   cursor: Cursor;
   placeholder: string;
   focus: boolean;
+  /**
+   * Selected span as buffer offsets, `[start, end)`, or `null`. Painted
+   * in inverse video — the same mark the caret uses, because a terminal
+   * has exactly one way to say "this text is picked out" and no colour
+   * that survives every palette.
+   */
+  selection?: readonly [number, number] | null;
+  /** Buffer offset of the first character of each rendered line. */
+  onDragStart?: (row: number, col: number) => void;
+  onDragMove?: (row: number, col: number) => void;
+  onDragEnd?: () => void;
   /**
    * Move the caret to a clicked cell. `row`/`col` are already relative
    * to the text, gutter excluded; the owner clamps and converts them to
@@ -32,15 +43,43 @@ export function EditorBody({
   cursor,
   placeholder,
   focus,
+  selection = null,
   onClickCursor,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
 }: EditorBodyProps): ReactElement {
   // One target for the whole buffer: the click's local row is the line,
   // its local column minus the gutter is the character. Lines are not
   // soft-wrapped here, so the mapping is exact.
+  const mouse = useMouseCommands();
   const bodyRef = useMouseTarget((hit) => {
-    if (!isPrimaryPress(hit.event) || !onClickCursor) return false;
-    onClickCursor(hit.localY, hit.localX - GUTTER_COLUMNS);
-    return true;
+    const row = hit.localY;
+    const col = hit.localX - GUTTER_COLUMNS;
+    // A press starts a drag AND places the caret: press-move-release is
+    // one gesture, and a press that turns out to be a plain click has
+    // already done the right thing by the time the release arrives.
+    if (isPrimaryPress(hit.event)) {
+      onClickCursor?.(row, col);
+      onDragStart?.(row, col);
+      // Take the pointer for the gesture: hit-testing routes by
+      // position, so a drag that wanders out of the composer would
+      // otherwise deliver its motion — and its release — to whatever
+      // sits under the cursor, leaving the selection neither extended
+      // nor ended.
+      mouse?.registry.capturePointer(bodyRef);
+      return true;
+    }
+    if (hit.event.kind === "motion" && hit.event.button === "left") {
+      onDragMove?.(row, col);
+      return true;
+    }
+    if (hit.event.kind === "release") {
+      mouse?.registry.releasePointer();
+      onDragEnd?.();
+      return true;
+    }
+    return false;
   });
   if (value.length === 0) {
     return (
@@ -52,6 +91,13 @@ export function EditorBody({
     );
   }
   const lines = value.split("\n");
+  // Buffer offset of each line's first character; +1 per newline.
+  const lineStarts: number[] = [];
+  let offset = 0;
+  for (const line of lines) {
+    lineStarts.push(offset);
+    offset += line.length + 1;
+  }
   return (
     <Box flexDirection="column" ref={bodyRef}>
       {lines.map((line, idx) => (
@@ -59,22 +105,51 @@ export function EditorBody({
           <Text color={theme.colors.accent}>
             {idx === 0 ? `${theme.glyphs.promptCaret} ` : "  "}
           </Text>
-          {renderLineWithCursor(
+          {renderLine({
             line,
-            idx === cursor.row ? cursor.col : -1,
+            cursorCol: idx === cursor.row ? cursor.col : -1,
             focus,
-          )}
+            // Offsets of this line within the buffer, so the selection
+            // (which is buffer-relative) can be clipped to it.
+            lineStart: lineStarts[idx] ?? 0,
+            selection,
+          })}
         </Box>
       ))}
     </Box>
   );
 }
 
-function renderLineWithCursor(
-  line: string,
-  cursorCol: number,
-  focus: boolean,
-): ReactElement {
+/**
+ * One rendered line: the selected span in inverse video, and the caret
+ * as an inverse cell. When both want the same cell the selection wins —
+ * a caret drawn inside a highlighted run would be an inverse cell on an
+ * inverse ground, i.e. invisible.
+ */
+function renderLine({
+  line,
+  cursorCol,
+  focus,
+  lineStart,
+  selection,
+}: {
+  line: string;
+  cursorCol: number;
+  focus: boolean;
+  lineStart: number;
+  selection: readonly [number, number] | null;
+}): ReactElement {
+  const span = selection ? clipToLine(selection, lineStart, line.length) : null;
+  if (span) {
+    const [from, to] = span;
+    return (
+      <Text>
+        {line.slice(0, from)}
+        <Text inverse>{line.slice(from, to)}</Text>
+        {line.slice(to)}
+      </Text>
+    );
+  }
   if (cursorCol < 0 || !focus) {
     return <Text>{line}</Text>;
   }
@@ -88,4 +163,20 @@ function renderLineWithCursor(
       {after}
     </Text>
   );
+}
+
+/**
+ * Intersect a buffer-relative selection with one line, returning
+ * line-relative columns, or `null` when the line is outside it.
+ */
+function clipToLine(
+  selection: readonly [number, number],
+  lineStart: number,
+  lineLength: number,
+): [number, number] | null {
+  const lineEnd = lineStart + lineLength;
+  const from = Math.max(selection[0], lineStart);
+  const to = Math.min(selection[1], lineEnd);
+  if (to <= from) return null;
+  return [from - lineStart, to - lineStart];
 }

--- a/src/tui/components/multi-line-editor-newline.test.tsx
+++ b/src/tui/components/multi-line-editor-newline.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+import { MultiLineEditor } from "./multi-line-editor.js";
+
+/**
+ * Enter versus newline, at the byte level.
+ *
+ * The distinction is a terminal-protocol fact, not an app choice: in the
+ * legacy encoding Enter and Shift+Enter are the same byte (`\r`), so the
+ * modifier is invisible and Shift+Enter cannot mean anything. Under the
+ * kitty keyboard protocol (which `tui-command` negotiates at startup
+ * when the terminal answers `CSI ? u`) Shift+Enter arrives as
+ * `ESC [ 13 ; 2 u` and the composer's existing `key.shift` branch fires.
+ *
+ * These cases drive real byte sequences through Ink's own parser, which
+ * is the only way to tell the two encodings apart from a test.
+ */
+const CSI = String.fromCharCode(27) + "[";
+
+const CASES: ReadonlyArray<{
+  name: string;
+  bytes: string;
+  expect: "submit" | "newline";
+}> = [
+  { name: "legacy Enter", bytes: "\r", expect: "submit" },
+  // The one that cannot be fixed in JS: identical bytes to Enter.
+  { name: "legacy Shift+Enter", bytes: "\r", expect: "submit" },
+  { name: "legacy Alt+Enter", bytes: String.fromCharCode(27) + "\r", expect: "newline" },
+  { name: "legacy Ctrl+J", bytes: "\n", expect: "newline" },
+  { name: "kitty Enter", bytes: `${CSI}13u`, expect: "submit" },
+  { name: "kitty Shift+Enter", bytes: `${CSI}13;2u`, expect: "newline" },
+  { name: "kitty Alt+Enter", bytes: `${CSI}13;3u`, expect: "newline" },
+  { name: "kitty Ctrl+Enter", bytes: `${CSI}13;5u`, expect: "newline" },
+  // Under kitty this stops being a literal "\n" and becomes ctrl+j.
+  { name: "kitty Ctrl+J", bytes: `${CSI}106;5u`, expect: "newline" },
+];
+
+describe("composer newline encoding", () => {
+  for (const testCase of CASES) {
+    it(`${testCase.name} → ${testCase.expect}`, async () => {
+      const onSubmit = vi.fn();
+      const onChange = vi.fn();
+      const { stdin, unmount } = render(
+        <MultiLineEditor
+          value="hi"
+          focus
+          onChange={onChange}
+          onSubmit={onSubmit}
+        />,
+      );
+      await new Promise((r) => setTimeout(r, 30));
+      stdin.write(testCase.bytes);
+      await new Promise((r) => setTimeout(r, 60));
+
+      if (testCase.expect === "submit") {
+        expect(onSubmit).toHaveBeenCalledWith("hi");
+        expect(onChange).not.toHaveBeenCalled();
+      } else {
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(onChange).toHaveBeenCalledWith("hi\n");
+      }
+      unmount();
+    });
+  }
+});

--- a/src/tui/components/multi-line-editor-selection.test.tsx
+++ b/src/tui/components/multi-line-editor-selection.test.tsx
@@ -1,0 +1,144 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+import { ClipboardProvider } from "../clipboard/clipboard-context.js";
+import type { ClipboardWriter } from "../clipboard/copy-to-clipboard.js";
+import { MultiLineEditor } from "./multi-line-editor.js";
+
+/**
+ * Selecting text in the composer, and copying it.
+ *
+ * The terminal takes its own drag-to-select away the moment mouse
+ * reporting is on, so the composer has to provide the gesture itself:
+ * Shift+arrows from the keyboard, click-drag from the mouse, and
+ * Ctrl+C to copy what is picked.
+ */
+const CSI = String.fromCharCode(27) + "[";
+/** xterm modifier encoding: 1 + 1 = shift. */
+const SHIFT_LEFT = CSI + "1;2D";
+const SHIFT_RIGHT = CSI + "1;2C";
+const CTRL_C = String.fromCharCode(3);
+
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 40));
+
+function writer(): ClipboardWriter & { copied: string[] } {
+  const copied: string[] = [];
+  return {
+    copied,
+    copy: async (text: string) => {
+      copied.push(text);
+      return true;
+    },
+  };
+}
+
+function mount(value: string, clipboard: ClipboardWriter) {
+  const onChange = vi.fn();
+  const onSubmit = vi.fn();
+  const onInterrupt = vi.fn();
+  const onSelectionChange = vi.fn();
+  const app = render(
+    <ClipboardProvider writer={clipboard}>
+      <MultiLineEditor
+        value={value}
+        focus
+        onChange={onChange}
+        onSubmit={onSubmit}
+        onInterrupt={onInterrupt}
+        onSelectionChange={onSelectionChange}
+      />
+    </ClipboardProvider>,
+  );
+  return { ...app, onChange, onSubmit, onInterrupt, onSelectionChange };
+}
+
+describe("composer selection", () => {
+  it("extends a selection with shift+arrows and copies it with ctrl+c", async () => {
+    const clipboard = writer();
+    const app = mount("hello world", clipboard);
+    await settle();
+    // The caret starts at the end; three shift+lefts pick "rld".
+    for (let i = 0; i < 3; i += 1) {
+      app.stdin.write(SHIFT_LEFT);
+      // One keystroke per tick: `handleKey` reads the caret from the
+      // render closure, so a burst written into a single tick would all
+      // move from the same starting point.
+      await settle();
+    }
+    expect(app.onSelectionChange).toHaveBeenLastCalledWith(true);
+
+    app.stdin.write(CTRL_C);
+    await settle();
+    expect(clipboard.copied).toEqual(["rld"]);
+    // Copy is not an interrupt while text is picked.
+    expect(app.onInterrupt).not.toHaveBeenCalled();
+    app.unmount();
+  });
+
+  it("still interrupts on ctrl+c when nothing is selected", async () => {
+    const clipboard = writer();
+    const app = mount("hello", clipboard);
+    await settle();
+    app.stdin.write(CTRL_C);
+    await settle();
+    expect(app.onInterrupt).toHaveBeenCalled();
+    expect(clipboard.copied).toEqual([]);
+    app.unmount();
+  });
+
+  it("collapses the selection on an unshifted move", async () => {
+    const clipboard = writer();
+    const app = mount("hello", clipboard);
+    await settle();
+    app.stdin.write(SHIFT_LEFT);
+    await settle();
+    expect(app.onSelectionChange).toHaveBeenLastCalledWith(true);
+    app.stdin.write(CSI + "D");
+    await settle();
+    expect(app.onSelectionChange).toHaveBeenLastCalledWith(false);
+    app.unmount();
+  });
+
+  it("replaces the selection when the operator types over it", async () => {
+    const clipboard = writer();
+    const app = mount("hello", clipboard);
+    await settle();
+    for (let i = 0; i < 2; i += 1) {
+      app.stdin.write(SHIFT_LEFT);
+      await settle();
+    }
+    app.stdin.write("y");
+    await settle();
+    expect(app.onChange).toHaveBeenLastCalledWith("hely");
+    app.unmount();
+  });
+
+  it("deletes the selection on backspace", async () => {
+    const clipboard = writer();
+    const app = mount("hello", clipboard);
+    await settle();
+    for (let i = 0; i < 2; i += 1) {
+      app.stdin.write(SHIFT_LEFT);
+      await settle();
+    }
+    app.stdin.write(String.fromCharCode(127));
+    await settle();
+    expect(app.onChange).toHaveBeenLastCalledWith("hel");
+    app.unmount();
+  });
+
+  it("paints the selected span in inverse video", async () => {
+    const clipboard = writer();
+    const app = mount("hello", clipboard);
+    await settle();
+    for (let i = 0; i < 2; i += 1) {
+      app.stdin.write(SHIFT_LEFT);
+      await settle();
+    }
+    // ink-testing-library strips colour, so assert on the buffer text
+    // staying intact rather than on the escape codes.
+    expect(app.lastFrame() ?? "").toContain("hello");
+    app.unmount();
+  });
+})

--- a/src/tui/components/multi-line-editor.tsx
+++ b/src/tui/components/multi-line-editor.tsx
@@ -1,5 +1,6 @@
 import { Box, useInput, type Key } from "ink";
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
+import { useClipboard } from "../clipboard/clipboard-context.js";
 import { theme } from "../theme/theme.js";
 import { EditorBody } from "./multi-line-editor-body.js";
 import {
@@ -54,6 +55,15 @@ export interface MultiLineEditorProps {
    * itself because focus lives in the app's state.
    */
   onClickFocus?: () => void;
+  /**
+   * The selection appeared or disappeared. The app lifts this into its
+   * own state because Ctrl+C means "copy" while text is selected and
+   * "stop / quit" otherwise, and those two handlers live in different
+   * key layers.
+   */
+  onSelectionChange?: (hasSelection: boolean) => void;
+  /** Text was copied to the clipboard, so the app can say so. */
+  onCopy?: (text: string) => void;
 }
 
 /**
@@ -87,8 +97,19 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
     onAutocomplete,
     bare = false,
     onClickFocus,
+    onSelectionChange,
+    onCopy,
   } = props;
   const [cursorPos, setCursorPos] = useState<number>(value.length);
+  /**
+   * Where the current selection was started, or `null` when there is
+   * none. The other end is always the caret, so extending a selection is
+   * just moving the caret and leaving the anchor where it was — the same
+   * model every text editor uses, and the reason Shift+arrow needs no
+   * separate bookkeeping.
+   */
+  const [anchor, setAnchor] = useState<number | null>(null);
+  const clipboard = useClipboard();
   // Distinguish our own edits (keystrokes routed through `setBuffer`)
   // from external buffer replacements: slash-seeding from panel hotkeys
   // (the LLM tab dispatches `input_changed "/"` on `/`), history recall,
@@ -104,6 +125,16 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
     lastInternalValue.current = value;
     setCursorPos(value.length);
   }, [value]);
+
+  /** `[start, end)` in buffer offsets, or `null` when nothing is picked. */
+  const selection: readonly [number, number] | null =
+    anchor === null || anchor === cursorPos
+      ? null
+      : [Math.min(anchor, cursorPos), Math.max(anchor, cursorPos)];
+  const hasSelection = selection !== null;
+  useEffect(() => {
+    onSelectionChange?.(hasSelection);
+  }, [hasSelection, onSelectionChange]);
 
   const setBuffer = useCallback(
     (next: string, nextCursor: number) => {
@@ -136,6 +167,10 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
         value,
         cursor: cursorPos,
         setBuffer,
+        selection,
+        anchor,
+        setAnchor,
+        copySelection,
         onSubmit,
         onEscape,
         onInterrupt,
@@ -157,11 +192,58 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
    * in the empty space to the right of a line meaning "end of this
    * line", which is what every editor does.
    */
+  /** Buffer offset for a clicked cell, clamped to the line. */
+  const offsetAt = (row: number, col: number): number => {
+    const lines = value.split("\n");
+    const safeRow = Math.max(0, Math.min(row, lines.length - 1));
+    const safeCol = Math.max(0, Math.min(col, (lines[safeRow] ?? "").length));
+    return rowColToCursor(lines, safeRow, safeCol);
+  };
+
+  /**
+   * Press: drop the anchor and take the pointer. Capture matters because
+   * hit-testing routes by position — without it, a drag that wanders out
+   * of the composer would deliver its motion, and its release, to
+   * whatever sits under the cursor, and the selection would neither
+   * extend nor end.
+   */
+  const beginDrag = (row: number, col: number): void => {
+    if (disabled) return;
+    setAnchor(offsetAt(row, col));
+  };
+
+  const extendDrag = (row: number, col: number): void => {
+    if (disabled) return;
+    setCursorPos(offsetAt(row, col));
+  };
+
+  const endDrag = (): void => {
+    // A drag that never moved is a click, not a selection.
+    setAnchor((current) => (current === null || current === cursorPos ? null : current));
+  };
+
+  /**
+   * Copy the selection. Both mechanisms in `copy-to-clipboard` are
+   * advisory in their own way — OSC 52 has no reply and the platform
+   * command may not exist — so the app is told what was copied and lets
+   * the operator judge; a silent failure would be worse than a claim.
+   */
+  const copySelection = (): void => {
+    if (!selection) return;
+    const text = value.slice(selection[0], selection[1]);
+    if (text.length === 0) return;
+    void clipboard.copy(text);
+    onCopy?.(text);
+  };
+
   const placeCursorAt = (row: number, col: number): void => {
     if (disabled) return;
     // Ask for focus first: a click that moves a caret the operator
     // cannot then type into is a click that did nothing.
     onClickFocus?.();
+    // A fresh press collapses whatever was selected — `beginDrag` sets
+    // the new anchor immediately afterwards.
+    setAnchor(null);
     const lines = value.split("\n");
     const safeRow = Math.max(0, Math.min(row, lines.length - 1));
     const safeCol = Math.max(0, Math.min(col, (lines[safeRow] ?? "").length));
@@ -174,7 +256,11 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
         cursor={cursor}
         placeholder={placeholder ?? ""}
         focus={focus && !disabled}
+        selection={selection}
         onClickCursor={placeCursorAt}
+        onDragStart={beginDrag}
+        onDragMove={extendDrag}
+        onDragEnd={endDrag}
       />
     );
   }
@@ -190,7 +276,11 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
         cursor={cursor}
         placeholder={placeholder ?? ""}
         focus={focus && !disabled}
+        selection={selection}
         onClickCursor={placeCursorAt}
+        onDragStart={beginDrag}
+        onDragMove={extendDrag}
+        onDragEnd={endDrag}
       />
     </Box>
   );
@@ -202,6 +292,13 @@ interface KeyContext {
   value: string;
   cursor: number;
   setBuffer: (next: string, cursor: number) => void;
+  /** Selected span in buffer offsets, or `null`. */
+  selection: readonly [number, number] | null;
+  /** Where the selection was started; `null` means none is active. */
+  anchor: number | null;
+  setAnchor: (anchor: number | null) => void;
+  /** Copy the current selection; the caller keeps or clears it. */
+  copySelection: () => void;
   onSubmit: (value: string) => void;
   onEscape?: () => void;
   onInterrupt?: () => void;
@@ -213,10 +310,21 @@ interface KeyContext {
 }
 
 function handleKey(ctx: KeyContext): void {
-  const { input, key, value, cursor, setBuffer } = ctx;
-  if (key.ctrl && input === "c" && ctx.onInterrupt) {
-    ctx.onInterrupt();
-    return;
+  const { input, key, value, cursor, setBuffer, selection } = ctx;
+  if (key.ctrl && input === "c") {
+    // Selected text turns Ctrl+C into copy, the way it behaves in every
+    // editor people arrive from. With nothing selected it is still the
+    // interrupt — `app-key-bindings` stands down for the first case, so
+    // one keystroke never means both.
+    if (selection) {
+      ctx.copySelection();
+      ctx.setAnchor(null);
+      return;
+    }
+    if (ctx.onInterrupt) {
+      ctx.onInterrupt();
+      return;
+    }
   }
   // Ignore keys owned by the global app-level handler so the editor
   // never inserts Ctrl+C as "c" or swallows F-key escape sequences.
@@ -231,6 +339,14 @@ function handleKey(ctx: KeyContext): void {
   }
   if (key.tab) {
     ctx.onTab?.();
+    return;
+  }
+  // Ctrl+J is a documented newline binding. In the legacy encoding it
+  // arrives as a literal "\n" and falls through to the text-insert path
+  // below; under the kitty protocol it arrives as `ctrl` + `j` and would
+  // otherwise be dropped by the catch-all, silently losing the binding.
+  if (key.ctrl && input === "j") {
+    insertText(ctx, "\n");
     return;
   }
   if (key.return) {
@@ -249,34 +365,56 @@ function handleKey(ctx: KeyContext): void {
     return;
   }
   if (key.upArrow) {
-    if (isOnFirstLine(value, cursor)) {
+    // Shift+Up on the first line extends to the start of the buffer
+    // instead of recalling history — history would replace the very
+    // text being selected.
+    if (isOnFirstLine(value, cursor) && !key.shift) {
       ctx.onHistoryPrev?.();
+      return;
+    }
+    updateAnchorForMove(ctx);
+    if (isOnFirstLine(value, cursor)) {
+      setBuffer(value, 0);
       return;
     }
     moveCursorVertically(ctx, -1);
     return;
   }
   if (key.downArrow) {
-    if (isOnLastLine(value, cursor)) {
+    if (isOnLastLine(value, cursor) && !key.shift) {
       ctx.onHistoryNext?.();
+      return;
+    }
+    updateAnchorForMove(ctx);
+    if (isOnLastLine(value, cursor)) {
+      setBuffer(value, value.length);
       return;
     }
     moveCursorVertically(ctx, 1);
     return;
   }
   if (key.leftArrow) {
+    updateAnchorForMove(ctx);
     setBuffer(value, Math.max(0, cursor - 1));
     return;
   }
   if (key.rightArrow) {
-    if (cursor >= value.length && ctx.onAutocomplete) {
+    // Shift+Right extends the selection to the end of the buffer rather
+    // than accepting a completion: the operator is picking text, not
+    // asking for the rest of a command.
+    if (cursor >= value.length && ctx.onAutocomplete && !key.shift) {
       ctx.onAutocomplete();
       return;
     }
+    updateAnchorForMove(ctx);
     setBuffer(value, Math.min(value.length, cursor + 1));
     return;
   }
   if (key.backspace || key.delete) {
+    if (selection) {
+      deleteSelection(ctx);
+      return;
+    }
     if (key.delete && !key.backspace) {
       // Forward delete
       if (cursor < value.length) {
@@ -341,11 +479,43 @@ function isGlobalHotkey(input: string, key: Key): boolean {
 }
 
 function insertText(ctx: KeyContext, text: string): void {
-  const { value, cursor, setBuffer } = ctx;
+  const { value, cursor, setBuffer, selection } = ctx;
   const clean = normalizeInsertText(text);
   if (clean.length === 0) return;
+  // Typing over a selection replaces it, which is what every editor
+  // does and what makes select-then-retype work.
+  if (selection) {
+    const [from, to] = selection;
+    ctx.setAnchor(null);
+    const next = value.slice(0, from) + clean + value.slice(to);
+    setBuffer(next, from + clean.length);
+    return;
+  }
   const next = value.slice(0, cursor) + clean + value.slice(cursor);
   setBuffer(next, cursor + clean.length);
+}
+
+/** Remove the selected span and put the caret where it started. */
+function deleteSelection(ctx: KeyContext): void {
+  const { value, setBuffer, selection } = ctx;
+  if (!selection) return;
+  const [from, to] = selection;
+  ctx.setAnchor(null);
+  setBuffer(value.slice(0, from) + value.slice(to), from);
+}
+
+/**
+ * Called before every caret move. Shift keeps (or drops) an anchor so
+ * the move extends a selection; an unshifted move collapses it. Holding
+ * the anchor rather than a range is what lets one rule cover every
+ * movement key.
+ */
+function updateAnchorForMove(ctx: KeyContext): void {
+  if (ctx.key.shift) {
+    if (ctx.anchor === null) ctx.setAnchor(ctx.cursor);
+    return;
+  }
+  if (ctx.anchor !== null) ctx.setAnchor(null);
 }
 
 function moveCursorVertically(ctx: KeyContext, direction: -1 | 1): void {

--- a/src/tui/components/multi-line-editor.tsx
+++ b/src/tui/components/multi-line-editor.tsx
@@ -47,6 +47,13 @@ export interface MultiLineEditorProps {
    * editor body.
    */
   bare?: boolean;
+  /**
+   * The operator clicked into the buffer. Fired even when the editor is
+   * not focused — clicking an input is how every other application is
+   * told "put the keyboard here", and the editor cannot move focus
+   * itself because focus lives in the app's state.
+   */
+  onClickFocus?: () => void;
 }
 
 /**
@@ -79,6 +86,7 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
     onShiftTab,
     onAutocomplete,
     bare = false,
+    onClickFocus,
   } = props;
   const [cursorPos, setCursorPos] = useState<number>(value.length);
   // Distinguish our own edits (keystrokes routed through `setBuffer`)
@@ -151,6 +159,9 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
    */
   const placeCursorAt = (row: number, col: number): void => {
     if (disabled) return;
+    // Ask for focus first: a click that moves a caret the operator
+    // cannot then type into is a click that did nothing.
+    onClickFocus?.();
     const lines = value.split("\n");
     const safeRow = Math.max(0, Math.min(row, lines.length - 1));
     const safeCol = Math.max(0, Math.min(col, (lines[safeRow] ?? "").length));

--- a/src/tui/components/prompt-meta-bar.tsx
+++ b/src/tui/components/prompt-meta-bar.tsx
@@ -120,15 +120,15 @@ function ComposerButton({
   onPress,
 }: ComposerButtonProps): ReactElement {
   const background = !enabled
-    ? theme.colors.railBackground
+    ? theme.colors.badgeBackground
     : primary
-      ? theme.colors.accent
+      ? theme.colors.chipBackground
       : theme.colors.border;
   const foreground = !enabled
-    ? theme.colors.railMuted
+    ? theme.colors.muted
     : primary
-      ? theme.colors.railForeground
-      : theme.colors.railBackground;
+      ? theme.colors.chipForeground
+      : theme.colors.chipBackground;
   const chip = (
     <Text backgroundColor={background} color={foreground} bold={enabled}>
       {label}

--- a/src/tui/components/prompt-shell.tsx
+++ b/src/tui/components/prompt-shell.tsx
@@ -92,7 +92,20 @@ export function PromptShell(props: PromptShellProps): ReactElement {
   const canSend = !disabled && value.trim().length > 0;
   return (
     <Box flexDirection="column" marginTop={1} flexShrink={0}>
-      <Box borderStyle="round" borderColor={accent} flexDirection="column">
+      {/*
+        The design seats the composer on its own panel rather than on the
+        page. `badgeBackground` is the palette's one-step-off-the-ground
+        surface, so the panel reads on every theme — and, unlike painting
+        it in the accent, it leaves the editor's own (uncoloured) text
+        legible, which matters because the buffer is drawn by
+        `MultiLineEditor` with no foreground of its own.
+      */}
+      <Box
+        borderStyle="round"
+        borderColor={accent}
+        backgroundColor={theme.colors.badgeBackground}
+        flexDirection="column"
+      >
         {/*
           Padding lives on the editor row, not on the frame: the action
           bar has to reach both borders for its ground to read as a

--- a/src/tui/components/session-delete-modal.tsx
+++ b/src/tui/components/session-delete-modal.tsx
@@ -1,0 +1,183 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+
+import {
+  MouseTarget,
+  useMouseCommands,
+  useMouseTarget,
+} from "../mouse/mouse-context.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { MOUSE_LAYER_MODAL } from "../mouse/mouse-registry.js";
+import { chromeTheme } from "../theme/theme.js";
+import type { SessionDeleteConfirm } from "../tui-state.js";
+
+/** Popup width, clamped to the pane on narrow windows. */
+const PREFERRED_WIDTH = 48;
+
+interface SessionDeleteModalProps {
+  confirm: SessionDeleteConfirm;
+  /** Rows available in the pane the dialog floats over. */
+  availableRows: number;
+  /** Columns available in that pane. */
+  availableColumns: number;
+  onConfirm: (sessionId: string) => void;
+  onCancel: () => void;
+  onFocus: (cursor: "yes" | "cancel") => void;
+}
+
+/**
+ * "Delete the session?" — the same surface as the operator menu: a
+ * painted panel centred in the content pane, the app dimmed behind it,
+ * and the same mouse contract (click a control, click outside to
+ * dismiss, wheel swallowed rather than scrolling the transcript
+ * underneath).
+ *
+ * The two controls are deliberately unlike each other. `Yes` is the
+ * raised chip the composer uses for Send — the affirmative control
+ * everywhere else in the app. `Cancel` is the same footprint drawn as
+ * an outline: a frame in the panel's own foreground with no fill, which
+ * is what "secondary" looks like when a terminal has no greys to spend.
+ * The cursor still starts on Cancel: Enter on a dialog nobody read must
+ * not delete a thread.
+ */
+export function SessionDeleteModal({
+  confirm,
+  availableRows,
+  availableColumns,
+  onConfirm,
+  onCancel,
+  onFocus,
+}: SessionDeleteModalProps): ReactElement {
+  const width = Math.max(24, Math.min(PREFERRED_WIDTH, availableColumns - 2));
+  const inner = width - 2;
+  // Title, blank, preview, blank, the button row, plus two border rows.
+  const height = 7;
+  const offsetTop = Math.max(0, Math.floor((availableRows - height) / 2));
+  const offsetLeft = Math.max(0, Math.floor((availableColumns - width) / 2));
+  // Same trick as the menu: the ref rides the absolutely-positioned
+  // panel itself, so no wrapper Box can displace the offsets. Presses
+  // are claimed and dropped so a click on the panel's own chrome cannot
+  // fall through to the backdrop and dismiss it.
+  const ref = useMouseTarget(
+    (hit) => {
+      if (hit.event.kind === "wheel") return true;
+      return isPrimaryPress(hit.event);
+    },
+    { layer: MOUSE_LAYER_MODAL },
+  );
+  return (
+    <Box
+      ref={ref}
+      position="absolute"
+      marginTop={offsetTop}
+      marginLeft={offsetLeft}
+      borderStyle="round"
+      borderColor={chromeTheme.colors.railMuted}
+      backgroundColor={chromeTheme.colors.railBackground}
+      width={width}
+      flexDirection="column"
+    >
+      <Text color={chromeTheme.colors.railForeground} bold>
+        {fit(" DELETE THE SESSION?", inner)}
+      </Text>
+      <Text>{fit("", inner)}</Text>
+      <Text color={chromeTheme.colors.railForeground}>
+        {fit(` ${confirm.preview}`, inner)}
+      </Text>
+      <Text>{fit("", inner)}</Text>
+      <Box width={inner}>
+        <Text>{" "}</Text>
+        <ConfirmButton
+          label="Yes"
+          tone="primary"
+          focused={confirm.cursor === "yes"}
+          onPress={() => onConfirm(confirm.sessionId)}
+          onFocus={() => onFocus("yes")}
+        />
+        <Text>{"  "}</Text>
+        <ConfirmButton
+          label="Cancel"
+          tone="outline"
+          focused={confirm.cursor === "cancel"}
+          onPress={onCancel}
+          onFocus={() => onFocus("cancel")}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * One dialog control.
+ *
+ * `primary` is the composer's Send chip — a light face under dark text,
+ * the affirmative control everywhere else in the app. `outline` is the
+ * same label inside a bracket frame with no fill: brackets rather than
+ * a bordered Box because Ink draws a border on its own rows, which
+ * would make a two-button row three rows tall and push the dialog out
+ * of shape. On one line, `[ Cancel ]` is what a frame looks like.
+ *
+ * Focus is a leading chevron, not a colour: the panel is painted, so a
+ * colour change is quiet against it, and under NO_COLOR it says nothing
+ * at all. The chevron is the same cursor mark the rail and the menu use.
+ */
+function ConfirmButton({
+  label,
+  tone,
+  focused,
+  onPress,
+  onFocus,
+}: {
+  label: string;
+  tone: "primary" | "outline";
+  focused: boolean;
+  onPress: () => void;
+  onFocus: () => void;
+}): ReactElement {
+  const marker = focused ? chromeTheme.glyphs.chevronRight : " ";
+  const body = (
+    <>
+      <Text color={chromeTheme.colors.railForeground} bold>
+        {marker}
+      </Text>
+      {tone === "primary" ? (
+        <Text
+          color={chromeTheme.colors.chipForeground}
+          backgroundColor={chromeTheme.colors.chipBackground}
+          bold
+        >
+          {` ${label} `}
+        </Text>
+      ) : (
+        <Text color={chromeTheme.colors.railForeground} bold={focused}>
+          {`[ ${label} ]`}
+        </Text>
+      )}
+    </>
+  );
+  const mouse = useMouseCommands();
+  if (!mouse) return <Box flexShrink={0}>{body}</Box>;
+  return (
+    <MouseTarget
+      layer={MOUSE_LAYER_MODAL}
+      flexShrink={0}
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        onFocus();
+        onPress();
+        return true;
+      }}
+    >
+      {body}
+    </MouseTarget>
+  );
+}
+
+/** Pad or truncate to exactly `width` columns, so the panel is opaque. */
+function fit(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (text.length > width) {
+    return width <= 1 ? text.slice(0, width) : `${text.slice(0, width - 1)}…`;
+  }
+  return text.padEnd(width);
+}

--- a/src/tui/components/sidebar.test.tsx
+++ b/src/tui/components/sidebar.test.tsx
@@ -133,6 +133,39 @@ describe("Sidebar", () => {
     expect(chevronCount).toBe(1);
   });
 
+  it("puts the close mark on the selected session row only", () => {
+    // An `x` on every row is a mis-click waiting to happen, so it rides
+    // the row the cursor is already on.
+    const focused = render(
+      <Sidebar
+        width={32}
+        sessions={SESSIONS}
+        sessionsCursor={0}
+        currentSessionId="abcdef1234"
+        tasks={TASKS}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={true}
+      />,
+    );
+    const text = strip(focused.lastFrame() ?? "");
+    expect((text.match(/\[x\]/g) ?? []).length).toBe(1);
+
+    const blurred = render(
+      <Sidebar
+        width={32}
+        sessions={SESSIONS}
+        sessionsCursor={0}
+        currentSessionId="abcdef1234"
+        tasks={TASKS}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={false}
+      />,
+    );
+    expect(strip(blurred.lastFrame() ?? "")).not.toContain("[x]");
+  });
+
   it("renders task rows with status badges", () => {
     const { lastFrame } = render(
       <Sidebar

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -6,6 +6,7 @@ import {
   useMouseTarget,
 } from "../mouse/mouse-context.js";
 import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { MOUSE_LAYER_BASE } from "../mouse/mouse-registry.js";
 import { computeRowWindow } from "../row-window.js";
 import type { TaskSummaryRow } from "../tasks/tasks-panel-state.js";
 import { theme } from "../theme/theme.js";
@@ -444,21 +445,89 @@ function SessionRow({
   previewWidth,
   inner,
 }: SessionRowProps): ReactElement {
-  const preview = truncate(entry.preview, previewWidth);
+  // Two marks, two questions: the chevron is "Enter opens this row",
+  // the dot is "this is the thread you are in". The ground answers the
+  // first one too, but only in colour — and a colour is nothing under
+  // NO_COLOR or in a pipe, so the glyph stays.
+  const chevron = selected ? theme.glyphs.chevronRight : " ";
   const marker = current ? theme.glyphs.assistantMarker : " ";
+  // The ground runs almost the full width of the rail with one column of
+  // air either side, so a selected row reads as a row in a list rather
+  // than as a highlighted word. The close affordance lives inside that
+  // ground, at its right edge — visible only on the selected row,
+  // because an `x` on every row is a mis-click waiting to happen.
+  const groundWidth = Math.max(4, inner - 2 * ROW_MARGIN_COLUMNS);
+  const closeWidth = selected ? CLOSE_COLUMNS : 0;
+  const preview = truncate(
+    entry.preview,
+    Math.max(1, Math.min(previewWidth, groundWidth - 5 - closeWidth)),
+  );
+  const label = `${chevron} ${marker} ${preview}`;
+  // Every cell width is computed here, so nothing may flex. Yoga
+  // shrinks text children by default and Ink re-wraps a squeezed
+  // `<Text>` rather than clipping it — the trap
+  // `MouseTargetProps.flexShrink` warns about, one row away from here.
+  const ground = ` ${label}`.padEnd(Math.max(0, groundWidth - closeWidth));
   return (
-    <RailRow
-      inner={inner}
-      // The row the thread is actually on gets the accent bar; the
-      // cursor gets the ground. They are different questions ("which
-      // session am I in" vs "which row will Enter open"), and the design
-      // answers them with two different marks.
-      bar={current}
-      filled={selected}
-      bold={selected || current}
+    <Box width={inner} flexShrink={0}>
+      <Text>{" ".repeat(ROW_MARGIN_COLUMNS)}</Text>
+      <Box flexShrink={0} width={Math.max(0, groundWidth - closeWidth)}>
+        <Text
+          color={theme.colors.railForeground}
+          bold={selected || current}
+          wrap="truncate"
+          {...(selected ? { inverse: true } : {})}
+        >
+          {ground}
+        </Text>
+      </Box>
+      {selected ? <CloseSessionButton entry={entry} /> : null}
+      <Text>{" ".repeat(ROW_MARGIN_COLUMNS)}</Text>
+    </Box>
+  );
+}
+
+/** Air either side of a rail list row's ground. */
+const ROW_MARGIN_COLUMNS = 1;
+/** Cells the close affordance occupies inside the ground: `[x]` + a pad. */
+const CLOSE_COLUMNS = 4;
+
+/**
+ * The `x` at the right edge of the selected session's ground. It opens
+ * the confirmation rather than deleting: this is one click away from
+ * losing a thread, and the rail is a place people click while looking
+ * somewhere else.
+ */
+function CloseSessionButton({
+  entry,
+}: {
+  entry: SessionPickerEntry;
+}): ReactElement {
+  const mouse = useMouseCommands();
+  // `[x]`, the same mark the design uses. It sits inside the row's
+  // ground, so it carries the same inverse video as the label.
+  const glyph = (
+    <Text color={theme.colors.railForeground} bold inverse>
+      {"[x] "}
+    </Text>
+  );
+  if (!mouse) return glyph;
+  return (
+    <MouseTarget
+      layer={MOUSE_LAYER_BASE}
+      flexShrink={0}
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        mouse.dispatch({
+          type: "session_delete_requested",
+          sessionId: entry.sessionId,
+          preview: entry.preview,
+        });
+        return true;
+      }}
     >
-      {`${marker} ${preview}`}
-    </RailRow>
+      {glyph}
+    </MouseTarget>
   );
 }
 

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -12,6 +12,7 @@ import { theme } from "../theme/theme.js";
 import type { SessionPickerEntry } from "../tui-state.js";
 import { getAppVersion } from "../../version.js";
 import { RAIL_MARK } from "./logo.js";
+import { Chip } from "./chip.js";
 
 export type SidebarSection = "sessions" | "tasks";
 
@@ -126,8 +127,12 @@ export function Sidebar(props: SidebarProps): ReactElement {
     >
       <RailBrand inner={inner} sessionId={sessionId} />
       <RailBlank />
-      <SectionHeader title="Sessions" active={sessionsActive} inner={inner} />
-      <NewSessionButton inner={inner} />
+      <SectionHeader
+        title="Sessions"
+        active={sessionsActive}
+        inner={inner}
+        trailing={<NewSessionButton />}
+      />
       <SessionsList
         sessions={sessions}
         cursor={sessionsCursor}
@@ -138,7 +143,12 @@ export function Sidebar(props: SidebarProps): ReactElement {
         inner={inner}
       />
       <RailBlank />
-      <SectionHeader title="Tasks" active={tasksActive} inner={inner} />
+      <SectionHeader
+        title="Tasks"
+        active={tasksActive}
+        inner={inner}
+        counter={`${runningCount(tasks)} running`}
+      />
       <TasksList
         tasks={tasks}
         cursor={tasksCursor}
@@ -259,13 +269,9 @@ const MARK_COLUMNS = 6;
  * that is the list it adds to — and because `/new` was the only way to
  * reach it, which is not a thing a first-time operator knows.
  */
-function NewSessionButton({ inner }: { inner: number }): ReactElement {
+function NewSessionButton(): ReactElement {
   const mouse = useMouseCommands();
-  const label = (
-    <RailLine inner={inner} color={theme.colors.accent}>
-      {"  + New session"}
-    </RailLine>
-  );
+  const label = <Chip label="+ new" />;
   if (!mouse) return label;
   return (
     <MouseTarget
@@ -289,9 +295,13 @@ function NewSessionButton({ inner }: { inner: number }): ReactElement {
 function MenuButton({ inner }: { inner: number }): ReactElement {
   const mouse = useMouseCommands();
   const label = (
-    <RailLine inner={inner} bold>
-      {`${theme.glyphs.menuGlyph} Menu${" ".repeat(Math.max(1, inner - 17))}ctrl+p`}
-    </RailLine>
+    <Box width={inner} flexShrink={0}>
+      <Chip label={`${theme.glyphs.menuGlyph} Menu`} />
+      <Box flexGrow={1} />
+      <Text color={theme.colors.railMuted} wrap="truncate">
+        ctrl+p
+      </Text>
+    </Box>
   );
   if (!mouse) return label;
   return (
@@ -316,18 +326,45 @@ interface SectionHeaderProps {
   title: string;
   active: boolean;
   inner: number;
+  /** Right-aligned status, e.g. `0 running`. */
+  counter?: string;
+  /** Right-aligned control, e.g. the `+ new` chip. */
+  trailing?: ReactNode;
 }
 
-function SectionHeader({ title, active, inner }: SectionHeaderProps): ReactElement {
+function SectionHeader({
+  title,
+  active,
+  inner,
+  counter,
+  trailing,
+}: SectionHeaderProps): ReactElement {
+  // The header is a row, not a line: the counter and the `+ new` control
+  // are pushed to the right edge of the rail the way the design sets
+  // them, which a single clipped string cannot express.
   return (
-    <RailLine
-      inner={inner}
-      bold
-      color={active ? theme.colors.accent : theme.colors.railForeground}
-    >
-      {title.toUpperCase()}
-    </RailLine>
+    <Box width={inner} flexShrink={0}>
+      <Text
+        color={active ? theme.colors.accent : theme.colors.railForeground}
+        bold
+        wrap="truncate"
+      >
+        {title.toUpperCase()}
+      </Text>
+      <Box flexGrow={1} />
+      {counter ? (
+        <Text color={theme.colors.railMuted} wrap="truncate">
+          {counter}
+        </Text>
+      ) : null}
+      {trailing ?? null}
+    </Box>
   );
+}
+
+/** Tasks the design counts in the header: the ones actually running. */
+function runningCount(tasks: readonly TaskSummaryRow[]): number {
+  return tasks.filter((row) => row.status === "running").length;
 }
 
 interface SessionsListProps {
@@ -403,15 +440,67 @@ function SessionRow({
 }: SessionRowProps): ReactElement {
   const preview = truncate(entry.preview, previewWidth);
   const marker = current ? theme.glyphs.assistantMarker : " ";
-  const chevron = selected ? theme.glyphs.chevronRight : " ";
   return (
-    <RailLine
+    <RailRow
       inner={inner}
+      // The row the thread is actually on gets the accent bar; the
+      // cursor gets the ground. They are different questions ("which
+      // session am I in" vs "which row will Enter open"), and the design
+      // answers them with two different marks.
+      bar={current}
+      filled={selected}
       bold={selected || current}
-      color={selected ? theme.colors.accent : theme.colors.railForeground}
     >
-      {`${chevron} ${marker} ${preview}`}
-    </RailLine>
+      {`${marker} ${preview}`}
+    </RailRow>
+  );
+}
+
+/**
+ * A rail list row: an optional 1-cell accent bar, then the label on an
+ * optional filled ground.
+ *
+ * The design draws the bar as a 3px rule down the left edge of the row
+ * and the selection as a translucent fill. Neither has a sub-cell
+ * equivalent, so the bar is `▎` in the accent colour and the fill is a
+ * real background on the label — the two marks the design uses, at the
+ * resolution a terminal has.
+ */
+function RailRow({
+  inner,
+  children,
+  bar,
+  filled,
+  bold,
+  color,
+}: {
+  inner: number;
+  children: string;
+  bar?: boolean;
+  filled?: boolean;
+  bold?: boolean;
+  color?: string;
+}): ReactElement {
+  const label = clip(children, Math.max(0, inner - 2));
+  // One column of chrome, three states. The cursor keeps a glyph rather
+  // than relying on the fill alone: the fill is a colour, and a colour
+  // is nothing under NO_COLOR, in a pipe, or in the test renderer — the
+  // one mark that says "Enter opens this row" has to survive all three.
+  const mark = filled ? theme.glyphs.chevronRight : bar ? "▎" : " ";
+  return (
+    <Box width={inner} flexShrink={0}>
+      <Text color={theme.colors.brandMark} bold>
+        {mark}
+      </Text>
+      <Text
+        color={color ?? theme.colors.railForeground}
+        bold={bold ?? false}
+        wrap="truncate"
+        {...(filled ? { inverse: true } : {})}
+      >
+        {` ${label} `}
+      </Text>
+    </Box>
   );
 }
 
@@ -482,16 +571,19 @@ function TaskRow({
   inner,
 }: TaskRowProps): ReactElement {
   const preview = truncate(row.userMessage, previewWidth);
-  const chevron = selected ? theme.glyphs.chevronRight : " ";
   const badge = statusBadge(row);
   return (
-    <RailLine
+    <RailRow
       inner={inner}
+      // A running task earns the bar for the same reason the current
+      // session does: it is the row that is live, not the row the cursor
+      // happens to sit on.
+      bar={row.status === "running"}
+      filled={selected}
       bold={selected}
-      color={selected ? theme.colors.accent : theme.colors.railForeground}
     >
-      {`${chevron} ${badge} ${preview}`}
-    </RailLine>
+      {`${badge} ${preview}`}
+    </RailRow>
   );
 }
 

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -165,6 +165,12 @@ export function Sidebar(props: SidebarProps): ReactElement {
       */}
       <Box flexGrow={1} />
       <MenuButton inner={inner} />
+      {/*
+        The design seats the Menu control above the rail's bottom edge
+        rather than on it — a control flush against the edge of its own
+        panel reads as part of the frame instead of as a button.
+      */}
+      <RailBlank />
     </Box>
   );
 }

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -272,9 +272,14 @@ function RailBrand({
 const MARK_COLUMNS = 6;
 
 /**
- * Starts a fresh thread. It sits at the head of the session list because
- * that is the list it adds to — and because `/new` was the only way to
- * reach it, which is not a thing a first-time operator knows.
+ * Starts a fresh thread. It sits on the Sessions header because that is
+ * the list the thread joins — once it has been spoken to. A brand-new
+ * session shows no row: it has no name yet, and an unnamed row is
+ * indistinguishable from every other unnamed row. The row appears with
+ * the first prompt, named by it.
+ *
+ * `/new` does the same thing, and used to be the only way to reach it —
+ * which is not a thing a first-time operator knows.
  */
 function NewSessionButton(): ReactElement {
   const mouse = useMouseCommands();

--- a/src/tui/components/splash-banner.test.tsx
+++ b/src/tui/components/splash-banner.test.tsx
@@ -25,7 +25,7 @@ describe("SplashBanner", () => {
     expect(frame).toContain("Local AI-First Agent");
   });
 
-  it("advertises the core slash commands and hotkeys", () => {
+  it("advertises the core slash commands", () => {
     const frame = frameAt(96, 40);
     expect(frame).toContain("/help");
     expect(frame).toContain("/sessions");
@@ -33,7 +33,11 @@ describe("SplashBanner", () => {
     expect(frame).toContain("/model");
     expect(frame).toContain("/tasks");
     expect(frame).toContain("/import");
-    expect(frame).toContain("Ctrl+C");
+    // The two plain-hotkey rows (Enter, Ctrl+C x2) are gone: every row
+    // is now a command a click can put in the composer, and the hint
+    // strip carries both keys at the foot of the screen anyway.
+    expect(frame).not.toContain("Ctrl+C");
+    expect(frame).not.toMatch(/•\s+Enter/u);
   });
 
   it("keeps the most useful tips when the surface is too short for all of them", () => {
@@ -56,14 +60,14 @@ describe("SplashBanner", () => {
     // rows, so on a 4-row surface it would leave nothing for the tips
     // and Ink would paint it over the chat above. Tips win.
     const frame = frameAt(38, 4);
-    expect(frame).toContain("Enter");
+    expect(frame).toContain("/help");
     expect(frame).not.toMatch(/:::|[█▀▄]/u);
   });
 
   it("still shows a brand mark and a tip once there is room for both", () => {
     const frame = frameAt(38, 8);
     expect(frame).toMatch(/:::|[█▀▄]/u);
-    expect(frame).toContain("Enter");
+    expect(frame).toContain("/help");
   });
 
   it("measures the terminal itself when no size is given", () => {

--- a/src/tui/components/splash-banner.tsx
+++ b/src/tui/components/splash-banner.tsx
@@ -2,6 +2,8 @@ import { Box, Text } from "ink";
 import type { ReactElement } from "react";
 import { useTerminalSize } from "../hooks/use-terminal-size.js";
 import { computeChatViewportRows, computeChatWidth } from "../layout.js";
+import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { theme } from "../theme/theme.js";
 import { Logo } from "./logo.js";
 import {
@@ -17,7 +19,7 @@ import {
  * Welcome screen shown in place of an empty chat-log. Renders the brand
  * `Logo` (atomic-plus mark + wordmark) vertically centred via flexGrow
  * spacers, with a compact tip-list underneath that surfaces the most
- * useful slash commands and hotkeys.
+ * useful slash commands.
  *
  * Everything on it is sized against the live terminal: the mark shrinks
  * (34×20 → 17×10 → one line) as the window narrows or shortens, the tip
@@ -75,12 +77,36 @@ interface TipProps {
 function Tip({ tip, fit }: TipProps): ReactElement {
   const label =
     fit.labelWidth > 0 ? tip.label.padEnd(fit.labelWidth, " ") : tip.label;
-  return (
+  const mouse = useMouseCommands();
+  const row = (
     <Text wrap="truncate">
       <Text color={theme.colors.muted}>  {theme.glyphs.bullet} </Text>
       <Text color={theme.colors.accent}>{label}</Text>
       <Text color={theme.colors.muted}>{description(tip, fit.descriptions)}</Text>
     </Text>
+  );
+  if (!mouse) return row;
+  return (
+    <MouseTarget
+      flexShrink={0}
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        // Put the command in the composer rather than running it: the
+        // row is a suggestion, and Enter is the operator's to press.
+        // `/model` and friends take arguments, and a click that fired
+        // them outright would rob a mis-click of its undo.
+        if (mouse.getState().chatFocus !== "editor") {
+          mouse.dispatch({ type: "chat_focus_set", focus: "editor" });
+        }
+        // Trailing space, matching the palette's own completion: it
+        // leaves the caret past the command and keeps `slashPrefix`
+        // from re-opening the palette over the buffer we just seeded.
+        mouse.dispatch({ type: "input_changed", value: `${tip.command} ` });
+        return true;
+      }}
+    >
+      {row}
+    </MouseTarget>
   );
 }
 

--- a/src/tui/components/splash-fit.test.ts
+++ b/src/tui/components/splash-fit.test.ts
@@ -49,8 +49,9 @@ describe("computeSplashFit", () => {
       logo: "mini",
       wordmark: false,
       tagline: false,
-      // 12 rows − 4 for the mark − 1 margin leaves 7 of the 8 tips.
-      tipCount: SPLASH_TIPS.length - 1,
+      // 12 rows − 4 for the mark − 1 margin leaves room for all six
+      // tips (the list lost its two hotkey rows).
+      tipCount: SPLASH_TIPS.length,
       labelWidth: 10,
       descriptions: "short",
     });

--- a/src/tui/components/splash-fit.ts
+++ b/src/tui/components/splash-fit.ts
@@ -3,7 +3,7 @@
  * many tips to keep, and how wide the tip columns may be for a given
  * chat-surface size.
  *
- * The splash used to be a fixed 83×20 mark plus eight fixed tip rows,
+ * The splash used to be a fixed 83×20 mark plus the fixed tip rows,
  * i.e. it needed 90 columns and ~29 rows no matter what the terminal
  * offered. Ink 7 does not clip an over-tall frame — it overlaps
  * earlier lines (see `../row-window.ts`) — so a short window garbled
@@ -58,6 +58,14 @@ export interface SplashTip {
   description: string;
   /** Terse copy for narrow surfaces. */
   short: string;
+  /**
+   * What a click on the row puts in the composer. Every tip is a slash
+   * command now — the two rows that were plain hotkeys (`Enter`,
+   * `Ctrl+C ×2`) are gone, because a hint you cannot click reads as a
+   * broken control next to seven you can, and the hint strip already
+   * carries both keys at the foot of the screen.
+   */
+  command: string;
 }
 
 /**
@@ -67,36 +75,40 @@ export interface SplashTip {
  */
 export const SPLASH_TIPS: readonly SplashTip[] = [
   {
-    label: "Enter",
-    description: "submit message to the agent",
-    short: "send message",
-  },
-  {
     label: "/help",
     description: "list all slash commands",
     short: "all commands",
+    command: "/help",
   },
   {
     label: "/sessions",
     description: "switch to a previous thread",
     short: "past threads",
+    command: "/sessions",
   },
-  { label: "/new", description: "start a fresh session", short: "new session" },
-  { label: "/model", description: "change the chat model", short: "pick model" },
+  {
+    label: "/new",
+    description: "start a fresh session",
+    short: "new session",
+    command: "/new",
+  },
+  {
+    label: "/model",
+    description: "change the chat model",
+    short: "pick model",
+    command: "/model",
+  },
   {
     label: "/tasks",
     description: "jump to the Tasks tab (cron + ingress UI)",
     short: "Tasks tab",
+    command: "/tasks",
   },
   {
     label: "/import",
     description: "open the Import tab (Hermes migration)",
     short: "Hermes import",
-  },
-  {
-    label: "Ctrl+C ×2",
-    description: "quit (once aborts a running turn)",
-    short: "quit",
+    command: "/import",
   },
 ];
 

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -8,6 +8,7 @@ import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { theme } from "../theme/theme.js";
 import type { TuiState } from "../tui-state.js";
 import { getAppVersion } from "../../version.js";
+import { Chip, tracked } from "./chip.js";
 
 interface StatusBarProps {
   state: TuiState;
@@ -44,6 +45,7 @@ export function StatusBar({
   brand = true,
 }: StatusBarProps): ReactElement {
   const section = getCurrentSection(state);
+  const title = currentSessionTitle(state);
   return (
     <Box>
       {brand ? (
@@ -57,8 +59,31 @@ export function StatusBar({
       ) : null}
       <Breadcrumb state={state} section={section} />
       <SessionTag sessionId={state.session.sessionId} />
+      {title ? (
+        <Text color={theme.colors.muted}>
+          {"  "}
+          {theme.glyphs.dotSeparator}{" "}
+          <Text color={theme.colors.assistant} bold>
+            {title}
+          </Text>
+        </Text>
+      ) : null}
     </Box>
   );
+}
+
+/**
+ * The preview of the session being worked on, which the design puts in
+ * the top bar beside the id. Read from the rail's own session list so
+ * the two can never disagree about what the current thread is called.
+ */
+function currentSessionTitle(state: TuiState): string | null {
+  const id = state.session.sessionId;
+  if (!id) return null;
+  const entry = state.sessionPickerList.find((row) => row.sessionId === id);
+  const preview = entry?.preview?.trim();
+  if (!preview) return null;
+  return preview.length > 32 ? `${preview.slice(0, 31)}…` : preview;
 }
 
 const SECTION_LABELS: Record<TuiSection, string> = {
@@ -90,12 +115,12 @@ function Breadcrumb({
     state.uiMode === "debug" ? menuPlaceByTab(state.activeTab)?.label : undefined;
   const label = (
     <Text>
-      <Text color={theme.colors.accentSoft} bold>
-        {SECTION_LABELS[section]}
-      </Text>
+      <Chip label={tracked(SECTION_LABELS[section])} tone="badge" />
       {tabLabel ? (
         <Text color={theme.colors.muted}>
-          {" "}
+          {/* The badge carries its own trailing pad; a second space here
+              would set the breadcrumb a full cell off from every other
+              separator in the bar. */}
           {theme.glyphs.chevronRight} <Text>{tabLabel}</Text>
         </Text>
       ) : null}
@@ -126,14 +151,12 @@ interface SessionTagProps {
 
 function SessionTag({ sessionId }: SessionTagProps): ReactElement | null {
   if (!sessionId) return null;
+  // The design sets this as `session <id>` in plain dim type, with a dot
+  // before the title that follows — no pipe. One separator glyph in the
+  // bar, used once, reads as punctuation; two read as a table.
   return (
     <Text>
-      <Text color={theme.colors.muted}>
-        {"  "}
-        {theme.glyphs.pipeSeparator}
-        {"  "}
-        session{" "}
-      </Text>
+      <Text color={theme.colors.muted}>{"   session "}</Text>
       <Text>{shortenId(sessionId)}</Text>
     </Text>
   );

--- a/src/tui/components/user-bubble.tsx
+++ b/src/tui/components/user-bubble.tsx
@@ -8,19 +8,24 @@ interface UserBubbleProps {
 }
 
 /**
- * opencode-style user message: a colored vertical left border plus
- * generous vertical padding around the body. The role itself is
- * implied by the border color (blue = user) — there is no inline
- * "you" label, so consecutive user / assistant turns read as a
- * coloured ribbon rather than a labelled list. `marginTop=1` between
+ * A user message: a `YOU` label over a coloured left border and
+ * generous vertical padding around the body. `marginTop=1` between
  * messages prevents bubbles from touching.
+ *
+ * The label used to be absent, on the theory that the border colour is
+ * the label. Colour alone says nothing under NO_COLOR, in a pipe, or to
+ * a reader who cannot separate the two hues — and the design puts the
+ * word back, which is also the accessible answer.
  *
  * No markdown rendering — the user authored the text and expects to
  * see exactly what they typed.
  */
 export function UserBubble({ text }: UserBubbleProps): ReactElement {
   return (
-    <Box marginTop={1}>
+    <Box marginTop={1} flexDirection="column">
+      <Text color={theme.colors.user} bold>
+        {"  YOU"}
+      </Text>
       <Box
         borderStyle="single"
         borderTop={false}
@@ -28,7 +33,6 @@ export function UserBubble({ text }: UserBubbleProps): ReactElement {
         borderBottom={false}
         borderLeft
         borderColor={theme.colors.user}
-        paddingTop={1}
         paddingBottom={1}
         paddingLeft={2}
         paddingRight={1}

--- a/src/tui/composer-visibility.test.tsx
+++ b/src/tui/composer-visibility.test.tsx
@@ -1,0 +1,114 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+
+import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "./tui-app.js";
+import type { TuiSessionInfo } from "./tui-state.js";
+
+/**
+ * The composer belongs to the Run screen. Observe and Manage are for
+ * watching and configuring; a prompt under a settings panel invites a
+ * message nobody reads from there.
+ *
+ * The exception is a surface whose keyboard the composer owns while it
+ * is open — most sharply the slash palette, which `handleAppKey`
+ * refuses to close (`!state.slashPaletteOpen`), so unmounting the
+ * composer under it would leave it with no way out at all.
+ */
+const SESSION: TuiSessionInfo = {
+  sessionId: "s1",
+  workingDir: "/tmp/smoke",
+  llamaUrl: "http://127.0.0.1:8080",
+  browserChannel: "chrome",
+  browserHeadless: false,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+const ESC = String.fromCharCode(27);
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 60));
+const strip = (value: string): string =>
+  value.replace(new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g"), "");
+
+function callbacks(): TuiAppCallbacks {
+  return {
+    onApprovalDecision: () => {},
+    onAbort: () => {},
+    onQuit: () => {},
+    onMessageSubmitted: () => {},
+  };
+}
+
+/** The composer's own furniture: the caret and the Send control. */
+const composerMarks = (frame: string): boolean =>
+  frame.includes("send") && frame.includes("\u276f");
+
+function mount() {
+  const bus = makeTuiEventBus();
+  const app = render(
+    <TuiApp session={SESSION} bus={bus} callbacks={callbacks()} />,
+  );
+  return { bus, ...app, frame: () => strip(app.lastFrame() ?? "") };
+}
+
+describe("composer visibility", () => {
+  it("is on screen on the Run screen", async () => {
+    const app = mount();
+    await settle();
+    expect(composerMarks(app.frame())).toBe(true);
+    app.unmount();
+  });
+
+  it("is gone on a Manage tab", async () => {
+    const app = mount();
+    await settle();
+    app.bus.emit({ type: "ui_mode_set", mode: "debug" });
+    app.bus.emit({ type: "tab_changed", tab: "tasks" });
+    await settle();
+    expect(app.frame()).toContain("Tasks");
+    expect(composerMarks(app.frame())).toBe(false);
+    app.unmount();
+  });
+
+  it("is gone on an Observe tab", async () => {
+    const app = mount();
+    await settle();
+    app.bus.emit({ type: "ui_mode_set", mode: "debug" });
+    app.bus.emit({ type: "tab_changed", tab: "feed" });
+    await settle();
+    expect(composerMarks(app.frame())).toBe(false);
+    app.unmount();
+  });
+
+  it("comes back for the slash palette, which types into it", async () => {
+    const app = mount();
+    await settle();
+    app.bus.emit({ type: "ui_mode_set", mode: "debug" });
+    app.bus.emit({ type: "tab_changed", tab: "llm" });
+    await settle();
+    expect(composerMarks(app.frame())).toBe(false);
+
+    app.bus.emit({ type: "slash_palette_opened", query: "" });
+    await settle();
+    expect(app.frame()).toContain("/help");
+    expect(composerMarks(app.frame())).toBe(true);
+    app.unmount();
+  });
+
+  it("Esc still returns to Run from an Observe tab", async () => {
+    // This used to be the editor's job, through an `onEscape` it no
+    // longer has there — the Observe tabs have no key layer of their
+    // own, so `handlePanelEscape` never sees the keypress either.
+    const app = mount();
+    await settle();
+    app.bus.emit({ type: "ui_mode_set", mode: "debug" });
+    app.bus.emit({ type: "tab_changed", tab: "feed" });
+    await settle();
+    app.stdin.write(ESC);
+    await settle();
+    expect(composerMarks(app.frame())).toBe(true);
+    expect(app.frame()).toContain("R U N");
+    app.unmount();
+  });
+});

--- a/src/tui/detect-kitty-keyboard.ts
+++ b/src/tui/detect-kitty-keyboard.ts
@@ -1,0 +1,97 @@
+import type { Writable } from "node:stream";
+
+/**
+ * Does this terminal speak the kitty keyboard protocol?
+ *
+ * It matters for exactly one reason: in the legacy encoding a terminal
+ * sends the same byte (`\r`) for Enter and for Shift+Enter, so the
+ * modifier is not observable and Shift+Enter cannot mean "newline". The
+ * kitty protocol encodes it as `ESC [ 13 ; 2 u`, which Ink's parser
+ * already turns into `key.return` + `key.shift`.
+ *
+ * The probe is the protocol's own query — `CSI ? u` — answered by
+ * `CSI ? <flags> u`. Terminals that do not implement it answer nothing,
+ * which is why this is a timeout rather than an error.
+ *
+ * Ink can auto-detect this itself (`kittyKeyboard: { mode: "auto" }`),
+ * but its probe listener and the App's own reader both see the reply,
+ * so the answer can be typed into the composer as `[?1u` before the
+ * first render. Asking here — before `render`, on a stdin we hand back
+ * exactly as we found it — keeps the reply out of the app entirely, and
+ * gives the hint strip something to tell the truth with.
+ *
+ * The safety properties mirror `detectTerminalBackground`, deliberately:
+ * never touch raw mode off a TTY, restore raw/flow state, resolve once,
+ * and never keep the event loop alive for a probe.
+ */
+export interface DetectKittyKeyboardDeps {
+  readonly stdin?: NodeJS.ReadStream;
+  readonly stdout?: NodeJS.WriteStream;
+  readonly stderr?: NodeJS.WriteStream;
+  /** Fallback timeout in ms before giving up. Default 150. */
+  readonly timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 150;
+
+/** `CSI ? <flags> u` — the reply to the query below. */
+const KITTY_REPLY = /\x1b\[\?(\d{1,4})u/;
+
+/** `CSI ? u` — "which keyboard flags are set?". */
+const KITTY_QUERY = "\x1b[?u";
+
+export function detectKittyKeyboard(
+  deps: DetectKittyKeyboardDeps = {},
+): Promise<boolean> {
+  const stdin = deps.stdin ?? process.stdin;
+  const stdout = deps.stdout ?? process.stdout;
+  const stderr = deps.stderr ?? process.stderr;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  if (!stdin.isTTY) return Promise.resolve(false);
+
+  const out: NodeJS.WriteStream | null = stdout.isTTY
+    ? stdout
+    : stderr.isTTY
+      ? stderr
+      : null;
+  if (!out) return Promise.resolve(false);
+
+  return new Promise<boolean>((resolve) => {
+    let buffer = "";
+    let resolved = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const hadRaw = stdin.isRaw === true;
+    const wasPaused =
+      typeof stdin.isPaused === "function" ? stdin.isPaused() : false;
+
+    const cleanup = (): void => {
+      if (timer) clearTimeout(timer);
+      stdin.removeListener("data", onData);
+      if (typeof stdin.setRawMode === "function") stdin.setRawMode(hadRaw);
+      if (wasPaused && typeof stdin.pause === "function") stdin.pause();
+    };
+
+    const finish = (supported: boolean): void => {
+      if (resolved) return;
+      resolved = true;
+      cleanup();
+      resolve(supported);
+    };
+
+    const onData = (chunk: Buffer | string): void => {
+      buffer += typeof chunk === "string" ? chunk : chunk.toString("latin1");
+      if (KITTY_REPLY.test(buffer)) finish(true);
+    };
+
+    if (typeof stdin.setRawMode === "function") stdin.setRawMode(true);
+    stdin.on("data", onData);
+    if (typeof stdin.resume === "function") stdin.resume();
+
+    (out as unknown as Writable).write(KITTY_QUERY);
+
+    timer = setTimeout(() => finish(false), timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+  });
+}

--- a/src/tui/escape-chat-editor.test.tsx
+++ b/src/tui/escape-chat-editor.test.tsx
@@ -44,6 +44,45 @@ function trackingCallbacks(counts: { quit: number; abort: number }): TuiAppCallb
 }
 
 describe("Esc in the chat editor", () => {
+  it("opens the menu when there is nothing left to cancel", async () => {
+    // Esc keeps every meaning it had; opening the menu is the last
+    // branch, reached only when the key would otherwise have done
+    // nothing at all.
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+    stdin.write(ESC);
+    await settle();
+    expect(strip(lastFrame() ?? "")).toContain("MENU");
+    expect(counts.quit).toBe(0);
+    expect(counts.abort).toBe(0);
+    unmount();
+  });
+
+  it("clears a draft first — the menu only opens on an empty buffer", async () => {
+    const counts = { quit: 0, abort: 0 };
+    const bus = makeTuiEventBus();
+    const { lastFrame, stdin, unmount } = render(
+      <TuiApp session={SESSION} bus={bus} callbacks={trackingCallbacks(counts)} />,
+    );
+    await settle();
+    stdin.write("half a thought");
+    await settle();
+    stdin.write(ESC);
+    await settle();
+    const afterFirst = strip(lastFrame() ?? "");
+    expect(afterFirst).not.toContain("half a thought");
+    expect(afterFirst).not.toContain("MENU");
+    // Second Esc, now with nothing to clear, is the one that opens it.
+    stdin.write(ESC);
+    await settle();
+    expect(strip(lastFrame() ?? "")).toContain("MENU");
+    unmount();
+  });
+
   it("does not quit an idle agent", async () => {
     const counts = { quit: 0, abort: 0 };
     const bus = makeTuiEventBus();

--- a/src/tui/escape-chat-editor.test.tsx
+++ b/src/tui/escape-chat-editor.test.tsx
@@ -139,7 +139,7 @@ describe("Esc in the chat editor", () => {
 
     stdin.write(ESC);
     await settle();
-    expect(strip(lastFrame() ?? "")).toContain("Run");
+    expect(strip(lastFrame() ?? "")).toContain("R U N");
     expect(counts.quit).toBe(0);
 
     stdin.write(ESC);

--- a/src/tui/escape-import-tab.test.tsx
+++ b/src/tui/escape-import-tab.test.tsx
@@ -49,7 +49,7 @@ describe("Esc on the Import tab", () => {
     bus.emit({ type: "ui_mode_set", mode: "debug" });
     bus.emit({ type: "tab_changed", tab: "import" });
     await settle();
-    expect(strip(lastFrame() ?? "")).toContain("Manage ▸");
+    expect(strip(lastFrame() ?? "")).toContain("MANAGE ▸");
 
     stdin.write(ESC);
     await settle();
@@ -57,7 +57,7 @@ describe("Esc on the Import tab", () => {
     // The configure-mode handler ends in a catch-all `return true` that
     // swallows stray letters; before the fix it swallowed Esc too, so the
     // operator was stuck on the tab with no "back" gesture at all.
-    expect(strip(lastFrame() ?? "")).toContain("Run");
+    expect(strip(lastFrame() ?? "")).toContain("R U N");
     expect(quit).toBe(0);
     unmount();
   });

--- a/src/tui/escape-observe-tabs.test.tsx
+++ b/src/tui/escape-observe-tabs.test.tsx
@@ -57,7 +57,7 @@ describe("Esc on the Observe tabs", () => {
       bus.emit({ type: "ui_mode_set", mode: "debug" });
       bus.emit({ type: "tab_changed", tab });
       await settle();
-      expect(strip(lastFrame() ?? "")).toContain("Observe ▸");
+      expect(strip(lastFrame() ?? "")).toContain("OBSERVE ▸");
 
       stdin.write(ESC);
       await settle();
@@ -67,7 +67,7 @@ describe("Esc on the Observe tabs", () => {
       // reached the still-focused chat editor and quit the process.
       expect(counts.quit).toBe(0);
       expect(counts.abort).toBe(0);
-      expect(strip(lastFrame() ?? "")).toContain("Run");
+      expect(strip(lastFrame() ?? "")).toContain("R U N");
       unmount();
     });
   }

--- a/src/tui/layout.test.ts
+++ b/src/tui/layout.test.ts
@@ -90,15 +90,13 @@ describe("computeSidebarRowBudget", () => {
     // app frame (brand lockup, version, Menu button) and so spends more of
     // the height on itself. What this pins is the 2:1 ratio, and that both
     // panes shrink together rather than one starving the other.
-    // 24 rows leaves 10 usable since `+ new` moved onto the Sessions
-    // header and gave a row back to the lists; the ceil in the split
-    // hands that row to Sessions, so the ratio is "roughly 2:1", not
-    // exactly.
+    // `+ new` moved onto the Sessions header and gave a row back; the
+    // blank that lifts the Menu button off the rail's bottom edge took
+    // it again, so 24 rows still leaves 9 usable.
     const budget = computeSidebarRowBudget(24);
-    expect(budget.sessions).toBe(7);
+    expect(budget.sessions).toBe(6);
     expect(budget.tasks).toBe(3);
-    expect(budget.sessions).toBeGreaterThanOrEqual(budget.tasks * 2);
-    expect(budget.sessions).toBeLessThanOrEqual(Math.ceil(budget.tasks * 2.5));
+    expect(budget.sessions).toBe(budget.tasks * 2);
     const tall = computeSidebarRowBudget(40);
     expect(tall.sessions).toBe(10);
     expect(tall.tasks).toBe(5);

--- a/src/tui/layout.test.ts
+++ b/src/tui/layout.test.ts
@@ -90,10 +90,15 @@ describe("computeSidebarRowBudget", () => {
     // app frame (brand lockup, version, Menu button) and so spends more of
     // the height on itself. What this pins is the 2:1 ratio, and that both
     // panes shrink together rather than one starving the other.
+    // 24 rows leaves 10 usable since `+ new` moved onto the Sessions
+    // header and gave a row back to the lists; the ceil in the split
+    // hands that row to Sessions, so the ratio is "roughly 2:1", not
+    // exactly.
     const budget = computeSidebarRowBudget(24);
-    expect(budget.sessions).toBe(6);
+    expect(budget.sessions).toBe(7);
     expect(budget.tasks).toBe(3);
-    expect(budget.sessions).toBe(budget.tasks * 2);
+    expect(budget.sessions).toBeGreaterThanOrEqual(budget.tasks * 2);
+    expect(budget.sessions).toBeLessThanOrEqual(Math.ceil(budget.tasks * 2.5));
     const tall = computeSidebarRowBudget(40);
     expect(tall.sessions).toBe(10);
     expect(tall.tasks).toBe(5);

--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -35,7 +35,8 @@ const SIDEBAR_WIDTH_RATIO = 0.25;
  * version line and the Menu button, on top of the two section headers,
  * the blank row between the panes and a "↓ N more" footer per pane.
  * The `+ new` control costs nothing: it sits on the Sessions header row
- * rather than on a line of its own.
+ * rather than on a line of its own; the blank row under the Menu button,
+ * which lifts it off the rail's bottom edge, does cost one.
  * Counted off the rendered component rather
  * than estimated — the left border costs no rows because `sidebar.tsx`
  * turns the top and bottom edges off — and pinned by
@@ -43,7 +44,7 @@ const SIDEBAR_WIDTH_RATIO = 0.25;
  * asserts it comes to exactly `sessions + tasks + SIDEBAR_CHROME_ROWS`
  * rows.
  */
-export const SIDEBAR_CHROME_ROWS = 12;
+export const SIDEBAR_CHROME_ROWS = 13;
 
 /**
  * Rows the rail costs outside its own frame: the status bar above it

--- a/src/tui/layout.ts
+++ b/src/tui/layout.ts
@@ -34,6 +34,8 @@ const SIDEBAR_WIDTH_RATIO = 0.25;
  * the rail became the app frame it also carries the brand lockup, the
  * version line and the Menu button, on top of the two section headers,
  * the blank row between the panes and a "↓ N more" footer per pane.
+ * The `+ new` control costs nothing: it sits on the Sessions header row
+ * rather than on a line of its own.
  * Counted off the rendered component rather
  * than estimated — the left border costs no rows because `sidebar.tsx`
  * turns the top and bottom edges off — and pinned by
@@ -41,7 +43,7 @@ const SIDEBAR_WIDTH_RATIO = 0.25;
  * asserts it comes to exactly `sessions + tasks + SIDEBAR_CHROME_ROWS`
  * rows.
  */
-export const SIDEBAR_CHROME_ROWS = 13;
+export const SIDEBAR_CHROME_ROWS = 12;
 
 /**
  * Rows the rail costs outside its own frame: the status bar above it
@@ -63,11 +65,18 @@ const SIDEBAR_RESERVED_ROWS = SIDEBAR_CHROME_ROWS + SIDEBAR_OUTER_ROWS;
 export const SIDEBAR_MIN_ROWS = SIDEBAR_RESERVED_ROWS + 2;
 
 /**
- * Rows of "chrome" outside the chat surface: status bar + prompt
- * meta-row + prompt input + prompt tail-cap + hotkey hint + a small
- * safety pad. Used to convert `terminal.rows` into the chat-area
- * viewport height. Slightly conservative — better to leave one empty
- * row than to clip the prompt.
+ * Rows of "chrome" outside the chat surface: status bar + the hairline
+ * under it + prompt meta-row + prompt input + prompt tail-cap + hotkey
+ * hint + a small safety pad. Used to convert `terminal.rows` into the
+ * chat-area viewport height. Slightly conservative — better to leave one
+ * empty row than to clip the prompt.
+ *
+ * The hairline under the status bar spends the row of slack this count
+ * always carried rather than adding one: raising the number shrinks the
+ * chat viewport, and at 24 rows that came straight out of the operator
+ * menu, which sheds its own key-hint footer first. A second hairline
+ * over the hint strip was drawn and then dropped for the same reason —
+ * the composer's border already reads as the edge it would have drawn.
  */
 export const CHROME_ROWS = 8;
 

--- a/src/tui/menu/menu-popup.tsx
+++ b/src/tui/menu/menu-popup.tsx
@@ -1,7 +1,12 @@
 import { Box, Text } from "ink";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
-import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
+import {
+  MouseTarget,
+  useMouseCommands,
+  useMouseTarget,
+  type MouseContextValue,
+} from "../mouse/mouse-context.js";
 import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { MOUSE_LAYER_MODAL } from "../mouse/mouse-registry.js";
 import { chromeTheme } from "../theme/theme.js";
@@ -98,16 +103,14 @@ export function MenuPopup({
   const offsetTop = Math.max(0, Math.floor((availableRows - height) / 2));
   const offsetLeft = Math.max(0, Math.floor((availableColumns - width) / 2));
 
+  const itemCount = itemIndexes.length;
   return (
-    <Box
-      position="absolute"
-      marginTop={offsetTop}
-      marginLeft={offsetLeft}
-      borderStyle="round"
-      borderColor={chromeTheme.colors.railMuted}
-      backgroundColor={chromeTheme.colors.railBackground}
+    <PopupFrame
+      offsetTop={offsetTop}
+      offsetLeft={offsetLeft}
       width={width}
-      flexDirection="column"
+      cursor={cursor}
+      itemCount={itemCount}
     >
       <TitleRow state={state} inner={inner} />
       {visible.map((row, idx) =>
@@ -135,8 +138,88 @@ export function MenuPopup({
       <Text color={chromeTheme.colors.railMuted}>
         {fit(` ${footer(state, hiddenAfter)}`, inner)}
       </Text>
+    </PopupFrame>
+  );
+}
+
+/**
+ * The popup's own box, plus the mouse behaviour that belongs to the
+ * panel rather than to any one row:
+ *
+ * - **Wheel** walks the cursor. The visible window is derived from the
+ *   cursor, so moving it *is* scrolling — one notch, one row, the same
+ *   as ↑/↓, which keeps the wheel and the keys on one model.
+ * - **Press** is claimed and dropped. Clicking the border, the title or
+ *   the footer must not fall through to the backdrop, which closes the
+ *   menu: a click inside the panel that shuts it would be the opposite
+ *   of what the operator meant.
+ *
+ * Row targets are smaller boxes on the same layer, so the registry
+ * offers them the event first (see `MouseTargetRegistry.dispatch`).
+ */
+function PopupFrame({
+  offsetTop,
+  offsetLeft,
+  width,
+  cursor,
+  itemCount,
+  children,
+}: {
+  offsetTop: number;
+  offsetLeft: number;
+  width: number;
+  cursor: number;
+  itemCount: number;
+  children: ReactNode;
+}): ReactElement {
+  const mouse = useMouseCommands();
+  // The ref goes on the popup box itself rather than on a `MouseTarget`
+  // wrapper: the box is absolutely positioned, and an extra Box between
+  // it and the pane would take the offsets with it.
+  const ref = useMouseTarget(
+    (hit) => {
+      if (!mouse) return false;
+      if (hit.event.kind === "wheel") {
+        moveMenuCursor(
+          mouse,
+          hit.event.wheel === "up" ? -1 : 1,
+          cursor,
+          itemCount,
+        );
+        return true;
+      }
+      return isPrimaryPress(hit.event);
+    },
+    { layer: MOUSE_LAYER_MODAL },
+  );
+  return (
+    <Box
+      ref={ref}
+      position="absolute"
+      marginTop={offsetTop}
+      marginLeft={offsetLeft}
+      borderStyle="round"
+      borderColor={chromeTheme.colors.railMuted}
+      backgroundColor={chromeTheme.colors.railBackground}
+      width={width}
+      flexDirection="column"
+    >
+      {children}
     </Box>
   );
+}
+
+/** One wheel notch, clamped — the list does not wrap on ↑/↓ either. */
+function moveMenuCursor(
+  mouse: MouseContextValue,
+  delta: number,
+  cursor: number,
+  itemCount: number,
+): void {
+  if (itemCount === 0) return;
+  const next = Math.max(0, Math.min(itemCount - 1, cursor + delta));
+  if (next === cursor) return;
+  mouse.dispatch({ type: "menu_cursor_set", cursor: next });
 }
 
 function TitleRow({

--- a/src/tui/menu/menu-popup.tsx
+++ b/src/tui/menu/menu-popup.tsx
@@ -19,8 +19,8 @@ import { MENU_LEADER_LABEL } from "./menu-keys.js";
 const PREFERRED_WIDTH = 64;
 /** Rows of list body at most, before the window starts scrolling. */
 const MAX_BODY_ROWS = 16;
-/** Border (2) + title row + footer row. */
-const CHROME_ROWS = 4;
+/** Border (2) + title row + the footer's hairline + footer row. */
+const CHROME_ROWS = 5;
 /** Column reserved for the entry label. */
 const LABEL_WIDTH = 26;
 
@@ -56,9 +56,11 @@ interface MenuPopupProps {
  * are laid out as fixed-width columns rather than with `flexGrow` — a flexed
  * row stops at its content and lets the background show through.
  *
- * A background colour would do the same job in one line, but only by picking
- * a colour, and the TUI ships eleven themes across light and dark grounds.
- * Spaces are theme-agnostic.
+ * The redesign gives the panel a ground of its own, so the padding now
+ * carries a colour too: `railBackground` / `railForeground`, the pair every
+ * palette already guarantees to be opposite. Picking a literal colour is what
+ * the old comment here refused to do, and rightly — a role is not a literal,
+ * and it flips polarity with the theme.
  *
  * The app behind is dimmed by `setBackdropDimmed` (see `theme.ts`); this
  * component reads {@link chromeTheme}, which ignores that flag, so the menu
@@ -102,14 +104,15 @@ export function MenuPopup({
       marginTop={offsetTop}
       marginLeft={offsetLeft}
       borderStyle="round"
-      borderColor={chromeTheme.colors.accent}
+      borderColor={chromeTheme.colors.railMuted}
+      backgroundColor={chromeTheme.colors.railBackground}
       width={width}
       flexDirection="column"
     >
       <TitleRow state={state} inner={inner} />
       {visible.map((row, idx) =>
         row.kind === "header" ? (
-          <Text key={`h-${row.label}-${idx}`} color={chromeTheme.colors.muted}>
+          <Text key={`h-${row.label}-${idx}`} color={chromeTheme.colors.railMuted}>
             {fit(` ${row.label.toUpperCase()}`, inner)}
           </Text>
         ) : (
@@ -126,7 +129,10 @@ export function MenuPopup({
       {rows.length === 0 ? (
         <Text color={chromeTheme.colors.warn}>{fit(" nothing matches", inner)}</Text>
       ) : null}
-      <Text color={chromeTheme.colors.muted}>
+      <Text color={chromeTheme.colors.railMuted}>
+        {chromeTheme.glyphs.toolBoxHorizontal.repeat(Math.max(0, inner))}
+      </Text>
+      <Text color={chromeTheme.colors.railMuted}>
         {fit(` ${footer(state, hiddenAfter)}`, inner)}
       </Text>
     </Box>
@@ -140,16 +146,20 @@ function TitleRow({
   state: TuiState;
   inner: number;
 }): ReactElement {
-  const title = selectMenuTitle(state);
+  // Upper case, matching the rail's own section headers — the menu is
+  // chrome, and the design sets every chrome heading the same way.
+  const title = selectMenuTitle(state).toUpperCase();
   const caret = `${chromeTheme.glyphs.promptCaret} ${state.menuQuery}`;
-  const left = fit(` ${title}`, Math.min(title.length + 3, inner));
+  const left = fit(` ${title}`, Math.min(title.length + 2, inner));
   const rest = inner - left.length;
   return (
     <Box>
-      <Text color={chromeTheme.colors.accentSoft} bold>
+      <Text color={chromeTheme.colors.railForeground} bold>
         {left}
       </Text>
-      <Text color={chromeTheme.colors.muted}>{fit(caret, Math.max(0, rest))}</Text>
+      <Text color={chromeTheme.colors.railMuted}>
+        {fit(caret, Math.max(0, rest))}
+      </Text>
     </Box>
   );
 }
@@ -170,28 +180,33 @@ function MenuItem({
 }): ReactElement {
   const mouse = useMouseCommands();
   const { node } = row;
-  const marker = selected ? chromeTheme.glyphs.chevronRight : " ";
+  const marker = selected ? chromeTheme.glyphs.menuCursor : " ";
   const arrow = node.kind === "submenu" ? ` ${chromeTheme.glyphs.arrowRight}` : "";
   // Leading and trailing space are part of the row, not Box padding, so the
   // whole line is opaque edge to edge.
   const label = fit(` ${marker} ${node.label}${arrow}`, Math.min(LABEL_WIDTH, inner));
-  const chordText = node.chord ? `${MENU_LEADER_LABEL} ${node.chord} ` : " ";
-  const chord = fit(chordText, Math.min(chordText.length, Math.max(0, inner - label.length)));
-  const detailWidth = Math.max(0, inner - label.length - chord.length);
+  // The shortcut is flush right, as drawn: it is a column the eye scans
+  // down, so it cannot float behind a label of whatever length.
+  const chordText = node.chord ? `${MENU_LEADER_LABEL} ${node.chord} ` : "";
+  const chordWidth = Math.min(chordText.length, Math.max(0, inner - label.length));
+  const chord = chordText.padStart(chordWidth).slice(0, chordWidth);
+  const detailWidth = Math.max(0, inner - label.length - chordWidth);
   const detail = fit(
     [row.crumb, row.status].filter((part) => part.length > 0).join("  "),
     detailWidth,
   );
   const body = (
     <>
-      <Text
-        color={selected ? chromeTheme.colors.accentSoft : undefined}
-        bold={selected}
-      >
+      {/*
+        Selection is weight plus the marker, not a second colour: on a
+        painted panel a colour swap either fights the ground or is too
+        faint to see, and the marker is the part that survives NO_COLOR.
+      */}
+      <Text color={chromeTheme.colors.railForeground} bold={selected}>
         {label}
       </Text>
-      <Text color={chromeTheme.colors.muted}>{detail}</Text>
-      <Text color={chromeTheme.colors.muted}>{chord}</Text>
+      <Text color={chromeTheme.colors.railMuted}>{detail}</Text>
+      <Text color={chromeTheme.colors.railMuted}>{chord}</Text>
     </>
   );
   if (!mouse) return <Box>{body}</Box>;

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "ink-testing-library";
 import { describe, expect, it } from "vitest";
+import { ClipboardProvider } from "../clipboard/clipboard-context.js";
 import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "../tui-app.js";
 import type { TuiSessionInfo } from "../tui-state.js";
 import { makeMouseSource, type MouseSourceEmitter } from "./mouse-source.js";
@@ -49,6 +50,33 @@ function click(x: number, y: number): TuiMouseEvent {
   return {
     kind: "press",
     button: "left",
+    wheel: null,
+    x,
+    y,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  };
+}
+
+/** A motion report sent while the left button is held (DECSET 1002). */
+function drag(x: number, y: number): TuiMouseEvent {
+  return {
+    kind: "motion",
+    button: "left",
+    wheel: null,
+    x,
+    y,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  };
+}
+
+function release(x: number, y: number): TuiMouseEvent {
+  return {
+    kind: "release",
+    button: "none",
     wheel: null,
     x,
     y,
@@ -114,6 +142,8 @@ async function clickUntil(
 
 function mountApp(): {
   frame: () => string;
+  /** Text the app asked the clipboard to hold. */
+  copied: string[];
   mouse: MouseSourceEmitter;
   stdin: { write: (data: string) => void };
   openSkillsPanel: () => void;
@@ -126,7 +156,15 @@ function mountApp(): {
   const bus = makeTuiEventBus();
   const mouse = makeMouseSource();
   const deleted: string[] = [];
+  const copied: string[] = [];
+  const clipboard = {
+    copy: async (text: string) => {
+      copied.push(text);
+      return true;
+    },
+  };
   const { lastFrame, stdin, unmount } = render(
+    <ClipboardProvider writer={clipboard}>
     <TuiApp
       session={SESSION}
       bus={bus}
@@ -135,13 +173,15 @@ function mountApp(): {
         onSessionDeleteConfirmed: (sessionId) => deleted.push(sessionId),
       }}
       mouse={mouse}
-    />,
+    />
+    </ClipboardProvider>,
   );
   return {
     frame: () => strip(lastFrame() ?? ""),
     mouse,
     stdin,
     deleted,
+    copied,
     seedSessions: () => {
       bus.emit({
         type: "recent_sessions_updated",
@@ -457,6 +497,50 @@ describe("TuiApp mouse", () => {
       expect(app.deleted).toEqual([]);
       app.unmount();
     });
+  });
+
+  it("puts a start-page tip in the composer when it is clicked", async () => {
+    // The rows are suggestions, not buttons: the command lands in the
+    // buffer with a trailing space and Enter stays the operator's.
+    const app = mountApp();
+    await waitUntil(() => app.frame().includes("/sessions"), "the start page");
+    await delay(150);
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const at = locate(app.frame(), "/sessions");
+      app.mouse.emit(click(at.x + 2, at.y));
+      await delay(70);
+      if (app.frame().includes("❯ /sessions")) break;
+    }
+    expect(app.frame()).toContain("❯ /sessions");
+    // Seeded, not run: no palette over the buffer we just filled.
+    expect(app.frame()).not.toContain("/dump");
+    app.unmount();
+  });
+
+  it("selects composer text by dragging, and copies it with ctrl+c", async () => {
+    // The terminal stops doing its own drag-to-select the moment mouse
+    // reporting is on, so this gesture is the replacement for it.
+    const app = mountApp();
+    await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
+    app.stdin.write("hello world");
+    await waitUntil(() => app.frame().includes("hello world"), "the buffer");
+    await delay(150);
+
+    const at = locate(app.frame(), "hello world");
+    // Press on "w", drag to the end of the word, release.
+    app.mouse.emit(click(at.x + 6, at.y));
+    await delay(60);
+    app.mouse.emit(drag(at.x + 9, at.y));
+    await delay(60);
+    app.mouse.emit(release(at.x + 9, at.y));
+    await delay(60);
+
+    app.stdin.write(String.fromCharCode(3));
+    await delay(120);
+    expect(app.copied).toEqual(["wor"]);
+    // The quit chord must not have been armed by that Ctrl+C.
+    expect(app.frame()).not.toContain("press again to quit");
+    app.unmount();
   });
 
   it("moves a panel cursor with the wheel", async () => {

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -117,15 +117,23 @@ function mountApp(): {
   mouse: MouseSourceEmitter;
   stdin: { write: (data: string) => void };
   openSkillsPanel: () => void;
+  /** Put two threads in the rail so its rows are clickable. */
+  seedSessions: () => void;
+  /** Session ids the app asked the host to delete. */
+  deleted: string[];
   unmount: () => void;
 } {
   const bus = makeTuiEventBus();
   const mouse = makeMouseSource();
+  const deleted: string[] = [];
   const { lastFrame, stdin, unmount } = render(
     <TuiApp
       session={SESSION}
       bus={bus}
-      callbacks={noopCallbacks()}
+      callbacks={{
+        ...noopCallbacks(),
+        onSessionDeleteConfirmed: (sessionId) => deleted.push(sessionId),
+      }}
       mouse={mouse}
     />,
   );
@@ -133,6 +141,30 @@ function mountApp(): {
     frame: () => strip(lastFrame() ?? ""),
     mouse,
     stdin,
+    deleted,
+    seedSessions: () => {
+      bus.emit({
+        type: "recent_sessions_updated",
+        sessions: [
+          {
+            sessionId: "s-1",
+            workingDir: "/tmp/smoke",
+            turnCount: 1,
+            stepCount: 1,
+            updatedAt: 2,
+            preview: "first thread",
+          },
+          {
+            sessionId: "s-2",
+            workingDir: "/tmp/smoke",
+            turnCount: 1,
+            stepCount: 1,
+            updatedAt: 1,
+            preview: "second thread",
+          },
+        ],
+      });
+    },
     openSkillsPanel: () => {
       bus.emit({ type: "ui_mode_set", mode: "debug" });
       bus.emit({ type: "tab_changed", tab: "skills" });
@@ -349,6 +381,80 @@ describe("TuiApp mouse", () => {
       app.mouse.emit(click(at.x, at.y));
       await delay(120);
       expect(app.frame()).toContain("MENU");
+      app.unmount();
+    });
+  });
+
+  /**
+   * The rail's close mark and the confirmation it opens. Deleting a
+   * thread is the most destructive thing the mouse can reach, so the
+   * path from click to gone is pinned end to end.
+   */
+  describe("session delete", () => {
+    const openDialog = async (
+      app: ReturnType<typeof mountApp>,
+    ): Promise<void> => {
+      await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
+      app.seedSessions();
+      await waitUntil(() => app.frame().includes("first thread"), "the rail rows");
+      app.stdin.write("\t");
+      await waitUntil(() => app.frame().includes("[x]"), "the selected row");
+      await clickUntil(
+        app.mouse,
+        () => {
+          const at = locate(app.frame(), "[x]");
+          return { x: at.x + 1, y: at.y };
+        },
+        () => app.frame().includes("DELETE THE SESSION?"),
+        "click the close mark",
+      );
+    };
+
+    it("opens the confirmation from the row's close mark", async () => {
+      const app = mountApp();
+      await openDialog(app);
+      expect(app.frame()).toContain("DELETE THE SESSION?");
+      expect(app.frame()).toContain("Cancel");
+      expect(app.deleted).toEqual([]);
+      app.unmount();
+    });
+
+    it("deletes only when Yes is clicked", async () => {
+      const app = mountApp();
+      await openDialog(app);
+      // Retry against the OUTCOME, not against the dialog disappearing:
+      // a click that arrives before the button's registration effect
+      // has flushed falls through to the backdrop, which dismisses the
+      // dialog — that would satisfy a "dialog is gone" predicate while
+      // deleting nothing. Re-open and try again until something is
+      // actually deleted.
+      for (let attempt = 0; attempt < 20 && app.deleted.length === 0; attempt += 1) {
+        if (!app.frame().includes("DELETE THE SESSION?")) {
+          await openDialog(app);
+        }
+        // The dialog's buttons register their targets in an effect that
+        // flushes a frame after the panel first paints; clicking inside
+        // that window falls through to the backdrop.
+        await delay(150);
+        const at = locate(app.frame(), "Yes");
+        app.mouse.emit(click(at.x + 1, at.y));
+        await delay(80);
+      }
+      expect(app.deleted).toEqual(["s-1"]);
+      expect(app.frame()).not.toContain("DELETE THE SESSION?");
+      app.unmount();
+    });
+
+    it("cancels on a click outside the panel, deleting nothing", async () => {
+      const app = mountApp();
+      await openDialog(app);
+      await clickUntil(
+        app.mouse,
+        () => ({ x: 0, y: 0 }),
+        () => !app.frame().includes("DELETE THE SESSION?"),
+        "click outside the dialog",
+      );
+      expect(app.deleted).toEqual([]);
       app.unmount();
     });
   });

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -169,10 +169,10 @@ describe("TuiApp mouse", () => {
   // job and is covered by `menu-behaviour.test.ts`.
   it("opens the menu when the breadcrumb is clicked", async () => {
     const app = mountApp();
-    await waitUntil(() => app.frame().includes("Run"), "the Run screen");
+    await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
     await clickUntil(
       app.mouse,
-      () => locate(app.frame(), "Run"),
+      () => locate(app.frame(), "R U N"),
       () => app.frame().includes("Observe"),
       "click on the breadcrumb",
     );
@@ -185,7 +185,7 @@ describe("TuiApp mouse", () => {
 
   it("ignores a click that lands on no target", async () => {
     const app = mountApp();
-    await waitUntil(() => app.frame().includes("Run"), "the Run screen");
+    await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
     const before = app.frame();
     app.mouse.emit(click(0, 0));
     await delay(150);
@@ -195,7 +195,7 @@ describe("TuiApp mouse", () => {
 
   it("places the editor caret where the prompt is clicked", async () => {
     const app = mountApp();
-    await waitUntil(() => app.frame().includes("Run"), "the Run screen");
+    await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
     app.stdin.write("hello");
     await waitUntil(() => app.frame().includes("hello"), "the typed buffer");
     // Click the second "l" (index 3) then type: the character has to land
@@ -220,7 +220,7 @@ describe("TuiApp mouse", () => {
 
   it("clamps a click past the end of a line to the line end", async () => {
     const app = mountApp();
-    await waitUntil(() => app.frame().includes("Run"), "the Run screen");
+    await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
     app.stdin.write("hi");
     await waitUntil(() => app.frame().includes("hi"), "the typed buffer");
     await clickUntil(

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -218,6 +218,37 @@ describe("TuiApp mouse", () => {
     app.unmount();
   });
 
+  it("takes the keyboard back from the rail when the prompt is clicked", async () => {
+    // Tab parks focus on the rail, where ↑/↓ walk the session list. A
+    // click on the input has to mean "type here" — otherwise the caret
+    // moves to a field the keys still do not reach.
+    const app = mountApp();
+    await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
+    app.stdin.write("\t");
+    await waitUntil(
+      () => app.frame().includes("SESSIONS"),
+      "the rail on screen",
+    );
+    await clickUntil(
+      app.mouse,
+      () => {
+        const at = locate(app.frame(), "❯");
+        return { x: at.x + 2, y: at.y };
+      },
+      () => true,
+      "click in the prompt",
+    );
+    // The proof is that typing lands in the buffer rather than driving
+    // the rail's cursor.
+    app.stdin.write("typed");
+    await waitUntil(
+      () => app.frame().includes("typed"),
+      "the character typed into the prompt",
+    );
+    expect(app.frame()).toContain("typed");
+    app.unmount();
+  });
+
   it("clamps a click past the end of a line to the line end", async () => {
     const app = mountApp();
     await waitUntil(() => app.frame().includes("R U N"), "the Run screen");

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -229,23 +229,22 @@ describe("TuiApp mouse", () => {
       () => app.frame().includes("SESSIONS"),
       "the rail on screen",
     );
-    await clickUntil(
-      app.mouse,
-      () => {
-        const at = locate(app.frame(), "❯");
-        return { x: at.x + 2, y: at.y };
-      },
-      () => true,
-      "click in the prompt",
-    );
-    // The proof is that typing lands in the buffer rather than driving
-    // the rail's cursor.
-    app.stdin.write("typed");
-    await waitUntil(
-      () => app.frame().includes("typed"),
-      "the character typed into the prompt",
-    );
-    expect(app.frame()).toContain("typed");
+    // Click, then try to type: the proof is that a character lands in the
+    // buffer instead of being swallowed by the rail's key handler. The
+    // pair is retried together because a click that arrives before the
+    // target's registration effect has flushed simply does nothing —
+    // clicking once and then asserting is what made this flaky under a
+    // loaded test run.
+    let landed = false;
+    for (let attempt = 0; attempt < 25 && !landed; attempt += 1) {
+      const at = locate(app.frame(), "❯");
+      app.mouse.emit(click(at.x + 2, at.y));
+      await delay(60);
+      app.stdin.write("z");
+      await delay(60);
+      landed = app.frame().includes("z");
+    }
+    expect(landed).toBe(true);
     app.unmount();
   });
 
@@ -270,6 +269,88 @@ describe("TuiApp mouse", () => {
     );
     expect(app.frame()).toContain("hi!");
     app.unmount();
+  });
+
+  /**
+   * The menu is the app's one modal surface, so its mouse rules are the
+   * ones an operator will try first: spin to scroll, click a row to run
+   * it, click away to dismiss.
+   */
+  describe("operator menu", () => {
+    const openMenu = async (app: ReturnType<typeof mountApp>): Promise<void> => {
+      await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
+      app.stdin.write(String.fromCharCode(16));
+      await waitUntil(() => app.frame().includes("MENU"), "the menu");
+    };
+    /** The row the ▶ marker is sitting on. */
+    const selected = (app: ReturnType<typeof mountApp>): string =>
+      app
+        .frame()
+        .split("\n")
+        .find((line) => line.includes("▶"))
+        ?.replace(/.*▶\s*/, "")
+        .trim() ?? "";
+
+    it("walks the cursor with the wheel", async () => {
+      const app = mountApp();
+      await openMenu(app);
+      expect(selected(app)).toContain("Run");
+      const at = locate(app.frame(), "MENU");
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        app.mouse.emit(wheel("down", at.x + 4, at.y + 3));
+        await delay(40);
+        if (!selected(app).includes("Run")) break;
+      }
+      expect(selected(app)).toContain("Toggle debug pane");
+      // And back up again: one notch, one row, the same as the keys.
+      app.mouse.emit(wheel("up", at.x + 4, at.y + 3));
+      await waitUntil(() => selected(app).includes("Run"), "the cursor back on Run");
+      app.unmount();
+    });
+
+    it("runs the row that is clicked", async () => {
+      const app = mountApp();
+      await openMenu(app);
+      await clickUntil(
+        app.mouse,
+        () => {
+          const at = locate(app.frame(), "Toggle debug pane");
+          return { x: at.x + 2, y: at.y };
+        },
+        () => !app.frame().includes("MENU"),
+        "click a menu row",
+      );
+      // Acting closes the menu — the row ran rather than just selecting.
+      expect(app.frame()).not.toContain("MENU");
+      app.unmount();
+    });
+
+    it("closes when the click lands outside the panel", async () => {
+      const app = mountApp();
+      await openMenu(app);
+      // Top-left of the viewport: the status bar, well clear of a popup
+      // that is centred in the pane.
+      await clickUntil(
+        app.mouse,
+        () => ({ x: 0, y: 0 }),
+        () => !app.frame().includes("MENU"),
+        "click outside the menu",
+      );
+      expect(app.frame()).not.toContain("MENU");
+      app.unmount();
+    });
+
+    it("stays open when the click lands on the panel's own chrome", async () => {
+      const app = mountApp();
+      await openMenu(app);
+      // The title row is inside the popup: clicking it must not fall
+      // through to the backdrop.
+      const at = locate(app.frame(), "MENU");
+      app.mouse.emit(click(at.x, at.y));
+      await delay(120);
+      expect(app.frame()).toContain("MENU");
+      app.unmount();
+    });
   });
 
   it("moves a panel cursor with the wheel", async () => {

--- a/src/tui/mouse/mouse-event.ts
+++ b/src/tui/mouse/mouse-event.ts
@@ -14,7 +14,13 @@
 
 export type MouseButton = "left" | "middle" | "right" | "none";
 
-export type MouseEventKind = "press" | "release" | "wheel";
+/**
+ * `motion` is a report sent while a button is held (DECSET 1002). It is
+ * a separate kind on purpose: the terminal encodes it as a press with
+ * bit 5 set, and folding it into `press` would make a drag across the
+ * UI fire a click per cell it crossed.
+ */
+export type MouseEventKind = "press" | "release" | "wheel" | "motion";
 
 export type WheelDirection = "up" | "down";
 
@@ -36,6 +42,8 @@ export interface TuiMouseEvent {
 /** True for a plain (unmodified) left-button press — the "click" gesture. */
 export function isPrimaryPress(event: TuiMouseEvent): boolean {
   return (
+    // `motion` is excluded by construction: it is its own kind, so every
+    // existing handler that gates on this keeps ignoring drags.
     event.kind === "press" &&
     event.button === "left" &&
     !event.shift &&

--- a/src/tui/mouse/mouse-registry.ts
+++ b/src/tui/mouse/mouse-registry.ts
@@ -63,6 +63,17 @@ export class MouseTargetRegistry {
   private readonly targets = new Map<number, RegisteredTarget>();
   private nextId = 1;
   private minLayer = MOUSE_LAYER_BASE;
+  /**
+   * The target holding the pointer for the duration of a drag, if any.
+   *
+   * Hit-testing by position is right for clicks and wrong for drags: a
+   * selection that starts in the composer and travels up into the chat
+   * log would otherwise deliver its motion — and its terminating
+   * release — to whatever sits under the cursor, so the selection would
+   * stop extending and never end. While captured, every event goes to
+   * the capturing target and to nobody else.
+   */
+  private captured: RegisteredTarget | null = null;
 
   /** Registers a target and returns its unregister function. */
   register(options: MouseTargetOptions): () => void {
@@ -83,10 +94,49 @@ export class MouseTargetRegistry {
    */
   setMinLayer(layer: number): void {
     this.minLayer = layer;
+    // A modal opening mid-drag ends the drag: the surface underneath is
+    // no longer eligible, and a capture that outlived it would keep
+    // feeding it events from behind the modal.
+    if (this.captured && this.captured.layer < layer) this.captured = null;
+  }
+
+  /**
+   * Route every event to `target` until {@link releasePointer}. Called
+   * by a target from inside its own press handler.
+   */
+  capturePointer(ref: RefObject<DOMElement | null>): void {
+    for (const target of this.targets.values()) {
+      if (target.ref === ref) {
+        this.captured = target;
+        return;
+      }
+    }
+  }
+
+  /** Hand routing back to hit-testing. Safe to call when nothing is captured. */
+  releasePointer(): void {
+    this.captured = null;
   }
 
   /** Offers `event` to the matching targets; `true` when one claimed it. */
   dispatch(event: TuiMouseEvent): boolean {
+    const captured = this.captured;
+    if (captured) {
+      // A captured target that has unmounted (or whose layer is now
+      // below the floor) cannot receive anything — drop the capture
+      // rather than swallow every event for the rest of the session.
+      const rect = absoluteRect(captured.ref.current);
+      if (!rect || captured.layer < this.minLayer) {
+        this.captured = null;
+      } else {
+        return captured.handler({
+          event,
+          localX: event.x - rect.left,
+          localY: event.y - rect.top,
+          rect,
+        });
+      }
+    }
     const hits: Array<{ target: RegisteredTarget; rect: MouseRect }> = [];
     for (const target of this.targets.values()) {
       if (target.layer < this.minLayer) continue;

--- a/src/tui/mouse/mouse-tracking.test.ts
+++ b/src/tui/mouse/mouse-tracking.test.ts
@@ -19,8 +19,8 @@ function makeStdout(isTty: boolean): FakeStdout {
   };
 }
 
-const ENABLE_TRACKING = "\u001B[?1000h";
-const DISABLE_TRACKING = "\u001B[?1000l";
+const ENABLE_TRACKING = "\u001B[?1002h";
+const DISABLE_TRACKING = "\u001B[?1002l";
 const ENABLE_SGR = "\u001B[?1006h";
 const DISABLE_SGR = "\u001B[?1006l";
 
@@ -31,13 +31,19 @@ describe("enableMouseTracking", () => {
     expect(stdout.writes).toEqual([ENABLE_TRACKING, ENABLE_SGR]);
   });
 
-  it("never asks for motion tracking", () => {
+  it("asks for button-event tracking but never any-motion", () => {
+    // 1002 reports motion only while a button is held, which is what
+    // drag-to-select in the composer needs. 1003 reports every pointer
+    // movement — a constant stream of wakeups, and the hit test walks
+    // the layout tree per event. Nothing here hovers.
     const stdout = makeStdout(true);
     const controller = enableMouseTracking({
       stdout: stdout as unknown as NodeJS.WriteStream,
     });
+    const enabling = stdout.writes.join("");
+    expect(enabling).toContain("1002");
+    expect(enabling).not.toContain("1003");
     controller.disable();
-    expect(stdout.writes.join("")).not.toContain("1002");
     expect(stdout.writes.join("")).not.toContain("1003");
   });
 

--- a/src/tui/mouse/mouse-tracking.ts
+++ b/src/tui/mouse/mouse-tracking.ts
@@ -6,10 +6,16 @@
  * terminal in reporting mode (where every click would print garbage
  * into the user's shell).
  *
- * We request **1000 (normal tracking)** plus **1006 (SGR encoding)**
- * only. 1002/1003 (drag / any-motion) are intentionally left off: the
- * app has no hover or drag affordance, and motion reports are a
- * constant stream of wakeups for a UI that does not use them.
+ * We request **1002 (button-event tracking)** plus **1006 (SGR
+ * encoding)**. 1002 is 1000 plus motion reports *while a button is
+ * held*, which is what makes drag-to-select in the composer possible;
+ * the parser decodes the motion bit into its own event kind so a drag
+ * cannot be mistaken for a click per cell it crosses.
+ *
+ * **1003 (any-motion) stays off.** It reports every pointer movement
+ * whether or not a button is down — a constant stream of wakeups, and
+ * the hit-test walks the Yoga tree for every registered target on each
+ * event. Nothing in this UI hovers, so there is nothing to spend it on.
  *
  * The trade-off this mode forces — the terminal stops doing its own
  * drag-to-select while reporting is on — is why mouse support is a
@@ -19,9 +25,9 @@
  */
 import type { Writable } from "node:stream";
 
-/** Normal tracking: press + release, no motion. */
-const ENABLE_BUTTON_TRACKING = "\u001B[?1000h";
-const DISABLE_BUTTON_TRACKING = "\u001B[?1000l";
+/** Button-event tracking: press, release, and motion while held. */
+const ENABLE_BUTTON_TRACKING = "\u001B[?1002h";
+const DISABLE_BUTTON_TRACKING = "\u001B[?1002l";
 /** SGR extended reports — required past column 223. */
 const ENABLE_SGR_REPORTS = "\u001B[?1006h";
 const DISABLE_SGR_REPORTS = "\u001B[?1006l";

--- a/src/tui/mouse/parse-mouse-events.ts
+++ b/src/tui/mouse/parse-mouse-events.ts
@@ -28,6 +28,12 @@ const SHIFT_BIT = 4;
 const ALT_BIT = 8;
 /** Bit 4. */
 const CTRL_BIT = 16;
+/**
+ * Bit 5 — set on reports the terminal sends while a button is held
+ * (DECSET 1002 button-event tracking). Without decoding it, a drag
+ * report is indistinguishable from a fresh press.
+ */
+const MOTION_BIT = 32;
 /** Bit 6 — wheel reports arrive as buttons 64 (up) / 65 (down). */
 const WHEEL_BIT = 64;
 
@@ -126,9 +132,18 @@ function buildEvent(
   released: boolean,
 ): TuiMouseEvent {
   const wheeling = (code & WHEEL_BIT) !== 0;
+  const dragging = !wheeling && !released && (code & MOTION_BIT) !== 0;
   const low = code & 3;
   return {
-    kind: wheeling ? "wheel" : released ? "release" : "press",
+    kind: wheeling
+      ? "wheel"
+      : released
+        ? "release"
+        : dragging
+          ? "motion"
+          : "press",
+    // A motion report still names the button being held, which is what
+    // lets a drag be attributed to the gesture that started it.
     button: wheeling || released ? "none" : buttonFromLowBits(low),
     wheel: wheeling ? (low === 0 ? "up" : "down") : null,
     // Terminals report 1-based cells; the layout engine is 0-based.

--- a/src/tui/rail-session-list.test.ts
+++ b/src/tui/rail-session-list.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptySessionState, recordTurn } from "../session/session-state.js";
+import { userTurn } from "../session/conversation-turn.js";
+import type { AgentRuntime } from "../runtime/bootstrap.js";
+import { ChatOrchestrator } from "./chat-orchestrator.js";
+import { makeTuiEventBus } from "./make-event-bus.js";
+import type { TuiAction } from "./tui-action.js";
+import type { SessionPickerEntry } from "./tui-state.js";
+
+/**
+ * The rail lists threads that have been spoken to. `+ new` mints a
+ * session immediately — the store row has to exist for scheduled tasks
+ * and webhooks that hold only an id — but an unnamed row says nothing,
+ * so it stays off the list until its first prompt names it.
+ */
+function blank(id: string) {
+  return createEmptySessionState({ id, workingDir: "/tmp" });
+}
+
+function spokenTo(id: string, text: string) {
+  return recordTurn(blank(id), userTurn(text));
+}
+
+function stubRuntime(
+  stored: ReturnType<typeof blank>[],
+  settleTurns = false,
+): AgentRuntime {
+  let created = 0;
+  return {
+    createSession: () => {
+      created += 1;
+      const fresh = blank(`s-new-${created}`);
+      stored.unshift(fresh);
+      return fresh;
+    },
+    steer: () => false,
+    // By default the turn never settles, so the tests observe the rail
+    // at the moment the prompt is sent. `settleTurns` is for the cases
+    // that need the orchestrator idle afterwards — deleting a session is
+    // refused while a turn holds it.
+    runTurn: (session: unknown) =>
+      settleTurns
+        ? Promise.resolve({ session, reason: "reply", stepCount: 1 })
+        : new Promise(() => {}),
+    sessionStore: {
+      listRecent: () => stored,
+      load: (id: string) => stored.find((s) => s.id === id) ?? null,
+      delete: (id: string) => {
+        const at = stored.findIndex((s) => s.id === id);
+        if (at >= 0) stored.splice(at, 1);
+      },
+    },
+    approvals: { clearSessionGrants: () => undefined },
+    config: {
+      update: { checkOnStartup: false, repo: "x/y" },
+      tracing: { trace: { dir: "/tmp", enabled: false } },
+    },
+    profileStore: { list: () => [] },
+    skillCatalog: [],
+  } as unknown as AgentRuntime;
+}
+
+function harness(stored: ReturnType<typeof blank>[], settleTurns = false) {
+  const bus = makeTuiEventBus();
+  const actions: TuiAction[] = [];
+  bus.subscribe((a) => actions.push(a));
+  const orchestrator = new ChatOrchestrator(stubRuntime(stored, settleTurns), bus, {
+    maxSteps: 5,
+    llamaUrl: "http://127.0.0.1:8080",
+  });
+  const rail = (): readonly SessionPickerEntry[] => {
+    for (let i = actions.length - 1; i >= 0; i -= 1) {
+      const action = actions[i];
+      if (action?.type === "recent_sessions_updated") return action.sessions;
+    }
+    return [];
+  };
+  const picker = (): readonly SessionPickerEntry[] => {
+    for (let i = actions.length - 1; i >= 0; i -= 1) {
+      const action = actions[i];
+      if (action?.type === "session_picker_opened") return action.sessions;
+    }
+    return [];
+  };
+  return { orchestrator, rail, picker, actions };
+}
+
+describe("rail session list", () => {
+  it("hides sessions nobody has spoken to", () => {
+    const stored = [spokenTo("s-old", "an older thread"), blank("s-blank")];
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((entry) => entry.sessionId)).toEqual(["s-old"]);
+  });
+
+  it("adds no row for a brand-new session", () => {
+    const stored = [spokenTo("s-old", "an older thread")];
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.newSession();
+    expect(rail().map((entry) => entry.sessionId)).toEqual(["s-old"]);
+  });
+
+  it("shows the row the moment the first prompt is sent, named by it", () => {
+    // The store cannot answer yet: the user turn only reaches SQLite
+    // when the whole turn finishes. The row is carried by the prompt.
+    const stored = [spokenTo("s-old", "an older thread")];
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.newSession();
+    orchestrator.sendMessage("build me a website");
+    const rows = rail();
+    expect(rows.map((entry) => entry.sessionId)).toEqual(["s-new-1", "s-old"]);
+    expect(rows[0]?.preview).toBe("build me a website");
+  });
+
+  it("does not double the row once the store catches up", () => {
+    // The stand-in and the stored row are the same session; the rail
+    // keys rows by id, so a duplicate would render twice.
+    const stored = [spokenTo("s-old", "older")];
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.newSession();
+    orchestrator.sendMessage("first prompt");
+    // The turn settles and the store now has the user turn.
+    const created = stored.find((s) => s.id === "s-new-1");
+    if (created) {
+      stored[stored.indexOf(created)] = recordTurn(created, userTurn("first prompt"));
+    }
+    orchestrator.refreshRecentSessions();
+    const ids = rail().map((entry) => entry.sessionId);
+    expect(ids).toEqual(["s-new-1", "s-old"]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("opens the picker on the same list the rail shows", () => {
+    // The menu's "N recent" badge counts the rail's entries, so a picker
+    // with its own idea of the set would contradict the number that
+    // advertised it.
+    const stored = [spokenTo("s-old", "older"), blank("s-blank")];
+    const { orchestrator, picker } = harness(stored);
+    orchestrator.openSessionPicker();
+    expect(picker().map((entry) => entry.sessionId)).toEqual(["s-old"]);
+  });
+
+  it("drops the stand-in when that session is deleted", async () => {
+    // Deletion is refused while a turn holds the session, so let the
+    // turn settle first — the stored row still has no user turn (the
+    // stub does not write one back), so only the stand-in is keeping
+    // the row on screen.
+    const stored = [spokenTo("s-old", "older")];
+    const { orchestrator, rail } = harness(stored, true);
+    orchestrator.newSession();
+    orchestrator.sendMessage("about to be deleted");
+    expect(rail().map((e) => e.sessionId)).toContain("s-new-1");
+    await new Promise((r) => setTimeout(r, 5));
+    orchestrator.deleteSession("s-new-1");
+    expect(rail().map((e) => e.sessionId)).not.toContain("s-new-1");
+  });
+});
+
+describe("rail session list — steering", () => {
+  it("names the session when /steer opens the conversation", () => {
+    // `steerMessage` can start the FIRST turn; a hook on sendMessage
+    // alone would leave the rail empty for that path.
+    const stored = [spokenTo("s-old", "older")];
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.newSession();
+    orchestrator.steerMessage("opening line");
+    expect(rail()[0]?.preview).toBe("opening line");
+  });
+});

--- a/src/tui/session-delete-keys.test.ts
+++ b/src/tui/session-delete-keys.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Key } from "ink";
+
+import { handleAppKey } from "./app-key-bindings.js";
+import {
+  createInitialTuiState,
+  type TuiSessionInfo,
+  type TuiState,
+} from "./tui-state.js";
+
+/**
+ * Keys for the "delete the session?" dialog. The load-bearing rule is
+ * the default: the cursor starts on Cancel, so Enter from a reflex is a
+ * dismissal rather than a deleted thread.
+ */
+function key(overrides: Partial<Key> = {}): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageDown: false,
+    pageUp: false,
+    home: false,
+    end: false,
+    return: false,
+    escape: false,
+    ctrl: false,
+    shift: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    meta: false,
+    super: false,
+    hyper: false,
+    capsLock: false,
+    numLock: false,
+    ...overrides,
+  } as Key;
+}
+
+function session(): TuiSessionInfo {
+  return {
+    sessionId: "s-x",
+    workingDir: "/tmp/w",
+    llamaUrl: "http://127.0.0.1:8080",
+    browserChannel: "chromium",
+    browserHeadless: true,
+    approvalLevel: 5,
+    maxSteps: 8,
+    skillCount: 0,
+  };
+}
+
+function confirming(cursor: "yes" | "cancel" = "cancel"): TuiState {
+  return {
+    ...createInitialTuiState(session()),
+    sessionDelete: { sessionId: "s-doomed", preview: "old thread", cursor },
+  };
+}
+
+function ctx(state: TuiState) {
+  return {
+    state,
+    dispatch: vi.fn(),
+    callbacks: {
+      onApprovalDecision: vi.fn(),
+      onAbort: vi.fn(),
+      onQuit: vi.fn(),
+      onSessionDeleteConfirmed: vi.fn(),
+    },
+    ctrlCArmed: false,
+    setCtrlCArmed: vi.fn(),
+    sidebarVisible: true,
+  };
+}
+
+describe("session delete confirmation keys", () => {
+  it("deletes on y", () => {
+    const c = ctx(confirming());
+    expect(handleAppKey("y", key(), c)).toBe(true);
+    expect(c.callbacks.onSessionDeleteConfirmed).toHaveBeenCalledWith("s-doomed");
+    expect(c.dispatch).toHaveBeenCalledWith({ type: "session_delete_closed" });
+  });
+
+  it("cancels on n and on Esc, without deleting", () => {
+    for (const stroke of [
+      { input: "n", k: key() },
+      { input: "", k: key({ escape: true }) },
+    ]) {
+      const c = ctx(confirming());
+      expect(handleAppKey(stroke.input, stroke.k, c)).toBe(true);
+      expect(c.callbacks.onSessionDeleteConfirmed).not.toHaveBeenCalled();
+      expect(c.dispatch).toHaveBeenCalledWith({ type: "session_delete_closed" });
+    }
+  });
+
+  it("Enter on the default cursor dismisses rather than deletes", () => {
+    // The dialog opens on Cancel. Someone who hits Enter without reading
+    // it must not lose a thread.
+    const c = ctx(confirming("cancel"));
+    expect(handleAppKey("", key({ return: true }), c)).toBe(true);
+    expect(c.callbacks.onSessionDeleteConfirmed).not.toHaveBeenCalled();
+    expect(c.dispatch).toHaveBeenCalledWith({ type: "session_delete_closed" });
+  });
+
+  it("Enter deletes once the cursor is moved to Yes", () => {
+    const c = ctx(confirming("yes"));
+    expect(handleAppKey("", key({ return: true }), c)).toBe(true);
+    expect(c.callbacks.onSessionDeleteConfirmed).toHaveBeenCalledWith("s-doomed");
+  });
+
+  it("arrows and Tab move between the two controls", () => {
+    const c = ctx(confirming("cancel"));
+    expect(handleAppKey("", key({ leftArrow: true }), c)).toBe(true);
+    expect(c.dispatch).toHaveBeenCalledWith({
+      type: "session_delete_cursor_set",
+      cursor: "yes",
+    });
+  });
+
+  it("swallows every other key so nothing reaches the rail behind it", () => {
+    const c = ctx(confirming());
+    expect(handleAppKey("q", key(), c)).toBe(true);
+    expect(c.callbacks.onQuit).not.toHaveBeenCalled();
+    expect(c.callbacks.onSessionDeleteConfirmed).not.toHaveBeenCalled();
+  });
+});

--- a/src/tui/shift-enter-support.ts
+++ b/src/tui/shift-enter-support.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether Shift+Enter reaches the app as a distinct keystroke.
+ *
+ * In the legacy terminal encoding it does not: Enter and Shift+Enter are
+ * both a bare `\r`, so the composer cannot tell them apart and the
+ * modifier means nothing. Under the kitty keyboard protocol it arrives
+ * as `ESC [ 13 ; 2 u` and does.
+ *
+ * `tui-command` probes for the protocol at startup and sets this once.
+ * The hint strip reads it so the newline chip names the key that will
+ * actually work — advertising Shift+Enter where Enter is indistinguishable
+ * would send a half-written message the first time someone believed it.
+ */
+let shiftEnterNewline = false;
+
+export function setShiftEnterNewline(supported: boolean): void {
+  shiftEnterNewline = supported;
+}
+
+export function hasShiftEnterNewline(): boolean {
+  return shiftEnterNewline;
+}

--- a/src/tui/theme/detect-terminal-background.test.ts
+++ b/src/tui/theme/detect-terminal-background.test.ts
@@ -253,11 +253,14 @@ describe("resolveStartupTheme", () => {
     expect(resolveStartupTheme("light")).toBe(THEMES["github-light"]);
   });
 
-  it("maps dark to github-dark", () => {
-    expect(resolveStartupTheme("dark")).toBe(THEMES["github-dark"]);
+  it("maps dark to the house palette", () => {
+    expect(resolveStartupTheme("dark")).toBe(THEMES["atomic-retro"]);
   });
 
-  it("falls back unknown to github-dark", () => {
-    expect(resolveStartupTheme("unknown")).toBe(THEMES["github-dark"]);
+  it("falls back unknown to the house palette", () => {
+    // Unknown means the probe got no answer, which is most often a dark
+    // terminal that does not answer OSC queries — so it lands where dark
+    // lands rather than on the light palette.
+    expect(resolveStartupTheme("unknown")).toBe(THEMES["atomic-retro"]);
   });
 });

--- a/src/tui/theme/detect-terminal-background.ts
+++ b/src/tui/theme/detect-terminal-background.ts
@@ -185,9 +185,9 @@ function classifyByLuminance(rgb: Rgb): TerminalBackgroundMode {
 
 /**
  * Map a detected background mode to the startup theme. The single switch point
- * for the autodetect feature: `dark`/`unknown` -> github-dark, `light` ->
+ * for the autodetect feature: `dark`/`unknown` -> atomic-retro, `light` ->
  * github-light.
  */
 export function resolveStartupTheme(mode: TerminalBackgroundMode): TuiTheme {
-  return mode === "light" ? THEMES["github-light"] : THEMES["github-dark"];
+  return mode === "light" ? THEMES["github-light"] : THEMES["atomic-retro"];
 }

--- a/src/tui/theme/theme-palettes.ts
+++ b/src/tui/theme/theme-palettes.ts
@@ -19,6 +19,44 @@
 
 import type { TuiColors } from "./theme.js";
 
+// "Atomic retro" — the house palette, and the one the app boots into.
+// Values are the design's own oklch tokens converted to sRGB; the two
+// exceptions are marked, and both exist because a browser mock can rely
+// on a page background that a terminal does not own.
+export const ATOMIC_RETRO_COLORS: TuiColors = {
+  // `primary` (oklch 42% .13 265 = #294793) is a *fill* in the design:
+  // the rail and the composer sit on it. As TEXT on a dark terminal it
+  // lands around 2:1 against the ground, so anything drawn in the accent
+  // uses the same hue lifted to oklch 68% instead. Same colour, readable.
+  user: "#7195e8",
+  assistant: "#5edb81",
+  system: "#858992",
+  reasoning: "#bb9af4",
+  tool: "#e6e8eb",
+  toolOk: "#5edb81",
+  toolError: "#eb6264",
+  accent: "#7195e8",
+  // The un-lifted fill. Anything that paints a ground (chips, the RUN
+  // badge, the composer) reaches for this, not for `accent`.
+  accentSoft: "#294793",
+  border: "#3c4048",
+  muted: "#858992",
+  error: "#eb6264",
+  warn: "#e6d35c",
+  warnStrong: "#f98f3a",
+  success: "#5edb81",
+  info: "#7195e8",
+  brandMark: "#c4d8ff",
+  // The design's sidebar is a solid indigo panel — the one place the
+  // fill colour is used as a fill, exactly as drawn.
+  railBackground: "#294793",
+  railForeground: "#e6e8eb",
+  railMuted: "#aebedf",
+  badgeBackground: "#1e2435",
+  chipBackground: "#f1f3f8",
+  chipForeground: "#13161d",
+};
+
 // GitHub Primer "dark (default)" — @primer/primitives functional tokens
 // (dist/css/functional/themes/dark.css). accent=fgColor-accent,
 // success=fgColor-success, attention=fgColor-attention,
@@ -45,6 +83,9 @@ export const GITHUB_DARK_COLORS: TuiColors = {
   railBackground: "#f0f6fc",
   railForeground: "#0d1117",
   railMuted: "#57606a",
+  badgeBackground: "#21262d",
+  chipBackground: "#f0f6fc",
+  chipForeground: "#0d1117",
 };
 
 // GitHub Primer "light (default)" — @primer/primitives functional tokens
@@ -70,6 +111,9 @@ export const GITHUB_LIGHT_COLORS: TuiColors = {
   railBackground: "#1f2328",
   railForeground: "#f6f8fa",
   railMuted: "#8c959f",
+  badgeBackground: "#eaeef2",
+  chipBackground: "#1f2328",
+  chipForeground: "#ffffff",
 };
 
 // Catppuccin Mocha — official palette (catppuccin/palette palette.json).
@@ -96,6 +140,9 @@ export const CATPPUCCIN_MOCHA_COLORS: TuiColors = {
   railBackground: "#eff1f5",
   railForeground: "#1e1e2e",
   railMuted: "#6c6f85",
+  badgeBackground: "#313244",
+  chipBackground: "#cdd6f4",
+  chipForeground: "#1e1e2e",
 };
 
 // Catppuccin Latte — official palette (light flavour).
@@ -120,6 +167,9 @@ export const CATPPUCCIN_LATTE_COLORS: TuiColors = {
   railBackground: "#1e1e2e",
   railForeground: "#eff1f5",
   railMuted: "#9ca0b0",
+  badgeBackground: "#dce0e8",
+  chipBackground: "#4c4f69",
+  chipForeground: "#eff1f5",
 };
 
 // Dracula — official spec (draculatheme.com). accent=purple, green,
@@ -146,6 +196,9 @@ export const DRACULA_COLORS: TuiColors = {
   railBackground: "#f8f8f2",
   railForeground: "#282a36",
   railMuted: "#6272a4",
+  badgeBackground: "#44475a",
+  chipBackground: "#f8f8f2",
+  chipForeground: "#282a36",
 };
 
 // Nord — official spec (nordtheme.com). accent=nord8 frost, nord14 green,
@@ -172,6 +225,9 @@ export const NORD_COLORS: TuiColors = {
   railBackground: "#eceff4",
   railForeground: "#2e3440",
   railMuted: "#6b7a90",
+  badgeBackground: "#3b4252",
+  chipBackground: "#eceff4",
+  chipForeground: "#2e3440",
 };
 
 // Tokyo Night ("Night" variant) — official spec
@@ -198,6 +254,9 @@ export const TOKYO_NIGHT_COLORS: TuiColors = {
   railBackground: "#c0caf5",
   railForeground: "#1a1b26",
   railMuted: "#565f89",
+  badgeBackground: "#292e42",
+  chipBackground: "#c0caf5",
+  chipForeground: "#1a1b26",
 };
 
 // Gruvbox Dark — official "bright" palette (morhetz/gruvbox). accent=blue,
@@ -224,6 +283,9 @@ export const GRUVBOX_DARK_COLORS: TuiColors = {
   railBackground: "#fbf1c7",
   railForeground: "#282828",
   railMuted: "#7c6f64",
+  badgeBackground: "#3c3836",
+  chipBackground: "#ebdbb2",
+  chipForeground: "#282828",
 };
 
 // Gruvbox Light — official "faded" palette on light bg (morhetz/gruvbox).
@@ -248,6 +310,9 @@ export const GRUVBOX_LIGHT_COLORS: TuiColors = {
   railBackground: "#282828",
   railForeground: "#fbf1c7",
   railMuted: "#928374",
+  badgeBackground: "#ebdbb2",
+  chipBackground: "#3c3836",
+  chipForeground: "#fbf1c7",
 };
 
 // Solarized Dark — official spec (Ethan Schoonover). Accents are shared
@@ -274,6 +339,9 @@ export const SOLARIZED_DARK_COLORS: TuiColors = {
   railBackground: "#fdf6e3",
   railForeground: "#002b36",
   railMuted: "#657b83",
+  badgeBackground: "#073642",
+  chipBackground: "#eee8d5",
+  chipForeground: "#002b36",
 };
 
 // Solarized Light — same accent set, light base. base1(muted), base2(border).
@@ -298,4 +366,7 @@ export const SOLARIZED_LIGHT_COLORS: TuiColors = {
   railBackground: "#002b36",
   railForeground: "#fdf6e3",
   railMuted: "#93a1a1",
+  badgeBackground: "#eee8d5",
+  chipBackground: "#073642",
+  chipForeground: "#fdf6e3",
 };

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -19,6 +19,7 @@
  */
 
 import {
+  ATOMIC_RETRO_COLORS,
   CATPPUCCIN_LATTE_COLORS,
   CATPPUCCIN_MOCHA_COLORS,
   DRACULA_COLORS,
@@ -64,6 +65,21 @@ export interface TuiColors {
   readonly railForeground: string;
   /** Secondary text on the rail — same role as `muted`, on the rail ground. */
   readonly railMuted: string;
+  /**
+   * Ground for an accent-tinted badge — one step off the terminal's own
+   * background, always read with `accent` text on top. A terminal has no
+   * alpha, so what the design expresses as "accent at 15% over the page"
+   * is baked per palette instead.
+   */
+  readonly badgeBackground: string;
+  /**
+   * Face and label of a raised control (`+ new`, `≡ Menu`, `send →`).
+   * Its own pair rather than the rail's, because a palette may paint the
+   * rail in a colour — this design does — and a button then has to stay
+   * legible against that panel rather than merge into it.
+   */
+  readonly chipBackground: string;
+  readonly chipForeground: string;
   readonly border: string;
   readonly muted: string;
   readonly error: string;
@@ -110,6 +126,7 @@ export interface TuiTheme {
 
 /** Canonical theme identifier used by the registry and resolver. */
 export type ThemeName =
+  | "atomic-retro"
   | "github-dark"
   | "github-light"
   | "catppuccin-mocha"
@@ -173,6 +190,7 @@ function makeTheme(colors: TuiColors): TuiTheme {
 
 /** Registry of every named theme, keyed by {@link ThemeName}. */
 export const THEMES: Readonly<Record<ThemeName, TuiTheme>> = {
+  "atomic-retro": makeTheme(ATOMIC_RETRO_COLORS),
   "github-dark": makeTheme(GITHUB_DARK_COLORS),
   "github-light": makeTheme(GITHUB_LIGHT_COLORS),
   "catppuccin-mocha": makeTheme(CATPPUCCIN_MOCHA_COLORS),
@@ -188,6 +206,7 @@ export const THEMES: Readonly<Record<ThemeName, TuiTheme>> = {
 
 /** Ordered list of theme names, for palettes / help / validation. */
 export const THEME_NAMES: readonly ThemeName[] = [
+  "atomic-retro",
   "github-dark",
   "github-light",
   "catppuccin-mocha",
@@ -207,9 +226,9 @@ export function isThemeName(name: string): name is ThemeName {
 }
 
 // Module-level active theme, swapped by `setActiveTheme`. Defaults to the
-// GitHub dark baseline so the proxy is usable from import time (before
+// house palette so the proxy is usable from import time (before
 // autodetection / an explicit `/theme` switch).
-let activeTheme: TuiTheme = THEMES["github-dark"];
+let activeTheme: TuiTheme = THEMES["atomic-retro"];
 
 /**
  * Swap the active theme behind the {@link theme} proxy. Call this at startup
@@ -231,7 +250,7 @@ export function getActiveThemeName(): ThemeName {
   for (const name of THEME_NAMES) {
     if (THEMES[name] === activeTheme) return name;
   }
-  return "github-dark";
+  return "atomic-retro";
 }
 
 /**

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -111,6 +111,8 @@ export interface TuiGlyphs {
   readonly ellipsis: string;
   readonly promptCaret: string;
   readonly chevronRight: string;
+  /** Filled marker on the operator menu's selected row. */
+  readonly menuCursor: string;
   /** Hamburger, for the rail's menu button. */
   readonly menuGlyph: string;
   readonly dotSeparator: string;
@@ -161,6 +163,7 @@ const GLYPHS: TuiGlyphs = {
   ellipsis: "…",
   promptCaret: "❯",
   chevronRight: "▸",
+  menuCursor: "▶",
   menuGlyph: "☰",
   dotSeparator: "·",
   pipeSeparator: "|",
@@ -280,10 +283,28 @@ export function isBackdropDimmed(): boolean {
   return backdropDimmed;
 }
 
+/**
+ * Roles that paint a ground rather than ink on one. Dimming these to
+ * `muted` alongside the text they sit under collapses the two into one
+ * flat slab — the rail stops being a rail and becomes a grey block. The
+ * backdrop should read as *faded*, not as *erased*: keep the grounds,
+ * fade what is written on them.
+ */
+const GROUND_ROLES = new Set<keyof TuiColors>([
+  "railBackground",
+  "badgeBackground",
+  "chipBackground",
+]);
+
 function dimColors(colors: TuiColors): TuiColors {
   if (dimmedColorsFor === colors && dimmedColorsCache) return dimmedColorsCache;
   const flat = Object.fromEntries(
-    Object.keys(colors).map((key) => [key, colors.muted]),
+    Object.keys(colors).map((key) => [
+      key,
+      GROUND_ROLES.has(key as keyof TuiColors)
+        ? colors[key as keyof TuiColors]
+        : colors.muted,
+    ]),
   ) as unknown as TuiColors;
   dimmedColorsFor = colors;
   dimmedColorsCache = flat;

--- a/src/tui/tui-action.ts
+++ b/src/tui/tui-action.ts
@@ -34,6 +34,8 @@ export type TuiAction =
   | { type: "session_delete_cursor_set"; cursor: "yes" | "cancel" }
   | { type: "session_delete_closed" }
   | { type: "approval_resolved"; approvalId: string; approved: boolean }
+  /** The composer gained or lost a text selection (drives Ctrl+C's meaning). */
+  | { type: "composer_selection_changed"; hasSelection: boolean }
   | { type: "metric"; sample: MetricSample }
   | { type: "log"; record: LogRecord }
   | { type: "skill_count_changed"; count: number }

--- a/src/tui/tui-action.ts
+++ b/src/tui/tui-action.ts
@@ -36,6 +36,8 @@ export type TuiAction =
   | { type: "approval_resolved"; approvalId: string; approved: boolean }
   /** The composer gained or lost a text selection (drives Ctrl+C's meaning). */
   | { type: "composer_selection_changed"; hasSelection: boolean }
+  /** Transient line in the composer meta row; `null` clears it. */
+  | { type: "composer_notice"; text: string | null }
   | { type: "metric"; sample: MetricSample }
   | { type: "log"; record: LogRecord }
   | { type: "skill_count_changed"; count: number }

--- a/src/tui/tui-action.ts
+++ b/src/tui/tui-action.ts
@@ -29,6 +29,10 @@ export type TuiAction =
   | { type: "system_message"; text: string; variant?: "normal" | "warn" }
   | { type: "agent_event"; event: AgentLoopEvent }
   | { type: "approval_requested"; request: ApprovalRequest }
+  /** The `x` on a rail session row: ask before removing the thread. */
+  | { type: "session_delete_requested"; sessionId: string; preview: string }
+  | { type: "session_delete_cursor_set"; cursor: "yes" | "cancel" }
+  | { type: "session_delete_closed" }
   | { type: "approval_resolved"; approvalId: string; approved: boolean }
   | { type: "metric"; sample: MetricSample }
   | { type: "log"; record: LogRecord }

--- a/src/tui/tui-app.test.tsx
+++ b/src/tui/tui-app.test.tsx
@@ -67,9 +67,9 @@ describe("TuiApp (smoke)", () => {
     expect(text).toContain("atomic-agent");
     // The status bar shows where you are, not a menu of where you could go —
     // the three-section pill row moved into the ctrl+p menu.
-    expect(text).toContain("Run");
-    expect(text).not.toContain("Observe");
-    expect(text).not.toContain("Manage");
+    expect(text).toContain("R U N");
+    expect(text).not.toContain("OBSERVE");
+    expect(text).not.toContain("MANAGE");
     // Both rail panes are part of the Run screen at this size.
     expect(text).toContain("SESSIONS");
     expect(text).toContain("TASKS");
@@ -105,7 +105,7 @@ describe("TuiApp (smoke)", () => {
     bus.emit({ type: "ui_mode_set", mode: "debug" });
     await new Promise((r) => setTimeout(r, 10));
     const text = strip(lastFrame() ?? "");
-    expect(text).toContain("Observe");
+    expect(text).toContain("OBSERVE");
     expect(text).toContain("Feed");
     expect(text).toContain("Logs");
     // Manage-only tabs should not be in the Observe sub-tab strip.
@@ -124,7 +124,7 @@ describe("TuiApp (smoke)", () => {
     bus.emit({ type: "tab_changed", tab: "tasks" });
     await new Promise((r) => setTimeout(r, 10));
     const text = strip(lastFrame() ?? "");
-    expect(text).toContain("Manage");
+    expect(text).toContain("MANAGE");
     expect(text).toContain("Tasks");
     expect(text).toContain("Skills");
     expect(text).toContain("Telegram");
@@ -174,7 +174,7 @@ describe("TuiApp (smoke)", () => {
     );
     await new Promise((r) => setTimeout(r, 10));
     const before = strip(lastFrame() ?? "");
-    expect(before).toContain("Run");
+    expect(before).toContain("R U N");
     stdin.write("\t");
     await new Promise((r) => setTimeout(r, 10));
     const after = strip(lastFrame() ?? "");
@@ -183,12 +183,12 @@ describe("TuiApp (smoke)", () => {
     if (before.includes("SESSIONS")) {
       // Sidebar visible: Tab lands focus on the rail and stays in
       // chat mode. Ctrl+B is the dedicated key for nav cycling.
-      expect(after).toContain("Run");
-      expect(after).not.toContain("Observe \u25b8");
+      expect(after).toContain("R U N");
+      expect(after).not.toContain("OBSERVE \u25b8");
     } else {
       // Sidebar collapsed (narrow runner): Tab falls back to the nav
       // cycle and lands on Observe → Feed.
-      expect(after).toContain("Observe \u25b8 Feed");
+      expect(after).toContain("OBSERVE \u25b8 Feed");
     }
     unmount();
   });
@@ -202,7 +202,7 @@ describe("TuiApp (smoke)", () => {
     stdin.write("\u0002");
     await new Promise((r) => setTimeout(r, 10));
     const text = strip(lastFrame() ?? "");
-    expect(text).toContain("Observe \u25b8 Feed");
+    expect(text).toContain("OBSERVE \u25b8 Feed");
     unmount();
   });
 
@@ -218,7 +218,7 @@ describe("TuiApp (smoke)", () => {
     // Shift+Tab from Run wraps to the LAST Manage sub-tab. That is
     // `privacy`, not `telegram` — see `MANAGE_TABS` in `section.ts`, which
     // gained `import` and `privacy` after this test was written.
-    expect(text).toContain("Manage \u25b8");
+    expect(text).toContain("MANAGE \u25b8");
     // `▸` marks the ACTIVE sub-tab. A bare "Privacy" would also match the
     // inactive chip in the strip, so it must carry the marker.
     expect(text).toContain("▸ Privacy");
@@ -370,13 +370,13 @@ describe("TuiApp (smoke)", () => {
     bus.emit({ type: "ui_mode_set", mode: "debug" });
     bus.emit({ type: "tab_changed", tab: "tasks" });
     await new Promise((r) => setTimeout(r, 10));
-    expect(strip(lastFrame() ?? "")).toContain("Manage \u25b8");
+    expect(strip(lastFrame() ?? "")).toContain("MANAGE \u25b8");
 
     stdin.write("\u001b");
     await new Promise((r) => setTimeout(r, 60));
     const text = strip(lastFrame() ?? "");
-    expect(text).toContain("Run");
-    expect(text).not.toContain("Manage \u25b8");
+    expect(text).toContain("R U N");
+    expect(text).not.toContain("MANAGE \u25b8");
     unmount();
   });
 
@@ -424,7 +424,7 @@ describe("TuiApp (smoke)", () => {
     stdin.write("t");
     await new Promise((r) => setTimeout(r, 30));
     const text = strip(lastFrame() ?? "");
-    expect(text).toContain("Manage");
+    expect(text).toContain("MANAGE");
     expect(text).toContain("Tasks");
     // Ink delivers every key to every useInput, child first — so the editor
     // sees the chord letter too. If the leader did not disable it, a stray
@@ -457,7 +457,7 @@ describe("TuiApp (smoke)", () => {
     // chip key, not its label: a narrow runner wraps the strip and can split
     // "menu" off its own chip.
     expect(idle).toContain("[ctrl+p]");
-    expect(idle).not.toContain("Manage ▸");
+    expect(idle).not.toContain("MANAGE ▸");
     unmount();
   });
 
@@ -474,7 +474,7 @@ describe("TuiApp (smoke)", () => {
     await new Promise((r) => setTimeout(r, 20));
     const text = strip(lastFrame() ?? "");
     expect(text).not.toContain("esc close");
-    expect(text).toContain("Run");
+    expect(text).toContain("R U N");
     unmount();
   });
 

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -80,6 +80,7 @@ import { handleProvidersTabKey } from "./providers/providers-key-bindings.js";
 import { handleTelegramTabKey } from "./telegram/telegram-key-bindings.js";
 import { handlePrivacyTabKey } from "./privacy/privacy-key-bindings.js";
 import { MouseProvider } from "./mouse/mouse-context.js";
+import { isPrimaryPress } from "./mouse/mouse-event.js";
 import {
   MOUSE_LAYER_BASE,
   MOUSE_LAYER_MODAL,
@@ -709,6 +710,7 @@ export function TuiApp({
   // raising the floor stops a click from reaching the list rendered
   // behind it. Same predicate the key layer gates on.
   const modalOwnsInput =
+    state.menuOpen ||
     Boolean(state.pendingApproval) ||
     Boolean(state.updatePrompt) ||
     state.updateStatus === "done" ||
@@ -750,6 +752,33 @@ export function TuiApp({
         ref: contentMouseRef,
         layer: MOUSE_LAYER_BASE,
         handler: (hit) => wheelHandlerRef.current(hit),
+      }),
+    [registry],
+  );
+
+  /**
+   * The menu's backdrop. Registered on the same root box as the wheel
+   * target but at the modal layer, so it is eligible exactly while the
+   * menu owns input — and, being the largest box on that layer, it is
+   * sorted last: every target inside the popup gets the event first.
+   * That ordering is what makes "click outside to close" safe to state
+   * as one rule instead of a list of exceptions.
+   */
+  const menuBackdropHandler = (hit: MouseHit): boolean => {
+    if (!state.menuOpen) return false;
+    if (hit.event.kind === "wheel") return true;
+    if (!isPrimaryPress(hit.event)) return false;
+    dispatch({ type: "menu_closed" });
+    return true;
+  };
+  const menuBackdropRef = useRef(menuBackdropHandler);
+  menuBackdropRef.current = menuBackdropHandler;
+  useEffect(
+    () =>
+      registry.register({
+        ref: contentMouseRef,
+        layer: MOUSE_LAYER_MODAL,
+        handler: (hit) => menuBackdropRef.current(hit),
       }),
     [registry],
   );

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -16,7 +16,7 @@ import {
   handlePanelEscape,
   isPanelModalOpen,
 } from "./app-key-bindings.js";
-import { APP_CHROME_ROWS } from "./components/debug-pane.js";
+import { appChromeRows } from "./components/debug-pane.js";
 import { MenuPopup } from "./menu/menu-popup.js";
 import type { MenuNode } from "./menu/menu-registry.js";
 import { ApprovalModal } from "./approval-modal.js";
@@ -639,6 +639,35 @@ export function TuiApp({
       (sidebarVisible ? sidebarWidth + RAIL_GUTTER_COLUMNS : 0),
   );
   const sidebarFocused = sidebarVisible && state.chatFocus === "sidebar";
+  /**
+   * The composer belongs to the Run screen. Observe and Manage are for
+   * watching and configuring, and a prompt sitting under a settings
+   * panel invites a message nobody is going to read from there.
+   *
+   * The three exceptions are surfaces whose keyboard the composer owns
+   * while they are open: the slash palette types into its buffer, and
+   * the theme and session pickers are closed by the editor's own Esc.
+   * `handleAppKey` explicitly declines Esc while the palette is open
+   * (`!state.slashPaletteOpen`), so unmounting the composer under it
+   * would leave the palette with no way out at all.
+   */
+  const composerVisible =
+    state.uiMode === "chat" ||
+    state.slashPaletteOpen ||
+    state.themePickerOpen ||
+    state.sessionPickerOpen;
+
+  /**
+   * Live mirror of {@link composerVisible}. The unmounting editor keeps
+   * the callbacks from its last render — the one where the composer was
+   * still on screen — so a guard that closed over the boolean would read
+   * `true` exactly when it matters. The ref's identity is stable, so the
+   * stale closure reads the current value through it. (Render-phase
+   * write: derived from state, never written from an effect.)
+   */
+  const composerVisibleRef = useRef(true);
+  composerVisibleRef.current = composerVisible;
+
   const editorFocus =
     !state.menuOpen &&
     !menuLeaderArmed &&
@@ -845,15 +874,41 @@ export function TuiApp({
       handlePanelEscape(key, { panelHandled, editorFocus, dispatch });
       return;
     }
+    // Esc back to Run, for the tabs that have no key layer of their own
+    // (the Observe five: feed / world / reasoning / logs / llm logs).
+    // `handlePanelEscape` above never sees their keys — it runs only
+    // when a panel handler claimed something — and this used to be the
+    // editor's job, through the `onEscape` it no longer has here.
+    if (
+      !composerVisible &&
+      key.escape &&
+      !isPanelModalOpen(state) &&
+      state.uiMode === "debug"
+    ) {
+      dispatch({ type: "ui_mode_set", mode: "chat" });
+    }
   });
 
   const submit = useCallback(
-    (buffer: string) => handleEditorSubmit(buffer, state, dispatch, callbacks),
+    (buffer: string) => {
+      // Same stale-subscription window as `onEditorChange`: an Enter
+      // that arrives while the composer is leaving must not send.
+      if (!composerVisibleRef.current) return;
+      handleEditorSubmit(buffer, state, dispatch, callbacks);
+    },
     [state, callbacks],
   );
 
   const onEditorChange = useCallback(
     (next: string) => {
+      // An editor that is unmounting keeps its `useInput` subscription
+      // until the passive effect tears it down, one tick later — so the
+      // composer leaving the screen still delivers the keystroke that
+      // took the operator off the Run screen. Refuse edits whenever the
+      // composer is not on screen: its buffer is not reachable then, and
+      // a "/" seeded into it would open the slash palette over a panel
+      // that owns that key itself.
+      if (!composerVisibleRef.current) return;
       dispatch({ type: "input_changed", value: next });
       const prefix = slashPrefix(next);
       if (prefix !== null) {
@@ -1017,7 +1072,10 @@ export function TuiApp({
   const rootHeight = isTty ? terminalSize.rows : undefined;
   // Rows the content pane actually has, so the overlay can sit on its bottom
   // edge and cap its own height. Same budget the debug pane already uses.
-  const menuPaneRows = Math.max(6, terminalSize.rows - APP_CHROME_ROWS);
+  const menuPaneRows = Math.max(
+    6,
+    terminalSize.rows - appChromeRows(composerVisible),
+  );
   const promptLlm = selectPromptLlmMeta(state);
   // No local backend chosen yet ⇒ no local health to report. Without this the
   // splash screen of a fresh install announces that a server the user never
@@ -1121,6 +1179,7 @@ export function TuiApp({
               <DebugPane
                 state={state}
                 maxVisible={maxVisibleRows}
+                composerVisible={composerVisible}
                 onMcpAddJsonChange={(json) =>
                   dispatch({ type: "mcp_add_json_changed", json })
                 }
@@ -1211,8 +1270,13 @@ export function TuiApp({
               <UpdateRestartPrompt />
             </Box>
           ) : null}
-          <QueuedMessages queued={state.queuedMessages} width={mainColumnWidth} />
-          <PromptShell
+          {composerVisible ? (
+            <>
+              <QueuedMessages
+                queued={state.queuedMessages}
+                width={mainColumnWidth}
+              />
+              <PromptShell
             value={state.inputValue}
             placeholder="Type a message or `/` for commands…"
             rotatingPlaceholders={PROMPT_PLACEHOLDERS}
@@ -1228,9 +1292,11 @@ export function TuiApp({
             onTab={onTab}
             onAutocomplete={onTab}
             onClickFocus={focusEditorFromClick}
-            onHistoryPrev={onHistoryPrev}
-            onHistoryNext={onHistoryNext}
-          />
+                onHistoryPrev={onHistoryPrev}
+                onHistoryNext={onHistoryNext}
+              />
+            </>
+          ) : null}
           <HotkeyHint
             state={state}
             ctrlCArmed={ctrlCArmed}

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -1291,7 +1291,19 @@ export function TuiApp({
             onEscape={onEscape}
             onTab={onTab}
             onAutocomplete={onTab}
-            onClickFocus={focusEditorFromClick}
+                onClickFocus={focusEditorFromClick}
+                onSelectionChange={(hasSelection) =>
+                  dispatch({
+                    type: "composer_selection_changed",
+                    hasSelection,
+                  })
+                }
+                onCopy={(text) =>
+                  dispatch({
+                    type: "runtime_info",
+                    line: `copied ${text.length} character${text.length === 1 ? "" : "s"} to the clipboard`,
+                  })
+                }
                 onHistoryPrev={onHistoryPrev}
                 onHistoryNext={onHistoryNext}
               />

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -114,6 +114,9 @@ const RAIL_GUTTER_COLUMNS = 3;
  */
 const MODAL_CLICK_GRACE_MS = 150;
 
+/** How long a composer notice ("copied 3 characters") stays up. */
+const COMPOSER_NOTICE_MS = 2500;
+
 /**
  * A one-row hairline. `flexShrink={0}` so a tall chat never eats it, and
  * the glyph run is built from the width the caller measured rather than
@@ -1083,7 +1086,21 @@ export function TuiApp({
   // un-started one. `localConfigured` latches on as soon as local is really
   // the route (config says so, or a probe answered), so real local users keep
   // the ● / ○ signal they rely on.
-  const promptLeftSlot = promptLlm.usesLocalHealth ? (
+  // A notice outranks the health badge for the couple of seconds it is
+  // up: it is the answer to a keystroke the operator just made, and the
+  // badge is ambient.
+  useEffect(() => {
+    if (!state.composerNotice) return;
+    const timer = setTimeout(
+      () => dispatch({ type: "composer_notice", text: null }),
+      COMPOSER_NOTICE_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [state.composerNotice]);
+
+  const promptLeftSlot = state.composerNotice ? (
+    <Text color={theme.colors.success}>{state.composerNotice}</Text>
+  ) : promptLlm.usesLocalHealth ? (
     state.llmHealth.localConfigured ? (
       <LlmHealthBadge health={state.llmHealth} />
     ) : null
@@ -1300,8 +1317,8 @@ export function TuiApp({
                 }
                 onCopy={(text) =>
                   dispatch({
-                    type: "runtime_info",
-                    line: `copied ${text.length} character${text.length === 1 ? "" : "s"} to the clipboard`,
+                    type: "composer_notice",
+                    text: `copied ${text.length} character${text.length === 1 ? "" : "s"}`,
                   })
                 }
                 onHistoryPrev={onHistoryPrev}

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -95,6 +95,22 @@ export interface TuiEventBus {
   subscribe(listener: (action: TuiAction) => void): () => void;
 }
 
+/**
+ * A one-row hairline. `flexShrink={0}` so a tall chat never eats it, and
+ * the glyph run is built from the width the caller measured rather than
+ * `width="100%"`: Ink pads a percentage-width Box with spaces, which
+ * paints a gap in the rule wherever the row is wider than the text.
+ */
+function Rule({ width }: { width: number }): ReactElement {
+  return (
+    <Box flexShrink={0}>
+      <Text color={theme.colors.border}>
+        {theme.glyphs.toolBoxHorizontal.repeat(Math.max(0, width))}
+      </Text>
+    </Box>
+  );
+}
+
 export interface TuiAppCallbacks {
   onApprovalDecision(
     approvalId: string,
@@ -969,6 +985,13 @@ export function TuiApp({
       <Box flexShrink={0}>
         <StatusBar state={state} brand={!sidebarVisible} />
       </Box>
+      {/*
+        The design separates the top bar and the hint strip from the
+        content with a hairline. In a terminal that is a row of box-drawing
+        characters — the one honest way to draw a 1px rule when the
+        smallest unit you own is a cell.
+      */}
+      <Rule width={terminalSize.columns - ROOT_PADDING_COLUMNS} />
       <Box flexDirection="row" flexGrow={1} flexShrink={1} overflow="hidden">
         {sidebarVisible ? (
           <Sidebar

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -26,6 +26,7 @@ import { HotkeyHint } from "./components/hotkey-hint.js";
 import { LlmHealthBadge } from "./components/llm-health-badge.js";
 import { PromptShell } from "./components/prompt-shell.js";
 import { QueuedMessages } from "./components/queued-messages.js";
+import { SessionDeleteModal } from "./components/session-delete-modal.js";
 import { SessionPicker } from "./components/session-picker.js";
 import { ThemePicker } from "./components/theme-picker.js";
 import {
@@ -106,6 +107,14 @@ export interface TuiEventBus {
 const RAIL_GUTTER_COLUMNS = 3;
 
 /**
+ * How long after a modal opens its backdrop refuses to dismiss it. One
+ * frame is enough for the modal's own click targets to register; 150ms
+ * covers a loaded machine without being long enough to swallow a
+ * deliberate click away.
+ */
+const MODAL_CLICK_GRACE_MS = 150;
+
+/**
  * A one-row hairline. `flexShrink={0}` so a tall chat never eats it, and
  * the glyph run is built from the width the caller measured rather than
  * `width="100%"`: Ink pads a percentage-width Box with spaces, which
@@ -127,6 +136,12 @@ export interface TuiAppCallbacks {
     approved: boolean,
     grant?: ApprovalGrantScope,
   ): void;
+  /**
+   * Remove a session for good. Confirmed by the operator in the dialog
+   * the rail's `x` opens — the host does the deleting and decides where
+   * the UI lands if the current thread was the one removed.
+   */
+  onSessionDeleteConfirmed?(sessionId: string): void;
   onAbort(): void;
   onQuit(): void;
   onMessageSubmitted(message: string): void;
@@ -711,6 +726,7 @@ export function TuiApp({
   // behind it. Same predicate the key layer gates on.
   const modalOwnsInput =
     state.menuOpen ||
+    Boolean(state.sessionDelete) ||
     Boolean(state.pendingApproval) ||
     Boolean(state.updatePrompt) ||
     state.updateStatus === "done" ||
@@ -765,12 +781,35 @@ export function TuiApp({
    * as one rule instead of a list of exceptions.
    */
   const menuBackdropHandler = (hit: MouseHit): boolean => {
-    if (!state.menuOpen) return false;
+    const open = state.menuOpen || Boolean(state.sessionDelete);
+    if (!open) return false;
     if (hit.event.kind === "wheel") return true;
     if (!isPrimaryPress(hit.event)) return false;
-    dispatch({ type: "menu_closed" });
+    // A modal's own targets register in an effect that flushes a frame
+    // after it first paints. In that window the backdrop is the only
+    // eligible target, so a second click arriving fast — a double-click
+    // on the rail's `[x]`, or an impatient one on `ctrl+p` — would be
+    // read as "clicked outside" and dismiss the surface that just
+    // opened. Ignore presses until the modal has had that frame.
+    if (Date.now() - modalOpenedAtRef.current < MODAL_CLICK_GRACE_MS) {
+      return true;
+    }
+    // Clicking away from a destructive confirmation cancels it — the
+    // same dismissal the menu gets, and the safe outcome either way.
+    dispatch(
+      state.sessionDelete
+        ? { type: "session_delete_closed" }
+        : { type: "menu_closed" },
+    );
     return true;
   };
+  // Stamped when a backdrop-owning surface opens; read by the handler
+  // above. A ref rather than state: it must not trigger a render.
+  const modalOpenedAtRef = useRef(0);
+  const backdropOwner = state.menuOpen || Boolean(state.sessionDelete);
+  useEffect(() => {
+    if (backdropOwner) modalOpenedAtRef.current = Date.now();
+  }, [backdropOwner]);
   const menuBackdropRef = useRef(menuBackdropHandler);
   menuBackdropRef.current = menuBackdropHandler;
   useEffect(
@@ -880,11 +919,19 @@ export function TuiApp({
     // back one level, so a single unannounced press killing the agent —
     // and the half-typed message with it — was a trap: no hint strip ever
     // advertised it, while Ctrl+C deliberately asks twice. Quitting stays
-    // on Ctrl+C twice and `/quit`; Esc clears the draft and no-ops on an
-    // empty buffer.
+    // on Ctrl+C twice and `/quit`; Esc clears the draft first.
     if (state.inputValue.length > 0) {
       dispatch({ type: "input_changed", value: "" });
+      return;
     }
+    // Nothing left to cancel: Esc opens the menu. It is the LAST branch
+    // on purpose — abort, close, back and clear-draft all outrank it, so
+    // the key keeps every meaning it already had and gains one only when
+    // it would otherwise have done nothing. `ctrl+p` still opens the
+    // menu from anywhere, including mid-turn.
+    dispatch({ type: "menu_path_set", path: null });
+    dispatch({ type: "menu_cursor_set", cursor: 0 });
+    dispatch({ type: "menu_opened" });
   }, [state, callbacks]);
 
   /**
@@ -1085,6 +1132,23 @@ export function TuiApp({
                 }
               />
             )}
+            {state.sessionDelete ? (
+              <SessionDeleteModal
+                confirm={state.sessionDelete}
+                availableRows={menuPaneRows}
+                availableColumns={
+                  terminalSize.columns - 4 - (sidebarVisible ? sidebarWidth : 0)
+                }
+                onConfirm={(sessionId) => {
+                  callbacks.onSessionDeleteConfirmed?.(sessionId);
+                  dispatch({ type: "session_delete_closed" });
+                }}
+                onCancel={() => dispatch({ type: "session_delete_closed" })}
+                onFocus={(cursor) =>
+                  dispatch({ type: "session_delete_cursor_set", cursor })
+                }
+              />
+            ) : null}
             {state.menuOpen ? (
               <MenuPopup
                 state={state}

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -96,6 +96,15 @@ export interface TuiEventBus {
 }
 
 /**
+ * Columns of air between the rail's right edge and the chat column. The
+ * rail paints its own ground, so without a gutter the transcript starts
+ * one cell after a block of colour and reads as if it were inside the
+ * panel. Subtracted from `mainColumnWidth` as well, or the hairline and
+ * the hint strip overflow the row they are measured for.
+ */
+const RAIL_GUTTER_COLUMNS = 3;
+
+/**
  * A one-row hairline. `flexShrink={0}` so a tall chat never eats it, and
  * the glyph run is built from the width the caller measured rather than
  * `width="100%"`: Ink pads a percentage-width Box with spaces, which
@@ -611,7 +620,7 @@ export function TuiApp({
     0,
     terminalSize.columns -
       ROOT_PADDING_COLUMNS -
-      (sidebarVisible ? sidebarWidth : 0),
+      (sidebarVisible ? sidebarWidth + RAIL_GUTTER_COLUMNS : 0),
   );
   const sidebarFocused = sidebarVisible && state.chatFocus === "sidebar";
   const editorFocus =
@@ -849,6 +858,16 @@ export function TuiApp({
     }
   }, [state, callbacks]);
 
+  /**
+   * Clicking the prompt takes the keyboard back from the rail. Without
+   * this the caret moved but the arrow keys still walked the session
+   * list, which is the behaviour of no other application anywhere.
+   */
+  const focusEditorFromClick = useCallback(() => {
+    if (state.chatFocus === "editor") return;
+    dispatch({ type: "chat_focus_set", focus: "editor" });
+  }, [state.chatFocus]);
+
   // Tab in the editor is reserved for slash-palette completion. Section
   // / sub-tab cycling lives entirely in `handleAppKey` so the same key
   // press cannot be acted on twice (once globally, once here through a
@@ -1007,7 +1026,12 @@ export function TuiApp({
             focused={sidebarFocused}
           />
         ) : null}
-        <Box flexDirection="column" flexGrow={1} overflow="hidden">
+        <Box
+          flexDirection="column"
+          flexGrow={1}
+          overflow="hidden"
+          {...(sidebarVisible ? { paddingLeft: RAIL_GUTTER_COLUMNS } : {})}
+        >
           <Box
             flexDirection="column"
             flexGrow={1}
@@ -1110,6 +1134,7 @@ export function TuiApp({
             onEscape={onEscape}
             onTab={onTab}
             onAutocomplete={onTab}
+            onClickFocus={focusEditorFromClick}
             onHistoryPrev={onHistoryPrev}
             onHistoryNext={onHistoryNext}
           />

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -294,6 +294,8 @@ export async function tuiCommand(args: string[]): Promise<number> {
         onSessionPickerRequested: () => orchestrator.openSessionPicker(),
         onSessionSwitchRequested: (id) => orchestrator.switchSession(id),
         onSessionNewRequested: () => orchestrator.newSession(),
+        onSessionDeleteConfirmed: (sessionId) =>
+          orchestrator.deleteSession(sessionId),
         onNewWindowRequested: () => openNewAgentWindow(parsed.workingDir, bus),
         onMemoryDumpRequested: () => orchestrator.dumpProfile(),
         onSkillCatalogRequested: () => orchestrator.dumpSkillCatalog(),

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -43,6 +43,8 @@ import {
   currentTerminalLaunchInput,
   openAgentTerminalWindow,
 } from "./open-terminal-window.js";
+import { detectKittyKeyboard } from "./detect-kitty-keyboard.js";
+import { setShiftEnterNewline } from "./shift-enter-support.js";
 import { makeTuiEventBus, TuiApp } from "./tui-app.js";
 import {
   detectTerminalBackground,
@@ -89,6 +91,13 @@ export async function tuiCommand(args: string[]): Promise<number> {
   } else {
     setActiveTheme(resolveStartupTheme(await detectTerminalBackground()));
   }
+  // Ask the terminal whether it speaks the kitty keyboard protocol
+  // BEFORE Ink starts reading stdin — see `detectKittyKeyboard`. It
+  // decides two things: whether Shift+Enter can mean "newline" at all,
+  // and therefore what the hint strip is allowed to promise.
+  const kittyKeyboard = await detectKittyKeyboard();
+  setShiftEnterNewline(kittyKeyboard);
+
   const skipLlamaWizard =
     parsed.skipLlamaSetup || process.env.ATOMIC_AGENT_TUI_SKIP_LLAMA_SETUP === "1";
   const startupGate = await runLocalModelsStartupGateIfNeeded({
@@ -492,6 +501,23 @@ export async function tuiCommand(args: string[]): Promise<number> {
       stdout: process.stdout,
       stderr: process.stderr,
       exitOnCtrlC: false,
+      // `disambiguateEscapeCodes` alone: it is what makes Shift+Enter a
+      // distinct keystroke (`ESC [ 13 ; 2 u`). `reportAllKeysAsEscapeCodes`
+      // would reroute ordinary typing through CSI u as well, putting the
+      // paste and text-insert paths at risk for nothing.
+      //
+      // `mode: "enabled"` rather than `"auto"`: Ink's own probe and the
+      // App's reader both see the terminal's reply, so auto can type
+      // `[?1u` into the composer before the first render. We already
+      // asked, above, on a stdin nobody else was reading.
+      ...(kittyKeyboard
+        ? {
+            kittyKeyboard: {
+              mode: "enabled" as const,
+              flags: ["disambiguateEscapeCodes" as const],
+            },
+          }
+        : {}),
     },
   );
 

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -285,6 +285,15 @@ export interface TuiState {
   reasoning: ReasoningEntry[];
   pendingApproval: ApprovalRequest | null;
   /**
+  /**
+   * Whether the composer currently holds a text selection. Lifted out of
+   * the editor for exactly one reason: Ctrl+C means "copy" while text is
+   * selected and "stop / quit" otherwise, and the two handlers live in
+   * different layers — the app's global key layer would arm the quit
+   * chord before the editor ever saw the key.
+   */
+  composerHasSelection: boolean;
+  /**
    * Open "delete the session?" confirmation, or `null`. Carries the
    * preview so the dialog can name what is about to go, and the focused
    * button so Enter has an unambiguous meaning.
@@ -528,6 +537,7 @@ export function createInitialTuiState(
     streamingToolCards: [],
     reasoning: [],
     pendingApproval: null,
+    composerHasSelection: false,
     sessionDelete: null,
     loadedSkills: [],
     worldSnapshot: null,

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -294,6 +294,16 @@ export interface TuiState {
    */
   composerHasSelection: boolean;
   /**
+  /**
+   * A short, transient line shown in the composer's meta row — "copied
+   * 3 characters", and nothing heavier. It exists because the obvious
+   * channels are both wrong for this: `runtime_info` appends to the
+   * Observe feed, which nobody is looking at while they copy, and
+   * `system_message` writes a chat entry, which would push the start
+   * page off screen to acknowledge a keystroke.
+   */
+  composerNotice: string | null;
+  /**
    * Open "delete the session?" confirmation, or `null`. Carries the
    * preview so the dialog can name what is about to go, and the focused
    * button so Enter has an unambiguous meaning.
@@ -538,6 +548,7 @@ export function createInitialTuiState(
     reasoning: [],
     pendingApproval: null,
     composerHasSelection: false,
+    composerNotice: null,
     sessionDelete: null,
     loadedSkills: [],
     worldSnapshot: null,

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -246,6 +246,17 @@ export interface SessionPickerEntry {
   preview: string;
 }
 
+/**
+ * The pending session deletion. `cursor` is the focused button, and it
+ * starts on `cancel`: Enter on a dialog nobody read must not delete a
+ * thread.
+ */
+export interface SessionDeleteConfirm {
+  sessionId: string;
+  preview: string;
+  cursor: "yes" | "cancel";
+}
+
 export interface TuiState {
   session: TuiSessionInfo;
   status: TuiStatus;
@@ -273,6 +284,12 @@ export interface TuiState {
   /** Per-run list of `<think>` blocks. Cleared on `goal_submitted`. */
   reasoning: ReasoningEntry[];
   pendingApproval: ApprovalRequest | null;
+  /**
+   * Open "delete the session?" confirmation, or `null`. Carries the
+   * preview so the dialog can name what is about to go, and the focused
+   * button so Enter has an unambiguous meaning.
+   */
+  sessionDelete: SessionDeleteConfirm | null;
   loadedSkills: readonly LoadedSkillBody[];
   worldSnapshot: WorldSnapshot | null;
   latestResult: LatestResult | null;
@@ -511,6 +528,7 @@ export function createInitialTuiState(
     streamingToolCards: [],
     reasoning: [],
     pendingApproval: null,
+    sessionDelete: null,
     loadedSkills: [],
     worldSnapshot: null,
     latestResult: null,


### PR DESCRIPTION
Ports the [retro-tui-revamp](https://retro-tui-revamp.lovable.app/) design onto the real TUI. One look for everyone — `atomic-retro` is the palette the app boots into, and the shapes ship with it rather than hiding behind a flag.

## Colour

Values are the design's own oklch tokens converted to sRGB: background `#1c1e24`, foreground `#e6e8eb`, primary `#294793`, success `#5edb81`, warning `#e6d35c`, destructive `#eb6264`, dim `#868991`, border `#3c4048`, card `#f1f3f8` on `#13161d`.

Two deliberate departures, both because a terminal owns less than a browser does:

1. **The accent is lifted for text.** `primary` is a *fill* in the design — the rail and the composer sit on it. As text on a dark ground it lands near 2:1, so anything drawn in the accent uses the same hue at oklch 68% (`#7195e8`). Fills still use `#294793`.
2. **There is no page background.** A terminal's ground belongs to the user's profile; painting every cell fights their theme and flickers on resize. The rail, the composer and the chips paint their own grounds — the chat keeps the terminal's. On a dark terminal the result is what the mock shows.

## Shape

Applied to all twelve palettes, because this is layout, not colour:

- **`RUN` badge** in the top bar — tinted ground, letter-spaced — with the session id and the thread's title beside it, over a hairline rule. Tracking is a full cell in a terminal, so it applies to labels of four characters or fewer; `OBSERVE` and `MANAGE` are upper-cased instead of doubled in width.
- **Raised controls**: `+ new` (now on the Sessions header row, not a line of its own), `≡ Menu` at the foot of the rail, `send →` in the composer. A cell has no room for a 2px bevel, so raised is a light face under dark text — what raised meant before bevels existed. New `chipBackground` / `chipForeground` roles carry that pair per palette: this design paints the rail a colour, so a chip can no longer borrow the rail's inverted pair.
- **Rail lists**: Tasks counts its running rows in the header; a row gets a left accent bar when it is the live one (current session, running task) and a filled ground when it is where the cursor sits. The cursor keeps a glyph as well as the fill — a fill is a colour, and a colour is nothing under `NO_COLOR` or in a pipe.
- **`AGENT` / `YOU` labels** over the transcript's coloured left borders. These were removed once on the theory that the border colour is the label; the design puts the word back, which is also the accessible answer.
- The composer sits on its own panel (`badgeBackground`, the palette's one-step-off-the-ground surface) rather than on the page. Not the design's indigo fill: the editor draws its buffer with no foreground of its own, so an accent ground would leave the text unreadable on the light palettes.

## Row arithmetic

The hairline spends the row of slack `CHROME_ROWS` always carried rather than adding one. Raising it shrinks the chat viewport, and at 24 rows that came straight out of the operator menu — which sheds its own key-hint footer first. A second rule over the hint strip was drawn and then dropped for the same reason; the composer's border already reads as that edge. `SIDEBAR_CHROME_ROWS` drops 13 → 12 because `+ new` moved onto the header row, which hands a row back to the lists.

## Verification

- `npm run lint` clean. Full suite **4882 passed, 3 failed** — `llm-health-poller`, `sidecar send_message concurrency` (both timing flakes) and `fs-glob-real` (hardcoded to `/Users/aleksejkalina`). All three fail identically on pristine `origin/main` in this checkout.
- Screenshotted through a real PTY with `pyte` at 120×34, before and after, plus a frame with a message in the log — cell-level colour dumps confirm the badge renders `#7195e8` on `#1e2435`, the rail ground `#294793`, and the chips `#f1f3f8`.
- Tests updated where the chrome changed rather than worked around: the breadcrumb assertions now read the badge, the mouse harness locates `R U N`, `resolveStartupTheme` expects the house palette, and the rail-budget test tracks the freed row.
- `/theme` still lists the other eleven palettes and `/theme github-dark` restores the previous look; the choice persists.
