### PR TITLE
fix(web): stop pinning every host to one address, and name the bot walls

### DIFF
--- a/src/tools/os/http-request-fetch.ts
+++ b/src/tools/os/http-request-fetch.ts
@@ -5,6 +5,7 @@ import {
 import { CurlUnavailableError, isCurlMissingError } from "./ensure-curl.js";
 import {
   assertHostAllowed,
+  formatResolveEntry,
   parseHttpUrl,
   SsrfBlockedError,
   type HostLookup,
@@ -71,12 +72,12 @@ export async function executeGuardedHttpRequest(
   let totalTime = 0;
 
   for (let hop = 0; ; hop += 1) {
-    const pinnedIp = await assertHostAllowed(currentUrl, {
+    const pinnedIps = await assertHostAllowed(currentUrl, {
       lookup: opts.lookup,
     });
     const curlArgs = buildPinnedCurlArgs({
       url: currentUrl,
-      pinnedIp,
+      pinnedIps,
       method,
       headers: args.headers,
       body,
@@ -165,7 +166,7 @@ export { SsrfBlockedError };
 
 interface BuildPinnedCurlArgs {
   url: URL;
-  pinnedIp: string;
+  pinnedIps: readonly string[];
   method: HttpMethod;
   headers: Record<string, string>;
   body: string | undefined;
@@ -176,9 +177,6 @@ function buildPinnedCurlArgs(input: BuildPinnedCurlArgs): string[] {
   const host = input.url.hostname.replace(/^\[|\]$/g, "");
   const port =
     input.url.port || (input.url.protocol === "https:" ? "443" : "80");
-  const resolveTarget = input.pinnedIp.includes(":")
-    ? `[${input.pinnedIp}]`
-    : input.pinnedIp;
   const argv: string[] = [
     "-sS",
     // Send `[`, `]`, `{`, `}` in URLs literally. Without this curl reads them
@@ -191,7 +189,7 @@ function buildPinnedCurlArgs(input: BuildPinnedCurlArgs): string[] {
     "--max-redirs",
     "0",
     "--resolve",
-    `${host}:${port}:${resolveTarget}`,
+    formatResolveEntry(host, port, input.pinnedIps),
   ];
   if (input.method !== "GET") argv.push("-X", input.method);
   for (const [key, value] of Object.entries(input.headers)) {

--- a/src/tools/os/web-fetch-challenge.test.ts
+++ b/src/tools/os/web-fetch-challenge.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeChallenge,
+  detectChallenge,
+} from "./web-fetch-challenge.js";
+
+const CLOUDFLARE_200 = `<!DOCTYPE html><html><head><title>Just a moment...</title>
+<meta http-equiv="refresh" content="390"></head><body>
+<div id="cf-wrapper"><h1>Enable JavaScript and cookies to continue</h1>
+<script src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1"></script>
+</div></body></html>`;
+
+const CLOUDFLARE_403 = `<!DOCTYPE html><html><head>
+<title>Attention Required! | Cloudflare</title></head><body>
+<h1>Sorry, you have been blocked</h1></body></html>`;
+
+const REAL_ARTICLE = `<!DOCTYPE html><html><head><title>Rate limiting</title>
+</head><body><article><h1>Rate limiting</h1><p>A rate limit is a cap on how
+many requests a client may make. Servers behind a CDN often enforce one.</p>
+</article></body></html>`;
+
+describe("detectChallenge", () => {
+  it("catches a challenge served as 200", () => {
+    // The one that mattered most: extraction succeeds on these, so the
+    // model received "Just a moment…" as the body of the article it
+    // asked for, with nothing anywhere saying it had been fenced out.
+    const verdict = detectChallenge({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: CLOUDFLARE_200,
+    });
+    expect(verdict.challenged).toBe(true);
+    expect(verdict.marker).toBe("just a moment...");
+  });
+
+  it("catches a challenge served as 403", () => {
+    const verdict = detectChallenge({
+      status: 403,
+      contentType: "text/html",
+      body: CLOUDFLARE_403,
+    });
+    expect(verdict.challenged).toBe(true);
+  });
+
+  it("leaves a real page alone even when it discusses rate limits", () => {
+    for (const status of [200, 403, 503]) {
+      expect(
+        detectChallenge({
+          status,
+          contentType: "text/html",
+          body: REAL_ARTICLE,
+        }).challenged,
+      ).toBe(false);
+    }
+  });
+
+  it("does not send the agent to a browser for an API refusal", () => {
+    // A JSON 403 is a server saying no. Opening Chrome would be a
+    // slower way to receive the same answer.
+    expect(
+      detectChallenge({
+        status: 403,
+        contentType: "application/json",
+        body: '{"error":"forbidden","detail":"please verify you are a human"}',
+      }).challenged,
+    ).toBe(false);
+  });
+
+  it("ignores statuses a challenge is never served under", () => {
+    expect(
+      detectChallenge({
+        status: 404,
+        contentType: "text/html",
+        body: CLOUDFLARE_200,
+      }).challenged,
+    ).toBe(false);
+  });
+
+  it("only scans the head of the body", () => {
+    // A long document that happens to quote a marker deep inside is a
+    // document, not a wall.
+    const buried = `${"<p>ordinary prose.</p>".repeat(400)}just a moment...`;
+    expect(
+      detectChallenge({
+        status: 200,
+        contentType: "text/html",
+        body: buried,
+      }).challenged,
+    ).toBe(false);
+  });
+
+  it("treats a missing content-type as possibly-html", () => {
+    expect(
+      detectChallenge({ status: 503, contentType: "", body: CLOUDFLARE_200 })
+        .challenged,
+    ).toBe(true);
+  });
+});
+
+describe("describeChallenge", () => {
+  it("names the tool that gets through, and says not to retry", () => {
+    const message = describeChallenge(
+      "https://example.com/a",
+      403,
+      "just a moment...",
+    );
+    expect(message).toContain("browser.navigate");
+    expect(message).toContain("browser.read_aria");
+    expect(message).toContain("do not re-fetch");
+  });
+});

--- a/src/tools/os/web-fetch-challenge.ts
+++ b/src/tools/os/web-fetch-challenge.ts
@@ -1,0 +1,108 @@
+/**
+ * Is this response a bot wall rather than the page that was asked for?
+ *
+ * `os.web.fetch` is curl with no JavaScript engine, so a site behind
+ * Cloudflare, Akamai or PerimeterX does not answer it with the article —
+ * it answers with an interstitial whose whole content is "prove you are
+ * a browser". Two things went wrong with that before:
+ *
+ *  1. A challenge served as **200** was extracted and returned as the
+ *     page. The model got "Just a moment…" as the body of the article
+ *     it asked for and had no way to know it had been fenced out.
+ *  2. A challenge served as **403** came back as `HTTP 403 for <url>`,
+ *     which is indistinguishable from a page that genuinely refuses
+ *     everyone — so the model either gave up on a reachable page or
+ *     re-fetched the same wall.
+ *
+ * Neither says the thing that would actually help, which is that this
+ * app has a real browser and the wall is exactly what it is for.
+ *
+ * Detection is markers-in-body, not status alone: plenty of 403s are
+ * ordinary refusals and plenty of challenges are 200s, so the status is
+ * corroboration rather than evidence.
+ */
+
+/**
+ * Phrases that appear in the *visible* text or the meta tags of the
+ * interstitials, chosen to be ones a normal article would not contain.
+ * Matched case-insensitively against the first slice of the body.
+ */
+const CHALLENGE_MARKERS: readonly string[] = [
+  // Cloudflare
+  "just a moment...",
+  "checking your browser before accessing",
+  "attention required! | cloudflare",
+  "cf-browser-verification",
+  "cf_chl_opt",
+  "/cdn-cgi/challenge-platform/",
+  "enable javascript and cookies to continue",
+  // Akamai
+  "reference #18.",
+  "access denied | akamai",
+  // PerimeterX / HUMAN
+  "px-captcha",
+  "please verify you are a human",
+  // Imperva / Incapsula
+  "incapsula incident id",
+  "request unsuccessful. incapsula",
+  // Generic
+  "ddos protection by",
+  "verifying you are human",
+  "captcha-delivery.com",
+];
+
+/**
+ * How much of the body to scan. A challenge page is small and says so
+ * immediately; a real article that happens to quote one of these phrases
+ * says it well past the first few kilobytes. The cap also keeps this off
+ * the hot path for a 2 MB document.
+ */
+const SCAN_BYTES = 4096;
+
+/** Statuses a challenge is served under. `200` is deliberately included. */
+const CHALLENGE_STATUSES = new Set([200, 202, 403, 429, 503]);
+
+export interface ChallengeVerdict {
+  challenged: boolean;
+  /** The marker that matched, for the message the model reads. */
+  marker: string | null;
+}
+
+export function detectChallenge(input: {
+  status: number;
+  contentType: string;
+  body: string;
+}): ChallengeVerdict {
+  if (!CHALLENGE_STATUSES.has(input.status)) {
+    return { challenged: false, marker: null };
+  }
+  // A JSON or plain-text 403 is an API saying no, not a wall asking for
+  // a browser. Sending the agent to Chrome for that would be a slower
+  // way to get the same refusal.
+  const type = input.contentType.toLowerCase();
+  if (type.length > 0 && !type.includes("html")) {
+    return { challenged: false, marker: null };
+  }
+  const head = input.body.slice(0, SCAN_BYTES).toLowerCase();
+  for (const marker of CHALLENGE_MARKERS) {
+    if (head.includes(marker)) return { challenged: true, marker };
+  }
+  return { challenged: false, marker: null };
+}
+
+/**
+ * What to tell the model. Names the tool that gets through, because the
+ * whole failure mode is an agent that does not realise there is one.
+ */
+export function describeChallenge(
+  url: string,
+  status: number,
+  marker: string,
+): string {
+  return (
+    `${url} answered with a bot-protection challenge (HTTP ${status}, matched ` +
+    `"${marker}") rather than the page. This is a JavaScript wall and ` +
+    `os.web.fetch cannot pass it. Open the page with browser.navigate and ` +
+    `read it with browser.read_aria instead; do not re-fetch this URL.`
+  );
+}

--- a/src/tools/os/web-fetch-ssrf-guard.test.ts
+++ b/src/tools/os/web-fetch-ssrf-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   assertHostAllowed,
+  formatResolveEntry,
   isBlockedIp,
   parseHttpUrl,
   SsrfBlockedError,
@@ -74,7 +75,55 @@ describe("assertHostAllowed", () => {
     const pinned = await assertHostAllowed(parseHttpUrl("https://example.com"), {
       lookup: lookupTo("93.184.216.34"),
     });
-    expect(pinned).toBe("93.184.216.34");
+    expect(pinned).toEqual(["93.184.216.34"]);
+  });
+
+  /**
+   * The guard used to return `addresses[0]`, which turned every
+   * multi-homed host into a single-address host: one blackholed CDN
+   * edge, or an AAAA record sorting first on a machine with no IPv6
+   * route, and the fetch failed on a site every other client could
+   * open. Handing over the whole list is safe precisely because the
+   * check above is all-or-nothing — a set that survives it is a set
+   * curl may try in any order.
+   */
+  it("returns every safe address, in resolver order", async () => {
+    const pinned = await assertHostAllowed(parseHttpUrl("https://example.com"), {
+      lookup: lookupTo("2606:2800:220:1::1", "93.184.216.34", "93.184.216.35"),
+    });
+    expect(pinned).toEqual([
+      "2606:2800:220:1::1",
+      "93.184.216.34",
+      "93.184.216.35",
+    ]);
+  });
+
+  it("still refuses the whole set when one address is private", async () => {
+    await expect(
+      assertHostAllowed(parseHttpUrl("https://evil.example"), {
+        lookup: lookupTo("93.184.216.34", "93.184.216.35", "127.0.0.1"),
+      }),
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  describe("formatResolveEntry", () => {
+    it("joins the list the way curl reads it", () => {
+      expect(
+        formatResolveEntry("example.com", "443", [
+          "93.184.216.34",
+          "93.184.216.35",
+        ]),
+      ).toBe("example.com:443:93.184.216.34,93.184.216.35");
+    });
+
+    it("brackets each IPv6 literal individually", () => {
+      expect(
+        formatResolveEntry("example.com", "443", [
+          "2606:2800:220:1::1",
+          "93.184.216.34",
+        ]),
+      ).toBe("example.com:443:[2606:2800:220:1::1],93.184.216.34");
+    });
   });
 
   it("throws when any resolved address is private (rebinding defense)", async () => {

--- a/src/tools/os/web-fetch-ssrf-guard.ts
+++ b/src/tools/os/web-fetch-ssrf-guard.ts
@@ -166,14 +166,30 @@ export interface AssertHostAllowedOptions {
 
 /**
  * Resolve `url`'s hostname and reject when **any** resolved address is in a
- * blocked range. Returns a single safe address to pin curl to via
+ * blocked range. Returns *every* safe address, to pin curl to via
  * `--resolve`, which closes the DNS-rebinding gap between this check and the
  * actual connection. Throws {@link SsrfBlockedError} on any violation.
+ *
+ * **Why all of them.** This used to return `addresses[0]` and hand curl a
+ * single pin, which quietly turned every multi-homed host into a
+ * single-address host. A browser, or curl left to its own resolver, gets
+ * the whole list and walks it: it opens the next address when one refuses
+ * the connection, and it runs Happy Eyeballs across the two families so a
+ * machine with no working IPv6 route still reaches a host whose AAAA
+ * record happens to sort first. Pinned to one address, none of that
+ * happens — one blackholed CDN edge, or one unreachable family, and the
+ * fetch fails outright on a site every other client on the machine can
+ * open. That is the "some websites are not reachable" report.
+ *
+ * The SSRF property is unchanged, and is why handing over the whole list
+ * is safe: the loop below rejects the request if *any* resolved address is
+ * private, so the set that survives is a set curl may try in any order.
+ * Order is preserved as the resolver gave it.
  */
 export async function assertHostAllowed(
   url: URL,
   options: AssertHostAllowedOptions = {},
-): Promise<string> {
+): Promise<readonly string[]> {
   const lookup = options.lookup ?? defaultLookup;
   const host = url.hostname.replace(/^\[|\]$/g, "");
   if (host.length === 0) {
@@ -207,5 +223,28 @@ export async function assertHostAllowed(
       );
     }
   }
-  return addresses[0]!.address;
+  return addresses.map(({ address }) => address);
+}
+
+/**
+ * Format the guard's safe-address list for one `--resolve` entry.
+ *
+ * curl accepts `host:port:addr[,addr]...` and treats that list the way it
+ * treats a resolver's own answer: it moves to the next address when one
+ * fails to connect, and runs Happy Eyeballs across the two families.
+ * Handing it a single address threw all of that away — see
+ * `assertHostAllowed` for what that cost.
+ *
+ * IPv6 literals are bracketed individually, which is what curl wants
+ * inside a comma-separated list.
+ */
+export function formatResolveEntry(
+  host: string,
+  port: string,
+  addresses: readonly string[],
+): string {
+  const list = addresses
+    .map((address) => (address.includes(":") ? `[${address}]` : address))
+    .join(",");
+  return `${host}:${port}:${list}`;
 }

--- a/src/tools/os/web-fetch.test.ts
+++ b/src/tools/os/web-fetch.test.ts
@@ -547,3 +547,116 @@ describe("os.web.fetch retries (#180)", () => {
     expect(waits).toEqual([]);
   });
 });
+
+/**
+ * The reachability half: what curl is actually told to do.
+ */
+describe("os.web.fetch reaches a host the way a browser would", () => {
+  function captureArgs(): { args: string[][]; runCommand: typeof RunCommandType } {
+    const args: string[][] = [];
+    const runCommand = (async (_command: string, argv: string[]) => {
+      args.push(argv);
+      return {
+        command: "curl",
+        args: argv,
+        exitCode: 0,
+        signal: null,
+        stdout: curlStdout({
+          body: ARTICLE,
+          status: 200,
+          contentType: "text/html",
+        }),
+        stderr: "",
+        durationMs: 1,
+        timedOut: false,
+        truncated: false,
+      };
+    }) as unknown as typeof RunCommandType;
+    return { args, runCommand };
+  }
+
+  it("pins every resolved address, not just the first", async () => {
+    // One `--resolve` carrying the whole list is what lets curl move on
+    // when an address refuses the connection, and what lets Happy
+    // Eyeballs pick a family the machine can actually route. Pinned to
+    // `addresses[0]`, a host whose AAAA sorts first was unreachable on
+    // an IPv4-only machine — on a site every other client could open.
+    const { args, runCommand } = captureArgs();
+    const tool = buildOsWebFetchTool({
+      runCommand,
+      lookup: async () => [
+        { address: "2606:2800:220:1::1", family: 6 },
+        { address: "93.184.216.34", family: 4 },
+        { address: "93.184.216.35", family: 4 },
+      ],
+      config: USER_CONFIG_DEFAULTS as never,
+    });
+    await tool.run({ url: "https://example.com/a" }, ctx());
+    const argv = args[0]!;
+    const resolveValue = argv[argv.indexOf("--resolve") + 1];
+    expect(resolveValue).toBe(
+      "example.com:443:[2606:2800:220:1::1],93.184.216.34,93.184.216.35",
+    );
+  });
+
+  it("asks for, and undoes, compression", async () => {
+    const { args, runCommand } = captureArgs();
+    const tool = buildOsWebFetchTool({
+      runCommand,
+      lookup: publicLookup,
+      config: USER_CONFIG_DEFAULTS as never,
+    });
+    await tool.run({ url: "https://example.com/a" }, ctx());
+    expect(args[0]).toContain("--compressed");
+  });
+});
+
+describe("os.web.fetch against a bot wall", () => {
+  const CHALLENGE = `<!DOCTYPE html><html><head><title>Just a moment...</title>
+</head><body><div id="cf-wrapper">Enable JavaScript and cookies to continue
+</div></body></html>`;
+
+  function toolReturning(status: number, body: string) {
+    return buildOsWebFetchTool({
+      runCommand: makeRunCommand(() => ({
+        stdout: curlStdout({ body, status, contentType: "text/html" }),
+      })),
+      lookup: publicLookup,
+      config: USER_CONFIG_DEFAULTS as never,
+      sleep: fakeSleep().sleep,
+    });
+  }
+
+  it("reports a 200-status challenge instead of returning it as the page", async () => {
+    // This is the one that silently poisoned answers: extraction works
+    // fine on a challenge page, so "Just a moment…" came back as the
+    // article's body with nothing saying otherwise.
+    const result = await toolReturning(200, CHALLENGE).run(
+      { url: "https://example.com/a" },
+      ctx(),
+    );
+    expect(result.status).toBe("error");
+    expect(result.summary).toContain("bot-protection challenge");
+    expect(result.summary).toContain("browser.navigate");
+    expect(result.summary).not.toContain("Just a moment");
+  });
+
+  it("names the browser rather than reporting a bare 403", async () => {
+    const result = await toolReturning(403, CHALLENGE).run(
+      { url: "https://example.com/a" },
+      ctx(),
+    );
+    expect(result.status).toBe("error");
+    expect(result.details.retryWith).toBe("browser.navigate");
+    expect(result.summary).toContain("do not re-fetch");
+  });
+
+  it("leaves an ordinary page alone", async () => {
+    const result = await toolReturning(200, ARTICLE).run(
+      { url: "https://example.com/a" },
+      ctx(),
+    );
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("Hello");
+  });
+});

--- a/src/tools/os/web-fetch.ts
+++ b/src/tools/os/web-fetch.ts
@@ -9,6 +9,7 @@ import { extractWebContent, type ExtractMode } from "./web-fetch-extract.js";
 import { CurlUnavailableError, isCurlMissingError } from "./ensure-curl.js";
 import {
   assertHostAllowed,
+  formatResolveEntry,
   parseHttpUrl,
   SsrfBlockedError,
   type HostLookup,
@@ -17,6 +18,11 @@ import {
 const TOOL_NAME = "os.web.fetch";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+import {
+  describeChallenge,
+  detectChallenge,
+} from "./web-fetch-challenge.js";
+
 const MAX_RESPONSE_BYTES = 2_000_000;
 const MAX_REDIRECTS = 3;
 const DEFAULT_MAX_CHARS = 50_000;
@@ -111,7 +117,9 @@ export function buildOsWebFetchTool(
       "extracts content: prefers Cloudflare 'Markdown for Agents' " +
       "(Accept: text/markdown), then Mozilla Readability, then a basic " +
       "tag-stripping fallback. GET only, no auth headers, no JavaScript " +
-      "(use browser.* for JS-heavy pages). Blocks private/internal " +
+      "(use browser.* for JS-heavy pages; a page that answers with a " +
+      "bot-protection challenge is reported as such, with browser.navigate " +
+      "named as the way through). Blocks private/internal " +
       "addresses (SSRF) and re-validates each redirect hop. Retries " +
       "transient failures (429/502/503/504, connection timeouts) with " +
       "exponential backoff. Optional `timeoutMs` overrides the configured " +
@@ -139,6 +147,33 @@ export function buildOsWebFetchTool(
           details: {
             url: args.url,
             blocked: err instanceof SsrfBlockedError,
+          },
+        });
+      }
+
+      // Before extraction: a challenge page extracts perfectly well, and
+      // that is the problem — "Just a moment…" comes back looking like
+      // the article's first paragraph.
+      const challenge = detectChallenge({
+        status: outcome.status,
+        contentType: outcome.contentType,
+        body: outcome.body,
+      });
+      if (challenge.challenged) {
+        return compressToolResult({
+          tool: TOOL_NAME,
+          status: "error",
+          output: describeChallenge(
+            outcome.finalUrl,
+            outcome.status,
+            challenge.marker ?? "",
+          ),
+          details: {
+            url: args.url,
+            finalUrl: outcome.finalUrl,
+            status: outcome.status,
+            challenge: challenge.marker,
+            retryWith: "browser.navigate",
           },
         });
       }
@@ -307,12 +342,12 @@ async function fetchHopWithRetry(
   for (let attempt = 0; ; attempt++) {
     // Re-resolve on every attempt: the guard must pin a freshly verified IP
     // rather than trusting one resolved before an arbitrary backoff wait.
-    const pinnedIp = await assertHostAllowed(url, { lookup: opts.lookup });
+    const pinnedIps = await assertHostAllowed(url, { lookup: opts.lookup });
 
     let res: CurlResponse | null = null;
     let failure: unknown = null;
     try {
-      res = await curlOnce(url, pinnedIp, opts);
+      res = await curlOnce(url, pinnedIps, opts);
     } catch (err) {
       // Only a curl timeout is worth another attempt; a missing curl binary or
       // an aborted run must surface immediately.
@@ -374,10 +409,10 @@ function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
 
 async function curlOnce(
   url: URL,
-  pinnedIp: string,
+  pinnedIps: readonly string[],
   opts: FetchWithGuardOptions,
 ): Promise<CurlResponse> {
-  const curlArgs = buildCurlArgs(url, pinnedIp, opts);
+  const curlArgs = buildCurlArgs(url, pinnedIps, opts);
   let result: CommandResult;
   try {
     result = await opts.runCommand("curl", curlArgs, {
@@ -403,12 +438,11 @@ async function curlOnce(
 
 function buildCurlArgs(
   url: URL,
-  pinnedIp: string,
+  pinnedIps: readonly string[],
   opts: Pick<FetchWithGuardOptions, "fetchCfg" | "timeoutMs">,
 ): string[] {
   const host = url.hostname.replace(/^\[|\]$/g, "");
   const port = url.port || (url.protocol === "https:" ? "443" : "80");
-  const resolveTarget = pinnedIp.includes(":") ? `[${pinnedIp}]` : pinnedIp;
   // Never let the connect budget exceed the overall one — a per-call
   // `timeoutMs` smaller than the configured connect timeout must still cap the
   // handshake.
@@ -430,7 +464,13 @@ function buildCurlArgs(
     "--max-redirs",
     "0",
     "--resolve",
-    `${host}:${port}:${resolveTarget}`,
+    formatResolveEntry(host, port, pinnedIps),
+    // Advertise the encodings curl can actually undo, and undo them.
+    // Without this, a server that compresses regardless of the request
+    // hands back bytes the extractor reads as binary noise — and some
+    // hosts behave differently for a client that claims no encoding
+    // support at all, since no browser has looked like that in years.
+    "--compressed",
     "-H",
     "Accept: text/markdown, text/html;q=0.9, */*;q=0.1",
     "-H",

--- a/src/tools/os/web-search/transport/search-http.ts
+++ b/src/tools/os/web-search/transport/search-http.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../../sandbox/command-runner.js";
 import {
   assertHostAllowed,
+  formatResolveEntry,
   parseHttpUrl,
   type HostLookup,
 } from "../../web-fetch-ssrf-guard.js";
@@ -110,12 +111,12 @@ async function sendOnce(
   const chain: string[] = [];
 
   for (let hop = 0; ; hop++) {
-    const pinnedIp = await assertHostAllowed(currentUrl, {
+    const pinnedIps = await assertHostAllowed(currentUrl, {
       lookup: request.lookup,
     });
     const curlArgs = buildCurlArgs({
       url: currentUrl,
-      pinnedIp,
+      pinnedIps,
       method,
       headers: request.headers ?? {},
       hasBody: request.body !== undefined,
@@ -182,7 +183,7 @@ function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
 
 function buildCurlArgs(input: {
   url: URL;
-  pinnedIp: string;
+  pinnedIps: readonly string[];
   method: SearchHttpMethod;
   headers: Record<string, string>;
   hasBody: boolean;
@@ -190,9 +191,6 @@ function buildCurlArgs(input: {
 }): string[] {
   const host = input.url.hostname.replace(/^\[|\]$/g, "");
   const port = input.url.port || (input.url.protocol === "https:" ? "443" : "80");
-  const resolveTarget = input.pinnedIp.includes(":")
-    ? `[${input.pinnedIp}]`
-    : input.pinnedIp;
   const args = [
     "-sS",
     // Send `[`, `]`, `{`, `}` in URLs literally. Without this curl reads them
@@ -203,7 +201,7 @@ function buildCurlArgs(input: {
     "--max-redirs",
     "0",
     "--resolve",
-    `${host}:${port}:${resolveTarget}`,
+    formatResolveEntry(host, port, input.pinnedIps),
     "-H",
     `User-Agent: ${USER_AGENT}`,
     "-H",


### PR DESCRIPTION
> *"some websites are not reachable, we need to find a better way to open websites"*

Three distinct causes. The first is the one I'd bet on for "not reachable".

## 1. The SSRF guard pinned curl to a single address

```ts
return addresses[0]!.address;   // ← web-fetch-ssrf-guard.ts
```

`assertHostAllowed` resolved the host, verified no resolved address was private, and returned **one** of them for `curl --resolve`. That closed the DNS-rebinding gap, which is what it was for — and quietly turned every multi-homed host into a single-address host.

A browser, or curl left to its own resolver, gets the whole list and walks it: it moves to the next address when one refuses the connection, and runs Happy Eyeballs across the two families. Pinned to one address, **none of that happens**:

- one blackholed CDN edge → the fetch fails outright
- one AAAA record sorting first, on a machine with no working IPv6 route → **every** fetch to that host fails, permanently, while `curl https://thathost/` on the same machine succeeds

The guard now returns every safe address and all three callers (`web-fetch`, `http-request-fetch`, `search-http`) pass them as one comma-separated `--resolve`:

```
example.com:443:[2606:2800:220:1::1],93.184.216.34,93.184.216.35
```

**The security property is untouched, and is exactly what makes this safe:** the check is all-or-nothing — if *any* resolved address is private the whole request is refused — so a set that survives it is a set curl may try in any order.

## 2. No `--compressed`

Servers that compress regardless of the request handed back bytes the extractor read as noise. And a client advertising no encoding support at all does not look like anything that has browsed the web in fifteen years, which some hosts notice.

## 3. A bot wall came back as if it were the page

`os.web.fetch` is curl with no JavaScript engine, so a site behind Cloudflare, Akamai or PerimeterX answers it with an interstitial. Two failure shapes, and the second is worse:

| served as | what the model got |
|---|---|
| **403** | `HTTP 403 for <url>` — indistinguishable from a page that refuses everyone. The agent abandoned a reachable page, or re-fetched the same wall. |
| **200** | The challenge was *extracted*. **"Just a moment…" was returned as the body of the requested article**, with nothing anywhere indicating the agent had been fenced out. |

Neither says the thing that helps: this app has a real browser, and a JavaScript wall is precisely what it is for.

Challenges are now detected and reported as a structured error:

```
https://example.com/a answered with a bot-protection challenge (HTTP 403,
matched "just a moment...") rather than the page. This is a JavaScript wall
and os.web.fetch cannot pass it. Open the page with browser.navigate and read
it with browser.read_aria instead; do not re-fetch this URL.
```

Detection is **marker-in-body**; status corroborates rather than decides, because plenty of 403s are ordinary refusals and plenty of challenges are 200s. Deliberately narrow on all three axes:

- **HTML only** — a JSON 403 is an API saying no, and opening Chrome for it is a slower way to receive the same answer.
- **First 4 KB only** — a challenge page says so immediately; an article that happens to quote one of these phrases says it well past the head. Tested with a 400-paragraph document ending in a marker.
- **Only the statuses a challenge is actually served under** — 200/202/403/429/503.

## Verification

```
npm run lint    clean
npm test        576 passed | 2 failed (578 files)
                5976 passed | 3 skipped | 2 failed (5981 tests)
```

New tests capture the argv curl is actually handed (the `--resolve` list and `--compressed`) rather than asserting on an intermediate, plus the three challenge shapes and the "leave a real page alone" case.

Both failures are pre-existing on `main` in this sandbox and unrelated (`fs-glob-real`, and an `EACCES` spawning a stub `llama-server`). Verified against `main` first.

## What this does not do

It does not auto-escalate a blocked fetch into launching Chrome. That is a much bigger behavioural change — process spawn, profile, latency, approval surface — and it should be the agent's decision with the wall named, not a side effect of asking to read a page. Happy to do it as a follow-up if you want it automatic.
