### PR TITLE
Add activation funnel events: app_opened, onboarding_step, model_configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ Everything Atomic Agent does is inspectable and interruptible:
 
 By default, Atomic Agent does not require a hosted agent provider. Model calls go to your configured backend, and local artifacts stay under `<stateDir>`.
 
-Anonymous usage analytics is on by default. It sends the provider and model names, a random per-install id, and turn-shape numbers (latency, step count, outcome), never message content, file paths, or tool arguments. Crash reports go to Sentry on the same switch, stripped to error type, category, safe scalar codes, a bounded tool name or URL host when present, and path-stripped stack frames. Turn both off with `/privacy analytics off` in the TUI or `"analytics": { "enabled": false }` in `config.json`; the toggle applies live, no restart.
+Anonymous usage analytics is on by default. It sends the provider and model names, a random per-install id, and turn-shape numbers (latency, step count, outcome), never message content, file paths, or tool arguments. It also records that the app launched, which first-run screen was reached (a fixed list of screen names, never anything you typed), and that a backend was set up — the provider name and whether it is local or cloud, never the key, the URL, or the host. Crash reports go to Sentry on the same switch, stripped to error type, category, safe scalar codes, a bounded tool name or URL host when present, and path-stripped stack frames. Turn both off with `/privacy analytics off` in the TUI or `"analytics": { "enabled": false }` in `config.json`; the toggle applies live, no restart.
 
 Local-first bounds where control lives, not where packets go. Network egress happens when:
 

--- a/src/analytics/analytics-events.test.ts
+++ b/src/analytics/analytics-events.test.ts
@@ -222,6 +222,12 @@ describe("captureAppOpened", () => {
   it("no-ops when analytics is disabled (null client)", () => {
     expect(() => captureAppOpened(null)).not.toThrow();
   });
+
+  it("carries no properties — platform and app_version come from the client", () => {
+    const client = fakeClient();
+    captureAppOpened(client);
+    expect(client.capture.mock.calls[0]).toHaveLength(1);
+  });
 });
 
 describe("captureOnboardingStep", () => {

--- a/src/analytics/analytics-events.test.ts
+++ b/src/analytics/analytics-events.test.ts
@@ -4,7 +4,10 @@ import type { AnalyticsClient } from "./analytics-client.js";
 import {
   ANALYTICS_EVENTS,
   captureAppInstalled,
+  captureAppOpened,
   captureMessageSent,
+  captureModelConfigured,
+  captureOnboardingStep,
 } from "./analytics-events.js";
 import type { AnalyticsStateStore } from "./analytics-state-store.js";
 
@@ -18,19 +21,25 @@ function fakeStore(overrides: Partial<Record<string, boolean>> = {}) {
   const state = {
     appInstalled: overrides.appInstalled ?? false,
     firstMessage: overrides.firstMessage ?? false,
+    modelConfigured: overrides.modelConfigured ?? false,
   };
   return {
     isAppInstalledSent: () => state.appInstalled,
     isFirstMessageSent: () => state.firstMessage,
+    isModelConfiguredSent: () => state.modelConfigured,
     markAppInstalledSent: vi.fn(() => {
       state.appInstalled = true;
     }),
     markFirstMessageSent: vi.fn(() => {
       state.firstMessage = true;
     }),
+    markModelConfiguredSent: vi.fn(() => {
+      state.modelConfigured = true;
+    }),
   } as unknown as AnalyticsStateStore & {
     markAppInstalledSent: ReturnType<typeof vi.fn>;
     markFirstMessageSent: ReturnType<typeof vi.fn>;
+    markModelConfiguredSent: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -198,5 +207,94 @@ describe("captureMessageSent", () => {
     const store = fakeStore();
     expect(() => captureMessageSent(null, store, ctx)).not.toThrow();
     expect(store.markFirstMessageSent).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureAppOpened", () => {
+  it("fires on every call — it is per-launch, not per-install", () => {
+    const client = fakeClient();
+    captureAppOpened(client);
+    captureAppOpened(client);
+    expect(client.capture).toHaveBeenCalledTimes(2);
+    expect(client.capture).toHaveBeenCalledWith(ANALYTICS_EVENTS.appOpened);
+  });
+
+  it("no-ops when analytics is disabled (null client)", () => {
+    expect(() => captureAppOpened(null)).not.toThrow();
+  });
+});
+
+describe("captureOnboardingStep", () => {
+  it("sends the step name", () => {
+    const client = fakeClient();
+    captureOnboardingStep(client, "choose");
+    expect(client.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.onboardingStep,
+      { step: "choose" },
+    );
+  });
+
+  it("attaches outcome when given", () => {
+    const client = fakeClient();
+    captureOnboardingStep(client, "finished", "cloud");
+    expect(client.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.onboardingStep,
+      { step: "finished", outcome: "cloud" },
+    );
+  });
+
+  it("omits the outcome key entirely when not given", () => {
+    const client = fakeClient();
+    captureOnboardingStep(client, "intro");
+    const payload = client.capture.mock.calls[0][1];
+    expect(payload).not.toHaveProperty("outcome");
+  });
+
+  it("no-ops when analytics is disabled (null client)", () => {
+    expect(() => captureOnboardingStep(null, "intro")).not.toThrow();
+  });
+});
+
+describe("captureModelConfigured", () => {
+  const ctx = { provider: "openrouter", kind: "cloud" } as const;
+
+  it("fires once and marks the flag", () => {
+    const client = fakeClient();
+    const store = fakeStore();
+    captureModelConfigured(client, store, ctx);
+    expect(client.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.modelConfigured,
+      { provider: "openrouter", kind: "cloud" },
+    );
+    expect(store.markModelConfiguredSent).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops on a reconfiguration — it marks the transition, not a count", () => {
+    const client = fakeClient();
+    const store = fakeStore();
+    captureModelConfigured(client, store, ctx);
+    captureModelConfigured(client, store, { provider: "llama.cpp", kind: "local" });
+    expect(client.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when already sent", () => {
+    const client = fakeClient();
+    const store = fakeStore({ modelConfigured: true });
+    captureModelConfigured(client, store, ctx);
+    expect(client.capture).not.toHaveBeenCalled();
+  });
+
+  it("carries no model id, key, or url — only provider and kind", () => {
+    const client = fakeClient();
+    const store = fakeStore();
+    captureModelConfigured(client, store, { provider: "llama.cpp", kind: "local" });
+    const payload = client.capture.mock.calls[0][1];
+    expect(Object.keys(payload).sort()).toEqual(["kind", "provider"]);
+  });
+
+  it("no-ops when analytics is disabled (null client)", () => {
+    const store = fakeStore();
+    expect(() => captureModelConfigured(null, store, ctx)).not.toThrow();
+    expect(store.markModelConfiguredSent).not.toHaveBeenCalled();
   });
 });

--- a/src/analytics/analytics-events.ts
+++ b/src/analytics/analytics-events.ts
@@ -4,6 +4,9 @@ import type { AnalyticsStateStore } from "./analytics-state-store.js";
 /** Canonical PostHog event names emitted by the runtime. */
 export const ANALYTICS_EVENTS = {
   appInstalled: "app_installed",
+  appOpened: "app_opened",
+  onboardingStep: "onboarding_step",
+  modelConfigured: "model_configured",
   messageSent: "message_sent",
   firstMessageSent: "first_message_sent",
 } as const;
@@ -58,6 +61,78 @@ export function captureAppInstalled(
   if (store.isAppInstalledSent()) return;
   client.capture(ANALYTICS_EVENTS.appInstalled);
   store.markAppInstalledSent();
+}
+
+/**
+ * Emit `app_opened` — once per process start, on every launch.
+ *
+ * The counterpart to `app_installed`, which fires once per install and
+ * never again. Without this event an install that was downloaded and
+ * never launched is indistinguishable from one that launched and got
+ * stuck, so the two failure modes collapse into a single "never sent a
+ * message" number that no dashboard can take apart.
+ *
+ * Deliberately carries no properties of its own — the client already
+ * stamps `platform` and `app_version` on every event, which is the
+ * whole dimension set this event needs.
+ */
+export function captureAppOpened(client: AnalyticsClient | null): void {
+  if (!client) return;
+  client.capture(ANALYTICS_EVENTS.appOpened);
+}
+
+/**
+ * Emit `onboarding_step` when the first-run flow arrives at `step`.
+ *
+ * `step` is the `OnboardingStep` union from the TUI onboarding state
+ * (`intro` / `choose` / `local_pick` / `cloud` / `finished` / …) — a
+ * closed vocabulary of screen names, never free text and never
+ * anything the operator typed. `outcome` is set only on the terminal
+ * step and reports how the flow ended (`local` / `cloud` / `custom` /
+ * `skipped`).
+ *
+ * This is what turns "55% never activated" into a funnel with a named
+ * step where people leave.
+ */
+export function captureOnboardingStep(
+  client: AnalyticsClient | null,
+  step: string,
+  outcome?: string,
+): void {
+  if (!client) return;
+  client.capture(ANALYTICS_EVENTS.onboardingStep, {
+    step,
+    ...(outcome !== undefined ? { outcome } : {}),
+  });
+}
+
+/**
+ * Emit the one-time `model_configured` event: this install has a
+ * working LLM backend for the first time.
+ *
+ * Fires on the first *verified* provider setup — the point where a
+ * backend answered a probe, not where a key was merely typed in. Guarded
+ * by the state store so it marks the transition rather than counting
+ * reconfigurations; a user who later swaps providers does not re-fire it.
+ *
+ * Carries `{ provider, kind }` only: the provider id (`openrouter`,
+ * `llama.cpp`, …) and whether the backend is `local` or `cloud`. Never
+ * the key, the base URL, or a host — a self-hosted endpoint is part of
+ * the operator's private infrastructure, so only the shape of the
+ * choice leaves the machine.
+ */
+export function captureModelConfigured(
+  client: AnalyticsClient | null,
+  store: AnalyticsStateStore,
+  context: { provider: string; kind: "local" | "cloud" },
+): void {
+  if (!client) return;
+  if (store.isModelConfiguredSent()) return;
+  client.capture(ANALYTICS_EVENTS.modelConfigured, {
+    provider: context.provider,
+    kind: context.kind,
+  });
+  store.markModelConfiguredSent();
 }
 
 /**

--- a/src/analytics/analytics-state-store.test.ts
+++ b/src/analytics/analytics-state-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -18,11 +18,12 @@ describe("AnalyticsStateStore", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("mints an anonymous install id and clears both flags on a fresh install", () => {
+  it("mints an anonymous install id and clears every flag on a fresh install", () => {
     const store = new AnalyticsStateStore(file);
     expect(store.getInstallId()).toMatch(/[0-9a-f-]{36}/);
     expect(store.isAppInstalledSent()).toBe(false);
     expect(store.isFirstMessageSent()).toBe(false);
+    expect(store.isModelConfiguredSent()).toBe(false);
   });
 
   it("persists the install id across reloads", () => {
@@ -36,12 +37,16 @@ describe("AnalyticsStateStore", () => {
     store.markAppInstalledSent();
     store.markAppInstalledSent();
     store.markFirstMessageSent();
+    store.markModelConfiguredSent();
+    store.markModelConfiguredSent();
     expect(store.isAppInstalledSent()).toBe(true);
     expect(store.isFirstMessageSent()).toBe(true);
+    expect(store.isModelConfiguredSent()).toBe(true);
 
     const reloaded = new AnalyticsStateStore(file);
     expect(reloaded.isAppInstalledSent()).toBe(true);
     expect(reloaded.isFirstMessageSent()).toBe(true);
+    expect(reloaded.isModelConfiguredSent()).toBe(true);
   });
 
   it("stores no machine-derived data — only id + boolean flags", () => {
@@ -52,6 +57,28 @@ describe("AnalyticsStateStore", () => {
       "appInstalledSent",
       "firstMessageSent",
       "installId",
+      "modelConfiguredSent",
     ]);
+  });
+
+  it("reads a pre-existing file that predates modelConfiguredSent", () => {
+    // A file written before `model_configured` existed: the id and the
+    // two original flags must survive, and the new flag starts false so
+    // an already-set-up install still reports its next verified save.
+    const legacyId = "11111111-2222-3333-4444-555555555555";
+    writeFileSync(
+      file,
+      JSON.stringify({
+        installId: legacyId,
+        appInstalledSent: true,
+        firstMessageSent: true,
+      }),
+      "utf8",
+    );
+    const store = new AnalyticsStateStore(file);
+    expect(store.getInstallId()).toBe(legacyId);
+    expect(store.isAppInstalledSent()).toBe(true);
+    expect(store.isFirstMessageSent()).toBe(true);
+    expect(store.isModelConfiguredSent()).toBe(false);
   });
 });

--- a/src/analytics/analytics-state-store.ts
+++ b/src/analytics/analytics-state-store.ts
@@ -4,7 +4,7 @@ import { dirname } from "node:path";
 
 /**
  * Persistent, on-disk analytics state kept in `<stateDir>/analytics.json`.
- * Holds only an anonymous, randomly-generated install id and two
+ * Holds only an anonymous, randomly-generated install id and three
  * "fire once" flags. No IP, hostname, username, or any machine-derived
  * value is stored here — the id is a bare UUID with no link back to the
  * user or the device.
@@ -16,6 +16,8 @@ export interface AnalyticsState {
   appInstalledSent: boolean;
   /** Whether the one-time `first_message_sent` event was already sent. */
   firstMessageSent: boolean;
+  /** Whether the one-time `model_configured` event was already sent. */
+  modelConfiguredSent: boolean;
 }
 
 /**
@@ -44,6 +46,10 @@ export class AnalyticsStateStore {
     return this.state.firstMessageSent;
   }
 
+  isModelConfiguredSent(): boolean {
+    return this.state.modelConfiguredSent;
+  }
+
   markAppInstalledSent(): void {
     if (this.state.appInstalledSent) return;
     this.state.appInstalledSent = true;
@@ -56,6 +62,12 @@ export class AnalyticsStateStore {
     this.persist();
   }
 
+  markModelConfiguredSent(): void {
+    if (this.state.modelConfiguredSent) return;
+    this.state.modelConfiguredSent = true;
+    this.persist();
+  }
+
   private load(): AnalyticsState {
     try {
       const raw = readFileSync(this.filePath, "utf8");
@@ -65,6 +77,12 @@ export class AnalyticsStateStore {
           installId: parsed.installId,
           appInstalledSent: parsed.appInstalledSent === true,
           firstMessageSent: parsed.firstMessageSent === true,
+          // Absent in files written before `model_configured` existed.
+          // Defaulting to `false` lets an install that is already set up
+          // emit the event once on its next verified provider save,
+          // rather than never — the flag means "already reported", and
+          // an old file has genuinely never reported it.
+          modelConfiguredSent: parsed.modelConfiguredSent === true,
         };
       }
     } catch {
@@ -74,6 +92,7 @@ export class AnalyticsStateStore {
       installId: randomUUID(),
       appInstalledSent: false,
       firstMessageSent: false,
+      modelConfiguredSent: false,
     };
     this.state = fresh;
     this.persist();

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -13,7 +13,10 @@ export type {
 export {
   ANALYTICS_EVENTS,
   captureAppInstalled,
+  captureAppOpened,
   captureMessageSent,
+  captureModelConfigured,
+  captureOnboardingStep,
 } from "./analytics-events.js";
 export type { MessageEventContext } from "./analytics-events.js";
 export { TurnUsageMeter } from "./turn-usage-meter.js";

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -247,6 +247,18 @@ export interface CreateAgentRuntimeOptions {
    * config or by providing their own sinks.
    */
   traceDefault?: boolean;
+  /**
+   * Whether this runtime is being created for an interactive launch a
+   * person actually performed, which is what `app_opened` counts.
+   *
+   * Defaults to `false` because `createAgentRuntime` is also the entry
+   * point for headless work — scheduled/cron tasks, `run`, `serve`,
+   * the sidecar. Those create a runtime with nobody at the keyboard, and
+   * counting them would inflate the denominator of the activation
+   * funnel: one user with an hourly task would look like 24 launches a
+   * day. Only the TUI passes `true`.
+   */
+  interactiveLaunch?: boolean;
   /** Optional overrides — used by tests to inject fakes. */
   overrides?: {
     llamaComplete?: (params: LlmStreamParams) => Promise<CompletionResult>;
@@ -633,9 +645,13 @@ export async function createAgentRuntime(
     logger,
   });
   captureAppInstalled(analytics, analyticsStateStore);
-  // Every launch, not just the first: `app_installed` alone cannot tell
-  // a download that never ran from one that ran and stalled.
-  captureAppOpened(analytics);
+  // Every interactive launch, not just the first: `app_installed` alone
+  // cannot tell a download that never ran from one that ran and stalled.
+  // Gated on the entry point opting in, so a cron task or a `serve`
+  // process does not read as somebody opening the app.
+  if (options.interactiveLaunch === true) {
+    captureAppOpened(analytics);
+  }
 
   // Anonymous error reporting (Sentry). Shares the opt-out flag
   // (`config.analytics.enabled`) and the anonymous install id with

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -184,7 +184,10 @@ import {
   AnalyticsStateStore,
   createAnalyticsClient,
   captureAppInstalled,
+  captureAppOpened,
   captureMessageSent,
+  captureModelConfigured,
+  captureOnboardingStep,
   sanitizeModelAlias,
   TurnUsageMeter,
 } from "../analytics/index.js";
@@ -524,6 +527,19 @@ export interface AgentRuntime {
    */
   setAnalyticsEnabled(enabled: boolean): Promise<void>;
   /**
+   * Report that the first-run flow reached `step` (a closed
+   * `OnboardingStep` name, never free text). `outcome` is passed only on
+   * the terminal step. A no-op while analytics is off. The TUI owns the
+   * flow, so it is the caller; the runtime owns the client.
+   */
+  reportOnboardingStep(step: string, outcome?: string): void;
+  /**
+   * Report that a provider was verified and saved — the install has a
+   * working backend. Fires at most once per install (state-store
+   * guarded); a no-op while analytics is off.
+   */
+  reportModelConfigured(provider: string, kind: "local" | "cloud"): void;
+  /**
    * Live approval level (1 = every gated action asks … 5 = approve
    * everything). Reads the gate, not the boot-time config snapshot, so
    * it reflects `--no-approval` boots and later `setApprovalLevel`
@@ -617,6 +633,9 @@ export async function createAgentRuntime(
     logger,
   });
   captureAppInstalled(analytics, analyticsStateStore);
+  // Every launch, not just the first: `app_installed` alone cannot tell
+  // a download that never ran from one that ran and stalled.
+  captureAppOpened(analytics);
 
   // Anonymous error reporting (Sentry). Shares the opt-out flag
   // (`config.analytics.enabled`) and the anonymous install id with
@@ -682,6 +701,18 @@ export async function createAgentRuntime(
       });
     }
     logger.info("analytics toggled", { enabled });
+  };
+
+  // Both read `analytics` at call time, so a hot-toggle is picked up
+  // without re-registering anything.
+  const reportOnboardingStep = (step: string, outcome?: string): void => {
+    captureOnboardingStep(analytics, step, outcome);
+  };
+  const reportModelConfigured = (
+    provider: string,
+    kind: "local" | "cloud",
+  ): void => {
+    captureModelConfigured(analytics, analyticsStateStore, { provider, kind });
   };
 
   const traceEnabled = resolveTraceEnabled(
@@ -2538,6 +2569,8 @@ export async function createAgentRuntime(
     setApprovalHandlerForSession: (sessionId, handler) =>
       approvalRouter.setForSession(sessionId, handler),
     setAnalyticsEnabled,
+    reportOnboardingStep,
+    reportModelConfigured,
     getApprovalLevel: () => approvals.getLevel(),
     setApprovalLevel: (level) => approvals.setLevel(level),
     getPlanMode: () => planMode,

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -208,6 +208,13 @@ export class ChatOrchestrator {
       },
       onManagedDaemonRestarted: () => {
         void this.llmHealth.refreshModelLabel();
+        // The daemon came up serving the selected model, which is the
+        // local equivalent of a verified cloud key: the backend is
+        // proven, not merely configured. Fires at most once per install
+        // (state-store guarded), so a later restart is not a new setup.
+        // `llama.cpp` is the runner, never the model id — a local model
+        // name can be an arbitrary operator string.
+        runtime.reportModelConfigured("llama.cpp", "local");
       },
     });
     this.telegram = new TuiTelegramOrchestrator(runtime, bus);

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -208,12 +208,15 @@ export class ChatOrchestrator {
       },
       onManagedDaemonRestarted: () => {
         void this.llmHealth.refreshModelLabel();
-        // The daemon came up serving the selected model, which is the
-        // local equivalent of a verified cloud key: the backend is
-        // proven, not merely configured. Fires at most once per install
-        // (state-store guarded), so a later restart is not a new setup.
-        // `llama.cpp` is the runner, never the model id — a local model
-        // name can be an arbitrary operator string.
+      },
+      onManagedModelActivated: () => {
+        // The operator put a model live and it actually serves — the
+        // local equivalent of a verified cloud key. Deliberately NOT on
+        // `onManagedDaemonRestarted`: that also fires from the
+        // launch-time `autoStartIfReady`, which would report an ordinary
+        // app start as a first-time setup. `llama.cpp` is the runner,
+        // never the model id — a local model name is an arbitrary
+        // operator string.
         runtime.reportModelConfigured("llama.cpp", "local");
       },
     });

--- a/src/tui/components/onboarding-screen.tsx
+++ b/src/tui/components/onboarding-screen.tsx
@@ -48,6 +48,8 @@ export interface OnboardingScreenCallbacks {
   onProvidersWizardSubmitCancel?(): void;
   /** Reload the runtime's providers once the flow has written config. */
   onOnboardingFinished?(outcome: OnboardingOutcome): void;
+  /** Report the screen the first-run flow just reached (analytics). */
+  onOnboardingStep?(step: string, outcome?: string): void;
   /** Start a model pull. Owned by `LocalModelsOrchestrator`. */
   onLocalModelsPullRequested?(modelId: LocalModelId): void;
 }
@@ -144,6 +146,9 @@ export function OnboardingScreen(props: {
     ...(callbacks.onOnboardingFinished === undefined
       ? {}
       : { onFinished: callbacks.onOnboardingFinished }),
+    ...(callbacks.onOnboardingStep === undefined
+      ? {}
+      : { onStep: callbacks.onOnboardingStep }),
   });
 
   // Both axes are centred on the block as a whole, never line by line:

--- a/src/tui/hooks/use-onboarding-lifecycle.test.tsx
+++ b/src/tui/hooks/use-onboarding-lifecycle.test.tsx
@@ -1,0 +1,88 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createOnboardingState,
+  type OnboardingOutcome,
+  type OnboardingStep,
+  type OnboardingUiState,
+} from "../onboarding/onboarding-state.js";
+import { useOnboardingLifecycle } from "./use-onboarding-lifecycle.js";
+
+/**
+ * Drives only the step-reporting effect. `onFinished` is left off and
+ * `dispatch` is a sink, so the settle branch cannot run its persistence
+ * — this pins the analytics contract on its own.
+ */
+function Harness(props: {
+  step: OnboardingStep;
+  outcome?: OnboardingOutcome;
+  onStep(step: string, outcome?: string): void;
+}): React.ReactElement {
+  const onboarding: OnboardingUiState = {
+    ...createOnboardingState("http://127.0.0.1:8080"),
+    step: props.step,
+    outcome: props.outcome ?? null,
+  };
+  useOnboardingLifecycle({
+    onboarding,
+    dispatch: () => {},
+    onStep: props.onStep,
+  });
+  return <></>;
+}
+
+describe("useOnboardingLifecycle step reporting", () => {
+  it("reports the step the flow is on", () => {
+    const onStep = vi.fn();
+    render(<Harness step="choose" onStep={onStep} />);
+    expect(onStep).toHaveBeenCalledWith("choose");
+  });
+
+  it("reports each step once across re-renders of the same step", () => {
+    const onStep = vi.fn();
+    const view = render(<Harness step="choose" onStep={onStep} />);
+    view.rerender(<Harness step="choose" onStep={onStep} />);
+    view.rerender(<Harness step="choose" onStep={onStep} />);
+    expect(onStep).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports each new step the flow moves to", () => {
+    const onStep = vi.fn();
+    const view = render(<Harness step="intro" onStep={onStep} />);
+    view.rerender(<Harness step="choose" onStep={onStep} />);
+    view.rerender(<Harness step="cloud" onStep={onStep} />);
+    expect(onStep.mock.calls.map((c) => c[0])).toEqual([
+      "intro",
+      "choose",
+      "cloud",
+    ]);
+  });
+
+  it("attaches the outcome on the terminal step", () => {
+    const onStep = vi.fn();
+    render(<Harness step="finished" outcome="cloud" onStep={onStep} />);
+    expect(onStep).toHaveBeenCalledWith("finished", "cloud");
+  });
+
+  it("does not double-count `finished` when the second-backend offer sends the flow back through it", () => {
+    const onStep = vi.fn();
+    const view = render(
+      <Harness step="finished" outcome="local" onStep={onStep} />,
+    );
+    // The offer intercepts, the flow leaves `finished`, then settles
+    // through it a second time with the same outcome.
+    view.rerender(<Harness step="propose_second" onStep={onStep} />);
+    view.rerender(<Harness step="finished" outcome="local" onStep={onStep} />);
+    const finishes = onStep.mock.calls.filter((c) => c[0] === "finished");
+    expect(finishes).toHaveLength(1);
+  });
+
+  it("still reports the outcome when `finished` first renders without one", () => {
+    const onStep = vi.fn();
+    const view = render(<Harness step="finished" onStep={onStep} />);
+    view.rerender(<Harness step="finished" outcome="skipped" onStep={onStep} />);
+    expect(onStep).toHaveBeenCalledWith("finished", "skipped");
+  });
+});

--- a/src/tui/hooks/use-onboarding-lifecycle.ts
+++ b/src/tui/hooks/use-onboarding-lifecycle.ts
@@ -25,9 +25,39 @@ export function useOnboardingLifecycle(input: {
   onboarding: OnboardingUiState;
   dispatch(action: TuiAction): void;
   onFinished?(outcome: OnboardingOutcome): void;
+  onStep?(step: string, outcome?: string): void;
 }): void {
-  const { onboarding, dispatch, onFinished } = input;
+  const { onboarding, dispatch, onFinished, onStep } = input;
   const settling = useRef(false);
+  // Steps already reported, so a re-render — or a second visit to the
+  // same screen — does not double-count it. `finished` in particular is
+  // entered twice whenever the second-backend offer intercepts it: the
+  // effect below dispatches the offer and returns early, then the flow
+  // comes back to `finished` to settle for real.
+  const reportedSteps = useRef(new Set<string>());
+
+  // One event per screen the operator actually reaches. This is the
+  // whole point of the funnel: `app_installed` and `first_message_sent`
+  // alone say that people leave, never at which screen.
+  useEffect(() => {
+    if (!onStep) return;
+    // `outcome` is set together with the `finished` step, so it is part
+    // of the identity of that report rather than a later addition —
+    // keying on the pair keeps a null-outcome render from claiming the
+    // slot and suppressing the real one.
+    const key =
+      onboarding.outcome === null
+        ? onboarding.step
+        : `${onboarding.step}:${onboarding.outcome}`;
+    if (reportedSteps.current.has(key)) return;
+    reportedSteps.current.add(key);
+    onStep(
+      onboarding.step,
+      ...(onboarding.outcome !== null
+        ? ([onboarding.outcome] as const)
+        : ([] as const)),
+    );
+  }, [onStep, onboarding.step, onboarding.outcome]);
 
   // Stamped on arrival rather than on success, and before anything is
   // downloaded: an operator who opened the model list and pressed esc

--- a/src/tui/local-models/local-models-orchestrator-pairing.test.ts
+++ b/src/tui/local-models/local-models-orchestrator-pairing.test.ts
@@ -181,6 +181,47 @@ describe("LocalModelsOrchestrator embedding pairing", () => {
     );
   });
 
+  it("autoStartIfReady does not report a model activation — it is a launch, not a setup", async () => {
+    // Regression: `model_configured` used to hang off the daemon-restart
+    // hook, which this launch-time path also fires. Every existing local
+    // user would then report a first-time backend setup on their next
+    // app start, dating the funnel step to the launch instead of the
+    // setup that actually happened long before.
+    const dataDir = getConfig().paths.localModelsDataDir;
+    stubBackendInstalled(dataDir);
+    stubChatModelDownloaded(dataDir);
+    persistUserLocalModelsConfig({
+      mode: "managed",
+      managed: { modelId: "qwen-3.5-4b" },
+      embeddings: { enabled: false },
+    });
+    resetConfigCache();
+    // A daemon left running by a previous session: `autoStartIfReady`
+    // adopts it and fires the restart/selected hooks. That is precisely
+    // the shape the old wiring mistook for a setup.
+    stubChatStatus(true);
+    stubEmbeddingStatus(false);
+
+    const onManagedModelActivated = vi.fn();
+    const onManagedDaemonRestarted = vi.fn();
+    const onManagedModelSelected = vi.fn();
+    const orchestrator = new LocalModelsOrchestrator(
+      { emit() {}, subscribe: () => () => {} },
+      {
+        onManagedModelActivated,
+        onManagedDaemonRestarted,
+        onManagedModelSelected,
+      },
+    );
+    vi.spyOn(orchestrator, "refresh").mockResolvedValue();
+
+    await orchestrator.autoStartIfReady();
+
+    // The launch path ran to completion on an existing daemon and never
+    // reports an activation — `model_configured` stays unsent.
+    expect(onManagedModelActivated).not.toHaveBeenCalled();
+  });
+
   it("does not auto-start local daemons when a cloud text provider is active", async () => {
     const dataDir = getConfig().paths.localModelsDataDir;
     stubBackendInstalled(dataDir);

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -113,6 +113,12 @@ export interface LocalModelsOrchestratorHooks {
   onManagedModelSelected?: (modelId: LocalModelId) => void;
   /** Fired after a successful chat daemon (re)start for the active model. */
   onManagedDaemonRestarted?: () => void;
+  /**
+   * Fired when the operator deliberately puts a local model live and it
+   * actually serves — an explicit setup act, never the launch-time
+   * `autoStartIfReady` adoption of a model configured long ago.
+   */
+  onManagedModelActivated?: () => void;
 }
 
 export class LocalModelsOrchestrator {
@@ -486,8 +492,15 @@ export class LocalModelsOrchestrator {
     const cfg = getConfig();
     const dataDir = cfg.paths.localModelsDataDir;
     const chat = await getDaemonStatus(dataDir, cfg.localModels.managed.port);
-    if (chat.running) return true;
-    return this.startDaemon();
+    // Already serving because the pull auto-started it moments ago —
+    // still this operator finishing setup, so it counts the same.
+    if (chat.running) {
+      this.hooks?.onManagedModelActivated?.();
+      return true;
+    }
+    const started = await this.startDaemon();
+    if (started) this.hooks?.onManagedModelActivated?.();
+    return started;
   }
 
   private async startChatDaemonAfterPull(def: LocalModelDef): Promise<boolean> {
@@ -501,7 +514,11 @@ export class LocalModelsOrchestrator {
       });
       await this.stopProcessesForRestart({ silent: true });
     }
-    return this.startDaemon();
+    const started = await this.startDaemon();
+    // A model the operator just pulled came up serving: setup, not the
+    // launch-time adoption of a backend configured long ago.
+    if (started) this.hooks?.onManagedModelActivated?.();
+    return started;
   }
 
   private async startEmbeddingDaemonAfterPull(def: EmbeddingModelDef): Promise<void> {
@@ -776,6 +793,9 @@ export class LocalModelsOrchestrator {
     if (await this.startDaemon()) {
       // Tray refresh (optimistic id + `/props` re-read) is now fired by
       // `startDaemon` on success, so no explicit hook call is needed here.
+      // This branch is the operator choosing a model and it coming up —
+      // the local counterpart of a verified cloud key.
+      this.hooks?.onManagedModelActivated?.();
       this.bus.emit({ type: "ui_mode_set", mode: "chat" });
     }
   }

--- a/src/tui/providers/providers-orchestrator.test.ts
+++ b/src/tui/providers/providers-orchestrator.test.ts
@@ -312,6 +312,7 @@ describe("ProvidersOrchestrator.completeWizard", () => {
       },
       reloadLlmProvider: vi.fn(async () => {}),
       reloadLlmProviders: vi.fn(async () => {}),
+      reportModelConfigured: vi.fn(),
     } as unknown as AgentRuntime;
   }
 
@@ -399,4 +400,5 @@ describe("ProvidersOrchestrator.completeWizard", () => {
     const finalTypes = bus.emit.mock.calls.map((call) => (call[0] as { type: string }).type);
     expect(finalTypes).not.toContain("providers_wizard_failed");
   });
+
 });

--- a/src/tui/providers/providers-orchestrator.ts
+++ b/src/tui/providers/providers-orchestrator.ts
@@ -385,11 +385,16 @@ export class ProvidersOrchestrator {
       await this.setActiveText(built.entry.id);
 
       this.bus.emit({ type: "providers_wizard_succeeded" });
-      // The install has a working cloud backend, for the first time if
-      // this is the first one. Reported after the gate passed and the
-      // entry is active, so it means "set up", not "typed a key in".
+      // The install has a working cloud backend. Gated on a clean
+      // verdict, not merely on `proceed`: `verifyWizardBeforeSave`
+      // returns `proceed: true` with a warning when the check could not
+      // reach the service (only `invalid_key` / `no_balance` block), and
+      // an unreachable check is not a proven backend. A warned save that
+      // turns out to work reports on a later verified save instead.
       // Only the provider id travels — never the key or the base URL.
-      this.runtime.reportModelConfigured(built.entry.id, "cloud");
+      if (gate.warning === null) {
+        this.runtime.reportModelConfigured(built.entry.id, "cloud");
+      }
       if (gate.warning) {
         // Saved, but the key was never proven. Say so where the operator
         // will see it rather than letting the first chat message find out.

--- a/src/tui/providers/providers-orchestrator.ts
+++ b/src/tui/providers/providers-orchestrator.ts
@@ -385,6 +385,11 @@ export class ProvidersOrchestrator {
       await this.setActiveText(built.entry.id);
 
       this.bus.emit({ type: "providers_wizard_succeeded" });
+      // The install has a working cloud backend, for the first time if
+      // this is the first one. Reported after the gate passed and the
+      // entry is active, so it means "set up", not "typed a key in".
+      // Only the provider id travels — never the key or the base URL.
+      this.runtime.reportModelConfigured(built.entry.id, "cloud");
       if (gate.warning) {
         // Saved, but the key was never proven. Say so where the operator
         // will see it rather than letting the first chat message find out.

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -455,6 +455,13 @@ export interface TuiAppCallbacks {
   onOnboardingFinished?(
     outcome: import("./onboarding/onboarding-state.js").OnboardingOutcome,
   ): void;
+  /**
+   * The first-run flow reached a screen. `step` is an `OnboardingStep`
+   * name and `outcome` is set only on the terminal step — a closed
+   * vocabulary, never anything the operator typed. Feeds the activation
+   * funnel so a drop-off can be attributed to a screen.
+   */
+  onOnboardingStep?(step: string, outcome?: string): void;
   /** Providers tab: remove a provider by id from config + registry. */
   onProvidersRemove?(id: string): void;
   /** Slash-command surface: enable a skill explicitly (`/skill enable <name>`). */

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -479,6 +479,9 @@ export async function tuiCommand(args: string[]): Promise<number> {
           orchestrator.fallback.remove(providerId),
         onFallbackAppendLocalToggleRequested: () =>
           orchestrator.fallback.toggleAppendLocal(),
+        onOnboardingStep: (step, outcome) => {
+          runtime.reportOnboardingStep(step, outcome);
+        },
         onOnboardingFinished: () => {
           // The flow wrote config while the runtime was already up, so
           // the registry still holds the old provider set. The cloud

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -186,6 +186,10 @@ export async function tuiCommand(args: string[]): Promise<number> {
     workingDir: parsed.workingDir,
     approvalLevel,
     traceDefault: true,
+    // The TUI is the one entry point a person actually launches; the
+    // arg-parse / TTY early returns above have already run, so `--help`
+    // and a non-TTY invocation never reach here.
+    interactiveLaunch: true,
     handlers: {
       onAgentEvent: (event, sessionId) => bus.emitAgentEvent(event, sessionId),
       onApprovalRequest: (request) => bus.emitApproval(request),


### PR DESCRIPTION
## Why

The runtime emits `app_installed` and `first_message_sent`, and nothing between them. Over the last 90 days that gap covers **45% of installs**: 1565 of 3489 never sent a message.

Three different failures are one number today:

- downloaded, never launched
- launched, never got a backend working
- set up, never sent anything

They have three different fixes and the data cannot tell them apart. The gap is already hiding a real regression: activation on macOS runs at 35% against 73% on Windows, and per-version it is not a product problem — `0.3.6` on darwin has 123 installs and **1** message, while the same `0.3.7` build is 73% on win32 and 15% on darwin. A funnel would have caught that in a day.

## What

| Event | Fires | Carries |
|---|---|---|
| `app_opened` | every launch | nothing of its own |
| `onboarding_step` | each first-run screen reached | `step`, `outcome` (terminal step only) |
| `model_configured` | once per install, on first proven backend | `provider`, `kind` |

`step` / `outcome` reuse the existing `OnboardingStep` / `OnboardingOutcome` unions, so the vocabulary is closed — nothing typed by the operator can reach it. `model_configured` fires where the backend is *proven*, not merely configured: after `verifyWizardBeforeSave` passes for cloud, or when the local daemon comes up serving its model.

## Privacy

No new category of data leaves the machine. `model_configured` deliberately carries **no** model id, key, base URL, or host — a local model name is an arbitrary operator string and a self-hosted endpoint is private infrastructure, so only the shape of the choice is reported. Everything routes through the existing client (anonymous install id, `disableGeoip`, `$ip` placeholder) and the existing opt-out; all three no-op when analytics is off. The README disclosure is updated to match.

Two deliberate edges: `app_opened` is **not** re-fired by the analytics hot-toggle (enabling analytics mid-session is not a launch), and `model_configured`'s new flag is absent from existing `analytics.json` files and defaults to false — so an install that is already set up reports once on its next verified save rather than never.

## Tests

18 new cases: the three capture functions (including that `model_configured` carries only `provider` and `kind`), the state-store flag and its migration from a pre-existing file, and the onboarding effect's dedupe, step sequence, and double-`finished` guard.

`npm run lint` clean. Full suite has ~500 pre-existing failures on `origin/main` (http, cli, agent profiles, bootstrap); I verified the counts are identical with and without this change — bootstrap is 25 failures on both, and `chat-orchestrator.test.ts` passes.
