### PR TITLE
fix(tui): the top bar keeps a multi-line first prompt on one row

### DIFF
--- a/src/tui/components/session-title.test.ts
+++ b/src/tui/components/session-title.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { sessionTitleLine } from "./session-title.js";
+
+describe("sessionTitleLine", () => {
+  it("collapses a multi-line prompt into one line", () => {
+    expect(sessionTitleLine("ONE\none\n1\n1\n1\n1\n1", 32)).toBe(
+      "ONE one 1 1 1 1 1",
+    );
+  });
+
+  it("collapses CRLF, tabs and runs of blank lines too", () => {
+    expect(sessionTitleLine("first\r\n\r\n\tsecond", 32)).toBe("first second");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(sessionTitleLine("\n\n  hello  \n\n", 32)).toBe("hello");
+  });
+
+  it("keeps a line that exactly fills the width", () => {
+    const exact = "x".repeat(32);
+    expect(sessionTitleLine(exact, 32)).toBe(exact);
+  });
+
+  it("ellipsises one cell early so the mark fits inside the width", () => {
+    const long = "x".repeat(40);
+    const title = sessionTitleLine(long, 32);
+    expect(title).toHaveLength(32);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("measures the collapsed length, not the raw one", () => {
+    // Ten cells of newline are worth nine cells of text once collapsed,
+    // so this fits and must not be cut.
+    expect(sessionTitleLine("a\n\n\n\n\n\n\n\n\n\nb", 5)).toBe("a b");
+  });
+
+  it("returns empty for a preview that is only whitespace", () => {
+    expect(sessionTitleLine("\n \t\n", 32)).toBe("");
+  });
+
+  it("returns empty when there is no room to draw", () => {
+    expect(sessionTitleLine("something", 0)).toBe("");
+  });
+});

--- a/src/tui/components/session-title.ts
+++ b/src/tui/components/session-title.ts
@@ -1,0 +1,22 @@
+/**
+ * A session preview — the thread's first user prompt, stored verbatim —
+ * rendered as one line of at most `max` cells.
+ *
+ * Verbatim is the point: the preview has to keep the prompt as it was
+ * typed, because the session picker's search and the delete dialog's
+ * "is this the thread I mean?" both read it. Every *display* of it,
+ * though, sits in a fixed-height row, and Ink honours a `\n` inside a
+ * `<Text>` by growing that row — a pasted prompt turns a one-row bar
+ * into an N-row one and reflows everything below it.
+ *
+ * So the newlines collapse to spaces rather than being cut at the first
+ * one: the rail already renders previews this way, and a title that
+ * agrees with the rail is worth more than the handful of extra
+ * characters a first-line-only rule would save.
+ */
+export function sessionTitleLine(preview: string, max: number): string {
+  const oneLine = preview.replace(/\s+/g, " ").trim();
+  if (max <= 0 || oneLine.length === 0) return "";
+  if (oneLine.length <= max) return oneLine;
+  return `${oneLine.slice(0, Math.max(1, max - 1))}…`;
+}

--- a/src/tui/components/status-bar.test.tsx
+++ b/src/tui/components/status-bar.test.tsx
@@ -1,0 +1,69 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+
+import { StatusBar } from "./status-bar.js";
+import { fakeSession } from "../test-fixtures.js";
+import {
+  createInitialTuiState,
+  type SessionPickerEntry,
+  type TuiState,
+} from "../tui-state.js";
+
+const SESSION_ID = "s-f134037c";
+
+function entry(preview: string): SessionPickerEntry {
+  return {
+    sessionId: SESSION_ID,
+    workingDir: "/tmp",
+    turnCount: 1,
+    stepCount: 1,
+    updatedAt: Date.now(),
+    preview,
+  };
+}
+
+function stateWithPreview(preview: string): TuiState {
+  const base = createInitialTuiState(fakeSession({ sessionId: SESSION_ID }));
+  return { ...base, recentSessions: [entry(preview)] };
+}
+
+/**
+ * The bar's rows, colour codes and all. Nothing here matches across a
+ * style change, so the frame is read raw rather than stripped: the
+ * assertions are about how many rows there are and which run of plain
+ * text sits inside one of them.
+ */
+function rowsOf(state: TuiState): string[] {
+  const { lastFrame } = render(<StatusBar state={state} brand={false} />);
+  return (lastFrame() ?? "").split("\n");
+}
+
+describe("StatusBar", () => {
+  it("stays one row when the first prompt was multi-line", () => {
+    // The bug: previews are stored as typed, so the newlines reached Ink
+    // and it grew the bar to seven rows, pushing the rail, the chat and
+    // the composer down the screen.
+    const rows = rowsOf(stateWithPreview("ONE\none\n1\n1\n1\n1\n1"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("ONE one 1 1 1 1 1");
+  });
+
+  it("still shows a single-line prompt unchanged", () => {
+    const rows = rowsOf(stateWithPreview("How are you?"));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("How are you?");
+  });
+
+  it("ellipsises a long prompt instead of running past the bar", () => {
+    const rows = rowsOf(stateWithPreview("word ".repeat(40)));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("…");
+  });
+
+  it("draws no title when the session has no readable preview", () => {
+    const rows = rowsOf(stateWithPreview("   \n\n  "));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("session ");
+    expect(rows[0]).not.toContain("·");
+  });
+});

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -9,6 +9,7 @@ import { theme } from "../theme/theme.js";
 import type { TuiState } from "../tui-state.js";
 import { getAppVersion } from "../../version.js";
 import { Chip, tracked } from "./chip.js";
+import { sessionTitleLine } from "./session-title.js";
 
 interface StatusBarProps {
   state: TuiState;
@@ -84,10 +85,16 @@ function currentSessionTitle(state: TuiState): string | null {
   // until someone opens the picker, so reading it meant the title only
   // ever appeared after an unrelated detour through Ctrl+G U.
   const entry = state.recentSessions.find((row) => row.sessionId === id);
-  const preview = entry?.preview?.trim();
-  if (!preview) return null;
-  return preview.length > 32 ? `${preview.slice(0, 31)}…` : preview;
+  // One line, always. Previews are stored as typed, so a multi-line
+  // first prompt used to arrive here with its newlines intact and Ink
+  // grew the bar to fit them — a one-row header became a paragraph and
+  // pushed the rail, the chat and the composer down the screen.
+  const title = sessionTitleLine(entry?.preview ?? "", TITLE_COLUMNS);
+  return title.length > 0 ? title : null;
 }
+
+/** How much of the prompt the bar shows before it ellipsises. */
+const TITLE_COLUMNS = 32;
 
 const SECTION_LABELS: Record<TuiSection, string> = {
   run: "Run",


### PR DESCRIPTION
## The bug

Start a session whose **first** message is multi-line and the top bar renders the whole prompt — newlines and all — inside a bar that is supposed to be one row. Ink grows the row to fit, so the header becomes as tall as the prompt and shoves the rail, the chat and the composer down the screen.

A seven-line first prompt produces a seven-row header:

```
RUN   session s-f13403… · ONE
                           one
                           1
                           1
                           1
                           1
                           1
```

## Why

Session previews are stored exactly as typed, and that is correct: the picker searches them, and the delete dialog asks "is this the thread you mean?" against them. Every surface that *shows* one is expected to one-line it first — the rail, the picker and the delete dialog each do. The top bar never did:

```ts
const preview = entry?.preview?.trim();
if (!preview) return null;
return preview.length > 32 ? `${preview.slice(0, 31)}…` : preview;
```

`.trim()` only touches the ends, and the 32-cell cut counts newlines as characters, so a `\n` in the middle reaches Ink untouched.

## The fix

The rule moves into `sessionTitleLine` and the bar calls it. Whitespace collapses to single spaces *before* the width is measured, so the bar shows `ONE one 1 1 1 1 1` — the same text the rail shows for the same session.

Collapsing rather than cutting at the first newline is the deliberate choice: the operator got here by clicking that rail row, and a title that disagrees with it reads as a different session.

Measuring after the collapse also fixes a smaller lie — a prompt whose *newlines* pushed it past 32 characters used to be ellipsised on its raw length, so `a\n\n\n\n\nb` claimed to be truncated when it is three cells long.

## Tests

- `session-title.test.ts` — collapsing, CRLF and tabs, blank-line runs, the exact-width boundary, ellipsis width, whitespace-only previews, zero width.
- `status-bar.test.tsx` (new file) — pins the **row count** of the rendered bar. The multi-line case fails against the old code with `expected [ …(7) ] to have a length of 1 but got 7`, which is exactly the screenshot above.

`npm run lint` clean; `npx vitest run src/tui` → 158 files, 1575 tests, all passing. (The run also reports a pre-existing unrelated `EACCES` spawning a stub `llama-server` in `local-models-orchestrator-auto-update.test.ts`.)

## Not in this PR

The rail, the picker and the delete dialog still carry their own private copies of this one-lining logic — four copies were how the bar came to be the one that forgot. Folding them onto `sessionTitleLine` is the obvious follow-up, but it churns three files that are not broken, so it belongs in its own change.
