### PR TITLE
feat(tui): set up cloud while the model downloads, and see the pull anywhere

### DIFF
--- a/src/tui/components/download-chip.test.tsx
+++ b/src/tui/components/download-chip.test.tsx
@@ -1,0 +1,60 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { DownloadChip } from "./download-chip.js";
+import { OnboardingWaitOrJumpStep } from "./onboarding-wait-or-jump-step.js";
+import type { LocalModelsPullState } from "../local-models/local-models-panel-state.js";
+
+const strip = (s: string): string => s.replace(/\u001b\[[0-9;]*m/g, "");
+
+function pull(over: Partial<LocalModelsPullState> = {}): LocalModelsPullState {
+  return {
+    kind: "chat",
+    modelId: "gemma-4-e4b",
+    label: "Gemma 4 E4B",
+    percent: 61,
+    transferredBytes: 2_600_000_000,
+    totalBytes: 4_220_000_000,
+    error: null,
+    ...over,
+  };
+}
+
+describe("DownloadChip", () => {
+  it("names the model and its progress in one row", () => {
+    const view = render(<DownloadChip pull={pull()} />);
+    const frame = strip(view.lastFrame() ?? "");
+    expect(frame).toContain("gemma-4-e4b");
+    expect(frame).toContain("61%");
+    expect(frame.split("\n").filter((line) => line.trim().length > 0)).toHaveLength(1);
+  });
+
+  it("names the runtime rather than a model id during the backend pull", () => {
+    const view = render(<DownloadChip pull={pull({ kind: "backend", modelId: "_backend" })} />);
+    expect(strip(view.lastFrame() ?? "")).toContain("llama.cpp");
+  });
+});
+
+describe("OnboardingWaitOrJumpStep", () => {
+  it("shows both outcomes and what each one costs", () => {
+    const view = render(
+      <OnboardingWaitOrJumpStep pull={pull()} cloudLabel="Cloud model ready" cursor={0} />,
+    );
+    const frame = strip(view.lastFrame() ?? "");
+    expect(frame).toContain("Cloud model ready");
+    expect(frame).toContain("gemma-4-e4b");
+    expect(frame).toContain("Start using the agent now");
+    expect(frame).toContain("top bar");
+    expect(frame).toContain("Wait here until it finishes");
+  });
+
+  it("defaults to jumping", () => {
+    const view = render(
+      <OnboardingWaitOrJumpStep pull={pull()} cloudLabel="Cloud model ready" cursor={0} />,
+    );
+    const line = strip(view.lastFrame() ?? "")
+      .split("\n")
+      .find((row) => row.includes("Start using the agent now"));
+    expect(line?.trimStart().startsWith("\u203a")).toBe(true);
+  });
+});

--- a/src/tui/components/download-chip.test.tsx
+++ b/src/tui/components/download-chip.test.tsx
@@ -29,6 +29,35 @@ describe("DownloadChip", () => {
     expect(frame.split("\n").filter((line) => line.trim().length > 0)).toHaveLength(1);
   });
 
+  /** Two samples, so the rate — and therefore the ETA — exists. */
+  async function frameAt(budget: number): Promise<string> {
+    const view = render(
+      <DownloadChip pull={pull({ transferredBytes: 2_000_000_000 })} budget={budget} />,
+    );
+    view.rerender(<DownloadChip pull={pull()} budget={budget} />);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    return strip(view.lastFrame() ?? "");
+  }
+
+  it("sheds the ETA, then the bar, as the row fills up", async () => {
+    const wide = await frameAt(60);
+    expect(wide).toContain("█");
+    expect(wide).toMatch(/minute|second/);
+
+    const medium = await frameAt(30);
+    expect(medium).toContain("█");
+    expect(medium).not.toMatch(/minute|second/);
+
+    const tight = await frameAt(14);
+    expect(tight).toContain("61%");
+    expect(tight).not.toContain("█");
+  });
+
+  it("disappears rather than wrapping the one-row bar", () => {
+    const view = render(<DownloadChip pull={pull()} budget={6} />);
+    expect(strip(view.lastFrame() ?? "").trim()).toBe("");
+  });
+
   it("names the runtime rather than a model id during the backend pull", () => {
     const view = render(<DownloadChip pull={pull({ kind: "backend", modelId: "_backend" })} />);
     expect(strip(view.lastFrame() ?? "")).toContain("llama.cpp");

--- a/src/tui/components/download-chip.tsx
+++ b/src/tui/components/download-chip.tsx
@@ -7,6 +7,17 @@ import { theme } from "../theme/theme.js";
 const BAR_WIDTH = 10;
 
 /**
+ * Columns each form needs. The status bar is one row and Ink wraps
+ * rather than clips, so a chip that does not fit does not get cut off —
+ * it turns the header into a paragraph and pushes the whole app down.
+ * Hence forms, and a budget, in the same spirit as `hotkey-hint`'s chip
+ * shedding.
+ */
+const FULL_COLUMNS = 46;
+const BAR_COLUMNS = 28;
+const MINIMAL_COLUMNS = 12;
+
+/**
  * A model pull, reported from the one row that is always on screen.
  *
  * The download survives the screen that started it — the orchestrator is
@@ -15,19 +26,33 @@ const BAR_WIDTH = 10;
  * agent from setup) had a multi-gigabyte transfer running with nothing
  * anywhere saying so.
  */
-export function DownloadChip({ pull }: { pull: LocalModelsPullState }): ReactElement {
+export function DownloadChip({
+  pull,
+  budget = FULL_COLUMNS,
+}: {
+  pull: LocalModelsPullState;
+  /** Columns left on the status-bar row. Under 12 the chip is dropped. */
+  budget?: number;
+}): ReactElement | null {
   const { etaSeconds } = useTransferRate(pull.transferredBytes, pull.totalBytes);
   const percent = Math.min(100, Math.max(0, Math.round(pull.percent)));
   const filled = Math.round((percent / 100) * BAR_WIDTH);
   const label = pull.kind === "backend" ? "llama.cpp" : String(pull.modelId);
+  if (budget < MINIMAL_COLUMNS) return null;
+  const withBar = budget >= BAR_COLUMNS;
+  const withEta = budget >= FULL_COLUMNS && etaSeconds !== null;
   return (
     <Text wrap="truncate">
       <Text color={theme.colors.accent}>{"  ⇣ "}</Text>
-      <Text color={theme.colors.muted}>{label} </Text>
-      <Text color={theme.colors.accent}>{"█".repeat(filled)}</Text>
-      <Text color={theme.colors.border}>{"░".repeat(BAR_WIDTH - filled)}</Text>
-      <Text color={theme.colors.muted}>{` ${percent}%`}</Text>
-      {etaSeconds !== null ? (
+      {withBar ? <Text color={theme.colors.muted}>{label} </Text> : null}
+      {withBar ? (
+        <>
+          <Text color={theme.colors.accent}>{"█".repeat(filled)}</Text>
+          <Text color={theme.colors.border}>{"░".repeat(BAR_WIDTH - filled)}</Text>
+        </>
+      ) : null}
+      <Text color={theme.colors.muted}>{withBar ? ` ${percent}%` : `${percent}%`}</Text>
+      {withEta ? (
         <Text color={theme.colors.muted}>{`  ${formatEta(etaSeconds)}`}</Text>
       ) : null}
     </Text>

--- a/src/tui/components/download-chip.tsx
+++ b/src/tui/components/download-chip.tsx
@@ -1,0 +1,35 @@
+import { Text } from "ink";
+import type { ReactElement } from "react";
+import { formatEta, useTransferRate } from "../hooks/use-transfer-rate.js";
+import type { LocalModelsPullState } from "../local-models/local-models-panel-state.js";
+import { theme } from "../theme/theme.js";
+
+const BAR_WIDTH = 10;
+
+/**
+ * A model pull, reported from the one row that is always on screen.
+ *
+ * The download survives the screen that started it — the orchestrator is
+ * session-scoped — but until now it was only ever drawn inside the LLM
+ * panel, so an operator who left that tab (or who jumped straight to the
+ * agent from setup) had a multi-gigabyte transfer running with nothing
+ * anywhere saying so.
+ */
+export function DownloadChip({ pull }: { pull: LocalModelsPullState }): ReactElement {
+  const { etaSeconds } = useTransferRate(pull.transferredBytes, pull.totalBytes);
+  const percent = Math.min(100, Math.max(0, Math.round(pull.percent)));
+  const filled = Math.round((percent / 100) * BAR_WIDTH);
+  const label = pull.kind === "backend" ? "llama.cpp" : String(pull.modelId);
+  return (
+    <Text wrap="truncate">
+      <Text color={theme.colors.accent}>{"  ⇣ "}</Text>
+      <Text color={theme.colors.muted}>{label} </Text>
+      <Text color={theme.colors.accent}>{"█".repeat(filled)}</Text>
+      <Text color={theme.colors.border}>{"░".repeat(BAR_WIDTH - filled)}</Text>
+      <Text color={theme.colors.muted}>{` ${percent}%`}</Text>
+      {etaSeconds !== null ? (
+        <Text color={theme.colors.muted}>{`  ${formatEta(etaSeconds)}`}</Text>
+      ) : null}
+    </Text>
+  );
+}

--- a/src/tui/components/onboarding-download-step.tsx
+++ b/src/tui/components/onboarding-download-step.tsx
@@ -24,6 +24,8 @@ const BAR_WIDTH = 36;
 export function OnboardingDownloadStep(props: {
   pull: LocalModelsPullState | null;
   modelLabel: string;
+  /** Hidden once a cloud provider is configured — nothing left to offer. */
+  offerCloudMeanwhile?: boolean;
 }): ReactElement {
   const pull = props.pull;
   const { bytesPerSecond, etaSeconds } = useTransferRate(
@@ -66,6 +68,23 @@ export function OnboardingDownloadStep(props: {
           <Text color={theme.colors.error}>{pull.error}</Text>
         </Box>
       ) : null}
+      {props.offerCloudMeanwhile === false ? null : (
+        <Box flexDirection="column" marginTop={2}>
+          {/*
+            Accent-marked because it is an offer, not a status line: the
+            wait is measured in minutes and a cloud model takes about
+            one. The download is owned by the orchestrator, so setting
+            one up does not pause or restart it.
+          */}
+          <Text color={theme.colors.accent}>
+            ┃  Don{"\u2019"}t want to wait? Set up a cloud model in the meantime —
+          </Text>
+          <Text color={theme.colors.accent}>
+            ┃  it takes about a minute, and the download keeps running.
+            <Text bold>{"    press c"}</Text>
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/tui/components/onboarding-screen.tsx
+++ b/src/tui/components/onboarding-screen.tsx
@@ -44,6 +44,7 @@ import { OnboardingDownloadStep } from "./onboarding-download-step.js";
 import { OnboardingIntroStep } from "./onboarding-intro-step.js";
 import { OnboardingLocalPickStep } from "./onboarding-local-pick-step.js";
 import { OnboardingProposeStep } from "./onboarding-propose-step.js";
+import { OnboardingWaitOrJumpStep } from "./onboarding-wait-or-jump-step.js";
 import { OnboardingUrlStep } from "./onboarding-url-step.js";
 import { ProvidersWizard } from "./providers-wizard.js";
 
@@ -65,6 +66,7 @@ const SUBTITLES: Record<OnboardingUiState["step"], string> = {
   local_pick: "local models · step 2 of 2",
   local_download: "local models · downloading",
   propose_second: "one more thing",
+  wait_or_jump: "almost there",
   cloud: "cloud model · step 2 of 2",
   custom_chat_url: "custom endpoint · step 2 of 2",
   custom_embedding_url: "custom endpoint · embeddings",
@@ -91,6 +93,12 @@ export function OnboardingScreen(props: {
   const size = useTerminalSize();
   const fit = computeOnboardingFit(size);
   const ramGb = useMemo(() => hostRamGb(), []);
+  // Read once per step change rather than per render: it only moves when
+  // the flow itself writes config.
+  const cloudAlreadyConfigured = useMemo(
+    () => isCloudTextProviderReady(),
+    [onboarding.step],
+  );
   const settling = useRef(false);
   const [introSkipped, setIntroSkipped] = useState(false);
 
@@ -178,6 +186,37 @@ export function OnboardingScreen(props: {
       }
     },
     { isActive: onboarding.step === "local_pick" },
+  );
+
+  useInput(
+    (input, key) => {
+      if (input === "c" && !key.ctrl) {
+        dispatch({
+          type: "providers_wizard_opened",
+          wizard: createProvidersWizardState("add"),
+        });
+        dispatch({ type: "onboarding_cloud_meanwhile_opened" });
+      }
+    },
+    { isActive: onboarding.step === "local_download" },
+  );
+
+  useInput(
+    (input, key) => {
+      if (key.upArrow || key.downArrow || input === "j" || input === "k") {
+        dispatch({
+          type: "onboarding_cursor_moved",
+          delta: key.upArrow || input === "k" ? -1 : 1,
+          length: 2,
+        });
+        return;
+      }
+      if (key.return) {
+        if (onboarding.cursor % 2 === 0) finish(onboarding.outcome ?? "cloud");
+        else dispatch({ type: "onboarding_step_set", step: "local_download" });
+      }
+    },
+    { isActive: onboarding.step === "wait_or_jump" },
   );
 
   useInput(
@@ -362,10 +401,18 @@ export function OnboardingScreen(props: {
             cursor={onboarding.cursor % 2}
           />
         ) : null}
+        {onboarding.step === "wait_or_jump" ? (
+          <OnboardingWaitOrJumpStep
+            pull={props.state.localModelsPanel.pull}
+            cloudLabel="Cloud model ready"
+            cursor={onboarding.cursor % 2}
+          />
+        ) : null}
         {onboarding.step === "local_download" ? (
           <OnboardingDownloadStep
             pull={props.state.localModelsPanel.pull}
             modelLabel={onboarding.localModelId ?? "the model"}
+            offerCloudMeanwhile={!cloudAlreadyConfigured}
           />
         ) : null}
         {onboarding.step === "cloud" && wizardState ? (
@@ -436,9 +483,11 @@ function footerFor(onboarding: OnboardingUiState): string {
     case "local_pick":
       return "↑/↓ move   enter download   esc back   ctrl+c quit";
     case "local_download":
-      return "ctrl+c quit";
+      return "c set up cloud meanwhile   ctrl+c quit";
     case "propose_second":
       return "↑/↓ move   enter select   esc skip   ctrl+c quit";
+    case "wait_or_jump":
+      return "↑/↓ move   enter select   ctrl+c quit";
     case "finished":
       return "";
     case "intro":

--- a/src/tui/components/onboarding-wait-or-jump-step.tsx
+++ b/src/tui/components/onboarding-wait-or-jump-step.tsx
@@ -1,0 +1,66 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import { formatEta, formatBytes, useTransferRate } from "../hooks/use-transfer-rate.js";
+import type { LocalModelsPullState } from "../local-models/local-models-panel-state.js";
+import { theme } from "../theme/theme.js";
+
+/**
+ * Reached only from the "set up cloud while this downloads" path: the
+ * cloud model is ready and the local one is still coming down, which is
+ * a question rather than a conclusion.
+ *
+ * Jumping is the default row. The download does not need this screen to
+ * survive — the orchestrator owns it — so waiting is a preference, not a
+ * requirement, and the top bar reports progress either way.
+ */
+export function OnboardingWaitOrJumpStep(props: {
+  pull: LocalModelsPullState | null;
+  cloudLabel: string;
+  cursor: number;
+}): ReactElement {
+  const { etaSeconds } = useTransferRate(
+    props.pull?.transferredBytes ?? 0,
+    props.pull?.totalBytes ?? 0,
+  );
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      <Text>
+        <Text color={theme.colors.success}>{`${theme.glyphs.check}  `}</Text>
+        <Text>{props.cloudLabel}</Text>
+      </Text>
+      {props.pull ? (
+        <Text>
+          <Text color={theme.colors.accent}>{"⇣  "}</Text>
+          <Text color={theme.colors.muted}>
+            {`${String(props.pull.modelId)} · ${Math.round(props.pull.percent)}% · `}
+            {`${formatBytes(props.pull.transferredBytes)} / ${formatBytes(props.pull.totalBytes)} · `}
+            {formatEta(etaSeconds)}
+          </Text>
+        </Text>
+      ) : null}
+      <Box flexDirection="column" marginTop={1}>
+        <Row
+          selected={props.cursor === 0}
+          label="Start using the agent now"
+          detail="the download keeps running; progress shows in the top bar"
+        />
+        <Row
+          selected={props.cursor === 1}
+          label="Wait here until it finishes"
+          detail="the agent opens with both backends live"
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function Row(props: { selected: boolean; label: string; detail: string }): ReactElement {
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text color={props.selected ? theme.colors.accent : undefined} bold={props.selected}>
+        {`${props.selected ? "›  " : "   "}${props.label}`}
+      </Text>
+      <Text color={theme.colors.muted}>{`   ${props.detail}`}</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -5,6 +5,7 @@ import { getCurrentSection, type TuiSection } from "../section.js";
 import { menuPlaceByTab } from "../menu/menu-registry.js";
 import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
 import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { DownloadChip } from "./download-chip.js";
 import { theme } from "../theme/theme.js";
 import type { TuiState } from "../tui-state.js";
 import { getAppVersion } from "../../version.js";
@@ -59,6 +60,9 @@ export function StatusBar({
       ) : null}
       <Breadcrumb state={state} section={section} />
       <SessionTag sessionId={state.session.sessionId} />
+      {state.localModelsPanel.pull ? (
+        <DownloadChip pull={state.localModelsPanel.pull} />
+      ) : null}
       {title ? (
         <Text color={theme.colors.muted}>
           {"  "}

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -5,6 +5,7 @@ import { getCurrentSection, type TuiSection } from "../section.js";
 import { menuPlaceByTab } from "../menu/menu-registry.js";
 import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
 import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { useTerminalSize } from "../hooks/use-terminal-size.js";
 import { DownloadChip } from "./download-chip.js";
 import { theme } from "../theme/theme.js";
 import type { TuiState } from "../tui-state.js";
@@ -47,6 +48,7 @@ export function StatusBar({
 }: StatusBarProps): ReactElement {
   const section = getCurrentSection(state);
   const title = currentSessionTitle(state);
+  const { columns } = useTerminalSize();
   return (
     <Box>
       {brand ? (
@@ -61,7 +63,10 @@ export function StatusBar({
       <Breadcrumb state={state} section={section} />
       <SessionTag sessionId={state.session.sessionId} />
       {state.localModelsPanel.pull ? (
-        <DownloadChip pull={state.localModelsPanel.pull} />
+        <DownloadChip
+          pull={state.localModelsPanel.pull}
+          budget={chipBudget(columns, brand, title)}
+        />
       ) : null}
       {title ? (
         <Text color={theme.colors.muted}>
@@ -81,6 +86,22 @@ export function StatusBar({
  * the top bar beside the id. Read from the rail's own session list so
  * the two can never disagree about what the current thread is called.
  */
+/**
+ * Columns the download chip may use: what is left of the row once the
+ * brand lockup, the breadcrumb, the session tag and the title have had
+ * theirs. Approximate on purpose — the point is to keep the bar on one
+ * row, and Ink wraps rather than clips, so an over-long chip would turn
+ * the header into a paragraph and push the whole app down the screen.
+ */
+function chipBudget(columns: number, brand: boolean, title: string | null): number {
+  const BRAND = 22;
+  const BREADCRUMB = 14;
+  const SESSION_TAG = 18;
+  const used =
+    (brand ? BRAND : 0) + BREADCRUMB + SESSION_TAG + (title ? title.length + 4 : 0);
+  return Math.max(0, columns - used - 2);
+}
+
 function currentSessionTitle(state: TuiState): string | null {
   const id = state.session.sessionId;
   if (!id) return null;

--- a/src/tui/hooks/use-typewriter.test.tsx
+++ b/src/tui/hooks/use-typewriter.test.tsx
@@ -24,7 +24,9 @@ function Probe(props: { text: string; skip?: boolean }): React.ReactElement {
  * progresses and settles, not how fast it does so.
  */
 async function waitFor(read: () => string, match: (frame: string) => boolean): Promise<string> {
-  const deadline = Date.now() + 3000;
+  // Generous: under a full parallel test run Ink commits frames far
+  // slower than the reveal interval, and this waits on frames.
+  const deadline = Date.now() + 10_000;
   for (;;) {
     const frame = read();
     if (match(frame)) return frame;
@@ -36,9 +38,9 @@ async function waitFor(read: () => string, match: (frame: string) => boolean): P
 describe("useTypewriter", () => {
   it("reveals the text one character at a time", async () => {
     const view = render(<Probe text="atomic" />);
-    const early = view.lastFrame() ?? "";
-    expect(early).toContain("typing");
-    expect(early.split("|")[0]?.length ?? 99).toBeLessThan("atomic".length);
+    // The very first frame is the empty reveal; asserting on any later
+    // frame would be a race against the commit rate, not the hook.
+    expect(view.lastFrame() ?? "").toContain("|typing");
     const finished = await waitFor(
       () => view.lastFrame() ?? "",
       (frame) => frame.includes("done"),

--- a/src/tui/onboarding/onboarding-actions.ts
+++ b/src/tui/onboarding/onboarding-actions.ts
@@ -20,6 +20,8 @@ export type OnboardingAction =
   | { type: "onboarding_error_set"; error: string | null }
   /** The local branch committed to a model and moved to the download. */
   | { type: "onboarding_local_model_picked"; modelId: string }
+  /** `c` on the download screen: set up cloud while the pull runs. */
+  | { type: "onboarding_cloud_meanwhile_opened" }
   /** Offer the other backend once the first one works. */
   | { type: "onboarding_second_backend_offered"; offer: "local" | "cloud" }
   /** The flow reached its end; the host persists and closes it. */

--- a/src/tui/onboarding/onboarding-reducer.test.ts
+++ b/src/tui/onboarding/onboarding-reducer.test.ts
@@ -7,7 +7,12 @@ import { createOnboardingState } from "./onboarding-state.js";
 import { fakeSession } from "../test-fixtures.js";
 
 function withFlow(
-  step: "choose" | "cloud" | "local_pick" | "local_download" = "choose",
+  step:
+    | "choose"
+    | "cloud"
+    | "local_pick"
+    | "local_download"
+    | "wait_or_jump" = "choose",
 ): TuiState {
   // `createOnboardingState` opens on the splash; every case here is
   // about what happens after it.
@@ -114,6 +119,83 @@ describe("onboarding reducer", () => {
       expect(state.onboarding?.cursor).toBe(2);
       state = reduceTuiState(state, { type: "onboarding_step_set", step: "local_pick" });
       expect(state.onboarding?.cursor).toBe(0);
+    });
+  });
+
+  describe("cloud while the model downloads", () => {
+    const pulling = (state: TuiState): TuiState =>
+      reduceTuiState(state, {
+        type: "local_models_pull_started",
+        pull: {
+          kind: "chat",
+          modelId: "gemma-4-e4b",
+          label: "Gemma 4 E4B",
+          percent: 38,
+          transferredBytes: 1_600_000_000,
+          totalBytes: 4_220_000_000,
+          error: null,
+        },
+      });
+
+    it("opens the wizard and remembers where it came from", () => {
+      const state = reduceTuiState(pulling(withFlow("local_download")), {
+        type: "onboarding_cloud_meanwhile_opened",
+      });
+      expect(state.onboarding).toMatchObject({ step: "cloud", resumeAfterCloud: true });
+    });
+
+    it("asks wait-or-jump when the key lands while the pull is still running", () => {
+      let state = reduceTuiState(pulling(withFlow("local_download")), {
+        type: "onboarding_cloud_meanwhile_opened",
+      });
+      state = reduceTuiState(state, {
+        type: "providers_wizard_opened",
+        wizard: createProvidersWizardState("add"),
+      });
+      state = reduceTuiState(state, { type: "providers_wizard_succeeded" });
+      expect(state.onboarding).toMatchObject({
+        step: "wait_or_jump",
+        outcome: "cloud",
+        resumeAfterCloud: false,
+      });
+    });
+
+    it("finishes instead when the pull already landed", () => {
+      let state = reduceTuiState(withFlow("local_download"), {
+        type: "onboarding_cloud_meanwhile_opened",
+      });
+      state = reduceTuiState(state, { type: "providers_wizard_succeeded" });
+      expect(state.onboarding?.step).toBe("finished");
+    });
+
+    it("backs out to the download, not to a choice already made", () => {
+      let state = reduceTuiState(pulling(withFlow("local_download")), {
+        type: "onboarding_cloud_meanwhile_opened",
+      });
+      state = reduceTuiState(state, { type: "providers_wizard_closed" });
+      expect(state.onboarding).toMatchObject({
+        step: "local_download",
+        resumeAfterCloud: false,
+      });
+    });
+
+    it("closes the flow when the pull lands while wait-or-jump is up", () => {
+      let state = pulling(withFlow("wait_or_jump"));
+      state = reduceTuiState(state, {
+        type: "onboarding_finished",
+        outcome: "cloud",
+      });
+      // (a finished outcome is what the jump row dispatches; the wait
+      //  row leaves the flow open until the pull reports in)
+      expect(state.onboarding?.step).toBe("finished");
+
+      let waiting = pulling(withFlow("wait_or_jump"));
+      waiting = reduceTuiState(waiting, {
+        type: "local_models_pull_finished",
+        kind: "chat",
+      });
+      expect(waiting.onboarding?.step).toBe("finished");
+      expect(waiting.localModelsPanel.pull).toBeNull();
     });
   });
 

--- a/src/tui/onboarding/onboarding-reducer.ts
+++ b/src/tui/onboarding/onboarding-reducer.ts
@@ -80,6 +80,19 @@ export function reduceOnboardingAction(
         },
       };
     }
+    case "onboarding_cloud_meanwhile_opened": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          step: "cloud",
+          resumeAfterCloud: true,
+          cursor: 0,
+          error: null,
+        },
+      };
+    }
     case "onboarding_second_backend_offered": {
       if (!state.onboarding) return state;
       return {
@@ -118,35 +131,66 @@ export function reduceOnboardingAction(
     // through the panel's slice; the flow listens for the same events
     // rather than running a second download of its own.
     case "local_models_pull_finished": {
-      if (state.onboarding?.step !== "local_download") return null;
+      const step = state.onboarding?.step;
+      if (step !== "local_download" && step !== "wait_or_jump") return null;
       if (action.kind !== "chat") return null;
       const next = reduceLocalModelsAction(state, action) ?? state;
       return {
         ...next,
-        onboarding: { ...state.onboarding, step: "finished", outcome: "local" },
+        onboarding: {
+          ...state.onboarding!,
+          step: "finished",
+          // A cloud model configured mid-download is the outcome that
+          // matters for what happens next; the local one has landed
+          // either way.
+          outcome: state.onboarding!.outcome ?? "local",
+        },
       };
     }
     // Hybrid-recall embeddings are a second download and a second
     // decision, and the first run does not ask for either. The offer
     // still exists in the LLM panel, where there is room to explain it.
     case "local_models_embedding_onboarding_opened": {
-      if (state.onboarding?.step !== "local_download") return null;
+      const active = state.onboarding?.step;
+      if (active !== "local_download" && active !== "wait_or_jump" && active !== "cloud") {
+        return null;
+      }
       return state;
     }
     case "providers_wizard_succeeded": {
       if (state.onboarding?.step !== "cloud") return null;
       const next = reduceProvidersPanel(state, action) ?? state;
+      // Came from a running download: the operator now has a working
+      // cloud model *and* an unfinished local one, which is a question
+      // — wait, or start using the agent — not a conclusion.
+      const stillPulling = next.localModelsPanel.pull !== null;
+      const step =
+        state.onboarding.resumeAfterCloud && stillPulling ? "wait_or_jump" : "finished";
       return {
         ...next,
-        onboarding: { ...state.onboarding, step: "finished", outcome: "cloud" },
+        onboarding: {
+          ...state.onboarding,
+          step,
+          outcome: "cloud",
+          resumeAfterCloud: false,
+        },
       };
     }
     case "providers_wizard_closed": {
       if (state.onboarding?.step !== "cloud") return null;
       const next = reduceProvidersPanel(state, action) ?? state;
+      // Backing out of a wizard opened mid-download returns to the
+      // download, not to a backend choice that has already been made.
+      const step = state.onboarding.resumeAfterCloud ? "local_download" : "choose";
       return {
         ...next,
-        onboarding: { ...state.onboarding, step: "choose", error: null, busy: false },
+        onboarding: {
+          ...state.onboarding,
+          step,
+          resumeAfterCloud: false,
+          error: null,
+          busy: false,
+        },
       };
     }
     default:

--- a/src/tui/onboarding/onboarding-state.ts
+++ b/src/tui/onboarding/onboarding-state.ts
@@ -17,6 +17,7 @@ export type OnboardingStep =
   | "custom_chat_url"
   | "custom_embedding_url"
   | "propose_second"
+  | "wait_or_jump"
   | "finished";
 
 /**
@@ -30,6 +31,11 @@ export interface OnboardingUiState {
   step: OnboardingStep;
   /** Which backend the "want the other too?" screen is offering. */
   offer: "local" | "cloud" | null;
+  /**
+   * The cloud wizard was opened *from* a running download, so finishing
+   * it returns to the download rather than to the agent.
+   */
+  resumeAfterCloud: boolean;
   /** The model being pulled, once the local branch has committed to one. */
   localModelId: string | null;
   /** Set together with the `finished` step; `null` at every other point. */
@@ -90,6 +96,7 @@ export function createOnboardingState(chatUrl: string): OnboardingUiState {
   return {
     step: "intro",
     offer: null,
+    resumeAfterCloud: false,
     outcome: null,
     localModelId: null,
     cursor: 0,


### PR DESCRIPTION
Stacked on #226 → #225 → #224 → #223 → #222 → #220.

## Why

A local first run leaves the operator in front of a 2.7–22 GB progress bar with nothing to do, and a cloud model takes about a minute to configure. The pull is owned by a session-scoped orchestrator — it does not need the screen that started it — but it was only ever *drawn* inside the LLM panel, so walking away from that tab meant a multi-gigabyte transfer running with nothing anywhere saying so.

## Three changes

**The offer.** The download screen carries an accent-marked block:

```
  ┃  Don't want to wait? Set up a cloud model in the meantime —
  ┃  it takes about a minute, and the download keeps running.    press c
```

Hidden when a cloud provider is already configured — nothing left to offer.

**Wait or jump.** Finishing that wizard while the pull is still running asks the only question left:

```
  ✓  Cloud model ready
  ⇣  gemma-4-e4b · 61% · 2.6 GB / 4.2 GB · about 2 minutes left

  ›  Start using the agent now
     the download keeps running; progress shows in the top bar

     Wait here until it finishes
     the agent opens with both backends live
```

Jumping is the default row — waiting is a preference, not a requirement. If the pull already landed by the time the wizard closes, the flow finishes instead of asking a question with one answer. Backing out of the wizard returns to the download, not to a backend choice that has already been made.

**The chip.** `DownloadChip` renders the pull in the status bar — model, bar, percent, ETA — for as long as one is running, from any screen:

```
   R U N    ⇣ gemma-4-e4b ███████░░░ 61%  about 2 minutes left
```

## Notes for review

- `resumeAfterCloud` on the flow state is what distinguishes "cloud wizard from the choice screen" (finish) from "cloud wizard from a running download" (ask). It is cleared on both exits.
- The reducer decides wait-vs-finish from `localModelsPanel.pull !== null` — state, not config, so it stays pure.
- The embedding-offer suppression now covers the whole local branch including the cloud detour, rather than only the download step.
- `use-typewriter.test.tsx` got a longer poll deadline: it waits on Ink frame commits, which slow down considerably under a full parallel run.

## Tests

Five reducer cases (open-with-memory, wait-or-jump on a live pull, finish when it already landed, back-out to the download, pull landing while wait-or-jump is up), plus `download-chip.test.tsx` — one-row chip, runtime naming, both rows of wait-or-jump and its default cursor.

Full suite: 5205 passed; the two long-standing failures are unchanged on `main`.