### PR TITLE
feat(tui): offer the other backend once the first one works

### DIFF
--- a/src/tui/components/onboarding-propose-step.test.tsx
+++ b/src/tui/components/onboarding-propose-step.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { OnboardingProposeStep } from "./onboarding-propose-step.js";
+
+const strip = (s: string): string => s.replace(/\u001b\[[0-9;]*m/g, "");
+
+describe("OnboardingProposeStep", () => {
+  it("offers local to a cloud operator, and says what it buys them", () => {
+    const view = render(
+      <OnboardingProposeStep offer="local" configuredLabel="Cloud model ready" cursor={0} />,
+    );
+    const frame = strip(view.lastFrame() ?? "");
+    expect(frame).toContain("Cloud model ready");
+    expect(frame).toContain("Set up local models too");
+    expect(frame).toContain("offline");
+    expect(frame).toContain("Skip");
+  });
+
+  it("mirrors for a local operator", () => {
+    const view = render(
+      <OnboardingProposeStep offer="cloud" configuredLabel="Local model ready" cursor={0} />,
+    );
+    const frame = strip(view.lastFrame() ?? "");
+    expect(frame).toContain("Local model ready");
+    expect(frame).toContain("Set up a cloud model too");
+  });
+
+  it("points the cursor at the row it is on", () => {
+    const view = render(
+      <OnboardingProposeStep offer="local" configuredLabel="Cloud model ready" cursor={1} />,
+    );
+    const lines = strip(view.lastFrame() ?? "").split("\n");
+    const skip = lines.find((line) => line.includes("Skip"));
+    expect(skip?.trimStart().startsWith("\u203a")).toBe(true);
+  });
+});

--- a/src/tui/components/onboarding-propose-step.tsx
+++ b/src/tui/components/onboarding-propose-step.tsx
@@ -1,0 +1,62 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import type { SecondBackendOffer } from "../onboarding/propose-second-backend.js";
+import { theme } from "../theme/theme.js";
+
+/**
+ * "You have one — want the other too?", shown once, after the first
+ * backend actually works.
+ *
+ * The pitch is the product's actual shape: local and cloud are not
+ * alternatives here, they run side by side and switch mid-session. An
+ * operator who set up one usually does not know that.
+ */
+export function OnboardingProposeStep(props: {
+  offer: NonNullable<SecondBackendOffer>;
+  configuredLabel: string;
+  cursor: number;
+}): ReactElement {
+  const rows =
+    props.offer === "local"
+      ? {
+          accept: "Set up local models too",
+          acceptDetail: "one download, then it runs offline and costs nothing per token",
+        }
+      : {
+          accept: "Set up a cloud model too",
+          acceptDetail: "an API key and a model — about a minute, for the heavy turns",
+        };
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      <Text>
+        <Text color={theme.colors.success}>{`${theme.glyphs.check}  `}</Text>
+        <Text>{props.configuredLabel}</Text>
+      </Text>
+      <Box flexDirection="column" marginTop={1} marginBottom={1}>
+        <Text color={theme.colors.muted}>
+          atomic-agent runs both side by side — local for private or offline work,
+        </Text>
+        <Text color={theme.colors.muted}>
+          cloud for the heavy turns, switchable mid-session. You have one of the two.
+        </Text>
+      </Box>
+      <Row selected={props.cursor === 0} label={rows.accept} detail={rows.acceptDetail} />
+      <Row
+        selected={props.cursor === 1}
+        label="Skip — take me to the agent"
+        detail="you can add it later from the menu (ctrl+p)"
+      />
+    </Box>
+  );
+}
+
+function Row(props: { selected: boolean; label: string; detail: string }): ReactElement {
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text color={props.selected ? theme.colors.accent : undefined} bold={props.selected}>
+        {`${props.selected ? "›  " : "   "}${props.label}`}
+      </Text>
+      <Text color={theme.colors.muted}>{`   ${props.detail}`}</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/onboarding-screen.tsx
+++ b/src/tui/components/onboarding-screen.tsx
@@ -7,7 +7,12 @@ import {
   useState,
   type ReactElement,
 } from "react";
+import { getConfig } from "../../config/index.js";
 import { checkLlamaServer } from "../../llm/llama-server-health.js";
+import {
+  isCloudTextProviderReady,
+  isLocalBackendConfigured,
+} from "../local-backend-readiness.js";
 import { useTerminalSize } from "../hooks/use-terminal-size.js";
 import {
   buildLocalModelPicks,
@@ -19,6 +24,7 @@ import {
   ONBOARDING_SIZE_ADVICE,
 } from "../onboarding/onboarding-fit.js";
 import { handleOnboardingKey } from "../onboarding/onboarding-key-bindings.js";
+import { decideSecondBackendOffer } from "../onboarding/propose-second-backend.js";
 import type { OnboardingOutcome, OnboardingUiState } from "../onboarding/onboarding-state.js";
 import {
   normalizeLocalLlmBaseUrl,
@@ -37,6 +43,7 @@ import { OnboardingHeader } from "./onboarding-header.js";
 import { OnboardingDownloadStep } from "./onboarding-download-step.js";
 import { OnboardingIntroStep } from "./onboarding-intro-step.js";
 import { OnboardingLocalPickStep } from "./onboarding-local-pick-step.js";
+import { OnboardingProposeStep } from "./onboarding-propose-step.js";
 import { OnboardingUrlStep } from "./onboarding-url-step.js";
 import { ProvidersWizard } from "./providers-wizard.js";
 
@@ -57,6 +64,7 @@ const SUBTITLES: Record<OnboardingUiState["step"], string> = {
   choose: "setup · step 1 of 2",
   local_pick: "local models · step 2 of 2",
   local_download: "local models · downloading",
+  propose_second: "one more thing",
   cloud: "cloud model · step 2 of 2",
   custom_chat_url: "custom endpoint · step 2 of 2",
   custom_embedding_url: "custom endpoint · embeddings",
@@ -172,6 +180,40 @@ export function OnboardingScreen(props: {
     { isActive: onboarding.step === "local_pick" },
   );
 
+  useInput(
+    (input, key) => {
+      if (key.escape) {
+        finish(onboarding.outcome ?? "skipped");
+        return;
+      }
+      if (key.upArrow || key.downArrow || input === "j" || input === "k") {
+        dispatch({
+          type: "onboarding_cursor_moved",
+          delta: key.upArrow || input === "k" ? -1 : 1,
+          length: 2,
+        });
+        return;
+      }
+      if (key.return) {
+        if (onboarding.cursor !== 0) {
+          finish(onboarding.outcome ?? "skipped");
+          return;
+        }
+        if (onboarding.offer === "local") {
+          persistUserLocalModelsConfig({ mode: "managed" });
+          dispatch({ type: "onboarding_step_set", step: "local_pick" });
+          return;
+        }
+        dispatch({
+          type: "providers_wizard_opened",
+          wizard: createProvidersWizardState("add"),
+        });
+        dispatch({ type: "onboarding_step_set", step: "cloud" });
+      }
+    },
+    { isActive: onboarding.step === "propose_second" },
+  );
+
   // The cloud step *is* the providers wizard — same keys, same
   // verification, same hot-swap — so it routes through the panel's own
   // handler rather than a second implementation of it.
@@ -266,12 +308,25 @@ export function OnboardingScreen(props: {
   // on the next launch, so it is written before the surface unmounts.
   useEffect(() => {
     if (onboarding.step !== "finished" || settling.current) return;
+    const outcome = onboarding.outcome ?? "skipped";
+    const config = getConfig();
+    const offer = decideSecondBackendOffer({
+      outcome,
+      cloudReady: isCloudTextProviderReady(),
+      localReady: isLocalBackendConfigured(),
+      alreadyProposed: config.tui.onboarding.proposedSecondBackendAt !== null,
+    });
+    if (offer) {
+      // Recorded when it is shown, not when it is answered: the offer
+      // was made either way, and a declined offer must not come back.
+      persistOnboardingState({ proposedSecondBackendAt: new Date().toISOString() });
+      dispatch({ type: "onboarding_second_backend_offered", offer });
+      return;
+    }
     settling.current = true;
     const now = new Date().toISOString();
-    persistOnboardingState(
-      onboarding.outcome === "skipped" ? { skippedAt: now } : { completedAt: now },
-    );
-    callbacks.onOnboardingFinished?.(onboarding.outcome ?? "skipped");
+    persistOnboardingState(outcome === "skipped" ? { skippedAt: now } : { completedAt: now });
+    callbacks.onOnboardingFinished?.(outcome);
     dispatch({ type: "onboarding_set", onboarding: null });
   }, [callbacks, dispatch, onboarding.outcome, onboarding.step]);
 
@@ -298,6 +353,13 @@ export function OnboardingScreen(props: {
             cursor={onboarding.cursor % Math.max(1, picks.length)}
             ramGb={ramGb}
             fit={fit}
+          />
+        ) : null}
+        {onboarding.step === "propose_second" && onboarding.offer ? (
+          <OnboardingProposeStep
+            offer={onboarding.offer}
+            configuredLabel={configuredLabel(onboarding.outcome)}
+            cursor={onboarding.cursor % 2}
           />
         ) : null}
         {onboarding.step === "local_download" ? (
@@ -354,6 +416,13 @@ export function OnboardingScreen(props: {
   );
 }
 
+/** What the flow just finished setting up, named on the offer screen. */
+function configuredLabel(outcome: OnboardingOutcome | null): string {
+  if (outcome === "local") return "Local model ready";
+  if (outcome === "cloud") return "Cloud model ready";
+  return "Backend ready";
+}
+
 function footerFor(onboarding: OnboardingUiState): string {
   switch (onboarding.step) {
     case "choose":
@@ -368,6 +437,8 @@ function footerFor(onboarding: OnboardingUiState): string {
       return "↑/↓ move   enter download   esc back   ctrl+c quit";
     case "local_download":
       return "ctrl+c quit";
+    case "propose_second":
+      return "↑/↓ move   enter select   esc skip   ctrl+c quit";
     case "finished":
       return "";
     case "intro":

--- a/src/tui/onboarding/onboarding-actions.ts
+++ b/src/tui/onboarding/onboarding-actions.ts
@@ -20,5 +20,7 @@ export type OnboardingAction =
   | { type: "onboarding_error_set"; error: string | null }
   /** The local branch committed to a model and moved to the download. */
   | { type: "onboarding_local_model_picked"; modelId: string }
+  /** Offer the other backend once the first one works. */
+  | { type: "onboarding_second_backend_offered"; offer: "local" | "cloud" }
   /** The flow reached its end; the host persists and closes it. */
   | { type: "onboarding_finished"; outcome: OnboardingOutcome };

--- a/src/tui/onboarding/onboarding-reducer.ts
+++ b/src/tui/onboarding/onboarding-reducer.ts
@@ -80,6 +80,20 @@ export function reduceOnboardingAction(
         },
       };
     }
+    case "onboarding_second_backend_offered": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          step: "propose_second",
+          offer: action.offer,
+          cursor: 0,
+          error: null,
+          busy: false,
+        },
+      };
+    }
     case "onboarding_finished": {
       if (!state.onboarding) return state;
       return {

--- a/src/tui/onboarding/onboarding-state.ts
+++ b/src/tui/onboarding/onboarding-state.ts
@@ -16,6 +16,7 @@ export type OnboardingStep =
   | "cloud"
   | "custom_chat_url"
   | "custom_embedding_url"
+  | "propose_second"
   | "finished";
 
 /**
@@ -27,6 +28,8 @@ export type OnboardingOutcome = "local" | "cloud" | "custom" | "skipped";
 
 export interface OnboardingUiState {
   step: OnboardingStep;
+  /** Which backend the "want the other too?" screen is offering. */
+  offer: "local" | "cloud" | null;
   /** The model being pulled, once the local branch has committed to one. */
   localModelId: string | null;
   /** Set together with the `finished` step; `null` at every other point. */
@@ -86,6 +89,7 @@ export const ONBOARDING_CHOICES: readonly OnboardingChoice[] = [
 export function createOnboardingState(chatUrl: string): OnboardingUiState {
   return {
     step: "intro",
+    offer: null,
     outcome: null,
     localModelId: null,
     cursor: 0,

--- a/src/tui/onboarding/propose-second-backend.test.ts
+++ b/src/tui/onboarding/propose-second-backend.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { decideSecondBackendOffer } from "./propose-second-backend.js";
+
+const base = {
+  outcome: "cloud" as const,
+  cloudReady: true,
+  localReady: false,
+  alreadyProposed: false,
+};
+
+describe("decideSecondBackendOffer", () => {
+  it("offers local to someone who just configured cloud", () => {
+    expect(decideSecondBackendOffer(base)).toBe("local");
+  });
+
+  it("offers cloud to someone who just downloaded a local model", () => {
+    expect(
+      decideSecondBackendOffer({
+        ...base,
+        outcome: "local",
+        cloudReady: false,
+        localReady: true,
+      }),
+    ).toBe("cloud");
+  });
+
+  it("says nothing when both backends are already configured", () => {
+    expect(
+      decideSecondBackendOffer({ ...base, outcome: "local", localReady: true }),
+    ).toBeNull();
+  });
+
+  it("never follows a custom endpoint — that operator has answered already", () => {
+    expect(
+      decideSecondBackendOffer({ ...base, outcome: "custom", cloudReady: false }),
+    ).toBeNull();
+  });
+
+  it("never follows a skip", () => {
+    expect(
+      decideSecondBackendOffer({ ...base, outcome: "skipped", cloudReady: false }),
+    ).toBeNull();
+  });
+
+  it("is offered once and never again", () => {
+    expect(decideSecondBackendOffer({ ...base, alreadyProposed: true })).toBeNull();
+  });
+});

--- a/src/tui/onboarding/propose-second-backend.ts
+++ b/src/tui/onboarding/propose-second-backend.ts
@@ -1,0 +1,37 @@
+import type { OnboardingOutcome } from "./onboarding-state.js";
+
+export interface SecondBackendInputs {
+  /** How the operator finished the first backend. */
+  outcome: OnboardingOutcome;
+  /** A cloud text provider is configured and usable. */
+  cloudReady: boolean;
+  /** A local backend was chosen (managed model picked, or an external URL). */
+  localReady: boolean;
+  /** `tui.onboarding.proposedSecondBackendAt` — the offer was already made. */
+  alreadyProposed: boolean;
+}
+
+/** Which backend the flow should offer next, or `null` to hand over. */
+export type SecondBackendOffer = "local" | "cloud" | null;
+
+/**
+ * Whether to offer the other backend, and which one.
+ *
+ * atomic-agent runs local and cloud side by side, and an operator who
+ * has just configured one rarely knows the other is a switch away. The
+ * offer is made once, and only when it would add something:
+ *
+ * - **Custom endpoint never sees it.** Someone pointing the agent at a
+ *   server they already run has answered this question by running it.
+ * - **Both configured, no offer.** There is nothing left to add.
+ * - **Skipped, no offer.** They asked to be left alone.
+ * - **Once only**, recorded in config, so a second first-run — after a
+ *   reset, or on a machine where setup was interrupted — does not nag.
+ */
+export function decideSecondBackendOffer(inputs: SecondBackendInputs): SecondBackendOffer {
+  if (inputs.alreadyProposed) return null;
+  if (inputs.outcome === "custom" || inputs.outcome === "skipped") return null;
+  if (inputs.cloudReady && inputs.localReady) return null;
+  if (inputs.outcome === "local") return inputs.cloudReady ? null : "cloud";
+  return inputs.localReady ? null : "local";
+}


### PR DESCRIPTION
Stacked on #225 → #224 → #223 → #222 → #220.

## Why

atomic-agent runs local and cloud side by side and switches between them mid-session. The first run never said so, so an operator who configured one left believing that was the choice they had made — and the second backend is a switch away, not a reinstall.

## The screen

```
  ✓  Cloud model ready

  atomic-agent runs both side by side — local for private or offline work,
  cloud for the heavy turns, switchable mid-session. You have one of the two.

  ›  Set up local models too
     one download, then it runs offline and costs nothing per token

     Skip — take me to the agent
     you can add it later from the menu (ctrl+p)
```

Mirrored when local came first ("Set up a cloud model too — an API key and a model, about a minute, for the heavy turns").

## When it is *not* shown

`decideSecondBackendOffer` is a pure function with the whole rule set, and a test per rule:

| situation | offer |
|---|---|
| finished with cloud, no local | local |
| finished with local, no cloud | cloud |
| both already configured | none |
| finished with a **custom endpoint** | none — that operator has answered the question by running the server |
| **skipped** setup | none — they asked to be left alone |
| already offered once | none |

The stamp is written when the offer is **shown**, not when it is answered: the offer was made either way, and a declined one must not come back on the next launch.

## Flow

Accepting re-enters the other branch — the model picker, or the providers wizard — and the flow finishes for real when that lands (by then `alreadyProposed` is set, so it closes rather than looping). Declining hands over to the agent.

The decision lives in the host effect rather than the reducer, because it reads config; the reducer stays pure.

## Tests

`propose-second-backend.test.ts` — one case per rule above. `onboarding-propose-step.test.tsx` — both directions of the offer and the cursor.

Full suite: 5196 passed. `fs-glob-real` and `send-message-concurrency` fail on `main`; `bootstrap.test.ts` flaked under parallel load and passes in isolation (26/26).