### PR TITLE
feat(tui): the backend choice reads like a choice

### DIFF
--- a/src/tui/components/onboarding-choose-step.tsx
+++ b/src/tui/components/onboarding-choose-step.tsx
@@ -11,6 +11,13 @@ import { theme } from "../theme/theme.js";
  * about it, and "llama-server not reachable" as the first line a new user
  * reads says otherwise.
  */
+/**
+ * Label column. Wide enough for `Custom endpoint` plus a gap, so the
+ * three details line up as a column of their own — a ragged left edge
+ * there makes three comparable options read as three unrelated ones.
+ */
+const LABEL_COLUMNS = 20;
+
 export function OnboardingChooseStep(props: {
   cursor: number;
   fit: OnboardingFit;
@@ -20,24 +27,29 @@ export function OnboardingChooseStep(props: {
       {props.fit.explainer ? (
         <Box flexDirection="column" marginBottom={1}>
           <Text color={theme.colors.muted}>
-            atomic-agent can drive models three ways. Nothing here is permanent —
+            atomic-agent can drive models three ways. Nothing here is permanent — you
           </Text>
           <Text color={theme.colors.muted}>
-            you can add the others at any time from the menu.
+            can add the others at any time from the menu.
           </Text>
         </Box>
       ) : null}
       {ONBOARDING_CHOICES.map((choice, idx) => {
         const selected = idx === props.cursor;
         return (
-          <Box key={choice.id} flexDirection="column">
-            <Text color={selected ? theme.colors.accent : undefined} bold={selected}>
-              {selected ? "› " : "  "}
-              {`[${idx + 1}] `}
-              {choice.label}
-            </Text>
+          <Box key={choice.id} flexDirection="column" marginBottom={1}>
+            <Box flexDirection="row">
+              <Text color={selected ? theme.colors.accent : undefined} bold={selected}>
+                {`${selected ? "›  " : "   "}${choice.label.padEnd(LABEL_COLUMNS)}`}
+              </Text>
+              {props.fit.rowDetails ? (
+                <Text color={theme.colors.muted}>{choice.detail[0]}</Text>
+              ) : null}
+            </Box>
             {props.fit.rowDetails ? (
-              <Text color={theme.colors.muted}>{`        ${choice.detail}`}</Text>
+              <Text color={theme.colors.muted}>
+                {`${" ".repeat(LABEL_COLUMNS + 3)}${choice.detail[1]}`}
+              </Text>
             ) : null}
           </Box>
         );

--- a/src/tui/components/onboarding-screen.test.tsx
+++ b/src/tui/components/onboarding-screen.test.tsx
@@ -65,9 +65,17 @@ describe("OnboardingScreen", () => {
     const frame = strip(view.lastFrame() ?? "");
     expect(frame).toContain("atomic");
     expect(frame).toContain("setup \u00b7 step 1 of 2");
-    expect(frame).toContain("[1] Local models");
-    expect(frame).toContain("[2] Cloud models");
-    expect(frame).toContain("[3] Custom endpoint");
+    expect(frame).toContain("Local models");
+    expect(frame).toContain("Cloud models");
+    expect(frame).toContain("Custom endpoint");
+    // What each one costs the operator, on the screen rather than behind it.
+    expect(frame).toContain("Private, free per token");
+    expect(frame).toContain("needs an API key");
+    expect(frame).toContain("Nothing is downloaded");
+    // The copy describes a choice, not the health probe that used to
+    // bring this screen up.
+    expect(frame).not.toContain("not reachable");
+    expect(frame).not.toContain("ECONNREFUSED");
     // The chrome the flow deliberately does not borrow.
     expect(frame).not.toContain("R U N");
     expect(frame).not.toContain("SESSIONS");

--- a/src/tui/onboarding/onboarding-state.ts
+++ b/src/tui/onboarding/onboarding-state.ts
@@ -39,7 +39,13 @@ export interface OnboardingUiState {
 export interface OnboardingChoice {
   readonly id: "local" | "cloud" | "custom";
   readonly label: string;
-  readonly detail: string;
+  /**
+   * Two lines, wrapped by hand rather than by Ink. The trade-off each
+   * backend asks the operator to make — privacy, money, time — is the
+   * thing they are actually choosing between, so it is on the screen
+   * instead of behind it.
+   */
+  readonly detail: readonly [string, string];
 }
 
 /**
@@ -50,17 +56,26 @@ export const ONBOARDING_CHOICES: readonly OnboardingChoice[] = [
   {
     id: "local",
     label: "Local models",
-    detail: "llama.cpp on this machine — download and run locally",
+    detail: [
+      "llama.cpp on this machine. Private, free per token,",
+      "one download of 2.7–22 GB.",
+    ],
   },
   {
     id: "cloud",
     label: "Cloud models",
-    detail: "configure an API key and pick a model",
+    detail: [
+      "OpenRouter, Anthropic, Gemini, Groq and 20 more.",
+      "Fastest to a working agent — needs an API key.",
+    ],
   },
   {
     id: "custom",
     label: "Custom endpoint",
-    detail: "an existing llama-server URL you already run",
+    detail: [
+      "An OpenAI-compatible or llama-server URL you already run.",
+      "Nothing is downloaded, nothing else is asked.",
+    ],
   },
 ];
 


### PR DESCRIPTION
Stacked on #223 → #222 → #220.

## Why

The three options told the operator what each backend *is*, never what it *costs* them. "Local models (llama.cpp) — download and run locally" does not say the download is 2.7–22 GB; "Cloud models — configure API key and pick a model" does not say it is the fastest way to a working agent; nothing said the custom-endpoint path downloads nothing at all. Those trade-offs — privacy, money, time — are the thing being chosen between.

## After

```
  atomic-agent can drive models three ways. Nothing here is permanent — you
  can add the others at any time from the menu.

  ›  Local models        llama.cpp on this machine. Private, free per token,
                         one download of 2.7–22 GB.

     Cloud models        OpenRouter, Anthropic, Gemini, Groq and 20 more.
                         Fastest to a working agent — needs an API key.

     Custom endpoint     An OpenAI-compatible or llama-server URL you already run.
                         Nothing is downloaded, nothing else is asked.

  ↑/↓ move   enter select   1–3 jump   esc skip   ctrl+c quit
```

Details are wrapped by hand into two lines rather than left to Ink, and the labels share a 20-column measure so the details line up as a column of their own — a ragged left edge there makes three comparable options read as three unrelated ones. The `[1]`/`[2]`/`[3]` prefixes are gone from the rows; the digits still work and the footer still says so.

The `rowDetails` tier from `onboarding-fit` already governs whether the details are drawn at all, so a narrow terminal gets the labels alone.

## Tests

`onboarding-screen.test.tsx` asserts the cost phrases are present and that the screen no longer contains "not reachable" or "ECONNREFUSED" — the failure report this screen used to open with.

Captured at 100×30; matches the reviewed design exactly.