### PR TITLE
fix(cli): switch Windows console to UTF-8 on startup

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execSync } from "node:child_process";
 import { isSea } from "node:sea";
 import { argv, exit } from "node:process";
 import { runAgentCommand } from "./run-agent.js";
@@ -159,7 +160,24 @@ function userArgsFromArgv(): string[] {
   return argv.slice(2);
 }
 
+/**
+ * Windows console defaults to CP866 for Cyrillic, which makes Russian input,
+ * output and copy/paste turn into mojibake because Node speaks UTF-8. Switch
+ * the console code page to UTF-8 (65001) at startup. This only changes the
+ * console's code page тАФ it does NOT touch stdout/stderr streams, so ink and
+ * readline rendering are unaffected.
+ */
+function ensureUtf8Console(): void {
+  if (process.platform !== "win32") return;
+  try {
+    execSync("chcp 65001 >nul", { stdio: "ignore" });
+  } catch {
+    // Non-fatal: some hosts disallow changing the code page.
+  }
+}
+
 async function main(): Promise<number> {
+  ensureUtf8Console();
   const [command, ...rest] = userArgsFromArgv();
   if (command === "-h" || command === "--help") {
     printHelp();


### PR DESCRIPTION
## Summary

On Windows, switch the console code page to UTF-8 (65001) at CLI startup so Cyrillic (and other non-ASCII) input, output and copy/paste no longer turn into mojibake.

## Motivation

The Windows console defaults to the **CP866** OEM code page, while Node and atomic-agent emit/consume **UTF-8**. The mismatch corrupts Russian text in three places at once:

- **Input** — what the user types is misread by readline;
- **Output** — what the agent prints (reply/status lines) displays garbled;
- **Copy/paste** — text copied from the terminal is pasted as mojibake (`╨Я╤А╨╕╨▓╨╡╤В` for "Привет").

## Changes

- `src/cli/index.ts` — add `ensureUtf8Console()`, called at the top of `main()`. On Windows only it runs `chcp 65001 >nul` (via `execSync`) and swallows failures (some hosts disallow changing the code page).

Design constraint honored here: the fix **does not touch `process.stdout` / `process.stderr`**. An earlier attempt that overrode `write` to emit raw UTF-8 bytes broke the interactive TUI (ink/readline frame rendering) — output lines "jumped" and the screen corrupted. Changing only the console code page fixes all three symptoms while leaving the stream mechanics untouched.

## Verification

- `npm run lint` — clean.
- `npm test` — full suite: **20 failed / 5939 passed**, identical to the pre-existing `main` baseline (same 20 environment-specific Windows failures; none introduced by this change).
- Manual (Windows): after launch `chcp` reports `65001`; Russian input, output and copy/paste are correct.

## Notes

- Orthogonal to the `--use-env-proxy` flag (documented separately); this change affects only the console code page.
- The `execSync` is wrapped in try/catch because `chcp` can fail on hosts that forbid changing the code page (non-interactive sessions, some terminals).