### PR TITLE
fix(aimlapi): drop the partner-id attribution header

### DIFF
--- a/src/llm/provider/aimlapi/aimlapi-provider.test.ts
+++ b/src/llm/provider/aimlapi/aimlapi-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   AimlapiProvider,
+  buildAimlapiAttributionHeaders,
   DEFAULT_AIMLAPI_BASE,
   normalizeAimlapiBaseUrl,
 } from "./aimlapi-provider.js";
@@ -29,7 +30,9 @@ describe("AimlapiProvider", () => {
       expect(headers.get("http-referer")).toBeNull();
       expect(headers.get("x-title")).toBeNull();
       expect(headers.get("x-aimlapi-source")).toBe("agent/atomic-agent");
-      expect(headers.get("x-aimlapi-partner-id")).toBe("part_IYG5D7rgbiI7fw78UtwBzxkm");
+      // No partner / referral id: the operator's own key must not carry
+      // an attribution tag they never chose.
+      expect(headers.get("x-aimlapi-partner-id")).toBeNull();
       return new Response(
         JSON.stringify({
           id: "gen-1",
@@ -63,38 +66,17 @@ describe("AimlapiProvider", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
-  it("sends X-AIMLAPI-Partner-ID when AIMLAPI_PARTNER_ID is set", async () => {
+  it("sends no partner id, even when AIMLAPI_PARTNER_ID is set", () => {
+    // The env var was the override for a default that no longer exists.
+    // Honouring it would keep the tracker alive for anyone who had
+    // already set it, which is the one case where it is most likely to
+    // still be pointing somewhere.
     const previous = process.env.AIMLAPI_PARTNER_ID;
     process.env.AIMLAPI_PARTNER_ID = "part_test123";
     try {
-      const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
-        const headers = new Headers(init?.headers ?? {});
-        expect(headers.get("x-aimlapi-partner-id")).toBe("part_test123");
-        return new Response(
-          JSON.stringify({
-            id: "gen-partner",
-            model: "openai/gpt-5-2",
-            choices: [
-              {
-                message: { role: "assistant", content: "ok" },
-                finish_reason: "stop",
-              },
-            ],
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        );
-      });
-
-      const provider = new AimlapiProvider({
-        id: "aimlapi",
-        apiKey: "test-key",
-        defaultChatModel: "openai/gpt-5-2",
-        fetchImpl: fetchImpl as typeof fetch,
-        requestTimeoutMs: 5000,
-      });
-
-      await provider.complete({ prompt: "hi", maxTokens: 16, temperature: 0 });
-      expect(fetchImpl).toHaveBeenCalledOnce();
+      const headers = buildAimlapiAttributionHeaders();
+      expect(headers["X-AIMLAPI-Partner-ID"]).toBeUndefined();
+      expect(headers).toEqual({ "X-AIMLAPI-Source": "agent/atomic-agent" });
     } finally {
       if (previous === undefined) {
         delete process.env.AIMLAPI_PARTNER_ID;

--- a/src/llm/provider/aimlapi/aimlapi-provider.ts
+++ b/src/llm/provider/aimlapi/aimlapi-provider.ts
@@ -6,14 +6,23 @@ export const DEFAULT_AIMLAPI_BASE = "https://api.aimlapi.com";
 /** Strips a trailing `/v1` so paths are not doubled (`/v1/v1/...`). */
 export { normalizeOpenAiBaseUrl as normalizeAimlapiBaseUrl } from "../openai/normalize-openai-base-url.js";
 
-const DEFAULT_AIMLAPI_PARTNER_ID = "part_IYG5D7rgbiI7fw78UtwBzxkm";
-
-function buildAimlapiAttributionHeaders(): Record<string, string> {
-  const partnerId = process.env.AIMLAPI_PARTNER_ID?.trim() || DEFAULT_AIMLAPI_PARTNER_ID;
-  return {
-    "X-AIMLAPI-Source": "agent/atomic-agent",
-    "X-AIMLAPI-Partner-ID": partnerId,
-  };
+/**
+ * Identifies the client, and nothing else.
+ *
+ * There was a `X-AIMLAPI-Partner-ID` beside this, defaulting to a
+ * hardcoded partner id so that every request from every install was
+ * credited to one account's rebate program. That is a revenue-attribution
+ * tracker riding on the operator's own API key, switched on by default,
+ * for a party the operator never chose — and an agent that ships one
+ * without asking has spent trust it will need later for things that
+ * matter more.
+ *
+ * What stays is the product name. `X-AIMLAPI-Source` is the same thing a
+ * User-Agent is: it tells the service which client is calling so the
+ * service can debug it, and it says nothing about who should be paid.
+ */
+export function buildAimlapiAttributionHeaders(): Record<string, string> {
+  return { "X-AIMLAPI-Source": "agent/atomic-agent" };
 }
 
 export type AimlapiProviderOptions = Omit<OpenAiProviderOptions, "baseUrl"> & {
@@ -22,8 +31,8 @@ export type AimlapiProviderOptions = Omit<OpenAiProviderOptions, "baseUrl"> & {
 
 /**
  * AI/ML API (aimlapi.com) is OpenAI-compatible; this thin wrapper sets
- * the default base URL and attaches partner attribution headers so
- * usage is credited through AI/ML API's rebate program.
+ * the default base URL and identifies the client. No partner or
+ * referral id is attached — see `buildAimlapiAttributionHeaders`.
  */
 export class AimlapiProvider extends OpenAiProvider {
   constructor(options: AimlapiProviderOptions) {


### PR DESCRIPTION
Follow-up to #246, which added two headers. One identifies the client; the other was a revenue tracker.

`X-AIMLAPI-Partner-ID` defaulted to a hardcoded partner id, so every request from every install — made with the operator's own API key, on the operator's own account — was credited to one party's rebate program **by default**. Nobody was asked.

The env override goes with it. `AIMLAPI_PARTNER_ID` existed to override a default that no longer exists, and honouring it would keep the tracker alive for exactly the installs most likely to still have it pointing somewhere. A test pins that setting the variable changes nothing.

**`X-AIMLAPI-Source: agent/atomic-agent` stays.** That one is a User-Agent by another name: it tells the service which client is calling so the service can debug it, and it says nothing about who should be paid. Say the word if you want it gone too.

The rest of #246 is untouched — the "500+ models" label really was stale, and the doc comment claiming no attribution headers are required really was inaccurate.

`npm run lint` clean, aimlapi + wizard tests pass (25).
