### PR TITLE
feat(tui): the intro splash — mark, ring, and a tagline that types itself

### DIFF
--- a/src/tui/components/onboarding-intro-step.tsx
+++ b/src/tui/components/onboarding-intro-step.tsx
@@ -1,0 +1,140 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import { useTypewriter } from "../hooks/use-typewriter.js";
+import { buildIntroArt, ORBIT_GLYPH } from "../onboarding/intro-art.js";
+import type { OnboardingFit } from "../onboarding/onboarding-fit.js";
+import { theme } from "../theme/theme.js";
+import { CROSS_MARKS } from "./logo-art.js";
+import { WORDMARK_ROWS, TAGLINE } from "./logo.js";
+
+/** Milliseconds per revealed character. ~0.9s for the whole tagline. */
+export const TAGLINE_MS_PER_CHAR = 45;
+/**
+ * Rows the intro spends on everything that is not the ring: two of
+ * wordmark, the tagline, the "press any key" line, their margins, and
+ * the pinned footer. The art gets what is left.
+ */
+export const INTRO_CHROME_ROWS = 9;
+/** `ATOMIC` is the first 23 columns of the shipped `ATOMIC AGENT` wordmark. */
+const WORDMARK_ATOMIC_COLUMNS = 23;
+
+const FACE_GLYPHS = new Set(["█", "#"]);
+const PRESS_ANY_KEY = "[ press any key to continue ]";
+
+/**
+ * The first screen of a first run: the mark inside a ring of smaller
+ * crosses, the wordmark, and the tagline typing itself in.
+ *
+ * The animation is a courtesy, not a gate — any key completes it, and a
+ * second key moves on. Everything but the tagline paints instantly, so
+ * the screen is legible from frame one.
+ */
+export function OnboardingIntroStep(props: {
+  columns: number;
+  rows: number;
+  fit: OnboardingFit;
+  /** True once a key has been pressed: finish the reveal immediately. */
+  skipAnimation: boolean;
+}): ReactElement {
+  const { fit } = props;
+  // The mark is chosen by the rows actually left over, not by the tier
+  // alone: Ink 7 overlaps rather than clips, so a mark one row too tall
+  // does not get cropped — it pushes the tagline and the footer off the
+  // screen and paints over whatever was there.
+  const budget = props.rows - INTRO_CHROME_ROWS;
+  const markRows =
+    fit.tier !== "minimal" && budget >= CROSS_MARKS.block.md.length
+      ? CROSS_MARKS.block.md
+      : budget >= CROSS_MARKS.block.sm.length
+        ? CROSS_MARKS.block.sm
+        : [];
+  const crossCount = fit.tier === "full" ? 14 : fit.tier === "reduced" ? 8 : 0;
+  const art = buildIntroArt({
+    columns: Math.max(20, props.columns),
+    rows: Math.max(markRows.length, budget),
+    markRows,
+    crossCount,
+  });
+  const { revealed, done } = useTypewriter(TAGLINE, {
+    active: true,
+    msPerChar: TAGLINE_MS_PER_CHAR,
+    skip: props.skipAnimation,
+  });
+  const wordmark = WORDMARK_ROWS.map((row) =>
+    row.slice(0, WORDMARK_ATOMIC_COLUMNS),
+  );
+
+  // The art rows already carry their own centring, so the block is laid
+  // out left-aligned and everything below it is padded to the same
+  // measure. Centring each row on its own would make them jitter as the
+  // tagline grows.
+  const pad = (text: string): string =>
+    " ".repeat(Math.max(0, Math.floor((props.columns - text.length) / 2))) + text;
+  const cursor = done ? "" : "▌";
+
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      {art.map((row, index) => (
+        <ArtRow key={index} row={row} />
+      ))}
+      <Box flexDirection="column" marginTop={1}>
+        {wordmark.map((row, index) => (
+          <Text key={index} bold color={theme.colors.accentSoft} wrap="truncate">
+            {pad(row)}
+          </Text>
+        ))}
+      </Box>
+      <Box marginTop={1}>
+        {/*
+          Padded by the *finished* tagline's width, so the line is
+          anchored where it will end up instead of sliding left as each
+          character lands.
+        */}
+        <Text color={theme.colors.muted} wrap="truncate">
+          {`${" ".repeat(Math.max(0, Math.floor((props.columns - TAGLINE.length) / 2)))}${revealed}${cursor}`}
+        </Text>
+      </Box>
+      <Box marginTop={2}>
+        <Text color={theme.colors.accent} wrap="truncate">
+          {pad(PRESS_ANY_KEY)}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * One row of the art. Split into runs so the ring, the mark's face and
+ * its depth each carry their own colour; the glyph ramp underneath still
+ * encodes the same thing, which is what keeps it readable with colour
+ * stripped.
+ */
+function ArtRow({ row }: { row: string }): ReactElement {
+  const runs: { text: string; kind: "face" | "depth" | "ring" }[] = [];
+  for (const glyph of row) {
+    const kind =
+      glyph === ORBIT_GLYPH ? "ring" : FACE_GLYPHS.has(glyph) ? "face" : "depth";
+    const last = runs[runs.length - 1];
+    if (last && last.kind === kind) last.text += glyph;
+    else runs.push({ text: glyph, kind });
+  }
+  return (
+    <Text wrap="truncate">
+      {runs.map((run, index) => (
+        <Text
+          key={index}
+          bold={run.kind !== "ring"}
+          color={
+            run.kind === "ring"
+              ? theme.colors.accentSoft
+              : run.kind === "face"
+                ? theme.colors.brandFace
+                : theme.colors.brandMark
+          }
+        >
+          {run.text}
+        </Text>
+      ))}
+    </Text>
+  );
+}

--- a/src/tui/components/onboarding-screen.test.tsx
+++ b/src/tui/components/onboarding-screen.test.tsx
@@ -26,7 +26,7 @@ const STATE_DIR_ENV = "ATOMIC_AGENT_STATE_DIR";
 const strip = (s: string): string => s.replace(/\u001b\[[0-9;]*m/g, "");
 const ESCAPE_KEY = "\u001b";
 
-function renderFlow(step: "choose" | "custom_chat_url" = "choose") {
+function renderFlow(step: "intro" | "choose" | "custom_chat_url" = "choose") {
   const actions: TuiAction[] = [];
   const onboarding = { ...createOnboardingState("http://127.0.0.1:8080"), step };
   const state = { ...createInitialTuiState(fakeSession(), 50), onboarding };
@@ -94,6 +94,33 @@ describe("OnboardingScreen", () => {
     view.stdin.write(ESCAPE_KEY);
     await new Promise((resolve) => setTimeout(resolve, 30));
     expect(actions).toContainEqual({ type: "onboarding_finished", outcome: "skipped" });
+  });
+
+  it("opens on the splash: mark, wordmark, tagline and the promise it makes", () => {
+    const { view } = renderFlow("intro");
+    const frame = strip(view.lastFrame() ?? "");
+    expect(frame).toContain("\u2588"); // the mark
+    expect(frame).toContain("press any key to continue");
+    // The wordmark's first row, `ATOMIC` only — not `ATOMIC AGENT`.
+    expect(frame).toContain("\u2584\u2580\u2588 \u2580\u2588\u2580 \u2588\u2580\u2588");
+    expect(frame).not.toContain("setup \u00b7 step 1 of 2");
+  });
+
+  it("takes two keys off the splash: one to finish the reveal, one to move on", async () => {
+    const { view, actions } = renderFlow("intro");
+    view.stdin.write("x");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(actions).toEqual([]);
+    view.stdin.write("x");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(actions).toContainEqual({ type: "onboarding_step_set", step: "choose" });
+  });
+
+  it("does not let Esc skip setup from a screen that has not offered it yet", async () => {
+    const { view, actions } = renderFlow("intro");
+    view.stdin.write(ESCAPE_KEY);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(actions).not.toContainEqual({ type: "onboarding_finished", outcome: "skipped" });
   });
 
   it("moves the cursor on a keypress", async () => {

--- a/src/tui/components/onboarding-screen.tsx
+++ b/src/tui/components/onboarding-screen.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useInput } from "ink";
-import { useCallback, useEffect, useRef, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { checkLlamaServer } from "../../llm/llama-server-health.js";
 import { useTerminalSize } from "../hooks/use-terminal-size.js";
 import {
@@ -21,6 +21,7 @@ import type { TuiAction } from "../tui-action.js";
 import type { TuiState } from "../tui-state.js";
 import { OnboardingChooseStep } from "./onboarding-choose-step.js";
 import { OnboardingHeader } from "./onboarding-header.js";
+import { OnboardingIntroStep } from "./onboarding-intro-step.js";
 import { OnboardingUrlStep } from "./onboarding-url-step.js";
 import { ProvidersWizard } from "./providers-wizard.js";
 
@@ -35,6 +36,7 @@ export interface OnboardingScreenCallbacks {
 }
 
 const SUBTITLES: Record<OnboardingUiState["step"], string> = {
+  intro: "",
   choose: "setup · step 1 of 2",
   cloud: "cloud model · step 2 of 2",
   custom_chat_url: "custom endpoint · step 2 of 2",
@@ -62,6 +64,7 @@ export function OnboardingScreen(props: {
   const size = useTerminalSize();
   const fit = computeOnboardingFit(size);
   const settling = useRef(false);
+  const [introSkipped, setIntroSkipped] = useState(false);
 
   const finish = useCallback(
     (outcome: OnboardingOutcome) => {
@@ -95,11 +98,27 @@ export function OnboardingScreen(props: {
       const result = handleOnboardingKey(input, key, onboarding);
       if (!result.handled) return;
       for (const action of result.actions) dispatch(action);
-      if (!result.intent) return;
-      if (result.intent.kind === "skip") finish("skipped");
-      else pick(result.intent.choice);
+      const intent = result.intent;
+      if (!intent) return;
+      if (intent.kind === "intro_key") {
+        // First key finishes the reveal, second moves on: a splash that
+        // cannot be hurried is a wait, and one that vanishes on the key
+        // that was meant to hurry it is a screen nobody ever reads.
+        if (!introSkipped) {
+          setIntroSkipped(true);
+          return;
+        }
+        // Recorded as it is dismissed, not at the end of the flow: an
+        // operator who quits at the backend choice has still seen the
+        // splash, and a later release may want to know that.
+        persistOnboardingState({ introSeenAt: new Date().toISOString() });
+        dispatch({ type: "onboarding_step_set", step: "choose" });
+        return;
+      }
+      if (intent.kind === "skip") finish("skipped");
+      else pick(intent.choice);
     },
-    { isActive: onboarding.step === "choose" },
+    { isActive: onboarding.step === "choose" || onboarding.step === "intro" },
   );
 
   // The cloud step *is* the providers wizard — same keys, same
@@ -199,9 +218,7 @@ export function OnboardingScreen(props: {
     settling.current = true;
     const now = new Date().toISOString();
     persistOnboardingState(
-      onboarding.outcome === "skipped"
-        ? { skippedAt: now }
-        : { completedAt: now, introSeenAt: now },
+      onboarding.outcome === "skipped" ? { skippedAt: now } : { completedAt: now },
     );
     callbacks.onOnboardingFinished?.(onboarding.outcome ?? "skipped");
     if (onboarding.outcome === "local") {
@@ -215,10 +232,18 @@ export function OnboardingScreen(props: {
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingTop={1}>
-      {fit.mark || fit.tier !== "minimal" ? (
+      {onboarding.step === "intro" ? null : (
         <OnboardingHeader subtitle={SUBTITLES[onboarding.step]} mark={fit.mark} />
-      ) : null}
+      )}
       <Box flexDirection="column" marginTop={1} flexShrink={0}>
+        {onboarding.step === "intro" ? (
+          <OnboardingIntroStep
+            columns={Math.max(20, size.columns - 4)}
+            rows={size.rows}
+            fit={fit}
+            skipAnimation={introSkipped}
+          />
+        ) : null}
         {onboarding.step === "choose" ? (
           <OnboardingChooseStep cursor={onboarding.cursor} fit={fit} />
         ) : null}
@@ -282,5 +307,7 @@ function footerFor(onboarding: OnboardingUiState): string {
       return "enter test & save   empty enter skips embeddings   esc back   ctrl+c quit";
     case "finished":
       return "";
+    case "intro":
+      return "ctrl+c quit";
   }
 }

--- a/src/tui/hooks/use-typewriter.test.tsx
+++ b/src/tui/hooks/use-typewriter.test.tsx
@@ -1,0 +1,58 @@
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { useTypewriter } from "./use-typewriter.js";
+
+function Probe(props: { text: string; skip?: boolean }): React.ReactElement {
+  const { revealed, done } = useTypewriter(props.text, {
+    active: true,
+    msPerChar: 10,
+    skip: props.skip ?? false,
+  });
+  return <Text>{`${revealed}|${done ? "done" : "typing"}`}</Text>;
+}
+
+/**
+ * Real timers on purpose. Faking `setInterval` would freeze Ink's own
+ * scheduler and the frame under assertion would never repaint — the trap
+ * documented in `chat-copy-button.test.tsx`. So these poll instead.
+ *
+ * Note the reveal rate under `ink-testing-library` is bounded by its
+ * frame commits (~4/s), not by `msPerChar`; a real terminal commits at
+ * ~30fps. Hence a short string here — the assertion is that the reveal
+ * progresses and settles, not how fast it does so.
+ */
+async function waitFor(read: () => string, match: (frame: string) => boolean): Promise<string> {
+  const deadline = Date.now() + 3000;
+  for (;;) {
+    const frame = read();
+    if (match(frame)) return frame;
+    if (Date.now() > deadline) return frame;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+  }
+}
+
+describe("useTypewriter", () => {
+  it("reveals the text one character at a time", async () => {
+    const view = render(<Probe text="atomic" />);
+    const early = view.lastFrame() ?? "";
+    expect(early).toContain("typing");
+    expect(early.split("|")[0]?.length ?? 99).toBeLessThan("atomic".length);
+    const finished = await waitFor(
+      () => view.lastFrame() ?? "",
+      (frame) => frame.includes("done"),
+    );
+    expect(finished).toContain("atomic|done");
+  });
+
+  it("skips straight to the end when asked", () => {
+    const view = render(<Probe text="Local AI-First Agent" skip />);
+    expect(view.lastFrame()).toContain("Local AI-First Agent|done");
+  });
+
+  it("reports done for an empty string instead of hanging", () => {
+    const view = render(<Probe text="" />);
+    expect(view.lastFrame()).toContain("|done");
+  });
+});

--- a/src/tui/hooks/use-typewriter.ts
+++ b/src/tui/hooks/use-typewriter.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+/**
+ * React hook: reveal `text` one character at a time, returning the
+ * revealed prefix and whether it is finished.
+ *
+ * Modelled on `use-spinner.ts` — the `if (!active) return;` guard makes
+ * it safe to call unconditionally, and the interval is cleared on
+ * unmount. `skip` jumps to the full string, which is what a keypress
+ * does: an animation nobody can interrupt is a wait, not a flourish.
+ *
+ * **One interval for the whole reveal.** An earlier version listed the
+ * revealed count in the effect's dependencies, so every character tore
+ * the timer down and armed a fresh one — with Ink's ~30fps commit in
+ * between, a 45ms/char reveal actually crawled at ~230ms/char. The
+ * count is advanced inside the tick instead, and the timer stops itself
+ * on the last character.
+ */
+export function useTypewriter(
+  text: string,
+  options: { active: boolean; msPerChar: number; skip?: boolean },
+): { revealed: string; done: boolean } {
+  const { active, msPerChar, skip = false } = options;
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!active || skip) return;
+    if (text.length === 0) return;
+    const handle = setInterval(() => {
+      setCount((prev) => {
+        const next = prev + 1;
+        if (next >= text.length) clearInterval(handle);
+        return Math.min(next, text.length);
+      });
+    }, msPerChar);
+    return () => clearInterval(handle);
+  }, [active, msPerChar, skip, text.length]);
+
+  // A skip has to land on the full length, not merely render as if it
+  // had: otherwise the next tick would rewind the reveal.
+  useEffect(() => {
+    if (skip) setCount(text.length);
+  }, [skip, text.length]);
+
+  const revealed = skip ? text : text.slice(0, count);
+  return { revealed, done: revealed.length >= text.length };
+}

--- a/src/tui/onboarding/intro-art.test.ts
+++ b/src/tui/onboarding/intro-art.test.ts
@@ -26,6 +26,19 @@ describe("buildIntroArt", () => {
     expect(art.join("\n")).toContain(ORBIT_GLYPH);
   });
 
+  it("rings it at the size the flow actually opens at", () => {
+    // 100×30 minus the intro's own chrome. A single-radius clearance
+    // rule silently dropped the ring here — the ellipse is wider than
+    // it is tall, so clearance has to be checked per axis.
+    const art = buildIntroArt({ columns: 96, rows: 21, markRows: MARK, crossCount: 14 });
+    expect(art.join("\n")).toContain(ORBIT_GLYPH);
+  });
+
+  it("drops the ring when the rows are too tight for it, however wide the window", () => {
+    const art = buildIntroArt({ columns: 200, rows: 16, markRows: MARK, crossCount: 14 });
+    expect(art.join("\n")).not.toContain(ORBIT_GLYPH);
+  });
+
   it("drops the ring rather than resting a cross against an arm", () => {
     // 40 columns cannot hold the mark's clear space, let alone a ring.
     const art = buildIntroArt({ columns: 40, rows: 26, markRows: MARK, crossCount: 14 });

--- a/src/tui/onboarding/intro-art.test.ts
+++ b/src/tui/onboarding/intro-art.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildIntroArt, ORBIT_GLYPH } from "./intro-art.js";
+import { CROSS_MARKS } from "../components/logo-art.js";
+
+const MARK = CROSS_MARKS.block.md;
+
+describe("buildIntroArt", () => {
+  it("centres the mark", () => {
+    const art = buildIntroArt({ columns: 100, rows: 24, markRows: MARK, crossCount: 0 });
+    const bar = art.find((row) => row.trim().startsWith("█".repeat(20)));
+    expect(bar).toBeDefined();
+    const left = (bar ?? "").length - (bar ?? "").trimStart().length;
+    const right = 100 - (bar ?? "").length;
+    expect(Math.abs(left - right)).toBeLessThanOrEqual(2);
+  });
+
+  it("never grows past the rows it was given", () => {
+    for (const rows of [12, 18, 24, 30]) {
+      const art = buildIntroArt({ columns: 100, rows, markRows: MARK, crossCount: 14 });
+      expect(art.length).toBeLessThanOrEqual(Math.max(rows, MARK.length));
+    }
+  });
+
+  it("rings the mark when there is room for the clear space", () => {
+    const art = buildIntroArt({ columns: 100, rows: 26, markRows: MARK, crossCount: 14 });
+    expect(art.join("\n")).toContain(ORBIT_GLYPH);
+  });
+
+  it("drops the ring rather than resting a cross against an arm", () => {
+    // 40 columns cannot hold the mark's clear space, let alone a ring.
+    const art = buildIntroArt({ columns: 40, rows: 26, markRows: MARK, crossCount: 14 });
+    expect(art.join("\n")).not.toContain(ORBIT_GLYPH);
+  });
+
+  it("draws the mark alone when asked for no crosses", () => {
+    const art = buildIntroArt({ columns: 100, rows: 24, markRows: MARK, crossCount: 0 });
+    expect(art.join("\n")).not.toContain(ORBIT_GLYPH);
+    expect(art.join("\n")).toContain("█");
+  });
+
+  it("never overwrites the mark with a cross", () => {
+    const art = buildIntroArt({ columns: 100, rows: 30, markRows: MARK, crossCount: 40 });
+    const markGlyphs = art.join("").split("").filter((g) => g === "█").length;
+    const plain = buildIntroArt({ columns: 100, rows: 30, markRows: MARK, crossCount: 0 });
+    const plainGlyphs = plain.join("").split("").filter((g) => g === "█").length;
+    expect(markGlyphs).toBe(plainGlyphs);
+  });
+});

--- a/src/tui/onboarding/intro-art.ts
+++ b/src/tui/onboarding/intro-art.ts
@@ -1,5 +1,9 @@
 import { CELL_ASPECT, computeOrbitField } from "./orbit-field.js";
 
+/** Blank rows and columns kept between the mark's box and the ring. */
+const RING_GAP_ROWS = 2;
+const RING_GAP_COLUMNS = 4;
+
 /** The glyph the ring is drawn with — the mark, shrunk past legibility. */
 export const ORBIT_GLYPH = "✛";
 
@@ -45,12 +49,16 @@ export function buildIntroArt(options: IntroArtOptions): string[] {
     crossCount > 0
       ? Math.min(verticalRadius * CELL_ASPECT, Math.floor(columns / 2) - 2)
       : 0;
-  // The mark's clear space is one arm width — a quarter of its box — and
-  // the ring is outside it or it is not drawn at all. A cross resting
-  // against an arm reads as a glitch in the logo, which is worse than a
-  // plain mark on a short terminal.
-  const minRadius = markWidth / 2 + markWidth / 4;
-  const radius = requested >= minRadius ? requested : 0;
+  // Clearance is checked per axis, against the mark's own box. A single
+  // radius threshold cannot express it: the ring is an ellipse and the
+  // mark is wider than it is tall, so one number is either too strict
+  // vertically or too loose horizontally — the first draft was the
+  // former and silently dropped the ring at 100×30, where it fits with
+  // room to spare. A cross resting against an arm reads as a glitch in
+  // the logo, so when either axis is short the ring is dropped whole.
+  const clearsRows = verticalRadius >= markRows.length / 2 + RING_GAP_ROWS;
+  const clearsColumns = requested >= markWidth / 2 + RING_GAP_COLUMNS;
+  const radius = clearsRows && clearsColumns ? requested : 0;
   const grid: string[][] = Array.from({ length: height }, () =>
     Array.from({ length: columns }, () => " "),
   );

--- a/src/tui/onboarding/intro-art.ts
+++ b/src/tui/onboarding/intro-art.ts
@@ -1,0 +1,85 @@
+import { CELL_ASPECT, computeOrbitField } from "./orbit-field.js";
+
+/** The glyph the ring is drawn with — the mark, shrunk past legibility. */
+export const ORBIT_GLYPH = "✛";
+
+export interface IntroArtOptions {
+  /** Usable width in cells. */
+  columns: number;
+  /** The mark, as its own rows. */
+  markRows: readonly string[];
+  /** How many crosses to place on the ring. Zero draws the mark alone. */
+  crossCount: number;
+  /**
+   * Rows the art block may occupy, mark included. The ring is sized to
+   * fit inside it — Ink 7 overlaps rather than clips, so art that
+   * outgrows its budget does not get cropped, it eats the rows above.
+   */
+  rows: number;
+}
+
+/**
+ * The intro's art block: the mark centred, with the cross ring around
+ * it, as one grid of rows.
+ *
+ * Composed into a character grid rather than layered with absolutely
+ * positioned boxes because the ring has to *interleave* with the mark's
+ * rows — and because a grid is a value a test can read, while an Ink
+ * layout is only a rendered frame.
+ */
+export function buildIntroArt(options: IntroArtOptions): string[] {
+  const { columns, markRows, crossCount } = options;
+  const markWidth = markRows.reduce((max, row) => Math.max(max, row.length), 0);
+  // The ring is sized by whichever runs out first — the rows it is
+  // allowed to use, or the columns. Sizing it to the mark and hoping it
+  // fits clips its top and bottom arcs and leaves crosses down the sides
+  // only; sizing it to the columns alone pushes the wordmark off screen.
+  // No padding when the budget is already smaller than the mark: the
+  // grid must never come out taller than it was allowed to be, and a
+  // ring with nowhere to sit is dropped below anyway.
+  const ringPadRows =
+    crossCount > 0 ? Math.max(0, Math.floor((options.rows - markRows.length) / 2)) : 0;
+  const height = markRows.length + ringPadRows * 2;
+  const verticalRadius = Math.max(0, height / 2 - 1);
+  const requested =
+    crossCount > 0
+      ? Math.min(verticalRadius * CELL_ASPECT, Math.floor(columns / 2) - 2)
+      : 0;
+  // The mark's clear space is one arm width — a quarter of its box — and
+  // the ring is outside it or it is not drawn at all. A cross resting
+  // against an arm reads as a glitch in the logo, which is worse than a
+  // plain mark on a short terminal.
+  const minRadius = markWidth / 2 + markWidth / 4;
+  const radius = requested >= minRadius ? requested : 0;
+  const grid: string[][] = Array.from({ length: height }, () =>
+    Array.from({ length: columns }, () => " "),
+  );
+  const markLeft = Math.max(0, Math.floor((columns - markWidth) / 2));
+  const markTop = ringPadRows;
+  for (const [rowIndex, row] of markRows.entries()) {
+    for (const [colIndex, glyph] of [...row].entries()) {
+      if (glyph === " ") continue;
+      const y = markTop + rowIndex;
+      const x = markLeft + colIndex;
+      if (y < 0 || y >= height || x < 0 || x >= columns) continue;
+      grid[y]![x] = glyph;
+    }
+  }
+  const center = {
+    column: markLeft + Math.floor(markWidth / 2),
+    row: markTop + Math.floor(markRows.length / 2),
+  };
+  const cells = computeOrbitField({
+    columns,
+    rows: height,
+    center,
+    radius,
+    count: crossCount,
+    phase: Math.PI / 12,
+  });
+  for (const cell of cells) {
+    if (grid[cell.row]?.[cell.column] !== " ") continue;
+    grid[cell.row]![cell.column] = ORBIT_GLYPH;
+  }
+  return grid.map((row) => row.join("").replace(/\s+$/u, ""));
+}

--- a/src/tui/onboarding/onboarding-key-bindings.test.ts
+++ b/src/tui/onboarding/onboarding-key-bindings.test.ts
@@ -11,8 +11,10 @@ const NO_KEY: Key = {
 } as Key;
 
 const key = (over: Partial<Key>): Key => ({ ...NO_KEY, ...over });
+/** The flow opens on the splash; these cases are about the choice screen. */
 const base = (over: Partial<OnboardingUiState> = {}): OnboardingUiState => ({
   ...createOnboardingState("http://127.0.0.1:8080"),
+  step: "choose",
   ...over,
 });
 
@@ -47,6 +49,20 @@ describe("handleOnboardingKey", () => {
       handled: true,
       actions: [],
       intent: { kind: "skip" },
+    });
+  });
+
+  it("claims every key on the splash, Esc included", () => {
+    const intro = base({ step: "intro" });
+    expect(handleOnboardingKey("x", NO_KEY, intro)).toEqual({
+      handled: true,
+      actions: [],
+      intent: { kind: "intro_key" },
+    });
+    expect(handleOnboardingKey("", key({ escape: true }), intro)).toEqual({
+      handled: true,
+      actions: [],
+      intent: { kind: "intro_key" },
     });
   });
 

--- a/src/tui/onboarding/onboarding-key-bindings.ts
+++ b/src/tui/onboarding/onboarding-key-bindings.ts
@@ -14,7 +14,9 @@ import {
  */
 export type OnboardingIntent =
   | { kind: "pick"; choice: "local" | "cloud" | "custom" }
-  | { kind: "skip" };
+  | { kind: "skip" }
+  /** Any key on the splash: finish the reveal, or move on if it is done. */
+  | { kind: "intro_key" };
 
 export type OnboardingKeyResult =
   | { handled: false }
@@ -35,6 +37,12 @@ export function handleOnboardingKey(
 ): OnboardingKeyResult {
   if (key.ctrl && input === "c") return { handled: false };
   if (stepOwnsItsKeyboard(onboarding.step)) return { handled: true, actions: [] };
+  // The splash promises "press any key", so it claims every key there is
+  // — including Esc, which must not skip setup from a screen that has
+  // not yet said setup is what comes next.
+  if (onboarding.step === "intro") {
+    return { handled: true, actions: [], intent: { kind: "intro_key" } };
+  }
 
   if (key.escape) {
     return { handled: true, actions: [], intent: { kind: "skip" } };

--- a/src/tui/onboarding/onboarding-reducer.test.ts
+++ b/src/tui/onboarding/onboarding-reducer.test.ts
@@ -7,16 +7,20 @@ import { createOnboardingState } from "./onboarding-state.js";
 import { fakeSession } from "../test-fixtures.js";
 
 function withFlow(step: "choose" | "cloud" = "choose"): TuiState {
+  // `createOnboardingState` opens on the splash; every case here is
+  // about what happens after it.
   const state = createInitialTuiState(fakeSession(), 50, {
     onboarding: createOnboardingState("http://127.0.0.1:8080"),
   });
-  return step === "choose"
-    ? state
-    : reduceTuiState(state, { type: "onboarding_step_set", step: "cloud" });
+  return reduceTuiState(state, { type: "onboarding_step_set", step });
 }
 
 describe("onboarding reducer", () => {
-  it("opens and closes on `onboarding_set`", () => {
+  it("opens on the splash, and closes on `onboarding_set`", () => {
+    const fresh = createInitialTuiState(fakeSession(), 50, {
+      onboarding: createOnboardingState("http://127.0.0.1:8080"),
+    });
+    expect(fresh.onboarding?.step).toBe("intro");
     const opened = withFlow();
     expect(opened.onboarding?.step).toBe("choose");
     const closed = reduceTuiState(opened, { type: "onboarding_set", onboarding: null });

--- a/src/tui/onboarding/onboarding-state.ts
+++ b/src/tui/onboarding/onboarding-state.ts
@@ -9,6 +9,7 @@
  * every one of them. Nothing branches on a slice it does not read.
  */
 export type OnboardingStep =
+  | "intro"
   | "choose"
   | "cloud"
   | "custom_chat_url"
@@ -65,7 +66,7 @@ export const ONBOARDING_CHOICES: readonly OnboardingChoice[] = [
 
 export function createOnboardingState(chatUrl: string): OnboardingUiState {
   return {
-    step: "choose",
+    step: "intro",
     outcome: null,
     cursor: 0,
     chatUrl,
@@ -89,7 +90,7 @@ export function moveOnboardingCursor(cursor: number, delta: number): number {
  * keystroke is processed twice.
  */
 export function stepOwnsItsKeyboard(step: OnboardingStep): boolean {
-  return step !== "choose";
+  return step !== "choose" && step !== "intro";
 }
 
 /** Steps where the flow is over and the host is closing it down. */

--- a/src/tui/onboarding/orbit-field.test.ts
+++ b/src/tui/onboarding/orbit-field.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { computeOrbitField, orbitRowMap, CELL_ASPECT } from "./orbit-field.js";
+
+const base = {
+  columns: 100,
+  rows: 40,
+  center: { column: 50, row: 20 },
+  radius: 22,
+  count: 12,
+};
+
+describe("computeOrbitField", () => {
+  it("draws an ellipse, not a circle — a cell is taller than it is wide", () => {
+    const cells = computeOrbitField(base);
+    const columns = cells.map((c) => c.column);
+    const rows = cells.map((c) => c.row);
+    const columnSpread = Math.max(...columns) - Math.min(...columns);
+    const rowSpread = Math.max(...rows) - Math.min(...rows);
+    expect(columnSpread).toBeGreaterThan(rowSpread);
+    expect(columnSpread / rowSpread).toBeCloseTo(CELL_ASPECT, 0);
+  });
+
+  it("keeps every cell inside the viewport", () => {
+    const cells = computeOrbitField({ ...base, radius: 400 });
+    for (const cell of cells) {
+      expect(cell.column).toBeGreaterThanOrEqual(0);
+      expect(cell.column).toBeLessThan(base.columns);
+      expect(cell.row).toBeGreaterThanOrEqual(0);
+      expect(cell.row).toBeLessThan(base.rows);
+    }
+  });
+
+  it("never returns the same cell twice", () => {
+    const cells = computeOrbitField({ ...base, count: 200 });
+    const keys = new Set(cells.map((c) => `${c.column},${c.row}`));
+    expect(keys.size).toBe(cells.length);
+  });
+
+  it("stays out of reserved bands", () => {
+    const cells = computeOrbitField({
+      ...base,
+      reserved: [{ top: 18, bottom: 22 }],
+    });
+    expect(cells.every((c) => c.row < 18 || c.row > 22)).toBe(true);
+  });
+
+  it("draws nothing for a zero count or a zero radius", () => {
+    expect(computeOrbitField({ ...base, count: 0 })).toEqual([]);
+    expect(computeOrbitField({ ...base, radius: 0 })).toEqual([]);
+  });
+
+  it("groups by row for the renderer", () => {
+    const map = orbitRowMap([
+      { column: 9, row: 2 },
+      { column: 3, row: 2 },
+      { column: 5, row: 7 },
+    ]);
+    expect(map.get(2)).toEqual([3, 9]);
+    expect(map.get(7)).toEqual([5]);
+  });
+});

--- a/src/tui/onboarding/orbit-field.ts
+++ b/src/tui/onboarding/orbit-field.ts
@@ -1,0 +1,72 @@
+/**
+ * Where the small crosses sit around the mark on the intro screen.
+ *
+ * An ellipse, not a circle: a terminal cell is roughly 2.2× taller than
+ * it is wide, so equal counts of rows and columns are not equal
+ * distances. The vertical radius is therefore the horizontal one divided
+ * by that aspect — draw a circle in cells and it reads as a wide oval.
+ *
+ * Pure and React-free so the placement can be asserted as a table rather
+ * than by reading it back out of a rendered frame.
+ */
+export const CELL_ASPECT = 2.2;
+
+export interface OrbitCell {
+  column: number;
+  row: number;
+}
+
+export interface OrbitFieldOptions {
+  columns: number;
+  rows: number;
+  /** Centre of the ring, normally the centre of the mark. */
+  center: OrbitCell;
+  /** Horizontal radius in columns. The vertical one is derived. */
+  radius: number;
+  count: number;
+  /** Rotation in radians, so a tier can offset its ring off the axes. */
+  phase?: number;
+  /** Rows the ring must not draw into (the mark, the wordmark, the footer). */
+  reserved?: readonly { top: number; bottom: number }[];
+}
+
+/**
+ * Ring positions, clipped to the viewport and to the reserved bands.
+ * Returns fewer cells than `count` when the ring does not fit — the
+ * caller draws what it gets rather than being handed coordinates that
+ * would overlap the wordmark.
+ */
+export function computeOrbitField(options: OrbitFieldOptions): OrbitCell[] {
+  const { columns, rows, center, radius, count } = options;
+  const phase = options.phase ?? 0;
+  const reserved = options.reserved ?? [];
+  if (count <= 0 || radius <= 0) return [];
+  const verticalRadius = radius / CELL_ASPECT;
+  const cells: OrbitCell[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < count; i += 1) {
+    const angle = (2 * Math.PI * i) / count + phase;
+    const column = Math.round(center.column + Math.cos(angle) * radius);
+    const row = Math.round(center.row + Math.sin(angle) * verticalRadius);
+    if (column < 0 || column >= columns) continue;
+    if (row < 0 || row >= rows) continue;
+    if (reserved.some((band) => row >= band.top && row <= band.bottom)) continue;
+    const key = `${column},${row}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    cells.push({ column, row });
+  }
+  return cells;
+}
+
+/** Group ring cells by row, so a renderer can emit one `<Text>` per line. */
+export function orbitRowMap(cells: readonly OrbitCell[]): Map<number, number[]> {
+  const byRow = new Map<number, number[]>();
+  for (const cell of cells) {
+    const columns = byRow.get(cell.row) ?? [];
+    columns.push(cell.column);
+    byRow.set(cell.row, columns);
+  }
+  for (const columns of byRow.values()) columns.sort((a, b) => a - b);
+  return byRow;
+}


### PR DESCRIPTION
Stacked on #222 (which is stacked on #220). Retarget as each merges.

## Why

A first run opened on three unstyled option rows. The product's name appeared nowhere on the screen a new user meets first — the mark, the wordmark and the tagline all shipped in `logo.tsx` and none of them were used until the operator was already inside the app.

## The screen

The mark inside a ring of smaller crosses, `ATOMIC` (the first 23 columns of the shipped `ATOMIC AGENT` wordmark), and `TAGLINE` — the string the codebase already carries — typing itself in at ~45 ms/char, then `[ press any key to continue ]`.

```
                                                  ✛
                                         ✛                ✛
                                             ███████░
                                  ✛         ████████░░
                                           █████████░░           ✛
                              ✛   █████████████████████████████░    ✛
                                  █████████████████████████████░░
                              ✛              ██████████░░░░░        ✛
                                 ✛           ███████░░░
                                        ✛                ✛
                                      ▄▀█ ▀█▀ █▀█ █▀▄▀█ █ █▀▀
                                      █▀█  █  █▄█ █ ▀ █ █ █▄▄
                                        Local AI-First Agent
                                   [ press any key to continue ]
  ctrl+c quit
```

## Three things worth reviewing

**`use-typewriter.ts` runs one interval for the whole reveal.** My first draft listed the revealed count in the effect's dependency array, so every character tore the timer down and armed a fresh one — with Ink's frame commit in between, a 45 ms/char reveal actually crawled at ~230 ms/char. The count advances inside the tick now and the timer stops itself on the last character. (Under `ink-testing-library` the rate is bounded by its ~4 fps commits regardless, which is why the test asserts progress-then-settle on a short string rather than a duration.)

**The ring is an ellipse.** A cell is ~2.2× taller than wide, so a circle drawn in cells reads as a wide oval. `orbit-field.ts` derives the vertical radius from `CELL_ASPECT`, clips to the viewport and to reserved bands, and dedupes cells that round onto each other.

**Nothing is allowed to outgrow its rows.** Ink 7 overlaps rather than clips, so an art block one row too tall does not get cropped — it paints over the lines above. `intro-art.ts` takes a row budget and sizes the ring by whichever runs out first, rows or columns; the mark steps md → sm → none by the rows actually left over rather than by the size tier; and the ring is dropped entirely if it cannot clear the mark's clear space (one arm width) instead of resting a cross against an arm.

## Interaction

Any key finishes the reveal, a second key moves on — an animation nobody can interrupt is a wait, and one that vanishes on the key meant to hurry it is a screen nobody reads. The splash claims Esc too: it must not skip setup from a screen that has not yet said setup is what comes next. `introSeenAt` is stamped as the splash is dismissed, not at the end of the flow.

## Verified in a PTY

- **100×30** — full ring, everything on screen, hints on the last row.
- **86×26** — ring dropped for clear space, mark + wordmark + tagline + advisory footer.
- **72×20** — sm mark with a small ring; the whole screen still fits.

## Tests

`orbit-field.test.ts` (ellipse ratio, viewport clipping, dedupe, reserved bands), `intro-art.test.ts` (mark centred, height never exceeds budget, ring present / dropped by clearance, crosses never overwrite the mark), `use-typewriter.test.tsx` (progresses, settles, skip lands on the full string, empty string is done), and four new `onboarding-screen.test.tsx` cases including "two keys off the splash" and "Esc does not skip from the splash".

Full suite: 5169 passed; the two failures on this machine (`fs-glob-real`, `send-message-concurrency`) fail identically on `main`.