### PR TITLE
feat(config): remember that onboarding happened — tui.onboarding (v43)

### DIFF
--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -7,6 +7,45 @@ import {
   parseUserConfigFile,
 } from "./config-schema.js";
 
+describe("tui.onboarding (config v43)", () => {
+  it("defaults every stamp to null on a file that predates the block", () => {
+    const parsed = parseUserConfigFile({ version: 42, tui: { theme: "nord" } });
+    expect(parsed.tui.onboarding).toEqual({
+      completedAt: null,
+      introSeenAt: null,
+      skippedAt: null,
+      proposedSecondBackendAt: null,
+    });
+    expect(parsed.tui.theme).toBe("nord");
+  });
+
+  it("round-trips ISO stamps", () => {
+    const stamp = "2026-08-21T18:04:05.000Z";
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      tui: { onboarding: { completedAt: stamp, introSeenAt: stamp } },
+    });
+    expect(parsed.tui.onboarding.completedAt).toBe(stamp);
+    expect(parsed.tui.onboarding.introSeenAt).toBe(stamp);
+    expect(parsed.tui.onboarding.skippedAt).toBeNull();
+  });
+
+  it("rejects a stamp that is not a date", () => {
+    expect(() =>
+      parseUserConfigFile({
+        version: USER_CONFIG_VERSION,
+        tui: { onboarding: { completedAt: "soon" } },
+      }),
+    ).toThrow(ConfigValidationError);
+  });
+
+  it("rejects a non-object onboarding block", () => {
+    expect(() =>
+      parseUserConfigFile({ version: USER_CONFIG_VERSION, tui: { onboarding: true } }),
+    ).toThrow(ConfigValidationError);
+  });
+});
+
 describe("parseUserConfigFile", () => {
   it("returns defaults when all fields are missing", () => {
     const parsed = parseUserConfigFile({ version: USER_CONFIG_VERSION });

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -716,6 +716,7 @@ export interface AtomicAgentConfig {
     theme: string;
     whileBusySubmit: WhileBusySubmitMode;
     mouse: boolean;
+    onboarding: OnboardingState;
   };
   /**
    * Anonymous product analytics (PostHog). Mirrors
@@ -1446,6 +1447,7 @@ export interface UserConfigFile {
     theme: string;
     whileBusySubmit: WhileBusySubmitMode;
     mouse: boolean;
+    onboarding: OnboardingState;
   };
   /**
    * Anonymous product analytics (PostHog). Added in config v33. Older
@@ -1518,12 +1520,18 @@ export interface UserConfigFile {
 // files stored an unused `false` default — those migrate to `true` so
 // existing installs pick up newer llama.cpp zips. Explicit `false` on
 // a v41+ file is honoured.
+// v43: new `tui.onboarding` block — four nullable ISO timestamps recording
+// that the first-run flow was seen, skipped, completed, and that the
+// "configure the other backend too" screen was already offered. Additive:
+// an older file parses with all four `null`, which reads as "never
+// onboarded" and opens the flow exactly once, instead of re-deriving the
+// answer from a health probe on every launch.
 // v42: no schema change. The bump exists to carry the forward-compat
 // rules below: a file whose `version` is *newer* than this constant is
 // now read instead of rejected, its version is preserved rather than
 // stamped down, and unknown top-level keys survive the round trip. See
 // `parseUserConfigFile` and `ensureUserConfigFileSync`.
-export const USER_CONFIG_VERSION = 42;
+export const USER_CONFIG_VERSION = 43;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1654,6 +1662,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   39,
   40,
   41,
+  42,
   USER_CONFIG_VERSION,
 ];
 
@@ -1901,6 +1910,12 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
     theme: "auto",
     whileBusySubmit: "steer",
     mouse: true,
+    onboarding: {
+      completedAt: null,
+      introSeenAt: null,
+      proposedSecondBackendAt: null,
+      skippedAt: null,
+    },
   },
   analytics: {
     enabled: true,
@@ -3652,6 +3667,7 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
         "tui.whileBusySubmit",
       ),
       mouse: parseBool(tui.mouse ?? USER_CONFIG_DEFAULTS.tui.mouse, "tui.mouse"),
+      onboarding: parseOnboardingState(tui.onboarding),
     },
     analytics: {
       enabled: parseBool(
@@ -3717,6 +3733,73 @@ export function parseWhileBusySubmit(
     field,
     `expected "steer" or "queue", got ${JSON.stringify(raw)}`,
   );
+}
+
+/**
+ * First-run flow state (config v43). Four nullable ISO-8601 timestamps,
+ * not booleans: knowing *when* a run was completed or skipped is what
+ * lets a later release decide whether an install predates a flow it
+ * would like to show again, and it costs the same byte budget.
+ *
+ * - `introSeenAt` — the splash was dismissed at least once.
+ * - `completedAt` — a backend was configured and the flow handed over to
+ *   the agent. Set for the "custom endpoint" branch too.
+ * - `skippedAt` — the operator escaped out. The flow does not reopen by
+ *   itself afterwards; before v43 nothing was written here, which is why
+ *   an escaped setup used to reappear on every single launch.
+ * - `proposedSecondBackendAt` — the "you have one, want the other too?"
+ *   screen was already offered, so it is never offered twice.
+ */
+export interface OnboardingState {
+  completedAt: string | null;
+  introSeenAt: string | null;
+  skippedAt: string | null;
+  proposedSecondBackendAt: string | null;
+}
+
+/**
+ * Parse `tui.onboarding`. Absent, `null`, or an empty object all mean a
+ * fresh install, so every field falls back to `null` rather than
+ * throwing — an older config file must never fail to load because it
+ * predates the block.
+ */
+export function parseOnboardingState(raw: unknown): OnboardingState {
+  const defaults = USER_CONFIG_DEFAULTS.tui.onboarding;
+  if (raw === undefined || raw === null) return { ...defaults };
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(
+      "tui.onboarding",
+      `expected object, got ${JSON.stringify(raw)}`,
+    );
+  }
+  const obj = raw as Record<string, unknown>;
+  return {
+    completedAt: parseTimestampOrNull(obj.completedAt, "tui.onboarding.completedAt"),
+    introSeenAt: parseTimestampOrNull(obj.introSeenAt, "tui.onboarding.introSeenAt"),
+    skippedAt: parseTimestampOrNull(obj.skippedAt, "tui.onboarding.skippedAt"),
+    proposedSecondBackendAt: parseTimestampOrNull(
+      obj.proposedSecondBackendAt,
+      "tui.onboarding.proposedSecondBackendAt",
+    ),
+  };
+}
+
+/**
+ * An ISO-8601 instant or `null`. Validated through `Date.parse` rather
+ * than a regex so a hand-edited file with a plausible-but-unparseable
+ * stamp is rejected at load instead of producing an `Invalid Date`
+ * somewhere far away.
+ */
+export function parseTimestampOrNull(raw: unknown, field: string): string | null {
+  if (raw === undefined || raw === null) return null;
+  const s = parseNonEmptyString(raw, field);
+  if (Number.isNaN(Date.parse(s))) {
+    throw new ConfigValidationError(
+      field,
+      `expected an ISO-8601 timestamp, got ${JSON.stringify(s)}`,
+    );
+  }
+  return s;
 }
 
 export function parseThemeName(raw: unknown, field: string): string {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,7 @@ export type {
   HttpApprovalMode,
   LocalLlmMode,
   LogLevel,
+  OnboardingState,
   TelegramConfig,
   TelegramParseMode,
   UserConfigFile,
@@ -18,6 +19,7 @@ export {
   ConfigValidationError,
   USER_CONFIG_DEFAULTS,
   USER_CONFIG_VERSION,
+  parseOnboardingState,
   parseUserConfigFile,
   parseWhileBusySubmit,
 } from "./config-schema.js";

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -492,6 +492,7 @@ export function loadConfig(): AtomicAgentConfig {
       theme: user.tui.theme,
       whileBusySubmit: user.tui.whileBusySubmit,
       mouse: user.tui.mouse,
+      onboarding: { ...user.tui.onboarding },
     },
     analytics: {
       enabled: user.analytics.enabled,

--- a/src/tui/onboarding/index.ts
+++ b/src/tui/onboarding/index.ts
@@ -1,0 +1,2 @@
+export { decideOnboarding, needsOnboarding } from "./needs-onboarding.js";
+export type { OnboardingDecision } from "./needs-onboarding.js";

--- a/src/tui/onboarding/needs-onboarding.test.ts
+++ b/src/tui/onboarding/needs-onboarding.test.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { decideOnboarding, needsOnboarding } from "./needs-onboarding.js";
+import { persistOnboardingState } from "../persist-onboarding-state.js";
+import { getConfig, resetConfigCache, USER_CONFIG_VERSION } from "../../config/index.js";
+
+const STATE_DIR_ENV = "ATOMIC_AGENT_STATE_DIR";
+const STAMP = "2026-08-21T18:04:05.000Z";
+
+function writeConfig(stateDir: string, patch: Record<string, unknown>): void {
+  writeFileSync(
+    join(stateDir, "config.json"),
+    JSON.stringify({ version: USER_CONFIG_VERSION, ...patch }, null, 2),
+  );
+  resetConfigCache();
+}
+
+describe("decideOnboarding", () => {
+  let stateDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "onboarding-decide-"));
+    mkdirSync(stateDir, { recursive: true });
+    originalEnv = process.env[STATE_DIR_ENV];
+    process.env[STATE_DIR_ENV] = stateDir;
+    resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[STATE_DIR_ENV];
+    else process.env[STATE_DIR_ENV] = originalEnv;
+    resetConfigCache();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("opens on a fresh install", () => {
+    expect(decideOnboarding()).toEqual({ needed: true, reason: "fresh_install" });
+  });
+
+  it("stays shut once the flow completed", () => {
+    persistOnboardingState({ completedAt: STAMP });
+    expect(decideOnboarding()).toEqual({ needed: false, reason: "completed" });
+  });
+
+  it("stays shut once the operator escaped out — the v0.3.6 groundhog bug", () => {
+    persistOnboardingState({ skippedAt: STAMP });
+    expect(needsOnboarding()).toBe(false);
+  });
+
+  it("stays shut when a cloud provider is already configured", () => {
+    writeConfig(stateDir, {
+      llm: {
+        activeTextProvider: "openrouter",
+        activeEmbeddingProvider: "local-llama",
+        providers: [
+          { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:8080" },
+          {
+            id: "openrouter",
+            kind: "openrouter",
+            apiKeyEnv: "OPENROUTER_API_KEY",
+            chatModel: "openrouter/auto",
+          },
+        ],
+      },
+    });
+    process.env.OPENROUTER_API_KEY = "sk-or-test";
+    try {
+      expect(decideOnboarding()).toEqual({ needed: false, reason: "backend_configured" });
+    } finally {
+      delete process.env.OPENROUTER_API_KEY;
+    }
+  });
+
+  it("stays shut when an external llama-server URL was configured", () => {
+    writeConfig(stateDir, { localModels: { mode: "external", url: "http://10.0.0.4:8080" } });
+    expect(decideOnboarding()).toEqual({ needed: false, reason: "backend_configured" });
+  });
+
+  it("still opens on the shipped defaults — a default URL nobody chose is not a backend", () => {
+    expect(getConfig().localModels.mode).toBe("external");
+    expect(getConfig().localModels.url).toBe("http://127.0.0.1:8080");
+    expect(needsOnboarding()).toBe(true);
+  });
+
+  it("stays shut when a managed model id was picked and pulled", () => {
+    writeConfig(stateDir, {
+      localModels: { mode: "managed", managed: { modelId: "gemma-4-e4b" } },
+    });
+    // `isManagedModeReadyOnDisk` also wants the weights on disk, which a
+    // temp state dir does not have; `isLocalBackendConfigured` is the one
+    // that answers here, and a chosen model is a deliberate choice.
+    expect(decideOnboarding()).toEqual({ needed: false, reason: "backend_configured" });
+  });
+});

--- a/src/tui/onboarding/needs-onboarding.ts
+++ b/src/tui/onboarding/needs-onboarding.ts
@@ -1,0 +1,36 @@
+import { getConfig } from "../../config/index.js";
+import {
+  isCloudTextProviderReady,
+  isLocalBackendConfigured,
+  isManagedModeReadyOnDisk,
+} from "../run-local-models-config-wizard.js";
+
+/** Why the first-run flow is (or is not) opening. Surfaced for tests and logs. */
+export type OnboardingDecision =
+  | { needed: false; reason: "completed" | "skipped" | "backend_configured" }
+  | { needed: true; reason: "fresh_install" };
+
+/**
+ * Whether the first-run flow should open on this launch.
+ *
+ * Config decides, not a health probe. The old startup gate re-derived
+ * the answer every launch from `checkLlamaServer()`, so an operator who
+ * escaped out of setup — or whose llama-server merely happened to be
+ * down — met the picker again on every single start. A backend that is
+ * *configured* counts as onboarded even when it is not answering right
+ * now; a backend that is down is the status bar's problem, not a reason
+ * to re-run setup.
+ */
+export function decideOnboarding(): OnboardingDecision {
+  const onboarding = getConfig().tui.onboarding;
+  if (onboarding.completedAt) return { needed: false, reason: "completed" };
+  if (onboarding.skippedAt) return { needed: false, reason: "skipped" };
+  if (isCloudTextProviderReady() || isManagedModeReadyOnDisk() || isLocalBackendConfigured()) {
+    return { needed: false, reason: "backend_configured" };
+  }
+  return { needed: true, reason: "fresh_install" };
+}
+
+export function needsOnboarding(): boolean {
+  return decideOnboarding().needed;
+}

--- a/src/tui/persist-onboarding-state.test.ts
+++ b/src/tui/persist-onboarding-state.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { persistOnboardingState } from "./persist-onboarding-state.js";
+import { getConfig, resetConfigCache } from "../config/index.js";
+
+const STATE_DIR_ENV = "ATOMIC_AGENT_STATE_DIR";
+const STAMP = "2026-08-21T18:04:05.000Z";
+const LATER = "2026-08-22T09:00:00.000Z";
+
+describe("persistOnboardingState", () => {
+  let stateDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "onboarding-persist-"));
+    mkdirSync(stateDir, { recursive: true });
+    originalEnv = process.env[STATE_DIR_ENV];
+    process.env[STATE_DIR_ENV] = stateDir;
+    resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[STATE_DIR_ENV];
+    else process.env[STATE_DIR_ENV] = originalEnv;
+    resetConfigCache();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("writes a stamp to config.json and getConfig() picks it up", () => {
+    expect(getConfig().tui.onboarding.completedAt).toBeNull();
+    persistOnboardingState({ completedAt: STAMP });
+    const onDisk = JSON.parse(readFileSync(getConfig().paths.userConfigFile, "utf8"));
+    expect(onDisk.tui.onboarding.completedAt).toBe(STAMP);
+    expect(getConfig().tui.onboarding.completedAt).toBe(STAMP);
+  });
+
+  it("merges rather than replaces — a second field keeps the first", () => {
+    persistOnboardingState({ introSeenAt: STAMP });
+    persistOnboardingState({ completedAt: LATER });
+    expect(getConfig().tui.onboarding).toEqual({
+      completedAt: LATER,
+      introSeenAt: STAMP,
+      skippedAt: null,
+      proposedSecondBackendAt: null,
+    });
+  });
+
+  it("leaves the rest of tui alone", () => {
+    persistOnboardingState({ skippedAt: STAMP });
+    expect(getConfig().tui.theme).toBe("auto");
+    expect(getConfig().tui.mouse).toBe(true);
+  });
+});

--- a/src/tui/persist-onboarding-state.ts
+++ b/src/tui/persist-onboarding-state.ts
@@ -1,0 +1,28 @@
+import type { OnboardingState } from "../config/index.js";
+import {
+  ensureUserConfigFileSync,
+  getConfig,
+  parseUserConfigFile,
+  resetConfigCache,
+  writeUserConfigFileSync,
+} from "../config/index.js";
+
+/**
+ * Record a step of the first-run flow into `tui.onboarding`, then
+ * invalidate the config cache so the next `getConfig()` sees it. Mirrors
+ * the other `persist-*` helpers: read → merge → validate → write → reset.
+ *
+ * The patch carries timestamps rather than booleans, and the caller
+ * stamps them (`new Date().toISOString()`), so tests can write a fixed
+ * instant instead of freezing the clock.
+ */
+export function persistOnboardingState(patch: Partial<OnboardingState>): void {
+  const path = getConfig().paths.userConfigFile;
+  const prev = ensureUserConfigFileSync(path);
+  const draft = {
+    ...prev,
+    tui: { ...prev.tui, onboarding: { ...prev.tui.onboarding, ...patch } },
+  };
+  writeUserConfigFileSync(path, parseUserConfigFile(draft));
+  resetConfigCache();
+}


### PR DESCRIPTION
## The bug this removes

The first-run flow has no memory. `runLocalModelsStartupGateIfNeeded` re-derives "does this user need setup?" on every launch from a health probe, and the Esc branch writes **nothing**. So an operator who skips the backend picker meets it again on the next launch, and every launch after that — a fresh 10-second gate, forever.

## What this adds

`tui.onboarding` (config **v43**), four nullable ISO-8601 stamps:

| field | meaning |
|---|---|
| `introSeenAt` | the splash was dismissed at least once |
| `completedAt` | a backend was configured and the flow handed over to the agent |
| `skippedAt` | the operator escaped out — the flow does not reopen by itself |
| `proposedSecondBackendAt` | the "you have one, want the other too?" screen was already offered |

Plus:

- `src/tui/persist-onboarding-state.ts` — read → merge → validate → write → reset, same shape as the other `persist-*` helpers. The **caller** stamps the instant, so tests write a fixed one instead of freezing the clock.
- `src/tui/onboarding/needs-onboarding.ts` — `decideOnboarding()` returns `{ needed, reason }`; `needsOnboarding()` is the boolean.

Timestamps rather than booleans: knowing *when* a run completed is what lets a later release decide whether an install predates a flow it would like to show again, at the same byte cost.

`decideOnboarding` answers from **config alone**, never a probe. A backend that is *configured* counts as onboarded even when it is not answering right now — a server that is down is the status bar's problem, not a reason to re-run setup. It reuses the three existing predicates (`isCloudTextProviderReady`, `isManagedModeReadyOnDisk`, `isLocalBackendConfigured`) rather than inventing a fourth definition of "configured".

## Scope

Nothing consumes the predicate yet — the first-run flow itself is the next PR in the series. This lands alone so the schema bump has its own reviewable diff.

`42` also joins `SUPPORTED_INPUT_VERSIONS`, which the bump would otherwise drop (the list carries the previous versions explicitly and the current one by constant).

## Compatibility

Additive. `parseUserConfigFile` fills absent keys, so a pre-v43 file parses with four `null`s and behaves exactly as it does today. No migration code, and a v42 file is still accepted.

## Tests

- `config-schema.test.ts` — defaults on a v42 file, ISO round-trip, a non-date stamp and a non-object block both rejected.
- `persist-onboarding-state.test.ts` — write + `getConfig()` pickup, merge semantics across two writes, and the rest of `tui` untouched.
- `onboarding/needs-onboarding.test.ts` — fresh install opens; completed, skipped, cloud-configured, external-URL and managed-model-picked all stay shut; the shipped default URL nobody chose still counts as unconfigured.

Full suite: 5132 passed. The two failures on this machine (`fs-glob-real` — a dev-machine path; `send-message-concurrency` — timing) also fail on `main` unchanged.