### PR TITLE
fix(tui): say what the number beside the context gauge actually is

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ atomic-agent task list
 atomic-agent trace list --limit 10
 ```
 
+**The context readout.** The chip at the right of the composer gauges the *transcript* against the ceiling it is packed to — not the prompt against the model's window. The window is the wrong scale for a bar (a 1M-token model sits at 1% all session); the transcript's ceiling is the number that moves, and reaching it is exactly when older turns start being dropped. When that ceiling is your own `agent.conversationMaxTokens` the chip labels it `cap`, so `6.4k/32k cap` cannot be misread as a 32k context window. Click the chip (or `/context`) for the full breakdown, including the physical window and which of the two is actually holding the transcript down.
+
+Set `agent.conversationMaxTokens` to `0` to drop the ceiling entirely and let the transcript fill whatever the window leaves — worth doing if you size your own `llama-server` with `-c`. The default stays at 32k because on a metered cloud model with a 200k window, filling it would multiply the per-step bill without anyone asking.
+
 Handy slash commands: `/help` lists every command, `/tools` lists the built-in tool families, `/model` jumps to the LLM panel and reopens the model picker for the active cloud provider, `/privacy` shows what leaves the machine (`/privacy analytics off` turns analytics off). The chat log scrolls with PgUp / PgDn (fn+arrows on macOS).
 
 **Answering an approval prompt.** `y` approves the call, `s` grants its category for the session, `n` denies, `esc` aborts the run. Two more ways out:

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -564,11 +564,22 @@ describe("parseUserConfigFile", () => {
     expect(parsed.agent.worldSnapshotMaxTokens).toBe(4_000);
   });
 
-  it("rejects non-positive conversationMaxTokens", () => {
+  it("accepts conversationMaxTokens: 0 as the auto sentinel", () => {
+    // `0` is not a request for a zero-token transcript: it is "let the
+    // window decide", the same sentinel `localModels.managed.contextSize`
+    // uses. It has to survive the parser to mean anything.
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      agent: { conversationMaxTokens: 0 },
+    });
+    expect(parsed.agent?.conversationMaxTokens).toBe(0);
+  });
+
+  it("rejects a negative conversationMaxTokens", () => {
     expect(() =>
       parseUserConfigFile({
         version: USER_CONFIG_VERSION,
-        agent: { conversationMaxTokens: 0 },
+        agent: { conversationMaxTokens: -1 },
       }),
     ).toThrow(/agent.conversationMaxTokens/);
   });

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -223,6 +223,20 @@ export interface AtomicAgentConfig {
      * Safety-net ceiling for the `### conversation` section of the prompt.
      * Typical sessions stay well under this cap — it exists to prevent
      * pathological growth, not to be a regular truncation mechanism.
+     *
+     * **`0` means auto:** the transcript takes whatever the model's
+     * window leaves after the scaffold, the memory sections and the
+     * reply reservation, with no fixed ceiling above it. Same sentinel
+     * and same reasoning as `localModels.managed.contextSize` — the
+     * useful value is a function of hardware this file cannot see.
+     *
+     * The default stays at 32k rather than becoming auto, and
+     * deliberately: on a local server the tokens are free, but on a
+     * metered cloud model with a 200k window "auto" would multiply the
+     * per-step bill without anyone asking for it. Operators who size
+     * their own `llama-server` are exactly the people who should set
+     * this to `0`, and the context panel now tells them so when their
+     * ceiling is what is holding the transcript below their window.
      */
     conversationMaxTokens: number;
     /**
@@ -3115,7 +3129,10 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
         agent.approvalLevel,
         agent.approvalRequired,
       ),
-      conversationMaxTokens: parsePositiveInt(
+      // Non-negative rather than positive: `0` is the "auto" sentinel
+      // (`CONVERSATION_CAP_AUTO`), not a request for a zero-token
+      // transcript.
+      conversationMaxTokens: parseNonNegativeInt(
         agent.conversationMaxTokens ??
           USER_CONFIG_DEFAULTS.agent.conversationMaxTokens,
         "agent.conversationMaxTokens",

--- a/src/prompt/build-prompt-types.ts
+++ b/src/prompt/build-prompt-types.ts
@@ -81,5 +81,15 @@ export interface BuiltPrompt {
   truncation: BuiltPromptTruncationFlags;
   contextWindow: number | null;
   conversationCapEffective: number;
+  /**
+   * `agent.conversationMaxTokens` was left at `0` — the transcript takes
+   * whatever the window leaves rather than sitting under a fixed
+   * ceiling. Reported rather than inferred: under auto the configured
+   * figure in `limits.conversation` is a *fallback* for an unknown
+   * window, not a ceiling, and comparing it against
+   * `conversationCapEffective` — which is how the UI decides what is
+   * holding the transcript down — would name the wrong knob.
+   */
+  conversationCapAuto: boolean;
   droppedTurns: number;
 }

--- a/src/prompt/build-prompt.ts
+++ b/src/prompt/build-prompt.ts
@@ -24,6 +24,7 @@ import { renderTaskPolicy } from "./render-task-policy.js";
 import {
   checkBudget,
   computeEffectiveConversationCap,
+  CONVERSATION_CAP_AUTO,
   defaultBudget,
   estimateTokens,
   truncateToTokens,
@@ -82,13 +83,17 @@ export function buildPrompt(input: BuildPromptInput): BuiltPrompt {
   const budgetTotal = input.tokenBudget ?? config.agent.tokenBudget;
   const conversationMaxTokens =
     input.conversationMaxTokens ?? config.agent.conversationMaxTokens;
+  // `0` means "let the window decide" (`CONVERSATION_CAP_AUTO`). The
+  // budget-share fallback below is still computed, because it is what
+  // the cap falls back to when nothing knows the window.
+  const conversationCapAuto = conversationMaxTokens <= CONVERSATION_CAP_AUTO;
   const worldSnapshotMaxTokens =
     input.worldSnapshotMaxTokens ?? config.agent.worldSnapshotMaxTokens;
   const completionMaxTokens =
     input.completionMaxTokens ?? config.localModels.completionMaxTokens;
 
   const limits = defaultBudget(budgetTotal, {
-    conversation: conversationMaxTokens,
+    ...(conversationCapAuto ? {} : { conversation: conversationMaxTokens }),
     worldSnapshot: worldSnapshotMaxTokens,
   });
 
@@ -215,6 +220,7 @@ export function buildPrompt(input: BuildPromptInput): BuiltPrompt {
     estimateTokens(sessionPartsForBudget) + loadedToolsTokens;
   const conversationCapEffective = computeEffectiveConversationCap({
     configuredCap: limits.conversation,
+    ...(conversationCapAuto ? { autoFill: true } : {}),
     contextWindow: contextWindow ?? undefined,
     stablePrefixTokens: estimateTokens(stablePrefix),
     sessionTokens: sessionTokenEstimate,
@@ -373,6 +379,7 @@ export function buildPrompt(input: BuildPromptInput): BuiltPrompt {
     truncation,
     contextWindow,
     conversationCapEffective,
+    conversationCapAuto,
     droppedTurns: packed.droppedCount,
   };
 }

--- a/src/prompt/token-budget.test.ts
+++ b/src/prompt/token-budget.test.ts
@@ -41,6 +41,65 @@ describe("computeEffectiveConversationCap", () => {
     completionMaxTokens: 4096,
   };
 
+  /**
+   * The report this behaviour came from: `llama-server -c 48000`, and
+   * the composer reads `32k`. Nothing is broken — 32k is
+   * `agent.conversationMaxTokens`, and it is a *ceiling*, so it does not
+   * move when the window grows past it. These pin both halves: that the
+   * old default really does decline the extra room, and that `0` claims
+   * it.
+   */
+  describe("a window larger than the configured ceiling", () => {
+    const window48k = { ...base, contextWindow: 48_000 };
+
+    it("holds the transcript at the configured ceiling", () => {
+      // 48000 - 2000 - 400 - 2000 - 4096 - 512 = 38 992 available, and
+      // the operator's 32k ceiling is the smaller of the two.
+      expect(computeEffectiveConversationCap(window48k)).toBe(32_000);
+    });
+
+    it("fills the window under auto", () => {
+      expect(
+        computeEffectiveConversationCap({ ...window48k, autoFill: true }),
+      ).toBe(38_992);
+    });
+
+    it("is unchanged by auto when the window is the smaller of the two", () => {
+      // A 32k window leaves 22 992 — under the 32k ceiling — so the
+      // ceiling was never what bound, and switching it off buys nothing.
+      // This is why the default can stay where it is: for everyone whose
+      // window is at or below it, auto is a no-op.
+      const window32k = { ...base, contextWindow: 32_768 };
+      expect(computeEffectiveConversationCap(window32k)).toBe(23_760);
+      expect(
+        computeEffectiveConversationCap({ ...window32k, autoFill: true }),
+      ).toBe(23_760);
+    });
+
+    it("falls back to the configured figure under auto with no window", () => {
+      // Auto cannot mean "unbounded": with no window there is nothing to
+      // subtract from, and an unbounded transcript against somebody
+      // else's server is a promise this process cannot keep.
+      expect(
+        computeEffectiveConversationCap({
+          ...base,
+          contextWindow: undefined,
+          autoFill: true,
+        }),
+      ).toBe(32_000);
+    });
+
+    it("keeps the floor under auto on a window too small to hold the prompt", () => {
+      expect(
+        computeEffectiveConversationCap({
+          ...base,
+          contextWindow: 4096,
+          autoFill: true,
+        }),
+      ).toBe(512);
+    });
+  });
+
   it("returns the configured cap when the model context window is unknown", () => {
     const cap = computeEffectiveConversationCap({
       ...base,

--- a/src/prompt/token-budget.ts
+++ b/src/prompt/token-budget.ts
@@ -103,6 +103,14 @@ export interface EffectiveConversationCapInput {
    */
   loadedToolsTokens?: number;
   completionMaxTokens: number;
+  /**
+   * `agent.conversationMaxTokens` was left at {@link CONVERSATION_CAP_AUTO}:
+   * the transcript takes whatever the window leaves rather than being
+   * held under a fixed ceiling. `configuredCap` is then only the
+   * fallback for an unknown window — see
+   * {@link computeEffectiveConversationCap}.
+   */
+  autoFill?: boolean;
 }
 
 /**
@@ -145,11 +153,35 @@ export function minUsableContextWindow(completionMaxTokens: number): number {
 export const CONVERSATION_CAP_FLOOR = 512;
 
 /**
+ * `agent.conversationMaxTokens: 0` — let the window decide.
+ *
+ * The same sentinel `localModels.managed.contextSize` already uses for
+ * the same idea, and for the same reason: the useful value is a function
+ * of hardware the config file cannot see, so the only honest fixed
+ * number is "don't fix it".
+ *
+ * The knob it replaces was a *ceiling*, and a ceiling that never rises
+ * is indistinguishable from a bug once the window grows past it. An
+ * operator who starts `llama-server` with `-c 48000` has said what they
+ * want the agent to have; a 32k cap sitting above that window quietly
+ * declines two thirds of the difference, and the only visible trace is a
+ * number in the composer that looks like it *is* the window.
+ */
+export const CONVERSATION_CAP_AUTO = 0;
+
+/**
  * Resolve the actual cap enforced on the `### conversation` section for
  * a given prompt-build. When the runtime knows the model's physical
  * `contextWindow` (from `llama-server /props`), clamp the user-chosen
  * `configuredCap` to the space that remains after all fixed costs.
  * When `contextWindow` is unknown, trust the user's config as-is.
+ *
+ * Under `autoFill` there is no configured ceiling at all: whatever the
+ * window leaves over is the cap. `configuredCap` is still read in that
+ * mode, but only as the fallback for a window nobody knows — a cloud
+ * model with no published context length gives the maths nothing to
+ * subtract from, and an unbounded transcript there would be a promise
+ * about someone else's server that this process cannot keep.
  */
 export function computeEffectiveConversationCap(
   input: EffectiveConversationCapInput,
@@ -170,6 +202,7 @@ export function computeEffectiveConversationCap(
     (input.loadedToolsTokens ?? 0) -
     input.completionMaxTokens -
     CONVERSATION_CAP_SAFETY_MARGIN;
+  if (input.autoFill) return Math.max(CONVERSATION_CAP_FLOOR, available);
   return Math.max(
     CONVERSATION_CAP_FLOOR,
     Math.min(input.configuredCap, available),

--- a/src/tui/components/context-chip.test.tsx
+++ b/src/tui/components/context-chip.test.tsx
@@ -51,7 +51,18 @@ describe("ContextChip", () => {
    * session on this model and never say anything.
    */
   it("gauges the transcript against its cap, and prints both", () => {
-    expect(label(usage())).toBe(" context [==      ]   6.4k/32k");
+    expect(label(usage())).toBe(" context [==      ]   6.4k/32k cap");
+  });
+
+  it("says `cap` only where the number could be mistaken for the window", () => {
+    // The word exists to stop `6.4k/32k` reading as a 32k context
+    // window, which is what it read as for anyone who had set their own
+    // `-c`. Where the window itself is what binds — or where the
+    // operator switched the ceiling off — the number *is* the window's
+    // remainder and the disclaimer would be noise.
+    expect(label(usage({ capSource: "window" }))).not.toContain("cap");
+    expect(label(usage({ capSource: "auto" }))).not.toContain("cap");
+    expect(label(usage({ capSource: "floor" }))).not.toContain("cap");
   });
 
   /**
@@ -81,7 +92,7 @@ describe("ContextChip", () => {
    */
   it("still gauges when the model's window is unknown", () => {
     expect(label(usage({ percent: null, contextWindow: null }))).toBe(
-      " context [==      ]   6.4k/32k",
+      " context [==      ]   6.4k/32k cap",
     );
   });
 

--- a/src/tui/components/context-chip.tsx
+++ b/src/tui/components/context-chip.tsx
@@ -92,7 +92,9 @@ export function ContextChip({
       : ` context [${renderProgressBar(
           usage.conversationPercent,
           GAUGE_WIDTH,
-        )}] ${pair(usage.conversationTokens, usage.conversationCap)} `;
+        )}] ${pair(usage.conversationTokens, usage.conversationCap)}${capSuffix(
+          usage,
+        )} `;
   const chip = (
     <Text backgroundColor={background} color={readableOn(background)} bold>
       {label}
@@ -131,6 +133,26 @@ export function groundFor(usage: ContextUsageView): string {
   if (fill === null || fill < STEP_LOW) return mixColor(accent, ground, FADE_LOW);
   if (fill < STEP_MID) return mixColor(accent, ground, FADE_MID);
   return accent;
+}
+
+/**
+ * One word for what the right-hand number *is*.
+ *
+ * Without it the chip reads `context 6.4k/32k`, and every operator who
+ * has ever set a context size reads that second figure as the window.
+ * It is not: it is the ceiling the transcript is packed to, which on a
+ * default install is `agent.conversationMaxTokens` and has no
+ * relationship to the window at all. Someone who starts `llama-server`
+ * with `-c 48000` and then reads `/32k` off the composer concludes the
+ * app ignored them — a conclusion this chip was, in fairness, doing
+ * everything to invite.
+ *
+ * The word is spent only where it is load-bearing. When the window is
+ * what binds, or when the operator has switched the ceiling off, the
+ * number *is* the window's own remainder and needs no disclaimer.
+ */
+function capSuffix(usage: ContextUsageView): string {
+  return usage.capSource === "config" ? " cap" : "";
 }
 
 /**

--- a/src/tui/components/context-panel.test.tsx
+++ b/src/tui/components/context-panel.test.tsx
@@ -194,6 +194,47 @@ describe("the trimming block", () => {
     );
   });
 
+  /**
+   * The report: `llama-server -c 48000`, and the composer says 32k. The
+   * panel already named the knob; what it did not say is what to set it
+   * to, or that two thirds of the window was going unused.
+   */
+  it("names the value that lifts the ceiling when the window is bigger", () => {
+    const body = lines(
+      usage({
+        capSource: "config",
+        conversationCap: 32_000,
+        contextWindow: 48_000,
+      }),
+    ).join("\n");
+    expect(body).toContain("capped by          agent.conversationMaxTokens");
+    expect(body).toContain("set it to 0 to fill the 48k window");
+  });
+
+  it("does not offer the fix when the ceiling is already above the window", () => {
+    // Nothing to claim: the transcript is not being held below anything.
+    const body = lines(
+      usage({
+        capSource: "config",
+        conversationCap: 32_000,
+        contextWindow: 16_384,
+      }),
+    ).join("\n");
+    expect(body).not.toContain("set it to 0");
+  });
+
+  it("says the cap is auto rather than naming a knob", () => {
+    const body = lines(
+      usage({
+        capSource: "auto",
+        conversationCap: 38_992,
+        contextWindow: 48_000,
+      }),
+    ).join("\n");
+    expect(body).toContain("capped by          auto — fills the 48k window");
+    expect(body).not.toContain("agent.conversationMaxTokens");
+  });
+
   it("names the window, with its size, when the window binds", () => {
     const body = lines(
       usage({ capSource: "window", conversationCap: 9000, contextWindow: 32_768 }),

--- a/src/tui/components/context-panel.tsx
+++ b/src/tui/components/context-panel.tsx
@@ -228,6 +228,27 @@ function trimmingLines(usage: ContextUsageView): readonly string[] {
   const source = ` capped by`.padEnd(LABEL_WIDTH);
   if (usage.capSource === "config") {
     lines.push(`${source}agent.conversationMaxTokens`);
+    // The actionable half of the actionable half. An operator who sized
+    // their own `llama-server` has already said how much context they
+    // want; if a ceiling below that window is what is holding the
+    // transcript down, the only thing left to tell them is the one
+    // value that lifts it — and how much it would buy.
+    if (usage.contextWindow !== null && cap < usage.contextWindow) {
+      lines.push(
+        `${" ".repeat(LABEL_WIDTH)}set it to 0 to fill the ${formatTokens(
+          usage.contextWindow,
+        )} window`,
+      );
+    }
+  } else if (usage.capSource === "auto") {
+    // No knob to name: the operator switched the ceiling off, so the
+    // window is the only thing left holding the transcript down. The
+    // panel is 58 columns wide, which is why this says it in five words.
+    lines.push(
+      usage.contextWindow === null
+        ? `${source}auto — fills the window`
+        : `${source}auto — fills the ${formatTokens(usage.contextWindow)} window`,
+    );
   } else if (usage.capSource === "window") {
     lines.push(
       `${source}the model's window${

--- a/src/tui/context-usage-from-prompt.ts
+++ b/src/tui/context-usage-from-prompt.ts
@@ -9,6 +9,7 @@ export const EMPTY_CONTEXT_USAGE: ContextUsageState = {
   conversationTokens: 0,
   conversationCap: null,
   conversationCapConfigured: null,
+  conversationCapAuto: false,
   sections: [],
 };
 
@@ -55,6 +56,7 @@ export function contextUsageFromPrompt(prompt: BuiltPrompt): ContextUsageState {
     conversationTokens: prompt.tokens.conversation,
     conversationCap: prompt.conversationCapEffective,
     conversationCapConfigured: prompt.limits.conversation,
+    conversationCapAuto: prompt.conversationCapAuto,
     sections,
   };
 }

--- a/src/tui/select-context-usage.test.ts
+++ b/src/tui/select-context-usage.test.ts
@@ -118,6 +118,37 @@ describe("which limit holds the transcript down", () => {
     );
     expect(view?.capSource).toBe("floor");
   });
+
+  /**
+   * Under auto the figure in `conversationCapConfigured` is the
+   * budget-share fallback for an unknown window, not a ceiling — and it
+   * is usually the *smaller* of the two, so the config-vs-effective
+   * comparison would report "config" and send an operator to raise a
+   * setting they have already switched off.
+   */
+  it("names nothing when the cap is auto, whichever way the numbers fall", () => {
+    for (const conversationCapConfigured of [11_200, 32_000, 64_000]) {
+      const view = selectContextUsage(
+        stateWith(
+          usage({
+            conversationCap: 38_992,
+            conversationCapConfigured,
+            conversationCapAuto: true,
+          }),
+        ),
+      );
+      expect(view?.capSource).toBe("auto");
+    }
+  });
+
+  it("still reports the floor ahead of auto", () => {
+    // A window too small to hold the prompt is a real problem, and auto
+    // is not the answer to it.
+    const view = selectContextUsage(
+      stateWith(usage({ conversationCap: 512, conversationCapAuto: true })),
+    );
+    expect(view?.capSource).toBe("floor");
+  });
 });
 
 describe("resolving the model's context window", () => {

--- a/src/tui/select-context-usage.ts
+++ b/src/tui/select-context-usage.ts
@@ -24,7 +24,7 @@ export interface ContextUsageView {
   /** Transcript fill as a percentage of that cap. */
   conversationPercent: number | null;
   /** What holds the cap down — drives the panel's "capped by" line. */
-  capSource: "config" | "window" | "floor" | null;
+  capSource: "config" | "window" | "floor" | "auto" | null;
   /**
    * Turns `packConversation` dropped to make the transcript fit. Any
    * non-zero value is the chip's violet state; the detail view spends
@@ -86,13 +86,21 @@ function resolveWindow(state: TuiState): number | null {
  * equal means the operator's own setting binds and naming it tells them
  * what to raise, lower means the window binds and no config change will
  * help.
+ *
+ * The comparison is only valid when there *is* a configured ceiling.
+ * Under `auto` the figure sitting in `conversationCapConfigured` is the
+ * budget-share fallback for an unknown window, and it is usually the
+ * smaller of the two — so the comparison would report "config" and send
+ * an operator to raise a setting they have already switched off.
  */
 function resolveCapSource(
   cap: number | null,
   configured: number | null,
+  auto: boolean,
 ): ContextUsageView["capSource"] {
   if (cap === null) return null;
   if (cap <= CONVERSATION_CAP_FLOOR) return "floor";
+  if (auto) return "auto";
   if (configured !== null && cap < configured) return "window";
   return "config";
 }
@@ -105,6 +113,7 @@ export function selectContextUsage(state: TuiState): ContextUsageView | null {
     conversationTokens,
     conversationCap,
     conversationCapConfigured,
+    conversationCapAuto,
   } = state.contextUsage;
   // Nothing has been built yet: the chip stays off the bar rather than
   // showing a zero, which would claim the window is empty when what we
@@ -124,7 +133,11 @@ export function selectContextUsage(state: TuiState): ContextUsageView | null {
       conversationCap === null || conversationCap <= 0
         ? null
         : Math.min(100, Math.round((conversationTokens / conversationCap) * 100)),
-    capSource: resolveCapSource(conversationCap, conversationCapConfigured),
+    capSource: resolveCapSource(
+      conversationCap,
+      conversationCapConfigured,
+      conversationCapAuto,
+    ),
     droppedTurns,
     sections,
   };

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -259,6 +259,13 @@ export interface ContextUsageState {
    * an operator which knob actually moves their limit.
    */
   conversationCapConfigured: number | null;
+  /**
+   * The configured cap is `0` — auto. `conversationCapConfigured` is
+   * then a fallback rather than a ceiling, so the comparison above says
+   * nothing and the panel must not name `agent.conversationMaxTokens`
+   * as what is holding the transcript down. Nothing is: the window is.
+   */
+  conversationCapAuto: boolean;
   /** Per-section breakdown, for the detail view. Empty before the first prompt. */
   sections: readonly ContextUsageSection[];
 }


### PR DESCRIPTION
## The question

> User set the context window to 48k in external llama.cpp, but when he runs it, it shows 32k. Is it correct?

**Yes — and it is the wrong number to show.**

The `48000` was read correctly from `/props` the whole time. The `32k` in the composer is not the window: it is `agent.conversationMaxTokens`, the ceiling the *transcript* is packed to, which defaults to a flat `32_000` ([`config-schema.ts:1724`](src/config/config-schema.ts#L1724)) and has no relationship to the window at all.

So the readout is accurate and unreadable. `context 6.4k/32k` is exactly the shape of "your context window is 32k", and anyone who has ever passed `-c` will read it that way. Worse, the ceiling is a *ceiling*: it does not rise when the window grows past it, so two thirds of the operator's extra 16k was being quietly declined with no visible trace except a number that looked like the window.

## Three changes, smallest first

### 1. The chip says `cap`

```
 context [==      ]   6.4k/32k cap
```

Only where the word is load-bearing. When the window is what binds, or when the ceiling has been switched off, the number *is* the window's remainder and the disclaimer would be noise.

### 2. The panel says what to do about it

It already named the knob. It now names the value that lifts it, and what that buys:

```
 transcript          31.9k of 32k before older turns go
 capped by           agent.conversationMaxTokens
                     set it to 0 to fill the 48k window
```

Only when the ceiling really is holding the transcript below a known window — nothing is offered when the ceiling already sits above it.

### 3. `agent.conversationMaxTokens: 0` means auto

The transcript takes whatever the window leaves after the scaffold, the memory sections and the reply reservation. Same sentinel and same reasoning as `localModels.managed.contextSize`: the useful value is a function of hardware the config file cannot see, so the only honest fixed number is *don't fix it*.

On the reported setup: **32 000 → 38 992**.

Auto is not unbounded. With no window to subtract from (a cloud model with no published context length) it falls back to the configured figure — an unbounded transcript against somebody else's server is a promise this process cannot keep. The 512-token floor still wins over auto on a window too small to hold the prompt.

## The default stays at 32k

On a local server the tokens are free; on a metered cloud model with a 200k window, auto would multiply the per-step bill without anyone asking. And for everyone whose window is at or below 32k the switch is a **no-op** — the window was already the binding limit:

| window | today | with `0` |
|---|---|---|
| 32 768 | 23 760 | 23 760 (no change) |
| 48 000 | 32 000 | **38 992** |
| 4 096 | 512 (floor) | 512 (floor) |

So the people it helps are precisely the people who sized their own `llama-server` — and they are now told so at the point of confusion rather than having to find the knob.

## One subtlety

Under auto, the figure in `conversationCapConfigured` is the budget-share fallback rather than a ceiling, and it is usually the *smaller* of the two. The config-vs-effective comparison that drives the "capped by" line would therefore report `config` and send an operator to raise a setting they had already switched off. The flag is threaded through `BuiltPrompt` rather than inferred from the numbers, and `select-context-usage.test.ts` checks all three orderings.

## Verification

`token-budget.test.ts` reproduces the reported setup directly — a 48k window against a 32k ceiling, with and without auto — rather than asserting on abstract numbers.

```
npm run lint    clean
npm test        575 passed | 2 failed (577 files)
                5971 passed | 3 skipped | 2 failed (5976 tests)
```

Both failures are pre-existing on `main` in this sandbox and unrelated (`fs-glob-real`, and an `EACCES` spawning a stub `llama-server` in `local-models-orchestrator-auto-update`). Verified against `main` first.
