### PR TITLE
fix(web-search): park a rate-limited provider instead of re-asking it

### DIFF
--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -307,7 +307,7 @@ describe("parseUserConfigFile", () => {
   it("fills cacheTtlMinutes/fallback defaults when migrating from v27", () => {
     const parsed = parseUserConfigFile({ version: 27 });
     expect(parsed.version).toBe(USER_CONFIG_VERSION);
-    expect(parsed.web.search.cacheTtlMinutes).toBe(15);
+    expect(parsed.web.search.cacheTtlMinutes).toBe(60);
     expect(parsed.web.search.provider).toBe("exa");
     expect(parsed.web.search.fallback).toEqual(["duckduckgo"]);
   });

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -87,6 +87,12 @@ export interface WebSearchConfig {
   /**
    * Per-runtime result cache TTL in minutes. `0` disables caching. The cache
    * is the primary defence against provider rate-limiting on repeated queries.
+   *
+   * An hour, raised from fifteen minutes. An agent re-issues near-identical
+   * queries across the steps of one task and across tasks in one run, and
+   * every expiry inside that window spends quota to re-fetch a result it
+   * already had (#179). Search results for the factual lookups this is
+   * mostly used for do not turn over in an hour; a rate limit does.
    */
   cacheTtlMinutes: number;
   /**
@@ -1737,7 +1743,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       provider: "exa",
       maxResults: 8,
       timeoutMs: 15_000,
-      cacheTtlMinutes: 15,
+      cacheTtlMinutes: 60,
       fallback: ["duckduckgo"],
       searxng: {
         instanceUrl: null,

--- a/src/tools/os/web-search/providers/assert-provider-status.ts
+++ b/src/tools/os/web-search/providers/assert-provider-status.ts
@@ -1,0 +1,36 @@
+import type { SearchHttpResponse } from "../transport/index.js";
+import { WebSearchRateLimitedError } from "../web-search-errors.js";
+import type { WebSearchProviderName } from "../web-search-provider.js";
+
+/**
+ * The one place a provider turns an HTTP status into a throw.
+ *
+ * It exists to make 429 a *typed* outcome. Every provider used to raise
+ * a bare `Error` with the status baked into the message — `Exa returned
+ * HTTP 429` — which the orchestrator could only treat as "something
+ * went wrong, try the next one". A quota and a broken endpoint are not
+ * the same failure and do not want the same response: one should stop
+ * being asked for a while, the other should be retried the moment the
+ * next query arrives.
+ *
+ * `label` is the provider's display name (`Exa`, `DuckDuckGo`); `name`
+ * is its registry key. Keeping both means the message an operator reads
+ * stays the one they are used to while the value the orchestrator
+ * matches on is the enum.
+ */
+export function assertProviderStatus(
+  response: Pick<SearchHttpResponse, "status" | "retryAfterMs">,
+  name: WebSearchProviderName,
+  label: string,
+): void {
+  if (response.status === 429) {
+    throw new WebSearchRateLimitedError(
+      name,
+      response.retryAfterMs,
+      `${label} returned HTTP 429 (rate limited)`,
+    );
+  }
+  if (response.status >= 400) {
+    throw new Error(`${label} returned HTTP ${response.status}`);
+  }
+}

--- a/src/tools/os/web-search/providers/brave-provider.ts
+++ b/src/tools/os/web-search/providers/brave-provider.ts
@@ -1,3 +1,4 @@
+import { assertProviderStatus } from "./assert-provider-status.js";
 import { searchHttp } from "../transport/search-http.js";
 import type {
   WebSearchHttpDeps,
@@ -46,9 +47,7 @@ export function createBraveProvider(
         runCommand: deps.runCommand,
         lookup: deps.lookup,
       });
-      if (response.status >= 400) {
-        throw new Error(`Brave search returned HTTP ${response.status}`);
-      }
+      assertProviderStatus(response, "brave", "Brave search");
       return parseBraveJson(response.body, options.maxResults);
     },
   };

--- a/src/tools/os/web-search/providers/duckduckgo-provider.ts
+++ b/src/tools/os/web-search/providers/duckduckgo-provider.ts
@@ -1,3 +1,4 @@
+import { assertProviderStatus } from "./assert-provider-status.js";
 import { parseHTML } from "linkedom";
 
 import { searchHttp } from "../transport/search-http.js";
@@ -40,9 +41,7 @@ export function createDuckDuckGoProvider(
         runCommand: deps.runCommand,
         lookup: deps.lookup,
       });
-      if (response.status >= 400) {
-        throw new Error(`DuckDuckGo returned HTTP ${response.status}`);
-      }
+      assertProviderStatus(response, "duckduckgo", "DuckDuckGo");
       const results = parseDuckDuckGoHtml(response.body, options.maxResults);
       if (results.length === 0 && isBotChallenge(response.body)) {
         throw new WebSearchBlockedError("duckduckgo");

--- a/src/tools/os/web-search/providers/exa-provider.ts
+++ b/src/tools/os/web-search/providers/exa-provider.ts
@@ -1,3 +1,4 @@
+import { assertProviderStatus } from "./assert-provider-status.js";
 import { searchHttp } from "../transport/search-http.js";
 import type {
   WebSearchHttpDeps,
@@ -66,9 +67,7 @@ export function createExaProvider(
           runCommand: deps.runCommand,
           lookup: deps.lookup,
         });
-        if (response.status >= 400) {
-          throw new Error(`Exa API returned HTTP ${response.status}`);
-        }
+        assertProviderStatus(response, "exa", "Exa API");
         return parseExaApiJson(response.body, options.maxResults);
       }
 
@@ -97,9 +96,7 @@ export function createExaProvider(
         runCommand: deps.runCommand,
         lookup: deps.lookup,
       });
-      if (response.status >= 400) {
-        throw new Error(`Exa returned HTTP ${response.status}`);
-      }
+      assertProviderStatus(response, "exa", "Exa");
       const text = extractExaText(response.body);
       return parseExaTextResults(text, options.maxResults);
     },

--- a/src/tools/os/web-search/providers/search-orchestrator.test.ts
+++ b/src/tools/os/web-search/providers/search-orchestrator.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { AtomicAgentConfig } from "../../../../config/index.js";
 import { runWebSearchWithFallback } from "./search-orchestrator.js";
+import { createProviderCooldown } from "../transport/provider-cooldown.js";
 import { createSearchCache } from "../transport/search-cache.js";
-import { WebSearchBlockedError } from "../web-search-errors.js";
+import {
+  WebSearchBlockedError,
+  WebSearchRateLimitedError,
+} from "../web-search-errors.js";
 import type {
   WebSearchProviderName,
   WebSearchProviderOptions,
@@ -199,5 +203,170 @@ describe("runWebSearchWithFallback", () => {
         env: {},
       }),
     ).rejects.toBeInstanceOf(WebSearchBlockedError);
+  });
+});
+
+/**
+ * Issue #179, reproduced at the level it actually bites.
+ *
+ * The transport already retries a 429 twice against the same provider,
+ * which is right for a burst. What the campaign measured was not a
+ * burst: 1341 429s spread evenly across 24 hours, 8-20 an hour, not
+ * tracking concurrency. Against a standing quota, every search paid for
+ * three doomed requests and ~1.5s of backoff before reaching the
+ * provider that was always going to answer it — and the answer, coming
+ * from the weaker fallback, looked exactly like a normal one.
+ */
+describe("a provider under a standing rate limit", () => {
+  const T0 = 5_000_000;
+
+  function limitedThenFallback() {
+    const exa = stubProvider("exa", async () => {
+      throw new WebSearchRateLimitedError("exa", null);
+    });
+    const ddg = stubProvider("duckduckgo", async () => [RESULT]);
+    vi.mocked(resolveProviderByName).mockImplementation((name) =>
+      name === "exa" ? exa : ddg,
+    );
+    return { exa, ddg };
+  }
+
+  it("stops asking it, instead of asking it again on every query", async () => {
+    const { exa, ddg } = limitedThenFallback();
+    const cooldown = createProviderCooldown();
+    const config = makeConfig({ provider: "exa", fallback: ["duckduckgo"] });
+    let clock = T0;
+
+    const first = await runWebSearchWithFallback({
+      config,
+      deps: {},
+      options: makeOptions(),
+      cooldown,
+      now: () => clock,
+    });
+    expect(first.provider).toBe("duckduckgo");
+    expect(exa.search).toHaveBeenCalledOnce();
+
+    // Ten more searches inside the park. Before this, each one re-entered
+    // the retry ladder against a provider that could not answer.
+    clock = T0 + 30_000;
+    for (let i = 0; i < 10; i++) {
+      const out = await runWebSearchWithFallback({
+        config,
+        deps: {},
+        options: { ...makeOptions(), query: `q${i}` },
+        cooldown,
+        now: () => clock,
+      });
+      expect(out.provider).toBe("duckduckgo");
+    }
+    expect(exa.search).toHaveBeenCalledOnce();
+    expect(ddg.search).toHaveBeenCalledTimes(11);
+  });
+
+  it("tries it again once the park expires", async () => {
+    const { exa } = limitedThenFallback();
+    const cooldown = createProviderCooldown();
+    const config = makeConfig({ provider: "exa", fallback: ["duckduckgo"] });
+    let clock = T0;
+
+    await runWebSearchWithFallback({
+      config, deps: {}, options: makeOptions(), cooldown, now: () => clock,
+    });
+    clock = T0 + 61_000;
+    await runWebSearchWithFallback({
+      config,
+      deps: {},
+      options: { ...makeOptions(), query: "later" },
+      cooldown,
+      now: () => clock,
+    });
+    expect(exa.search).toHaveBeenCalledTimes(2);
+  });
+
+  it("says out loud that the answer came from the fallback", async () => {
+    // The other half of #179: the chain worked, so nothing failed, so
+    // nothing was reported — and a whole campaign was quietly served by
+    // the weaker provider.
+    const { } = limitedThenFallback();
+    const cooldown = createProviderCooldown();
+    const config = makeConfig({ provider: "exa", fallback: ["duckduckgo"] });
+
+    const first = await runWebSearchWithFallback({
+      config, deps: {}, options: makeOptions(), cooldown, now: () => T0,
+    });
+    expect(first.degraded).toEqual([
+      "exa rate limited (HTTP 429), parked for 1m",
+    ]);
+
+    const second = await runWebSearchWithFallback({
+      config,
+      deps: {},
+      options: { ...makeOptions(), query: "next" },
+      cooldown,
+      now: () => T0 + 20_000,
+    });
+    expect(second.degraded).toEqual([
+      "exa skipped: rate limited, retrying in 40s",
+    ]);
+  });
+
+  it("still serves a parked provider's cached results", async () => {
+    // The park is about quota, not staleness. An answer already in hand
+    // is not worse because the provider that gave it has since run out.
+    const exa = stubProvider("exa", async () => [RESULT]);
+    vi.mocked(resolveProviderByName).mockReturnValue(exa);
+    const cooldown = createProviderCooldown();
+    const cache = createSearchCache({ ttlMs: 60_000 });
+    const config = makeConfig({ provider: "exa", fallback: [] });
+
+    await runWebSearchWithFallback({
+      config, deps: {}, options: makeOptions(), cache, cooldown, now: () => T0,
+    });
+    cooldown.park("exa", T0, null);
+
+    const out = await runWebSearchWithFallback({
+      config, deps: {}, options: makeOptions(), cache, cooldown, now: () => T0,
+    });
+    expect(out.fromCache).toBe(true);
+    expect(out.results).toEqual([RESULT]);
+    expect(exa.search).toHaveBeenCalledOnce();
+  });
+
+  it("does not park a provider that failed for some other reason", async () => {
+    // A blocked page or a dead endpoint should be retried on the next
+    // query; only a quota earns silence.
+    const exa = stubProvider("exa", async () => {
+      throw new WebSearchBlockedError("exa");
+    });
+    const ddg = stubProvider("duckduckgo", async () => [RESULT]);
+    vi.mocked(resolveProviderByName).mockImplementation((name) =>
+      name === "exa" ? exa : ddg,
+    );
+    const cooldown = createProviderCooldown();
+    const config = makeConfig({ provider: "exa", fallback: ["duckduckgo"] });
+
+    for (let i = 0; i < 3; i++) {
+      const out = await runWebSearchWithFallback({
+        config,
+        deps: {},
+        options: { ...makeOptions(), query: `q${i}` },
+        cooldown,
+        now: () => T0,
+      });
+      expect(out.degraded).toEqual([]);
+    }
+    expect(exa.search).toHaveBeenCalledTimes(3);
+  });
+
+  it("behaves exactly as before when no cooldown is supplied", async () => {
+    const { exa } = limitedThenFallback();
+    const config = makeConfig({ provider: "exa", fallback: ["duckduckgo"] });
+    for (let i = 0; i < 3; i++) {
+      await runWebSearchWithFallback({
+        config, deps: {}, options: { ...makeOptions(), query: `q${i}` },
+      });
+    }
+    expect(exa.search).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/tools/os/web-search/providers/search-orchestrator.ts
+++ b/src/tools/os/web-search/providers/search-orchestrator.ts
@@ -3,7 +3,14 @@ import {
   buildSearchCacheKey,
   type SearchCache,
 } from "../transport/search-cache.js";
-import { WebSearchBlockedError } from "../web-search-errors.js";
+import {
+  formatCooldown,
+  type ProviderCooldown,
+} from "../transport/provider-cooldown.js";
+import {
+  WebSearchBlockedError,
+  WebSearchRateLimitedError,
+} from "../web-search-errors.js";
 import type {
   WebSearchHttpDeps,
   WebSearchProviderName,
@@ -19,12 +26,32 @@ export interface WebSearchOrchestratorInput {
   cache?: SearchCache;
   /** Process env source for provider key checks; injectable for tests. */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Parked providers. Optional so existing callers and tests keep
+   * working; without it the chain behaves exactly as it did, which is
+   * to say it walks back into the same rate limit on every query.
+   */
+  cooldown?: ProviderCooldown;
+  /** Injectable clock, so a cooldown test does not wait out a real minute. */
+  now?: () => number;
 }
 
 export interface WebSearchOrchestratorResult {
   results: WebSearchResult[];
   provider: WebSearchProviderName;
   fromCache: boolean;
+  /**
+   * Providers that did not get to answer, and why — a rate limit they
+   * had just hit, or one they are still parked for. Empty on the happy
+   * path.
+   *
+   * This is the answer to the half of #179 that backoff does not touch:
+   * the fallback chain worked exactly as designed, so nothing failed,
+   * so nothing was reported — and a campaign spent 44% of its tool calls
+   * being quietly served by the weaker provider. A degradation nobody
+   * can see is not a degradation anybody fixes.
+   */
+  degraded: readonly string[];
 }
 
 /**
@@ -41,11 +68,24 @@ export async function runWebSearchWithFallback(
   const env = input.env ?? process.env;
   const chain = buildProviderChain(search.provider, search.fallback);
 
+  const now = input.now ?? Date.now;
+  const cooldown = input.cooldown;
   let firstError: unknown;
   let lastEmpty: WebSearchOrchestratorResult | undefined;
+  const degraded: string[] = [];
 
   for (const name of chain) {
     if (!isProviderUsable(name, input.config, env)) continue;
+
+    // Parked for a rate limit it hit earlier. Skipping it here is the
+    // whole point: against a standing quota the alternative is three
+    // requests that cannot succeed and ~1.5s of backoff, on every
+    // single query, before reaching the provider that was always going
+    // to serve it.
+    //
+    // The cache is still consulted first — a parked provider's earlier
+    // answers are not stale just because its quota ran out.
+    const parkedFor = cooldown?.remainingMs(name, now()) ?? 0;
 
     const cacheKey = buildSearchCacheKey(
       name,
@@ -55,9 +95,16 @@ export async function runWebSearchWithFallback(
     const cached = input.cache?.get(cacheKey);
     if (cached) {
       if (cached.length > 0) {
-        return { results: cached, provider: name, fromCache: true };
+        return { results: cached, provider: name, fromCache: true, degraded };
       }
-      lastEmpty = { results: cached, provider: name, fromCache: true };
+      lastEmpty = { results: cached, provider: name, fromCache: true, degraded };
+      continue;
+    }
+
+    if (parkedFor > 0) {
+      degraded.push(
+        `${name} skipped: rate limited, retrying in ${formatCooldown(parkedFor)}`,
+      );
       continue;
     }
 
@@ -65,12 +112,22 @@ export async function runWebSearchWithFallback(
     try {
       const results = await provider.search(input.options);
       input.cache?.set(cacheKey, results);
+      // It answered, so whatever it was parked for is over. Clearing
+      // the strike count here is what keeps the escalation honest: the
+      // ladder measures *consecutive* failures, not lifetime ones.
+      cooldown?.clear(name);
       if (results.length > 0) {
-        return { results, provider: name, fromCache: false };
+        return { results, provider: name, fromCache: false, degraded };
       }
-      lastEmpty = { results, provider: name, fromCache: false };
+      lastEmpty = { results, provider: name, fromCache: false, degraded };
     } catch (err) {
       if (firstError === undefined) firstError = err;
+      if (err instanceof WebSearchRateLimitedError && cooldown) {
+        const parked = cooldown.park(name, now(), err.retryAfterMs);
+        degraded.push(
+          `${name} rate limited (HTTP 429), parked for ${formatCooldown(parked)}`,
+        );
+      }
       // WebSearchBlockedError and transport throws both advance the chain.
     }
   }

--- a/src/tools/os/web-search/providers/searxng-provider.ts
+++ b/src/tools/os/web-search/providers/searxng-provider.ts
@@ -1,3 +1,4 @@
+import { assertProviderStatus } from "./assert-provider-status.js";
 import { searchHttp } from "../transport/search-http.js";
 import type {
   WebSearchHttpDeps,
@@ -40,9 +41,7 @@ export function createSearxngProvider(
         runCommand: deps.runCommand,
         lookup: deps.lookup,
       });
-      if (response.status >= 400) {
-        throw new Error(`SearXNG returned HTTP ${response.status}`);
-      }
+      assertProviderStatus(response, "searxng", "SearXNG");
       return parseSearxngJson(response.body, options.maxResults);
     },
   };

--- a/src/tools/os/web-search/tool/web-search-tool.ts
+++ b/src/tools/os/web-search/tool/web-search-tool.ts
@@ -6,6 +6,7 @@ import {
 import type { ToolDefinition } from "../../../tool-registry.js";
 import type { HostLookup } from "../../web-fetch-ssrf-guard.js";
 import { runWebSearchWithFallback } from "../providers/index.js";
+import { createProviderCooldown } from "../transport/provider-cooldown.js";
 import { createSearchCache } from "../transport/search-cache.js";
 import type { WebSearchResult } from "../web-search-provider.js";
 import { checkMissingSearchKey } from "./warn-missing-search-key.js";
@@ -34,6 +35,10 @@ export function buildOsWebSearchTool(options: OsWebSearchOptions): ToolDefinitio
   // HTTP round-trip — the primary defence against provider rate-limiting.
   const cfg0 = options.config.web.search;
   const cache = createSearchCache({ ttlMs: cfg0.cacheTtlMinutes * 60_000 });
+  // Same lifetime and same reason as the cache: a rate limit is a fact
+  // about the last few minutes of this process, so it lives in this
+  // closure rather than in a global or on disk.
+  const cooldown = createProviderCooldown();
 
   // Emitted once at construction, not per search: a keyless primary provider
   // degrades every subsequent query, and one line at startup is what turns
@@ -82,17 +87,21 @@ export function buildOsWebSearchTool(options: OsWebSearchOptions): ToolDefinitio
             signal: ctx.signal,
           },
           cache,
+          cooldown,
         });
         return compressToolResult(
           {
             tool: TOOL_NAME,
             status: "ok",
-            output: renderResults(outcome.results),
+            output: renderNotes(outcome.degraded) + renderResults(outcome.results),
             details: {
               provider: outcome.provider,
               fromCache: outcome.fromCache,
               query: args.query,
               results: outcome.results,
+              ...(outcome.degraded.length > 0
+                ? { degraded: outcome.degraded }
+                : {}),
             },
           },
           {
@@ -129,6 +138,22 @@ function parseArgs(
   }
   maxResults = Math.min(MAX_RESULTS_CAP, Math.max(1, maxResults));
   return { query: query.trim(), maxResults };
+}
+
+/**
+ * Whatever the chain had to skip to answer, printed above the results.
+ *
+ * In `details` as well, but `details` is structured metadata and this is
+ * the half the model reads. The degradation #179 measured was invisible
+ * precisely because it was not a failure: the fallback worked, results
+ * came back, and nothing anywhere said they came from the weaker
+ * provider because the stronger one was out of quota. A model that can
+ * see the line can say so in its answer; an operator reading the
+ * transcript can act on it.
+ */
+function renderNotes(degraded: readonly string[]): string {
+  if (degraded.length === 0) return "";
+  return `${degraded.map((note) => `[search] ${note}`).join("\n")}\n\n`;
 }
 
 function renderResults(results: readonly WebSearchResult[]): string {

--- a/src/tools/os/web-search/transport/index.ts
+++ b/src/tools/os/web-search/transport/index.ts
@@ -15,6 +15,14 @@ export {
 } from "./retry-after.js";
 export type { SearchRetryPolicy } from "./retry-after.js";
 export {
+  createProviderCooldown,
+  formatCooldown,
+} from "./provider-cooldown.js";
+export type {
+  ProviderCooldown,
+  ProviderCooldownOptions,
+} from "./provider-cooldown.js";
+export {
   buildSearchCacheKey,
   createSearchCache,
 } from "./search-cache.js";

--- a/src/tools/os/web-search/transport/provider-cooldown.test.ts
+++ b/src/tools/os/web-search/transport/provider-cooldown.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  createProviderCooldown,
+  formatCooldown,
+} from "./provider-cooldown.js";
+
+/**
+ * The behaviour issue #179 asked for, stated as a schedule rather than
+ * as "backoff": against a *standing* quota — 1341 429s spread evenly
+ * across 24 hours — the useful move is not waiting longer between
+ * retries, it is not sending the retries.
+ */
+describe("createProviderCooldown", () => {
+  const T0 = 1_000_000;
+
+  it("parks nothing until something is rate limited", () => {
+    const cooldown = createProviderCooldown();
+    expect(cooldown.isParked("exa", T0)).toBe(false);
+    expect(cooldown.remainingMs("exa", T0)).toBe(0);
+  });
+
+  it("parks for a minute on the first 429", () => {
+    const cooldown = createProviderCooldown();
+    expect(cooldown.park("exa", T0, null)).toBe(60_000);
+    expect(cooldown.isParked("exa", T0)).toBe(true);
+    expect(cooldown.remainingMs("exa", T0 + 59_000)).toBe(1000);
+    expect(cooldown.isParked("exa", T0 + 60_001)).toBe(false);
+  });
+
+  it("parks only the provider that was limited", () => {
+    const cooldown = createProviderCooldown();
+    cooldown.park("exa", T0, null);
+    expect(cooldown.isParked("duckduckgo", T0)).toBe(false);
+  });
+
+  it("doubles on each consecutive 429, up to the ceiling", () => {
+    const cooldown = createProviderCooldown();
+    expect(cooldown.park("exa", T0, null)).toBe(60_000);
+    expect(cooldown.park("exa", T0, null)).toBe(120_000);
+    expect(cooldown.park("exa", T0, null)).toBe(240_000);
+    expect(cooldown.park("exa", T0, null)).toBe(480_000);
+    expect(cooldown.park("exa", T0, null)).toBe(900_000);
+    expect(cooldown.park("exa", T0, null)).toBe(900_000);
+  });
+
+  it("keeps escalating across an expired park", () => {
+    // A provider limited three times in ten minutes has a standing
+    // quota whether or not its last park has lapsed. Restarting the
+    // ladder at one minute each time would walk straight back into it.
+    const cooldown = createProviderCooldown();
+    cooldown.park("exa", T0, null);
+    expect(cooldown.park("exa", T0 + 61_000, null)).toBe(120_000);
+  });
+
+  it("resets the ladder once the provider answers", () => {
+    const cooldown = createProviderCooldown();
+    cooldown.park("exa", T0, null);
+    cooldown.park("exa", T0, null);
+    cooldown.clear("exa");
+    expect(cooldown.isParked("exa", T0)).toBe(false);
+    expect(cooldown.park("exa", T0, null)).toBe(60_000);
+  });
+
+  it("honours a longer Retry-After than the ladder would pick", () => {
+    const cooldown = createProviderCooldown();
+    expect(cooldown.park("exa", T0, 300_000)).toBe(300_000);
+  });
+
+  it("ignores a Retry-After shorter than the ladder", () => {
+    // Otherwise a provider answering `Retry-After: 1` on every request
+    // defeats the escalation by being polite about it.
+    const cooldown = createProviderCooldown();
+    cooldown.park("exa", T0, null);
+    expect(cooldown.park("exa", T0, 1000)).toBe(120_000);
+  });
+
+  it("clamps a Retry-After that is really a lockout", () => {
+    // A day-long header would park the provider past the end of any
+    // session, on one server's say-so.
+    const cooldown = createProviderCooldown();
+    expect(cooldown.park("exa", T0, 86_400_000)).toBe(900_000);
+  });
+
+  it("treats a negative Retry-After as no advice at all", () => {
+    const cooldown = createProviderCooldown();
+    expect(cooldown.park("exa", T0, -5000)).toBe(60_000);
+  });
+});
+
+describe("formatCooldown", () => {
+  it("reads as a wait, not as a number of milliseconds", () => {
+    expect(formatCooldown(45_000)).toBe("45s");
+    expect(formatCooldown(60_000)).toBe("1m");
+    expect(formatCooldown(90_000)).toBe("1m 30s");
+    expect(formatCooldown(900_000)).toBe("15m");
+    expect(formatCooldown(0)).toBe("0s");
+    expect(formatCooldown(-1)).toBe("0s");
+  });
+});

--- a/src/tools/os/web-search/transport/provider-cooldown.ts
+++ b/src/tools/os/web-search/transport/provider-cooldown.ts
@@ -1,0 +1,139 @@
+import type { WebSearchProviderName } from "../web-search-provider.js";
+
+/**
+ * Which providers are parked, and until when.
+ *
+ * The transport already retries a 429 twice against the same provider
+ * before the orchestrator advances the chain, which is the right
+ * behaviour for a *burst*. Issue #179 measured what happens when the
+ * limit is not a burst: 1341 `Exa returned HTTP 429` errors in one
+ * campaign — 44% of all tool failures — spread evenly across all
+ * twenty-four hours, 8 to 20 an hour, not tracking concurrency at all.
+ * That is a standing quota on the keyless tier.
+ *
+ * Against a standing quota the retry ladder is worse than useless. Every
+ * search re-enters it from the top: three requests that cannot succeed,
+ * ~1.5s of backoff slept through, and only then the fallback that was
+ * always going to serve the query. Multiply by a search-heavy run.
+ *
+ * So a provider that is out of quota gets parked. The next search skips
+ * it outright — no request, no sleep — and goes straight to the
+ * provider that can actually answer. When the park expires it is tried
+ * again, and one success clears the record.
+ *
+ * **Per-runtime, like the result cache.** Not a global singleton and not
+ * persisted: a quota window is a fact about the last few minutes, and a
+ * cooldown restored from disk at start-up would park a provider on
+ * yesterday's evidence.
+ */
+export interface ProviderCooldown {
+  /** True while `name` is parked — the orchestrator skips it. */
+  isParked(name: WebSearchProviderName, now: number): boolean;
+  /** Milliseconds left on the park, or `0` when it is not parked. */
+  remainingMs(name: WebSearchProviderName, now: number): number;
+  /**
+   * Record a rate limit and park the provider. Returns the park length
+   * actually applied, so the caller can say it out loud.
+   */
+  park(
+    name: WebSearchProviderName,
+    now: number,
+    retryAfterMs: number | null,
+  ): number;
+  /** A provider answered. Forget its history so the next park starts small. */
+  clear(name: WebSearchProviderName): void;
+}
+
+export interface ProviderCooldownOptions {
+  /** First park after a single 429. */
+  baseMs?: number;
+  /** Ceiling on the doubling. */
+  maxMs?: number;
+}
+
+/**
+ * One minute, then two, then four… A single 429 is often a burst that
+ * the transport's retries did not quite outlast, and parking such a
+ * provider for a quarter of an hour would be its own kind of silent
+ * degradation. Repeated 429s are the signal that the limit is standing,
+ * and that is what the doubling is listening for.
+ */
+const DEFAULT_BASE_MS = 60_000;
+
+/**
+ * Fifteen minutes. Long enough that a search-heavy run stops paying the
+ * failed-request tax, short enough that a quota which resets hourly is
+ * noticed within the same session.
+ */
+const DEFAULT_MAX_MS = 15 * 60_000;
+
+/**
+ * A `Retry-After` this long is not advice about the next few seconds,
+ * it is a lockout — and honouring it verbatim would park the provider
+ * past the end of most sessions on one header. Clamped to the same
+ * ceiling the doubling respects.
+ */
+const MAX_HONOURED_RETRY_AFTER_MS = DEFAULT_MAX_MS;
+
+interface CooldownEntry {
+  until: number;
+  /** Consecutive parks, for the doubling. */
+  strikes: number;
+}
+
+export function createProviderCooldown(
+  options: ProviderCooldownOptions = {},
+): ProviderCooldown {
+  const baseMs = options.baseMs ?? DEFAULT_BASE_MS;
+  const maxMs = options.maxMs ?? DEFAULT_MAX_MS;
+  const entries = new Map<WebSearchProviderName, CooldownEntry>();
+
+  function remainingMs(name: WebSearchProviderName, now: number): number {
+    const entry = entries.get(name);
+    if (!entry) return 0;
+    return Math.max(0, entry.until - now);
+  }
+
+  return {
+    remainingMs,
+    isParked(name, now) {
+      return remainingMs(name, now) > 0;
+    },
+    park(name, now, retryAfterMs) {
+      const previous = entries.get(name);
+      // Strikes survive an expired park on purpose: a provider that has
+      // been rate-limited three times in the last ten minutes has a
+      // standing quota whether or not its last park has lapsed, and
+      // restarting the ladder at one minute each time would walk it
+      // back into the same wall. `clear` is what resets this, and only
+      // a successful search calls `clear`.
+      const strikes = (previous?.strikes ?? 0) + 1;
+      const escalated = Math.min(maxMs, baseMs * 2 ** (strikes - 1));
+      // The server's own number wins when it gave one — it is the only
+      // party that knows when the window actually resets — but never
+      // below the escalated floor, or a provider answering
+      // `Retry-After: 1` on every request would defeat the ladder by
+      // being polite about it.
+      const advertised =
+        retryAfterMs === null
+          ? 0
+          : Math.min(MAX_HONOURED_RETRY_AFTER_MS, Math.max(0, retryAfterMs));
+      const parkMs = Math.max(escalated, advertised);
+      entries.set(name, { until: now + parkMs, strikes });
+      return parkMs;
+    },
+    clear(name) {
+      entries.delete(name);
+    },
+  };
+}
+
+/** `90000` -> `1m 30s`, for the line the model reads. */
+export function formatCooldown(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  if (minutes === 0) return `${seconds}s`;
+  if (seconds === 0) return `${minutes}m`;
+  return `${minutes}m ${seconds}s`;
+}

--- a/src/tools/os/web-search/transport/search-http.ts
+++ b/src/tools/os/web-search/transport/search-http.ts
@@ -53,6 +53,13 @@ export interface SearchHttpResponse {
   body: string;
   truncated: boolean;
   redirectChain: string[];
+  /**
+   * The server's parsed `Retry-After`, or `null` when it did not send
+   * one. Surfaced rather than consumed internally: once the retry
+   * ladder is spent, how long to park the provider is a question only
+   * the server can answer, and the caller is the one parking it.
+   */
+  retryAfterMs: number | null;
 }
 
 interface CurlResponse {
@@ -76,14 +83,16 @@ export async function searchHttp(
   // advance the chain, so a transient limit cannot permanently downgrade the
   // session to a weaker provider.
   for (let attempt = 0; ; attempt++) {
-    const { retryAfter, ...response } = await sendOnce(request);
+    const { retryAfter, ...rest } = await sendOnce(request);
+    const retryAfterMs = parseRetryAfterMs(retryAfter, now());
+    const response: SearchHttpResponse = { ...rest, retryAfterMs };
     if (response.status !== 429 || attempt >= policy.maxRetries) {
       return response;
     }
     const delayMs = computeRetryDelayMs({
       attempt: attempt + 1,
       policy,
-      retryAfterMs: parseRetryAfterMs(retryAfter, now()),
+      retryAfterMs,
     });
     await sleep(delayMs, request.signal);
     // The operator pressed Esc (or the turn was aborted) while we were
@@ -95,8 +104,8 @@ export async function searchHttp(
   }
 }
 
-/** Internal shape: the public response plus the header the retry loop reads. */
-interface SearchHttpAttempt extends SearchHttpResponse {
+/** Internal shape: the raw header, before the retry loop parses it. */
+interface SearchHttpAttempt extends Omit<SearchHttpResponse, "retryAfterMs"> {
   retryAfter: string;
 }
 

--- a/src/tools/os/web-search/web-search-errors.ts
+++ b/src/tools/os/web-search/web-search-errors.ts
@@ -15,3 +15,33 @@ export class WebSearchBlockedError extends Error {
     this.provider = provider;
   }
 }
+
+/**
+ * A provider answered 429 after the transport had already spent its
+ * retries on it.
+ *
+ * A subclass of {@link WebSearchBlockedError} rather than a sibling,
+ * because everything that already treats a blocked provider as "advance
+ * the chain" should keep doing exactly that. What the subclass adds is
+ * the one fact the orchestrator needs to stop *re-asking*: this was a
+ * quota, not a bad page, and asking again in two seconds will produce
+ * the same answer.
+ *
+ * `retryAfterMs` carries the server's own `Retry-After` when it sent
+ * one. It is the difference between guessing how long to wait and being
+ * told.
+ */
+export class WebSearchRateLimitedError extends WebSearchBlockedError {
+  /** Server-advertised wait, or `null` when it did not say. */
+  readonly retryAfterMs: number | null;
+
+  constructor(
+    provider: WebSearchProviderName,
+    retryAfterMs: number | null = null,
+    message?: string,
+  ) {
+    super(provider, message ?? `${provider} returned HTTP 429 (rate limited)`);
+    this.name = "WebSearchRateLimitedError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}


### PR DESCRIPTION
Closes #179.

## What was already there

Backoff (`retry-after.ts`) and the startup key warning (`warn-missing-search-key.ts`) both shipped — suggestions 3 and 1 from the issue. The transport retries a 429 twice against the same provider before the chain advances, which is exactly right **for a burst**.

## What the issue actually measured

Not a burst. 1341 `Exa returned HTTP 429` errors — 44% of all 3039 tool failures — spread evenly across all twenty-four hours, 8–20 an hour, not tracking concurrency from 1 to 6 parallel agents. That is the keyless tier's **standing quota**.

Against a standing quota the retry ladder is worse than nothing. Every single search re-enters it from the top: three requests that cannot succeed, ~1.5s slept in backoff, and only then the fallback that was always going to serve the query. Multiply by a search-heavy run.

## The fix

**A rate-limited provider gets parked.** One minute, then two, then four, to a ceiling of fifteen. The doubling is what distinguishes a burst the retries did not quite outlast from a limit that is simply there.

- A `Retry-After` wins when the server sent one — it is the only party that knows when the window resets — but **never below the escalated floor**, or a provider answering `Retry-After: 1` on every request defeats the ladder by being polite about it. A day-long header is clamped: that is a lockout, not advice.
- **Strikes survive an expired park.** A provider limited three times in ten minutes has a standing quota whether or not its last park lapsed; restarting at one minute each time walks straight back into it. Only a *successful* search resets the ladder.
- Parked providers are skipped **without a request**. Their cached answers are still served — the park is about quota, not staleness.

## And the degradation says its own name

This is the half backoff does not touch, and the reason #179 took a whole campaign to notice: the fallback chain worked exactly as designed, so nothing failed, so nothing was reported, and 44% of a run's searches were quietly answered by the weaker provider.

Every skip and every park now prints above the results the model reads:

```
[search] exa rate limited (HTTP 429), parked for 1m
[search] exa skipped: rate limited, retrying in 40s

1. Result title
URL: https://…
```

A model that can see the line can say so in its answer; an operator reading the transcript can act on it.

## Supporting changes

**429 is a typed outcome.** Providers raised a bare `Error` with the status in the message (`Exa returned HTTP 429`), so the orchestrator could only read it as "something went wrong, try the next one" — but a quota and a dead endpoint want opposite responses. `WebSearchRateLimitedError` extends `WebSearchBlockedError`, so everything that treats a blocked provider as *advance the chain* keeps doing so, and it carries the parsed `Retry-After`. One `assertProviderStatus` helper replaces four hand-rolled status checks across the providers.

**`SearchHttpResponse` surfaces `retryAfterMs`.** The transport parsed the header and dropped it; how long to park is a question only the server can answer, and the caller is the one parking.

## Cache TTL: 15 → 60 minutes

Suggestion 2 from the issue. An agent re-issues near-identical queries across the steps of one task and across tasks in one run; every expiry inside that window spends quota to re-fetch a result it already had. The facts these lookups want do not turn over in an hour. A rate limit does.

## Verification

The orchestrator test reproduces the reported shape rather than asserting on abstractions — a rate-limited primary, then eleven searches:

| | before | after |
|---|---|---|
| requests to the limited provider | 11 (× 3 with retries) | **1** |
| backoff slept | ~16s | **0** |
| searches answered | 11 (all by the fallback) | 11 (all by the fallback) |
| times the operator was told | 0 | **11** |

Also pinned: the park expires and the provider is retried; a `WebSearchBlockedError` that is *not* a rate limit does **not** park (a bad page should be retried on the next query — only a quota earns silence); cached results survive the park; and an orchestrator called without a cooldown behaves exactly as it did before.

The cooldown is per-runtime, in the same closure as the result cache and for the same reason: a quota window is a fact about the last few minutes of this process, and one restored from disk at start-up would park a provider on yesterday's evidence.

```
npm run lint    clean
npm test        576 passed | 2 failed (578 files)
                5976 passed | 3 skipped | 2 failed (5981 tests)
```

Both failures are pre-existing on `main` in this sandbox and unrelated (`fs-glob-real`, and an `EACCES` spawning a stub `llama-server`). Verified against `main` first.
