### PR TITLE
feat(tui): local models get their own screens, not the admin panel

### DIFF
--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -38,6 +38,14 @@ import type { RunOutcome, StreamingToolCall, TuiState } from "./tui-state.js";
 export type { TuiAction } from "./tui-action.js";
 
 export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
+  // First in the chain, and only ever claims an action while the
+  // first-run flow is open. Several actions belong to two owners then —
+  // a finished model pull, a saved provider — and the flow has to see
+  // them to advance. A handled action never reaches the rest of the
+  // chain, so it delegates the panel half to the owning slice rather
+  // than duplicating it.
+  const onboardingHandled = reduceOnboardingAction(state, action);
+  if (onboardingHandled !== null) return onboardingHandled;
   const localModelsHandled = reduceLocalModelsAction(state, action);
   if (localModelsHandled !== null) return localModelsHandled;
   const tasksHandled = reduceTasksAction(state, action);
@@ -50,11 +58,6 @@ export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
   if (mcpHandled !== null) return mcpHandled;
   const importHandled = reduceImportAction(state, action);
   if (importHandled !== null) return importHandled;
-  // Ahead of the providers slice on purpose: while the cloud step is up,
-  // the wizard's "succeeded" / "closed" also move the flow, and the
-  // onboarding reducer delegates the panel half rather than duplicating it.
-  const onboardingHandled = reduceOnboardingAction(state, action);
-  if (onboardingHandled !== null) return onboardingHandled;
   const providersHandled = reduceProvidersPanel(state, action);
   if (providersHandled !== null) return providersHandled;
   const llmPanelHandled = reduceLlmPanelAction(state, action);

--- a/src/tui/components/onboarding-download-step.test.tsx
+++ b/src/tui/components/onboarding-download-step.test.tsx
@@ -1,0 +1,80 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { OnboardingDownloadStep } from "./onboarding-download-step.js";
+import type { LocalModelsPullState } from "../local-models/local-models-panel-state.js";
+
+const strip = (s: string): string => s.replace(/\u001b\[[0-9;]*m/g, "");
+
+function pull(over: Partial<LocalModelsPullState> = {}): LocalModelsPullState {
+  return {
+    kind: "chat",
+    modelId: "gemma-4-e4b",
+    label: "Gemma 4 E4B",
+    percent: 38,
+    transferredBytes: 1_600_000_000,
+    totalBytes: 4_220_000_000,
+    error: null,
+    ...over,
+  };
+}
+
+describe("OnboardingDownloadStep", () => {
+  it("says what is happening before the first progress event lands", () => {
+    const view = render(<OnboardingDownloadStep pull={null} modelLabel="gemma-4-e4b" />);
+    const frame = strip(view.lastFrame() ?? "");
+    expect(frame).toContain("Downloading gemma-4-e4b");
+    expect(frame).toContain("starting");
+  });
+
+  it("reports bytes and percent for the phase in flight", () => {
+    const view = render(<OnboardingDownloadStep pull={pull()} modelLabel="gemma-4-e4b" />);
+    const frame = strip(view.lastFrame() ?? "");
+    expect(frame).toContain("model weights");
+    expect(frame).toContain("38%");
+    expect(frame).toContain("1.6 GB / 4.2 GB");
+  });
+
+  it("shows the runtime phase as done once the weights start", () => {
+    const view = render(<OnboardingDownloadStep pull={pull()} modelLabel="gemma-4-e4b" />);
+    const line = strip(view.lastFrame() ?? "")
+      .split("\n")
+      .find((row) => row.includes("llama.cpp runtime"));
+    expect(line).toContain("done");
+  });
+
+  it("marks the weights as waiting while the runtime is still coming down", () => {
+    const view = render(
+      <OnboardingDownloadStep
+        pull={pull({ kind: "backend", modelId: "_backend", percent: 6 })}
+        modelLabel="gemma-4-e4b"
+      />,
+    );
+    const frame = strip(view.lastFrame() ?? "");
+    const weights = frame.split("\n").find((row) => row.includes("model weights"));
+    expect(weights).toContain("waiting");
+    expect(frame).toContain("6%");
+  });
+
+  it("surfaces a failed pull instead of a silent stall", () => {
+    const view = render(
+      <OnboardingDownloadStep
+        pull={pull({ error: "connection reset" })}
+        modelLabel="gemma-4-e4b"
+      />,
+    );
+    expect(strip(view.lastFrame() ?? "")).toContain("connection reset");
+  });
+
+  it("estimates a rate once a second sample arrives", async () => {
+    const view = render(
+      <OnboardingDownloadStep pull={pull({ transferredBytes: 1_000_000_000 })} modelLabel="m" />,
+    );
+    expect(strip(view.lastFrame() ?? "")).toContain("estimating");
+    view.rerender(
+      <OnboardingDownloadStep pull={pull({ transferredBytes: 1_400_000_000 })} modelLabel="m" />,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(strip(view.lastFrame() ?? "")).toMatch(/\/s /);
+  });
+});

--- a/src/tui/components/onboarding-download-step.tsx
+++ b/src/tui/components/onboarding-download-step.tsx
@@ -1,0 +1,96 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import {
+  formatBytes,
+  formatEta,
+  useTransferRate,
+} from "../hooks/use-transfer-rate.js";
+import type { LocalModelsPullState } from "../local-models/local-models-panel-state.js";
+import { theme } from "../theme/theme.js";
+
+const BAR_WIDTH = 36;
+
+/**
+ * The download, as its own screen.
+ *
+ * The panel's banner reports a percentage and a byte count; a
+ * multi-gigabyte pull also raises "how long", which a percentage cannot
+ * answer. Rate and ETA are derived here from the same progress events.
+ *
+ * Two phases share one progress slot in state — the llama.cpp runtime
+ * zip, then the weights — so the checklist above the bar is derived from
+ * which one is currently reporting.
+ */
+export function OnboardingDownloadStep(props: {
+  pull: LocalModelsPullState | null;
+  modelLabel: string;
+}): ReactElement {
+  const pull = props.pull;
+  const { bytesPerSecond, etaSeconds } = useTransferRate(
+    pull?.transferredBytes ?? 0,
+    pull?.totalBytes ?? 0,
+  );
+  const phase = pull?.kind === "backend" ? "runtime" : "weights";
+
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      <Text color={theme.colors.muted}>
+        {`Downloading ${props.modelLabel}. You can leave this running.`}
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        <PhaseLine
+          label="llama.cpp runtime"
+          state={phase === "runtime" ? "active" : "done"}
+          pull={phase === "runtime" ? pull : null}
+        />
+        <PhaseLine
+          label="model weights"
+          state={phase === "weights" ? "active" : "pending"}
+          pull={phase === "weights" ? pull : null}
+        />
+      </Box>
+      {pull ? (
+        <Box marginTop={1}>
+          <Text color={theme.colors.muted}>
+            {bytesPerSecond ? `${formatBytes(bytesPerSecond)}/s · ` : ""}
+            {formatEta(etaSeconds)}
+          </Text>
+        </Box>
+      ) : (
+        <Box marginTop={1}>
+          <Text color={theme.colors.muted}>starting…</Text>
+        </Box>
+      )}
+      {pull?.error ? (
+        <Box marginTop={1}>
+          <Text color={theme.colors.error}>{pull.error}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function PhaseLine(props: {
+  label: string;
+  state: "active" | "done" | "pending";
+  pull: LocalModelsPullState | null;
+}): ReactElement {
+  const percent = props.state === "done" ? 100 : (props.pull?.percent ?? 0);
+  const filled = Math.round((Math.min(100, Math.max(0, percent)) / 100) * BAR_WIDTH);
+  const bar = "█".repeat(filled) + "░".repeat(BAR_WIDTH - filled);
+  const trailing =
+    props.state === "done"
+      ? "done"
+      : props.pull
+        ? `${Math.round(percent)}%   ${formatBytes(props.pull.transferredBytes)} / ${formatBytes(props.pull.totalBytes)}`
+        : "waiting";
+  return (
+    <Text wrap="truncate">
+      <Text color={theme.colors.muted}>{props.label.padEnd(20)}</Text>
+      <Text color={props.state === "pending" ? theme.colors.border : theme.colors.accent}>
+        {bar}
+      </Text>
+      <Text color={theme.colors.muted}>{`  ${trailing}`}</Text>
+    </Text>
+  );
+}

--- a/src/tui/components/onboarding-local-pick-step.tsx
+++ b/src/tui/components/onboarding-local-pick-step.tsx
@@ -1,0 +1,81 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import type { LocalModelPick } from "../onboarding/local-model-picks.js";
+import type { OnboardingFit } from "../onboarding/onboarding-fit.js";
+import { theme } from "../theme/theme.js";
+
+/** Rows drawn at once; the rest are counted in a trailing line. */
+export const LOCAL_PICK_WINDOW = 6;
+
+/**
+ * Pick a model to download. This used to be the Manage ▸ LLM panel —
+ * tab strip, `kv —`, `tools 0ok/0err` and a `status: ready` header over
+ * an install with nothing on disk. What a first run needs from that
+ * screen is one decision, so this is that decision and nothing else.
+ */
+export function OnboardingLocalPickStep(props: {
+  picks: readonly LocalModelPick[];
+  cursor: number;
+  ramGb: number;
+  fit: OnboardingFit;
+}): ReactElement {
+  const start = Math.max(
+    0,
+    Math.min(props.cursor - LOCAL_PICK_WINDOW + 2, props.picks.length - LOCAL_PICK_WINDOW),
+  );
+  const visible = props.picks.slice(start, start + LOCAL_PICK_WINDOW);
+  const below = props.picks.length - (start + visible.length);
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      {props.fit.explainer ? (
+        <Box marginBottom={1}>
+          <Text color={theme.colors.muted}>
+            {`One download, then it runs offline. This machine reports ${props.ramGb} GB of RAM.`}
+          </Text>
+        </Box>
+      ) : null}
+      {visible.map((pick) => {
+        const selected = props.picks[props.cursor]?.id === pick.id;
+        return (
+          <Text
+            key={pick.id}
+            color={selected ? theme.colors.accent : undefined}
+            bold={selected}
+            wrap="truncate"
+          >
+            {`${selected ? "›  " : "   "}${pick.label.padEnd(18)}${pick.sizeLabel.padStart(8)}    `}
+            <Text color={noteColour(pick)}>{note(pick, props.fit)}</Text>
+          </Text>
+        );
+      })}
+      {below > 0 ? (
+        <Text color={theme.colors.muted}>{`${" ".repeat(3)}↓ ${below} more`}</Text>
+      ) : null}
+    </Box>
+  );
+}
+
+/**
+ * What the row says after the size. RAM comes before the description
+ * because it is the part that decides whether the model will run here —
+ * and because the description is what truncation should eat first.
+ */
+function note(pick: LocalModelPick, fit: OnboardingFit): string {
+  const parts: string[] = [];
+  if (pick.recommended) parts.push("★ recommended");
+  parts.push(pick.fit === "over" ? `needs ${pick.ramLabel}` : pick.ramLabel);
+  if (fit.rowDetails) parts.push(pick.description);
+  return parts.join(" · ");
+}
+
+/**
+ * Colour says whether the machine can run it, so the row does not have
+ * to be read twice: a model over the host's RAM is dimmed to the warn
+ * tone rather than hidden — an operator who knows their swap situation
+ * is allowed to pick it.
+ */
+function noteColour(pick: LocalModelPick): string {
+  if (pick.fit === "over") return theme.colors.warn;
+  if (pick.recommended) return theme.colors.success;
+  return theme.colors.muted;
+}

--- a/src/tui/components/onboarding-screen.tsx
+++ b/src/tui/components/onboarding-screen.tsx
@@ -1,7 +1,19 @@
 import { Box, Text, useInput } from "ink";
-import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
 import { checkLlamaServer } from "../../llm/llama-server-health.js";
 import { useTerminalSize } from "../hooks/use-terminal-size.js";
+import {
+  buildLocalModelPicks,
+  hostRamGb,
+  orderLocalModelPicks,
+} from "../onboarding/local-model-picks.js";
 import {
   computeOnboardingFit,
   ONBOARDING_SIZE_ADVICE,
@@ -18,10 +30,13 @@ import { routeProvidersWizardKey } from "../providers/route-wizard-key.js";
 import { createProvidersWizardState } from "../providers/providers-wizard-state.js";
 import { theme } from "../theme/theme.js";
 import type { TuiAction } from "../tui-action.js";
+import type { LocalModelId } from "../../local-llm/index.js";
 import type { TuiState } from "../tui-state.js";
 import { OnboardingChooseStep } from "./onboarding-choose-step.js";
 import { OnboardingHeader } from "./onboarding-header.js";
+import { OnboardingDownloadStep } from "./onboarding-download-step.js";
 import { OnboardingIntroStep } from "./onboarding-intro-step.js";
+import { OnboardingLocalPickStep } from "./onboarding-local-pick-step.js";
 import { OnboardingUrlStep } from "./onboarding-url-step.js";
 import { ProvidersWizard } from "./providers-wizard.js";
 
@@ -33,11 +48,15 @@ export interface OnboardingScreenCallbacks {
   onProvidersWizardSubmitCancel?(): void;
   /** Reload the runtime's providers once the flow has written config. */
   onOnboardingFinished?(outcome: OnboardingOutcome): void;
+  /** Start a model pull. Owned by `LocalModelsOrchestrator`. */
+  onLocalModelsPullRequested?(modelId: LocalModelId): void;
 }
 
 const SUBTITLES: Record<OnboardingUiState["step"], string> = {
   intro: "",
   choose: "setup · step 1 of 2",
+  local_pick: "local models · step 2 of 2",
+  local_download: "local models · downloading",
   cloud: "cloud model · step 2 of 2",
   custom_chat_url: "custom endpoint · step 2 of 2",
   custom_embedding_url: "custom endpoint · embeddings",
@@ -63,6 +82,7 @@ export function OnboardingScreen(props: {
   const { onboarding, dispatch, callbacks } = props;
   const size = useTerminalSize();
   const fit = computeOnboardingFit(size);
+  const ramGb = useMemo(() => hostRamGb(), []);
   const settling = useRef(false);
   const [introSkipped, setIntroSkipped] = useState(false);
 
@@ -87,8 +107,10 @@ export function OnboardingScreen(props: {
         dispatch({ type: "onboarding_step_set", step: "custom_chat_url" });
         return;
       }
+      // Managed mode is recorded now so a Ctrl+C mid-download does not
+      // lose the choice; the model id follows when the pull completes.
       persistUserLocalModelsConfig({ mode: "managed" });
-      finish("local");
+      dispatch({ type: "onboarding_step_set", step: "local_pick" });
     },
     [dispatch, finish],
   );
@@ -119,6 +141,35 @@ export function OnboardingScreen(props: {
       else pick(intent.choice);
     },
     { isActive: onboarding.step === "choose" || onboarding.step === "intro" },
+  );
+
+  const picks = useMemo(
+    () => orderLocalModelPicks(buildLocalModelPicks(ramGb)),
+    [ramGb],
+  );
+
+  useInput(
+    (input, key) => {
+      if (key.escape) {
+        dispatch({ type: "onboarding_step_set", step: "choose" });
+        return;
+      }
+      if (key.upArrow || input === "k") {
+        dispatch({ type: "onboarding_cursor_moved", delta: -1, length: picks.length });
+        return;
+      }
+      if (key.downArrow || input === "j") {
+        dispatch({ type: "onboarding_cursor_moved", delta: 1, length: picks.length });
+        return;
+      }
+      if (key.return) {
+        const pick = picks[onboarding.cursor % Math.max(1, picks.length)];
+        if (!pick) return;
+        dispatch({ type: "onboarding_local_model_picked", modelId: pick.id });
+        callbacks.onLocalModelsPullRequested?.(pick.id as LocalModelId);
+      }
+    },
+    { isActive: onboarding.step === "local_pick" },
   );
 
   // The cloud step *is* the providers wizard — same keys, same
@@ -221,12 +272,6 @@ export function OnboardingScreen(props: {
       onboarding.outcome === "skipped" ? { skippedAt: now } : { completedAt: now },
     );
     callbacks.onOnboardingFinished?.(onboarding.outcome ?? "skipped");
-    if (onboarding.outcome === "local") {
-      // Until the standalone model picker lands, "local models" hands
-      // over to the LLM tab, which is where the download lives today.
-      dispatch({ type: "ui_mode_set", mode: "debug" });
-      dispatch({ type: "tab_changed", tab: "llm" });
-    }
     dispatch({ type: "onboarding_set", onboarding: null });
   }, [callbacks, dispatch, onboarding.outcome, onboarding.step]);
 
@@ -246,6 +291,20 @@ export function OnboardingScreen(props: {
         ) : null}
         {onboarding.step === "choose" ? (
           <OnboardingChooseStep cursor={onboarding.cursor} fit={fit} />
+        ) : null}
+        {onboarding.step === "local_pick" ? (
+          <OnboardingLocalPickStep
+            picks={picks}
+            cursor={onboarding.cursor % Math.max(1, picks.length)}
+            ramGb={ramGb}
+            fit={fit}
+          />
+        ) : null}
+        {onboarding.step === "local_download" ? (
+          <OnboardingDownloadStep
+            pull={props.state.localModelsPanel.pull}
+            modelLabel={onboarding.localModelId ?? "the model"}
+          />
         ) : null}
         {onboarding.step === "cloud" && wizardState ? (
           <ProvidersWizard wizard={wizardState} />
@@ -305,6 +364,10 @@ function footerFor(onboarding: OnboardingUiState): string {
       return "enter test & continue   esc back   ctrl+c quit";
     case "custom_embedding_url":
       return "enter test & save   empty enter skips embeddings   esc back   ctrl+c quit";
+    case "local_pick":
+      return "↑/↓ move   enter download   esc back   ctrl+c quit";
+    case "local_download":
+      return "ctrl+c quit";
     case "finished":
       return "";
     case "intro":

--- a/src/tui/hooks/use-transfer-rate.ts
+++ b/src/tui/hooks/use-transfer-rate.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface TransferRate {
+  /** Bytes per second, smoothed. `null` until two samples exist. */
+  bytesPerSecond: number | null;
+  /** Seconds remaining at the current rate, or `null` when unknowable. */
+  etaSeconds: number | null;
+}
+
+/** Weight of each new sample. Low enough that a stalled chunk does not
+ * make the estimate lurch, high enough to follow a real slowdown. */
+const SMOOTHING = 0.3;
+
+/**
+ * Turn a growing byte count into a rate and an ETA.
+ *
+ * The progress events carry totals, not speed — a percentage alone
+ * cannot answer "do I have time to make coffee", which is the only
+ * question a multi-gigabyte download raises. Smoothed with an EMA
+ * because raw deltas between two HTTP chunks swing wildly.
+ */
+export function useTransferRate(
+  transferredBytes: number,
+  totalBytes: number,
+): TransferRate {
+  const [rate, setRate] = useState<number | null>(null);
+  const last = useRef<{ bytes: number; at: number } | null>(null);
+
+  useEffect(() => {
+    const now = Date.now();
+    const previous = last.current;
+    last.current = { bytes: transferredBytes, at: now };
+    if (!previous) return;
+    const elapsedSeconds = (now - previous.at) / 1000;
+    const delta = transferredBytes - previous.bytes;
+    // A restart (a new download reusing the slot) resets the estimate
+    // rather than reporting a negative rate.
+    if (delta < 0) {
+      setRate(null);
+      return;
+    }
+    if (elapsedSeconds <= 0) return;
+    const sample = delta / elapsedSeconds;
+    setRate((prev) => (prev === null ? sample : prev + SMOOTHING * (sample - prev)));
+  }, [transferredBytes]);
+
+  const remaining = Math.max(0, totalBytes - transferredBytes);
+  const etaSeconds = rate && rate > 0 ? Math.round(remaining / rate) : null;
+  return { bytesPerSecond: rate, etaSeconds };
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1_000_000_000) return `${(bytes / 1_000_000_000).toFixed(1)} GB`;
+  if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`;
+  if (bytes >= 1_000) return `${Math.round(bytes / 1_000)} kB`;
+  return `${bytes} B`;
+}
+
+export function formatEta(seconds: number | null): string {
+  if (seconds === null) return "estimating…";
+  if (seconds < 60) return "less than a minute left";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `about ${minutes} minute${minutes === 1 ? "" : "s"} left`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return `about ${hours}h ${rest}m left`;
+}

--- a/src/tui/onboarding/local-model-picks.test.ts
+++ b/src/tui/onboarding/local-model-picks.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLocalModelPicks,
+  orderLocalModelPicks,
+  recommendLocalModel,
+  FIRST_RUN_MAX_DOWNLOAD_GB,
+} from "./local-model-picks.js";
+import type { LocalModelDef, LocalModelId } from "../../local-llm/index.js";
+
+function def(
+  id: string,
+  fileSizeGb: number,
+  minRamGb: number,
+  recommendedRamGb: number,
+): LocalModelDef {
+  return {
+    id: id as LocalModelId,
+    name: id,
+    filename: `${id}.gguf`,
+    huggingFaceUrl: "https://example.invalid/model.gguf",
+    fileSizeGb,
+    sizeLabel: `${fileSizeGb} GB`,
+    description: "test model",
+    maxContextLength: 8192,
+    contextLabel: "8K",
+    minRamGb,
+    recommendedRamGb,
+    family: "qwen",
+  } as LocalModelDef;
+}
+
+const CATALOG = [
+  def("tiny", 2, 4, 6),
+  def("small", 4, 6, 8),
+  def("medium", 7, 8, 12),
+  def("large", 18, 24, 32),
+];
+
+describe("recommendLocalModel", () => {
+  it("picks the largest quick download the machine runs comfortably", () => {
+    expect(recommendLocalModel(32, CATALOG)).toBe("medium");
+  });
+
+  it("never recommends a download past the first-run ceiling", () => {
+    const big = [def("huge", FIRST_RUN_MAX_DOWNLOAD_GB + 10, 8, 8)];
+    // The only comfortable model is over the ceiling, so it is chosen as
+    // the fallback — but a catalog with a smaller option prefers it.
+    expect(recommendLocalModel(64, big)).toBe("huge");
+    expect(recommendLocalModel(64, CATALOG)).toBe("medium");
+  });
+
+  it("falls back to the smallest model when nothing fits comfortably", () => {
+    expect(recommendLocalModel(2, CATALOG)).toBe("tiny");
+  });
+
+  it("has nothing to say about an empty catalog", () => {
+    expect(recommendLocalModel(16, [])).toBeNull();
+  });
+});
+
+describe("buildLocalModelPicks", () => {
+  it("marks how each model fits this machine", () => {
+    const picks = buildLocalModelPicks(8, CATALOG);
+    expect(picks.map((p) => p.fit)).toEqual(["fits", "fits", "tight", "over"]);
+  });
+
+  it("marks exactly one recommendation", () => {
+    const picks = buildLocalModelPicks(16, CATALOG);
+    expect(picks.filter((p) => p.recommended)).toHaveLength(1);
+  });
+});
+
+describe("orderLocalModelPicks", () => {
+  it("puts the recommendation first, then what runs here", () => {
+    const ordered = orderLocalModelPicks(buildLocalModelPicks(8, CATALOG));
+    expect(ordered[0]?.recommended).toBe(true);
+    expect(ordered.at(-1)?.fit).toBe("over");
+  });
+});

--- a/src/tui/onboarding/local-model-picks.ts
+++ b/src/tui/onboarding/local-model-picks.ts
@@ -1,0 +1,90 @@
+import { totalmem } from "node:os";
+import { LOCAL_MODELS_CATALOG, type LocalModelDef, type LocalModelId } from "../../local-llm/index.js";
+
+/** Host physical RAM in whole decimal GB, the same measure the panel uses. */
+export function hostRamGb(): number {
+  return Math.max(1, Math.floor(totalmem() / 1_000_000_000));
+}
+
+export interface LocalModelPick {
+  id: LocalModelId;
+  label: string;
+  sizeLabel: string;
+  /** "fits" — runs comfortably here; "tight" — over recommended; "over" — under minimum. */
+  fit: "fits" | "tight" | "over";
+  ramLabel: string;
+  description: string;
+  recommended: boolean;
+}
+
+/**
+ * Ceiling on the *recommended* download, in GB. The catalog goes up to
+ * 22 GB, and a machine with the RAM to run that can still be an hour
+ * from its first answer. A first run should reach a working agent, not
+ * the best possible one — the bigger models stay one row away.
+ */
+export const FIRST_RUN_MAX_DOWNLOAD_GB = 8;
+
+/**
+ * The catalog as first-run rows: size, what it needs, and one
+ * recommendation.
+ */
+export function buildLocalModelPicks(
+  ramGb: number,
+  catalog: readonly LocalModelDef[] = LOCAL_MODELS_CATALOG,
+): LocalModelPick[] {
+  const recommendedId = recommendLocalModel(ramGb, catalog);
+  return catalog.map((def) => ({
+    id: def.id,
+    label: def.id,
+    sizeLabel: def.sizeLabel,
+    fit: fitFor(def, ramGb),
+    ramLabel: `${def.recommendedRamGb} GB RAM`,
+    description: def.description,
+    recommended: def.id === recommendedId,
+  }));
+}
+
+/**
+ * The best first model for this machine: the largest one that runs
+ * comfortably *and* stays under the download ceiling. Falling back, in
+ * order: anything that runs comfortably, then the smallest model in the
+ * catalog — something that runs beats something that was recommended.
+ */
+export function recommendLocalModel(
+  ramGb: number,
+  catalog: readonly LocalModelDef[] = LOCAL_MODELS_CATALOG,
+): LocalModelId | null {
+  if (catalog.length === 0) return null;
+  const comfortable = catalog.filter((def) => def.recommendedRamGb <= ramGb);
+  const quick = comfortable.filter(
+    (def) => def.fileSizeGb <= FIRST_RUN_MAX_DOWNLOAD_GB,
+  );
+  const largest = (defs: readonly LocalModelDef[]): LocalModelDef =>
+    defs.reduce((best, def) => (def.fileSizeGb > best.fileSizeGb ? def : best));
+  if (quick.length > 0) return largest(quick).id;
+  if (comfortable.length > 0) {
+    return comfortable.reduce((best, def) =>
+      def.fileSizeGb < best.fileSizeGb ? def : best,
+    ).id;
+  }
+  return catalog.reduce((best, def) =>
+    def.fileSizeGb < best.fileSizeGb ? def : best,
+  ).id;
+}
+
+function fitFor(def: LocalModelDef, ramGb: number): LocalModelPick["fit"] {
+  if (def.recommendedRamGb <= ramGb) return "fits";
+  if (def.minRamGb <= ramGb) return "tight";
+  return "over";
+}
+
+/** Rows ordered for the first run: the recommendation first, then by size. */
+export function orderLocalModelPicks(picks: readonly LocalModelPick[]): LocalModelPick[] {
+  return [...picks].sort((a, b) => {
+    if (a.recommended !== b.recommended) return a.recommended ? -1 : 1;
+    const fitRank = { fits: 0, tight: 1, over: 2 } as const;
+    if (fitRank[a.fit] !== fitRank[b.fit]) return fitRank[a.fit] - fitRank[b.fit];
+    return a.sizeLabel.localeCompare(b.sizeLabel, "en", { numeric: true });
+  });
+}

--- a/src/tui/onboarding/onboarding-actions.ts
+++ b/src/tui/onboarding/onboarding-actions.ts
@@ -8,10 +8,17 @@ export type OnboardingAction =
   /** Open the flow (first run) — `null` closes it and hands over to the agent. */
   | { type: "onboarding_set"; onboarding: OnboardingUiState | null }
   | { type: "onboarding_step_set"; step: OnboardingStep }
-  | { type: "onboarding_cursor_moved"; delta: number }
+  /**
+   * `length` is the row count of the list being moved through — the
+   * choice screen has three rows, the model picker has as many as the
+   * catalog. Absent means the choice screen.
+   */
+  | { type: "onboarding_cursor_moved"; delta: number; length?: number }
   | { type: "onboarding_cursor_set"; cursor: number }
   | { type: "onboarding_url_changed"; field: "chat" | "embedding"; value: string }
   | { type: "onboarding_busy_set"; busy: boolean }
   | { type: "onboarding_error_set"; error: string | null }
+  /** The local branch committed to a model and moved to the download. */
+  | { type: "onboarding_local_model_picked"; modelId: string }
   /** The flow reached its end; the host persists and closes it. */
   | { type: "onboarding_finished"; outcome: OnboardingOutcome };

--- a/src/tui/onboarding/onboarding-reducer.test.ts
+++ b/src/tui/onboarding/onboarding-reducer.test.ts
@@ -6,7 +6,9 @@ import { createProvidersWizardState } from "../providers/providers-wizard-state.
 import { createOnboardingState } from "./onboarding-state.js";
 import { fakeSession } from "../test-fixtures.js";
 
-function withFlow(step: "choose" | "cloud" = "choose"): TuiState {
+function withFlow(
+  step: "choose" | "cloud" | "local_pick" | "local_download" = "choose",
+): TuiState {
   // `createOnboardingState` opens on the splash; every case here is
   // about what happens after it.
   const state = createInitialTuiState(fakeSession(), 50, {
@@ -51,6 +53,68 @@ describe("onboarding reducer", () => {
   it("finishes with the outcome the host has to act on", () => {
     const state = reduceTuiState(withFlow(), { type: "onboarding_finished", outcome: "local" });
     expect(state.onboarding).toMatchObject({ step: "finished", outcome: "local" });
+  });
+
+  describe("local branch ↔ the model orchestrator", () => {
+    it("moves to the download and remembers the model", () => {
+      const state = reduceTuiState(withFlow("local_pick"), {
+        type: "onboarding_local_model_picked",
+        modelId: "gemma-4-e4b",
+      });
+      expect(state.onboarding).toMatchObject({
+        step: "local_download",
+        localModelId: "gemma-4-e4b",
+      });
+    });
+
+    it("finishes when the chat pull completes", () => {
+      const state = reduceTuiState(withFlow("local_download"), {
+        type: "local_models_pull_finished",
+        kind: "chat",
+      });
+      expect(state.onboarding).toMatchObject({ step: "finished", outcome: "local" });
+      expect(state.localModelsPanel.pull).toBeNull();
+    });
+
+    it("ignores a finished pull of some other kind", () => {
+      const state = reduceTuiState(withFlow("local_download"), {
+        type: "local_models_pull_finished",
+        kind: "embedding",
+      });
+      expect(state.onboarding?.step).toBe("local_download");
+    });
+
+    it("keeps the embedding offer out of the first run", () => {
+      const state = reduceTuiState(withFlow("local_download"), {
+        type: "local_models_embedding_onboarding_opened",
+        modelId: "embeddinggemma-300m",
+        name: "EmbeddingGemma 300M",
+        sizeLabel: "~84 MB",
+      });
+      expect(state.localModelsPanel.embeddingOnboardingPrompt).toBeNull();
+      expect(state.onboarding?.step).toBe("local_download");
+    });
+
+    it("still lets the panel show that offer when the flow is closed", () => {
+      const base = createInitialTuiState(fakeSession(), 50);
+      const state = reduceTuiState(base, {
+        type: "local_models_embedding_onboarding_opened",
+        modelId: "embeddinggemma-300m",
+        name: "EmbeddingGemma 300M",
+        sizeLabel: "~84 MB",
+      });
+      expect(state.localModelsPanel.embeddingOnboardingPrompt).not.toBeNull();
+    });
+
+    it("resets the cursor when a new list takes the screen", () => {
+      let state = reduceTuiState(withFlow("choose"), {
+        type: "onboarding_cursor_moved",
+        delta: 2,
+      });
+      expect(state.onboarding?.cursor).toBe(2);
+      state = reduceTuiState(state, { type: "onboarding_step_set", step: "local_pick" });
+      expect(state.onboarding?.cursor).toBe(0);
+    });
   });
 
   describe("cloud step ↔ providers wizard", () => {

--- a/src/tui/onboarding/onboarding-reducer.ts
+++ b/src/tui/onboarding/onboarding-reducer.ts
@@ -1,3 +1,4 @@
+import { reduceLocalModelsAction } from "../local-models/local-models-reducer.js";
 import { reduceProvidersPanel } from "../providers/providers-reducer.js";
 import type { TuiAction } from "../tui-action.js";
 import type { TuiState } from "../tui-state.js";
@@ -22,7 +23,15 @@ export function reduceOnboardingAction(
       if (!state.onboarding) return state;
       return {
         ...state,
-        onboarding: { ...state.onboarding, step: action.step, error: null, busy: false },
+        onboarding: {
+          ...state.onboarding,
+          step: action.step,
+          // Each list owns its own cursor; carrying the choice screen's
+          // row into the model picker would land it on an arbitrary model.
+          cursor: 0,
+          error: null,
+          busy: false,
+        },
       };
     }
     case "onboarding_cursor_moved": {
@@ -31,7 +40,11 @@ export function reduceOnboardingAction(
         ...state,
         onboarding: {
           ...state.onboarding,
-          cursor: moveOnboardingCursor(state.onboarding.cursor, action.delta),
+          cursor: moveOnboardingCursor(
+            state.onboarding.cursor,
+            action.delta,
+            action.length,
+          ),
         },
       };
     }
@@ -55,6 +68,18 @@ export function reduceOnboardingAction(
       if (!state.onboarding) return state;
       return { ...state, onboarding: { ...state.onboarding, error: action.error } };
     }
+    case "onboarding_local_model_picked": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          step: "local_download",
+          localModelId: action.modelId,
+          error: null,
+        },
+      };
+    }
     case "onboarding_finished": {
       if (!state.onboarding) return state;
       return {
@@ -75,6 +100,25 @@ export function reduceOnboardingAction(
     // the owning reducer and folds its own step change on top. Without
     // the delegation the panel would never clear its wizard, because a
     // handled action never reaches the rest of the chain.
+    // The pull is owned by `LocalModelsOrchestrator`, which reports
+    // through the panel's slice; the flow listens for the same events
+    // rather than running a second download of its own.
+    case "local_models_pull_finished": {
+      if (state.onboarding?.step !== "local_download") return null;
+      if (action.kind !== "chat") return null;
+      const next = reduceLocalModelsAction(state, action) ?? state;
+      return {
+        ...next,
+        onboarding: { ...state.onboarding, step: "finished", outcome: "local" },
+      };
+    }
+    // Hybrid-recall embeddings are a second download and a second
+    // decision, and the first run does not ask for either. The offer
+    // still exists in the LLM panel, where there is room to explain it.
+    case "local_models_embedding_onboarding_opened": {
+      if (state.onboarding?.step !== "local_download") return null;
+      return state;
+    }
     case "providers_wizard_succeeded": {
       if (state.onboarding?.step !== "cloud") return null;
       const next = reduceProvidersPanel(state, action) ?? state;

--- a/src/tui/onboarding/onboarding-state.ts
+++ b/src/tui/onboarding/onboarding-state.ts
@@ -11,6 +11,8 @@
 export type OnboardingStep =
   | "intro"
   | "choose"
+  | "local_pick"
+  | "local_download"
   | "cloud"
   | "custom_chat_url"
   | "custom_embedding_url"
@@ -25,6 +27,8 @@ export type OnboardingOutcome = "local" | "cloud" | "custom" | "skipped";
 
 export interface OnboardingUiState {
   step: OnboardingStep;
+  /** The model being pulled, once the local branch has committed to one. */
+  localModelId: string | null;
   /** Set together with the `finished` step; `null` at every other point. */
   outcome: OnboardingOutcome | null;
   /** Row cursor on the `choose` step. */
@@ -83,6 +87,7 @@ export function createOnboardingState(chatUrl: string): OnboardingUiState {
   return {
     step: "intro",
     outcome: null,
+    localModelId: null,
     cursor: 0,
     chatUrl,
     embeddingUrl: "",
@@ -91,10 +96,14 @@ export function createOnboardingState(chatUrl: string): OnboardingUiState {
   };
 }
 
-/** Wrapping row movement on the `choose` step. */
-export function moveOnboardingCursor(cursor: number, delta: number): number {
-  const count = ONBOARDING_CHOICES.length;
-  return (cursor + delta + count) % count;
+/** Wrapping row movement, over any list length. */
+export function moveOnboardingCursor(
+  cursor: number,
+  delta: number,
+  length: number = ONBOARDING_CHOICES.length,
+): number {
+  const count = Math.max(1, length);
+  return (((cursor + delta) % count) + count) % count;
 }
 
 /**
@@ -105,7 +114,7 @@ export function moveOnboardingCursor(cursor: number, delta: number): number {
  * keystroke is processed twice.
  */
 export function stepOwnsItsKeyboard(step: OnboardingStep): boolean {
-  return step !== "choose" && step !== "intro";
+  return step === "cloud" || step.startsWith("custom_");
 }
 
 /** Steps where the flow is over and the host is closing it down. */


### PR DESCRIPTION
Stacked on #224 → #223 → #222 → #220.

## Why

Picking **Local models** persisted `mode: "managed"` and dropped the operator into **MANAGE ▸ LLM** — tab strip, wrapped cwd line, `kv —`, `tools 0ok/0err`, `approval L1`, and a `status: ready` header sitting over an install with nothing on disk. The first decision of a first run was being made inside an operator console, with 2.7–22 GB downloads listed and no hint which one this machine should take.

## Two screens

**Pick a model**

```
  ›  gemma-4-12b         6.7 GB    ★ recommended · 12 GB RAM · Mid-size dense multimodal…
     qwen-3.5-4b         2.7 GB    8 GB RAM · Quality-size sweet spot
     gemma-4-e4b         4.2 GB    8 GB RAM · Compact multimodal reasoning (QAT)
     gemma-4-26b-a4b    14.2 GB    20 GB RAM · Fast MoE with 256K context (QAT)
     ↓ 6 more
```

RAM comes before the description because it decides whether the model runs here — and because the description is what truncation should eat first. Rows are coloured by fit: green for the recommendation, warn for anything past this machine's RAM (dimmed, not hidden — an operator who knows their swap situation may still pick it).

**The recommendation** is the largest model that runs comfortably here *and* stays under an 8 GB download ceiling (`FIRST_RUN_MAX_DOWNLOAD_GB`). On a 68 GB machine the naive "largest that fits" rule recommended a 22.4 GB download as the first thing a new user does; the ceiling makes it a 6.7 GB one, with the bigger models one row away. Nothing comfortable → the smallest model in the catalog: something that runs beats something that was recommended.

**Watch it download**

```
  llama.cpp runtime   ████████████████████████████████████  done
  model weights       ██████████████░░░░░░░░░░░░░░░░░░░░░░  38%   1.6 GB / 4.2 GB
                      12.4 MB/s · about 3 minutes left
```

Rate and ETA are derived from the same progress events (`use-transfer-rate.ts`, EMA-smoothed — raw deltas between two HTTP chunks swing wildly). The two phases share one progress slot in state, so the checklist is derived from which one is currently reporting.

## Wiring

Both screens drive the existing `LocalModelsOrchestrator`: `onLocalModelsPullRequested` starts the pull, `local_models_pull_*` feeds the bars. The download lifecycle is unchanged — it was already session-scoped and survives leaving the screen.

**Reducer order.** A finished pull and a saved provider now have two owners, so `reduceOnboardingAction` moves to the head of the chain and delegates the panel half to the owning slice. It only claims an action while the flow is open, so nothing else changes shape.

**Embeddings.** The hybrid-recall offer that fires after a first chat pull is suppressed during onboarding — a second download and a second decision, from a screen with no room to explain either. It still appears in the LLM panel, which has both. Pinned by a test in each direction.

## Tests

`local-model-picks.test.ts` (recommendation under/over the ceiling, no-comfortable-fit fallback, empty catalog, fit classification, ordering), `onboarding-download-step.test.tsx` (pre-progress state, bytes/percent, runtime-done derivation, waiting phase, error surfaced, rate appears on the second sample), and six new reducer cases including both directions of the embedding suppression and the cursor reset between lists.

Full suite: 5186 passed. `fs-glob-real` and `send-message-concurrency` fail on `main` too; `llm-health-poller` flaked under parallel load and passes in isolation.