### PR TITLE
feat(tui): bring back /debug, listed last under Go

### DIFF
--- a/src/tui/commands/slash-command-handler.test.ts
+++ b/src/tui/commands/slash-command-handler.test.ts
@@ -34,14 +34,13 @@ describe("dispatchSlashCommand", () => {
   });
 
   /**
-   * The toggle is gone: the debug pane is reached through Observe /
-   * Manage, which name where they land instead of flipping between two
-   * unnamed states.
+   * Off the menu, still a command: the row read badly among entries that
+   * name a destination, but typing it is an explicit act and the muscle
+   * memory is real.
    */
-  it("no longer answers /debug", () => {
+  it("toggles ui mode for /debug", () => {
     const result = dispatchSlashCommand("/debug");
-    expect(result.actions).toEqual([]);
-    expect(result.systemMessage).toBe("unknown command: /debug");
+    expect(result.actions).toEqual([{ type: "ui_mode_toggled" }]);
   });
 
   it("opens the Observe section default tab for /observe", () => {

--- a/src/tui/commands/slash-command-handler.ts
+++ b/src/tui/commands/slash-command-handler.ts
@@ -198,6 +198,8 @@ export function dispatchSlashCommand(buffer: string): SlashDispatchResult {
         triggerQuit: true,
         systemMessage: "exiting",
       });
+    case "debug":
+      return pureActions([{ type: "ui_mode_toggled" }]);
     case "context":
       return pureActions([{ type: "context_panel_toggled" }]);
     case "chat":

--- a/src/tui/commands/slash-commands.test.ts
+++ b/src/tui/commands/slash-commands.test.ts
@@ -13,6 +13,7 @@ describe("SLASH_COMMANDS registry", () => {
       "clear",
       "abort",
       "quit",
+      "debug",
       "chat",
       "feed",
       "logs",

--- a/src/tui/menu/menu-behaviour.test.ts
+++ b/src/tui/menu/menu-behaviour.test.ts
@@ -43,6 +43,7 @@ describe("menu rows", () => {
       "Run",
       "Observe",
       "Manage",
+      "Toggle debug pane",
     ]);
   });
 

--- a/src/tui/menu/menu-registry.test.ts
+++ b/src/tui/menu/menu-registry.test.ts
@@ -58,6 +58,11 @@ const V0_2_2_SLASH_COMMANDS = [
     aliases: ["exit"],
   },
   {
+    name: "debug",
+    description:
+      "toggle debug pane (feed / logs / world …)",
+  },
+  {
     name: "chat",
     description:
       "return to single-view chat mode",
@@ -286,5 +291,27 @@ describe("menu registry", () => {
       "Import",
       "Privacy",
     ]);
+  });
+});
+
+describe("the debug toggle", () => {
+  /**
+   * Last under Go, below the three destinations. Run / Observe / Manage
+   * each name a place; this one toggles between two states whose
+   * identity depends on where you already are, so it belongs after them
+   * rather than interleaved with them.
+   */
+  it("comes last in the Go group", () => {
+    expect(menuRoots("go").map((n) => n.label)).toEqual([
+      "Run",
+      "Observe",
+      "Manage",
+      "Toggle debug pane",
+    ]);
+  });
+
+  it("is a command as well as a row", () => {
+    expect(menuNodeById("go.debug")?.kind).toBe("action");
+    expect(SLASH_COMMANDS.map((c) => c.name)).toContain("debug");
   });
 });

--- a/src/tui/menu/menu-registry.ts
+++ b/src/tui/menu/menu-registry.ts
@@ -339,6 +339,23 @@ export const MENU: readonly MenuNode[] = [
   },
   {
     kind: "action",
+    id: "go.debug",
+    label: "Toggle debug pane",
+    group: "go",
+    // Last under Go, and deliberately below the three destinations.
+    // Run / Observe / Manage each name a place; this one toggles
+    // between two states whose identity depends on where you already
+    // are, so it reads as a verb appended to the list rather than as a
+    // fourth place to go.
+    slash: {
+      name: "debug",
+      description:
+        "toggle debug pane (feed / logs / world …)",
+      rank: 7,
+    },
+  },
+  {
+    kind: "action",
     id: "session.new",
     label: "New session",
     group: "session",

--- a/src/tui/reduce-ui-actions.ts
+++ b/src/tui/reduce-ui-actions.ts
@@ -20,6 +20,8 @@ export function reduceUiAction(
   action: TuiAction,
 ): TuiState | null {
   switch (action.type) {
+    case "ui_mode_toggled":
+      return { ...state, uiMode: state.uiMode === "chat" ? "debug" : "chat" };
     case "ui_mode_set":
       return { ...state, uiMode: action.mode };
     case "theme_set":

--- a/src/tui/tui-action.ts
+++ b/src/tui/tui-action.ts
@@ -53,6 +53,7 @@ export type TuiAction =
   | { type: "approval_level_changed"; approvalLevel: number }
   | { type: "session_created"; sessionId: string }
   | { type: "tab_changed"; tab: TuiTab }
+  | { type: "ui_mode_toggled" }
   | { type: "ui_mode_set"; mode: TuiUiMode }
   /**
    * Record the active theme name so the app re-renders after a runtime


### PR DESCRIPTION
## What

#218 removed the `Toggle debug pane` row on the grounds that every other entry under `Go` names where it lands, while that one flips between two unnamed states whose identity depends on where you already are.

Removing the node took the **command** with it, because the registry drives the menu, the slash palette and the `ctrl+g` chords from one array. Losing `/debug` was worse than the untidy row.

So it comes back — in the menu and as a command — but at the **end** of the Go group rather than second in it:

```
 GO
 ▶ Run                                               ctrl+g r
   Observe →
   Manage →
   Toggle debug pane
 SESSION
   New session                                       ctrl+g n
```

Run / Observe / Manage each name a place. The toggle reads as a verb appended to that list rather than as a fourth destination interleaved among three.

## How

The `go.debug` node is restored and moved to the tail of the Go group in the registry — `menuRoots` returns registry order, so position is the only change. `ui_mode_toggled` and its reducer arm come back with it; the slash handler was their only caller, which is why they went.

No new mechanism: an earlier draft of this PR added a `hiddenFromMenu` flag to keep the command while dropping the row, and that flag is gone now that the row is wanted — it would have been dead code with tests testing nothing.

## Verified in the real app

The menu, at the top of Go:

```
│ ▶ Run                                               ctrl+g r │
│   Observe →                                                  │
│   Manage →                                                   │
│   Toggle debug pane                                          │
```

`/debug` at the prompt:

```
|  atomic-agent v0.3.6  |   OBSERVE ▸ Feed
|  ▸ Feed (1)  |    World  |    Reasoning  |    Logs  |    LLM logs
```

## Notes

- The golden `V0_2_2_SLASH_COMMANDS` snapshot gets `debug` back at its original rank, so the palette is byte-for-byte what it was before #218 — only the menu order changed.
- `npm run lint` clean; `npx vitest run src/tui` → 1562 passing. The one failure is an `llm-health-poller` timing assertion that also fails on clean `main` and passes when the file runs on its own.
