### PR TITLE
feat(tui): Send moves inside the composer field

### DIFF
--- a/src/tui/components/composer-send-button.tsx
+++ b/src/tui/components/composer-send-button.tsx
@@ -1,0 +1,66 @@
+import { Text } from "ink";
+import type { ReactElement } from "react";
+import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { theme } from "../theme/theme.js";
+
+/** The label carries its own padding so the chip's ground reads as a button. */
+const SEND_LABEL = " send → ";
+
+export interface ComposerSendButtonProps {
+  /** A disabled button still renders: it says the affordance exists. */
+  enabled: boolean;
+  onPress: () => void;
+}
+
+/**
+ * The composer's one button, drawn as a chip inside the input field.
+ *
+ * It used to sit on the action bar under the field, at the far right.
+ * That put the app's primary verb a row away from the text it acts on,
+ * and it spent the one slot on the bar that a status readout wants. In
+ * the field it stays at the same column and lands next to the caret.
+ *
+ * Every colour here is a *pair* taken from the theme rather than a
+ * literal, and the pair is one the palette already guarantees to be
+ * opposite: `chipBackground` against `chipForeground`. That is what
+ * keeps the chip legible across all eleven palettes without a per-theme
+ * table — the tokens flip polarity with the theme.
+ *
+ * A disabled Send drops to `badgeBackground` / `muted`, which is the
+ * terminal's version of a ghost button: still there, still labelled,
+ * visibly not pressable.
+ */
+export function ComposerSendButton({
+  enabled,
+  onPress,
+}: ComposerSendButtonProps): ReactElement {
+  const background = enabled
+    ? theme.colors.chipBackground
+    : theme.colors.badgeBackground;
+  const foreground = enabled
+    ? theme.colors.chipForeground
+    : theme.colors.muted;
+  const chip = (
+    <Text backgroundColor={background} color={foreground} bold={enabled}>
+      {SEND_LABEL}
+    </Text>
+  );
+  const mouse = useMouseCommands();
+  // No provider (component tests, the wizard's separate Ink tree) or
+  // nothing to do: render the label and stop. Registering a target that
+  // swallows the click without acting would be worse than no target.
+  if (!mouse || !enabled) return chip;
+  return (
+    <MouseTarget
+      flexShrink={0}
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        onPress();
+        return true;
+      }}
+    >
+      {chip}
+    </MouseTarget>
+  );
+}

--- a/src/tui/components/prompt-meta-bar.tsx
+++ b/src/tui/components/prompt-meta-bar.tsx
@@ -1,12 +1,10 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
-import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
-import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { theme } from "../theme/theme.js";
 
 /**
- * The composer's action bar: what the model is on the left, the two
- * buttons on the right, drawn on the same inverted ground as the rail.
+ * The composer's status bar: what the model is on the left, the live
+ * readouts on the right, drawn on the same inverted ground as the rail.
  *
  * **Why inverted.** The bar is the composer's chrome, not its content.
  * A terminal has no borders-and-shadows to say "this strip is a
@@ -17,12 +15,17 @@ import { theme } from "../theme/theme.js";
  * the whole point of the change.
  *
  * The ground is one `backgroundColor` on the bar container, which Ink 7
- * paints across the empty space between the meta text and the buttons —
+ * paints across the empty space between the meta text and the readouts —
  * no filler cells, and no risk of the row growing taller than it looks.
  *
+ * Send used to live here, at the far right. It moved into the field
+ * itself (`composer-send-button.tsx`): the bar's right end is where a
+ * status readout belongs, and the app's primary verb belongs next to
+ * the text it submits.
+ *
  * **A caveat about the slots.** `leftSlot` / `rightSlot` arrive from the
- * chat surface already coloured (the LLM health pill, the context-window
- * counter), and those colours were chosen against the *normal* ground.
+ * chat surface already coloured (the LLM health pill, the while-busy
+ * hint), and those colours were chosen against the *normal* ground.
  * On the rail ground they read as low-contrast secondary text — which is
  * what they are — but on `github-dark` and `catppuccin-mocha` the muted
  * tone is close enough to the light rail ground to be genuinely faint.
@@ -35,15 +38,9 @@ export interface PromptMetaBarProps {
   leftSlot: ReactElement | null;
   model: string | null;
   provider: string | null;
-  /** Chat-surface content rendered just before the buttons. */
+  /** Chat-surface content rendered at the bar's right end. */
   rightSlot: ReactElement | null;
-  /** Whether Send has something to send; drives the primary/ghost look. */
-  canSend: boolean;
-  onSend: () => void;
 }
-
-/** Labels carry their own padding so the chip's ground reads as a button. */
-const SEND_LABEL = " send → ";
 
 const MODEL_LABEL_MAX_LEN = 32;
 
@@ -60,8 +57,6 @@ export function PromptMetaBar({
   model,
   provider,
   rightSlot,
-  canSend,
-  onSend,
 }: PromptMetaBarProps): ReactElement {
   return (
     <Box
@@ -71,90 +66,22 @@ export function PromptMetaBar({
       paddingX={1}
       // Matches the buffer's own padding above. The rows carry no
       // foreground, so the bar's ground paints straight through them and
-      // the model name and Send button sit inside a block rather than on
-      // a stripe.
+      // the model name and the readouts sit inside a block rather than
+      // on a stripe.
       paddingY={1}
     >
       {/*
         The meta group is the only thing allowed to give up columns: at
-        60 the buttons must survive intact, because a half-drawn button
-        is worse than a truncated model name.
+        60 the right-hand readout must survive intact, because a
+        half-drawn chip is worse than a truncated model name.
       */}
       <Box flexShrink={1} minWidth={0}>
         <MetaLeft leftSlot={leftSlot} model={model} provider={provider} />
       </Box>
       <Box flexShrink={0} flexDirection="row">
-        {rightSlot ? (
-          <Box flexShrink={0} marginRight={2}>
-            {rightSlot}
-          </Box>
-        ) : null}
-        <ComposerButton label={SEND_LABEL} primary enabled={canSend} onPress={onSend} />
+        {rightSlot ?? null}
       </Box>
     </Box>
-  );
-}
-
-interface ComposerButtonProps {
-  label: string;
-  /** Filled in the accent colour — the bar's one primary action. */
-  primary?: boolean;
-  /** A disabled button still renders: it says the affordance exists. */
-  enabled: boolean;
-  onPress: () => void;
-}
-
-/**
- * One button chip.
- *
- * Every colour here is a *pair* taken from the theme rather than a
- * literal, and each pair is one the palette already guarantees to be
- * opposite: `border` against `railBackground`, `accent` against
- * `railForeground`. That is what keeps the chips legible across all
- * eleven palettes without a per-theme table — the tokens flip polarity
- * with the theme, so the contrast holds on light and dark alike.
- *
- * A disabled Send drops its ground entirely and dims to `railMuted`,
- * which is the terminal's version of a ghost button: still there, still
- * labelled, visibly not pressable.
- */
-function ComposerButton({
-  label,
-  primary = false,
-  enabled,
-  onPress,
-}: ComposerButtonProps): ReactElement {
-  const background = !enabled
-    ? theme.colors.badgeBackground
-    : primary
-      ? theme.colors.chipBackground
-      : theme.colors.border;
-  const foreground = !enabled
-    ? theme.colors.muted
-    : primary
-      ? theme.colors.chipForeground
-      : theme.colors.chipBackground;
-  const chip = (
-    <Text backgroundColor={background} color={foreground} bold={enabled}>
-      {label}
-    </Text>
-  );
-  const mouse = useMouseCommands();
-  // No provider (component tests, the wizard's separate Ink tree) or
-  // nothing to do: render the label and stop. Registering a target that
-  // swallows the click without acting would be worse than no target.
-  if (!mouse || !enabled) return chip;
-  return (
-    <MouseTarget
-      flexShrink={0}
-      onMouse={(hit) => {
-        if (!isPrimaryPress(hit.event)) return false;
-        onPress();
-        return true;
-      }}
-    >
-      {chip}
-    </MouseTarget>
   );
 }
 

--- a/src/tui/components/prompt-shell.test.tsx
+++ b/src/tui/components/prompt-shell.test.tsx
@@ -29,7 +29,7 @@ describe("PromptShell", () => {
     unmount();
   });
 
-  it("shows the send button", () => {
+  it("shows the send button inside the field", () => {
     const { lastFrame, unmount } = render(
       <PromptShell
         value=""
@@ -77,7 +77,7 @@ describe("PromptShell", () => {
    * thing allowed to give up columns — a clipped button reads as a
    * rendering bug, a clipped model name reads as a long model name.
    */
-  it("keeps the send button whole in a 56-column chat column", () => {
+  it("keeps the send button whole, on the buffer row, at 56 columns", () => {
     const { lastFrame, unmount } = render(
       // A column, like the chat surface: the composer takes the
       // column's full width rather than its own intrinsic one.
@@ -102,9 +102,39 @@ describe("PromptShell", () => {
       expect(line.length).toBeLessThanOrEqual(56);
     }
     // [0] border, [1] pad, [2] buffer, [3] pad, [4] bar pad,
-    // [5] action bar, [6] bar pad, [7] border.
-    const bar = lines[5] ?? "";
-    expect(bar).toContain(" send → ");
+    // [5] status bar, [6] bar pad, [7] border.
+    expect(lines[2] ?? "").toContain(" send → ");
+    // The bar is where Send used to live; the readout owns that end now.
+    expect(lines[5] ?? "").not.toContain("send");
+    unmount();
+  });
+
+  /**
+   * Send rides the *last* line of a multi-line buffer, not the first:
+   * it is the verb for the message being typed, and the caret is at the
+   * bottom by the time the buffer has grown.
+   */
+  it("drops the send button to the last row of a multi-line buffer", () => {
+    const { lastFrame, unmount } = render(
+      <Box width={56} flexDirection="column">
+        <PromptShell
+          value={"first line\nsecond line\nthird line"}
+          focus
+          onChange={() => {}}
+          onSubmit={() => {}}
+        />
+      </Box>,
+    );
+    const lines = strip(lastFrame() ?? "")
+      .split("\n")
+      .filter((line) => line.trim().length > 0);
+    // [0] border, [1] pad, [2..4] buffer, [5] pad, …
+    expect(lines[2] ?? "").not.toContain("send");
+    expect(lines[3] ?? "").not.toContain("send");
+    expect(lines[4] ?? "").toContain(" send → ");
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(56);
+    }
     unmount();
   });
 

--- a/src/tui/components/prompt-shell.tsx
+++ b/src/tui/components/prompt-shell.tsx
@@ -2,11 +2,13 @@ import { Box } from "ink";
 import type { ReactElement } from "react";
 import { useRotatingPlaceholder } from "../hooks/use-rotating-placeholder.js";
 import { theme } from "../theme/theme.js";
+import { ComposerSendButton } from "./composer-send-button.js";
 import { MultiLineEditor, type MultiLineEditorProps } from "./multi-line-editor.js";
 import { PromptMetaBar } from "./prompt-meta-bar.js";
 
 /**
- * The composer: a framed input field with a toolbar under it.
+ * The composer: a framed input field with Send in it and a toolbar under
+ * it.
  *
  * It used to be an opencode-style left "tail" — a single border column
  * down the left of the editor, capped by a `╹`. That reads as a quote
@@ -16,6 +18,11 @@ import { PromptMetaBar } from "./prompt-meta-bar.js";
  * knows from every other message box they have used, and it costs one
  * row *less* than the tail did: border, editor, bar, border — where the
  * tail spent a top pad, a blank row above the meta and the cap glyph.
+ *
+ * Send sits **inside** the field, on the right of the buffer row, rather
+ * than on the bar under it: it is the verb for the text beside it, and
+ * keeping it out of the bar leaves that row free for the status readouts
+ * the chat surface passes in.
  *
  * The frame is deliberately the app's only fully-boxed surface besides
  * modals. Bounded height matters: Ink 7 does not clip a frame taller
@@ -58,7 +65,7 @@ export interface PromptShellProps
    * present.
    */
   leftSlot?: ReactElement | null;
-  /** Optional content rendered just before the buttons on the right. */
+  /** Optional content rendered at the toolbar's right end. */
   rightSlot?: ReactElement | null;
 }
 
@@ -116,29 +123,51 @@ export function PromptShell(props: PromptShellProps): ReactElement {
           `badgeBackground` shows through them and they read as the
           field's own padding rather than as gaps in it.
         */}
-        <Box paddingX={1} paddingY={1} flexDirection="column">
-          <MultiLineEditor
-            {...editorProps}
-            value={value}
-            focus={focus}
-            disabled={disabled}
-            onChange={onChange}
-            onSubmit={onSubmit}
-            placeholder={effectivePlaceholder}
-            bare
-          />
+        <Box
+          paddingX={1}
+          paddingY={1}
+          flexDirection="row"
+          // One line of buffer and the button is beside it either way;
+          // the choice only bites once the message grows. Bottom keeps
+          // Send next to the line being typed, which is where the eye
+          // already is — centring it against a ten-line paste would
+          // strand the button halfway up a wall of text.
+          alignItems={value.includes("\n") ? "flex-end" : "center"}
+        >
+          {/*
+            `minWidth={0}` is what lets the editor actually give up the
+            columns the button takes: a Yoga flex child defaults to its
+            content's min-width, so without this the row would overflow
+            the frame instead of the text rewrapping.
+          */}
+          <Box flexGrow={1} flexShrink={1} minWidth={0} flexDirection="column">
+            <MultiLineEditor
+              {...editorProps}
+              value={value}
+              focus={focus}
+              disabled={disabled}
+              onChange={onChange}
+              onSubmit={onSubmit}
+              placeholder={effectivePlaceholder}
+              bare
+            />
+          </Box>
+          <Box flexShrink={0} marginLeft={1}>
+            <ComposerSendButton
+              enabled={canSend}
+              // Exactly the callback Enter fires, with exactly the
+              // buffer Enter would submit. A second submit path would be
+              // a second place for slash-command handling and the
+              // busy-mode queue to drift out of sync.
+              onPress={() => onSubmit(value)}
+            />
+          </Box>
         </Box>
         <PromptMetaBar
           leftSlot={leftSlot ?? null}
           model={model ?? null}
           provider={provider ?? null}
           rightSlot={rightSlot ?? null}
-          canSend={canSend}
-          // Exactly the callback Enter fires, with exactly the buffer
-          // Enter would submit. A second submit path would be a second
-          // place for slash-command handling and the busy-mode queue to
-          // drift out of sync.
-          onSend={() => onSubmit(value)}
         />
       </Box>
     </Box>


### PR DESCRIPTION
## What

The composer's primary verb sat on the toolbar row under the input, at the far right — a row away from the text it submits, and occupying the one slot on that bar where a status readout belongs.

Send now rides the right-hand side of the buffer row itself, at the same column it always had. It centres against a one-line buffer and drops to the last line once the message is multi-line, so it stays next to the line being typed rather than stranded halfway up a wall of text.

## Before / after

Before — the button on the bar, under the field:

```
╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│ ❯ explain the retry policy in the fallback chain                             │
│                                                                              │
│                                                                              │
│ ● healthy · qwen3-30b-a3b-instruct-2507 · llama.cpp       ctx 32768  send →  │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

After — the button in the field, the bar's right end free:

```
╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│ ❯ explain the retry policy in the fallback chain                     send →  │
│                                                                              │
│                                                                              │
│ ● healthy · qwen3-30b-a3b-instruct-2507 · llama.cpp                ctx 32768 │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Multi-line — it follows the caret down:

```
╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│ ❯ first line                                                                 │
│   second line                                                                │
│   third line                                                         send →  │
│                                                                              │
│                                                                              │
│ ● healthy · qwen3-30b-a3b-instruct-2507 · llama.cpp                ctx 32768 │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

At 56 columns, with a soft-wrapped buffer — nothing clipped, no line over budget:

```
╭──────────────────────────────────────────────────────╮
│                                                      │
│ ❯ explain the retry policy in the                    │
│   cross-provider fallback chain and why      send →  │
│                                                      │
│                                                      │
│ ● healthy · qwen3-30b-a3b-instruct-2507 · …ctx 32768 │
│                                                      │
╰──────────────────────────────────────────────────────╯
```

## How

- `ComposerButton` moves out of `prompt-meta-bar.tsx` into its own `composer-send-button.tsx`, intact: same theme pair, same ghost state for a blank or disabled buffer, same `MouseTarget` with the primary-press guard, same single submit path (`onSubmit(value)` — exactly what Enter fires). Its unused secondary variant goes with the move.
- `PromptShell`'s editor row becomes a row-flex. `alignItems` is `center` for a one-line buffer and `flex-end` once it contains a newline.
- `PromptMetaBar` loses `canSend`/`onSend` and keeps the model group plus its slots.

## Notes

- **Height is unchanged** — still eight rendered rows plus the buffer, still `COMPOSER_ROWS = 10`. That matters here: Ink 7 does not clip a frame taller than the terminal, it overlaps the lines above.
- `minWidth={0}` on the editor box is what lets the text rewrap around the button instead of overflowing the frame — a Yoga flex child otherwise sizes to its content's min-width.
- The existing click / inert / right-button tests locate the button by searching the rendered frame, so they pass **untouched**. That they do is the proof the mouse target survived the move.

## Verification

- `npm run lint` clean.
- `npx vitest run src/tui` → 1485 passed. The two failures are `local-models-orchestrator-auto-update.test.ts` spawning a fixture `llama-server` binary and hitting `EACCES` in this sandbox — environmental, unrelated to this diff.