### PR TITLE
fix(tui): composer text you can read, and pickers you can click out of

### DIFF
--- a/src/tui/backdrop-dismissal.test.ts
+++ b/src/tui/backdrop-dismissal.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  backdropRevertsThemePreview,
+  resolveBackdropDismissal,
+} from "./backdrop-dismissal.js";
+import { createInitialTuiState, type TuiSessionInfo, type TuiState } from "./tui-state.js";
+
+function session(): TuiSessionInfo {
+  return {
+    sessionId: "s1",
+    workingDir: "/tmp/w",
+    llamaUrl: "http://127.0.0.1:8080",
+    browserChannel: "chromium",
+    browserHeadless: true,
+    approvalLevel: 1,
+    maxSteps: 8,
+    skillCount: 0,
+  };
+}
+
+function stateWith(overrides: Partial<TuiState>): TuiState {
+  return { ...createInitialTuiState(session()), ...overrides };
+}
+
+describe("what a click outside closes", () => {
+  it("declines the event when nothing is open", () => {
+    // Returning an action here would make every stray click in the chat
+    // dispatch a close for a surface that is not there.
+    expect(resolveBackdropDismissal(stateWith({}))).toBeNull();
+  });
+
+  /**
+   * The reported bug. `modalOwnsInput` raises the mouse floor for all
+   * three pickers, so while one was open every control on screen stopped
+   * answering — and no target took the click that would have closed it
+   * either. The picker was not modal, it was a hole in the app that only
+   * the keyboard could climb out of.
+   */
+  it("closes the theme picker", () => {
+    expect(resolveBackdropDismissal(stateWith({ themePickerOpen: true }))).toEqual(
+      { type: "theme_picker_closed" },
+    );
+  });
+
+  it("closes the session picker", () => {
+    expect(
+      resolveBackdropDismissal(stateWith({ sessionPickerOpen: true })),
+    ).toEqual({ type: "session_picker_closed" });
+  });
+
+  it("closes the slash palette", () => {
+    expect(
+      resolveBackdropDismissal(stateWith({ slashPaletteOpen: true })),
+    ).toEqual({ type: "slash_palette_closed" });
+  });
+
+  it("still closes everything it closed before", () => {
+    expect(resolveBackdropDismissal(stateWith({ menuOpen: true }))).toEqual({
+      type: "menu_closed",
+    });
+    expect(
+      resolveBackdropDismissal(stateWith({ contextPanelOpen: true })),
+    ).toEqual({ type: "context_panel_closed" });
+  });
+
+  it("resolves a stack to one action, in the documented order", () => {
+    // The chain is defensive rather than descriptive: the menu closes
+    // itself before activating a node (`handleMenuKey` dispatches
+    // `menu_closed` and *then* calls `activate`), so a menu and a picker
+    // do not actually coexist. What the order guarantees is that a click
+    // never dispatches two closes, and never picks a surface that is not
+    // the frontmost one when they do overlap — the confirm ladder, which
+    // genuinely does open over the menu.
+    expect(
+      resolveBackdropDismissal(
+        stateWith({ menuOpen: true, contextPanelOpen: true }),
+      ),
+    ).toEqual({ type: "context_panel_closed" });
+    expect(
+      resolveBackdropDismissal(
+        stateWith({ menuOpen: true, themePickerOpen: true }),
+      ),
+    ).toEqual({ type: "menu_closed" });
+  });
+});
+
+describe("cancelling the theme picker puts the palette back", () => {
+  it("asks for a revert only for the theme picker", () => {
+    // The picker previews live, so a dismissal that skipped the revert
+    // would silently *apply* whatever the cursor was resting on — the
+    // opposite of a cancel.
+    expect(backdropRevertsThemePreview(stateWith({ themePickerOpen: true }))).toBe(
+      true,
+    );
+    expect(backdropRevertsThemePreview(stateWith({ menuOpen: true }))).toBe(false);
+    expect(backdropRevertsThemePreview(stateWith({}))).toBe(false);
+  });
+
+  it("does not revert when another surface wins the click", () => {
+    // The revert is keyed off the resolved action, not off
+    // `themePickerOpen`, so it can never fire for a click that closed
+    // something else and left the picker up.
+    expect(
+      backdropRevertsThemePreview(
+        stateWith({ themePickerOpen: true, contextPanelOpen: true }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/tui/backdrop-dismissal.ts
+++ b/src/tui/backdrop-dismissal.ts
@@ -1,0 +1,56 @@
+import type { TuiAction } from "./tui-action.js";
+import type { TuiState } from "./tui-state.js";
+
+/**
+ * Which surface a click outside every popup should close, and how.
+ *
+ * Extracted from the handler in `tui-app.tsx` because it is a *policy*
+ * — one ordered list of "what is open, and what cancels it" — and it was
+ * the half of that handler nothing could reach: the surrounding closure
+ * also does grace-period timing, wheel swallowing and a live-preview
+ * revert, none of which a test wants to stand up in order to ask which
+ * action a given state should produce.
+ *
+ * **The order is the precedence.** Surfaces stack — an uninstall confirm
+ * opens from the menu, the menu can open over the slash palette — and
+ * the innermost one is the one a click outside should take. That is why
+ * this is a chain rather than a lookup: the same click means "cancel the
+ * uninstall" and "leave the menu alone" at the same time.
+ *
+ * Returns `null` when nothing is open, which is the caller's signal to
+ * decline the event so it falls through to whatever is underneath.
+ */
+export function resolveBackdropDismissal(state: TuiState): TuiAction | null {
+  if (state.uninstall) return { type: "uninstall_closed" };
+  if (state.sessionDelete) return { type: "session_delete_closed" };
+  if (state.contextPanelOpen) return { type: "context_panel_closed" };
+  if (state.composerSwitch) return { type: "composer_switch_closed" };
+  if (state.menuOpen) return { type: "menu_closed" };
+  // The three pickers were missing from this list, and that is the whole
+  // bug: `modalOwnsInput` raises the mouse floor for them, so while one
+  // was open every control on screen stopped answering — and nothing
+  // took the click that would have closed it either. The picker was not
+  // "modal", it was a hole in the app that only the keyboard could climb
+  // out of.
+  if (state.themePickerOpen) return { type: "theme_picker_closed" };
+  if (state.sessionPickerOpen) return { type: "session_picker_closed" };
+  if (state.slashPaletteOpen) return { type: "slash_palette_closed" };
+  return null;
+}
+
+/**
+ * True when closing `state`'s frontmost surface has to put the palette
+ * back first.
+ *
+ * The theme picker previews live — the arrow keys swap the real theme so
+ * you can see it — so cancelling it is two steps, and the second one is
+ * not a reducer action: `setActiveTheme` is a module singleton, not
+ * state. Esc has always done both; a click outside has to as well, or
+ * dismissing the picker would silently *apply* whatever was under the
+ * cursor.
+ */
+export function backdropRevertsThemePreview(state: TuiState): boolean {
+  return (
+    resolveBackdropDismissal(state)?.type === "theme_picker_closed"
+  );
+}

--- a/src/tui/components/multi-line-editor-body.tsx
+++ b/src/tui/components/multi-line-editor-body.tsx
@@ -13,6 +13,8 @@ export interface EditorBodyProps {
   value: string;
   cursor: Cursor;
   placeholder: string;
+  /** Ink for the buffer text; inherits the terminal default when absent. */
+  textColor?: string;
   focus: boolean;
   /**
    * Selected span as buffer offsets, `[start, end)`, or `null`. Painted
@@ -65,6 +67,7 @@ export function EditorBody({
   value,
   cursor,
   placeholder,
+  textColor,
   focus,
   selection = null,
   onClickCursor,
@@ -173,6 +176,7 @@ export function EditorBody({
               line,
               cursorCol: idx === cursor.row ? cursor.col : -1,
               focus,
+              ...(textColor !== undefined ? { textColor } : {}),
               // Offsets of this line within the buffer, so the selection
               // (which is buffer-relative) can be clipped to it.
               lineStart: lineStarts[idx] ?? 0,
@@ -197,18 +201,24 @@ function renderLine({
   focus,
   lineStart,
   selection,
+  textColor,
 }: {
   line: string;
   cursorCol: number;
   focus: boolean;
   lineStart: number;
   selection: readonly [number, number] | null;
+  textColor?: string;
 }): ReactElement {
+  // One `color` on the wrapping `<Text>`: the inverse runs (selection,
+  // caret) inherit it and swap it against the ground themselves, so the
+  // highlight keeps working without a second colour to keep in sync.
+  const ink = textColor !== undefined ? { color: textColor } : {};
   const span = selection ? clipToLine(selection, lineStart, line.length) : null;
   if (span) {
     const [from, to] = span;
     return (
-      <Text>
+      <Text {...ink}>
         {line.slice(0, from)}
         <Text inverse>{line.slice(from, to)}</Text>
         {line.slice(to)}
@@ -216,13 +226,13 @@ function renderLine({
     );
   }
   if (cursorCol < 0 || !focus) {
-    return <Text>{line}</Text>;
+    return <Text {...ink}>{line}</Text>;
   }
   const before = line.slice(0, cursorCol);
   const atCursor = line[cursorCol] ?? " ";
   const after = line.slice(cursorCol + 1);
   return (
-    <Text>
+    <Text {...ink}>
       {before}
       <Text inverse>{atCursor}</Text>
       {after}

--- a/src/tui/components/multi-line-editor.tsx
+++ b/src/tui/components/multi-line-editor.tsx
@@ -11,6 +11,19 @@ import { createEditorPointer } from "./multi-line-editor-pointer.js";
 export interface MultiLineEditorProps {
   value: string;
   placeholder?: string;
+  /**
+   * Ink colour for the buffer's own text.
+   *
+   * Absent means "inherit the terminal's default foreground", which is
+   * right for every field drawn straight on the page — and wrong for
+   * any field sitting on a ground the *app* painted, because the two
+   * have no relationship. The composer is the second kind: it sits on
+   * `badgeBackground`, and on a light palette that is a light panel,
+   * so a terminal whose default ink is light (i.e. any dark terminal
+   * running `classic-light`) rendered light text on it. See
+   * `prompt-shell.tsx`.
+   */
+  textColor?: string;
   focus: boolean;
   /** Disable interaction (reject keys silently) — keeps focus state intact. */
   disabled?: boolean;
@@ -98,6 +111,7 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
   const {
     value,
     placeholder,
+    textColor,
     focus,
     disabled = false,
     onChange,
@@ -273,6 +287,7 @@ export function MultiLineEditor(props: MultiLineEditorProps): ReactElement {
       value={value}
       cursor={cursor}
       placeholder={placeholder ?? ""}
+      {...(textColor !== undefined ? { textColor } : {})}
       focus={focus && !disabled}
       selection={selection}
       onClickCursor={placeCursorAt}

--- a/src/tui/components/prompt-shell.tsx
+++ b/src/tui/components/prompt-shell.tsx
@@ -2,6 +2,7 @@ import { Box } from "ink";
 import type { ReactElement } from "react";
 import type { ComposerBackendMeta } from "../composer-switch/composer-switch-rows.js";
 import { useRotatingPlaceholder } from "../hooks/use-rotating-placeholder.js";
+import { readableOn } from "../theme/readable-foreground.js";
 import { theme } from "../theme/theme.js";
 import { ComposerSendButton } from "./composer-send-button.js";
 import { MultiLineEditor, type MultiLineEditorProps } from "./multi-line-editor.js";
@@ -118,6 +119,11 @@ export function PromptShell(props: PromptShellProps): ReactElement {
     ? (rotated ?? placeholder ?? "")
     : "";
   const accent = focus && !disabled ? theme.colors.accent : theme.colors.border;
+  // Measured, not assumed: `readableOn` weighs the panel's ground
+  // against both ends of the palette's chip pair and takes the better
+  // one, so the buffer stays legible whichever side of the line the
+  // active theme sits on.
+  const composerInk = readableOn(theme.colors.badgeBackground);
   // Send is live on exactly the condition Enter is: a non-blank buffer
   // in an editor that is accepting input. `handleEditorSubmit` drops a
   // blank buffer anyway, but a button that visibly does nothing when
@@ -132,10 +138,16 @@ export function PromptShell(props: PromptShellProps): ReactElement {
       {/*
         The design seats the composer on its own panel rather than on the
         page. `badgeBackground` is the palette's one-step-off-the-ground
-        surface, so the panel reads on every theme — and, unlike painting
-        it in the accent, it leaves the editor's own (uncoloured) text
-        legible, which matters because the buffer is drawn by
-        `MultiLineEditor` with no foreground of its own.
+        surface, so the panel reads on every theme.
+
+        It used to rely on the buffer being *uncoloured* — inheriting the
+        terminal's default ink — and that assumption only holds while the
+        panel and the terminal are on the same side of the light/dark
+        line. They need not be: `classic-light` paints `#dde4f4` here, so
+        anyone running a light palette in a dark terminal typed light
+        text onto a light panel and could not read what they were
+        writing. The ink is measured against the ground now, the same way
+        every chip does it.
       */}
       <Box
         borderStyle="round"
@@ -173,6 +185,7 @@ export function PromptShell(props: PromptShellProps): ReactElement {
           <Box flexGrow={1} flexShrink={1} minWidth={0} flexDirection="column">
             <MultiLineEditor
               {...editorProps}
+              textColor={composerInk}
               value={value}
               focus={focus}
               disabled={disabled}

--- a/src/tui/composer-ink.test.tsx
+++ b/src/tui/composer-ink.test.tsx
@@ -1,0 +1,106 @@
+import { Box } from "ink";
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+// Ink resolves chalk's colour level once, at import time, from the
+// terminal it thinks it has — and under a test runner that is none, so
+// every frame comes back stripped and every assertion below would be
+// vacuously true. `vi.hoisted` runs before the imports, which is the
+// only place the flag can still be read. Same trick as
+// `composer-meta-controls.test.tsx`.
+vi.hoisted(() => {
+  process.env["FORCE_COLOR"] = "3";
+});
+
+import { PromptShell } from "./components/prompt-shell.js";
+import { contrastRatio } from "./theme/color-contrast.js";
+import {
+  setActiveTheme,
+  THEMES,
+  THEME_NAMES,
+  type ThemeName,
+} from "./theme/theme.js";
+
+/** SGR truecolour foreground for `#rrggbb`. */
+function ink(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `[38;2;${r};${g};${b}m`;
+}
+
+function frameWith(value: string): string {
+  const { lastFrame, unmount } = render(
+    <Box width={80}>
+      <PromptShell
+        value={value}
+        onChange={() => {}}
+        onSubmit={() => {}}
+        focus
+        backend={null}
+        model={null}
+        provider={null}
+        leftSlot={null}
+        rightSlot={null}
+        contextSlot={null}
+        modeSlot={null}
+      />
+    </Box>,
+  );
+  const out = lastFrame() ?? "";
+  unmount();
+  return out;
+}
+
+/**
+ * The composer sits on a panel the *app* paints (`badgeBackground`), and
+ * the buffer used to be drawn with no foreground at all — inheriting the
+ * terminal's default ink. That only works while the panel and the
+ * terminal agree about which way round light and dark are, and they need
+ * not: `classic-light` paints a near-white panel, so anyone running a
+ * light palette in a dark terminal typed light text onto it and could
+ * not read what they were writing.
+ */
+describe("what colour the composer types in", () => {
+  it("gives the buffer an explicit colour on every palette", () => {
+    for (const name of THEME_NAMES) {
+      setActiveTheme(THEMES[name]);
+      const frame = frameWith("hello world");
+      const colors = THEMES[name].colors;
+      // `readableOn` picks whichever end of the chip pair reads better
+      // on the panel; whichever it picked has to actually be emitted.
+      const chosen =
+        contrastRatio(colors.badgeBackground, colors.chipBackground) >=
+        contrastRatio(colors.badgeBackground, colors.chipForeground)
+          ? colors.chipBackground
+          : colors.chipForeground;
+      expect(frame, `${name}: buffer text is uncoloured`).toContain(
+        `${ink(chosen)}hello world`,
+      );
+    }
+  });
+
+  it("keeps that colour readable against the panel it sits on", () => {
+    for (const name of THEME_NAMES) {
+      const colors = THEMES[name].colors;
+      const chosen =
+        contrastRatio(colors.badgeBackground, colors.chipBackground) >=
+        contrastRatio(colors.badgeBackground, colors.chipForeground)
+          ? colors.chipBackground
+          : colors.chipForeground;
+      const ratio = contrastRatio(chosen, colors.badgeBackground);
+      expect(ratio, `${name}: ${ratio.toFixed(2)}:1 on the composer panel`)
+        .toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it("picks dark ink on the light palette and light ink on the dark one", () => {
+    // The regression stated as the two cases that actually shipped.
+    const light = THEMES["classic-light" as ThemeName].colors;
+    const dark = THEMES["classic-dark" as ThemeName].colors;
+    setActiveTheme(THEMES["classic-light" as ThemeName]);
+    expect(frameWith("abc")).toContain(`${ink(light.chipBackground)}abc`);
+    setActiveTheme(THEMES["classic-dark" as ThemeName]);
+    expect(frameWith("abc")).toContain(`${ink(dark.chipBackground)}abc`);
+  });
+});

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -5,6 +5,10 @@ import {
   resolveCodingMode,
   type CodingMode,
 } from "./coding-mode.js";
+import {
+  backdropRevertsThemePreview,
+  resolveBackdropDismissal,
+} from "./backdrop-dismissal.js";
 import { CodingModeChip } from "./components/coding-mode-chip.js";
 import { OnboardingScreen } from "./components/onboarding-screen.js";
 import { TerminalTooSmall } from "./components/terminal-too-small.js";
@@ -988,7 +992,10 @@ export function TuiApp({
       state.contextPanelOpen ||
       state.composerSwitch !== null ||
       Boolean(state.uninstall) ||
-      Boolean(state.sessionDelete);
+      Boolean(state.sessionDelete) ||
+      state.themePickerOpen ||
+      state.sessionPickerOpen ||
+      state.slashPaletteOpen;
     if (!open) return false;
     if (hit.event.kind === "wheel") return true;
     if (!isPrimaryPress(hit.event)) return false;
@@ -1003,20 +1010,23 @@ export function TuiApp({
     }
     // Clicking away from a destructive confirmation cancels it — the
     // same dismissal the menu gets, and the safe outcome either way.
-    dispatch(
-      // A click outside is a cancel, which is the safe direction on
-      // every surface in this chain — including the uninstall ladder,
-      // where it is the same answer Esc gives.
-      state.uninstall
-        ? { type: "uninstall_closed" }
-        : state.sessionDelete
-          ? { type: "session_delete_closed" }
-          : state.contextPanelOpen
-            ? { type: "context_panel_closed" }
-            : state.composerSwitch
-              ? { type: "composer_switch_closed" }
-              : { type: "menu_closed" },
-    );
+    // A click outside is a cancel, which is the safe direction on every
+    // surface in this chain — including the uninstall ladder, where it
+    // is the same answer Esc gives.
+    const dismissal = resolveBackdropDismissal(state);
+    if (!dismissal) return false;
+    // The theme picker previews live, so cancelling it is two steps:
+    // put the palette back before closing, exactly as Esc does. Doing
+    // it here rather than in the reducer keeps the swap where every
+    // other theme swap already lives — `setActiveTheme` is a module
+    // singleton, not state.
+    if (
+      backdropRevertsThemePreview(state) &&
+      isThemeName(state.themePickerOriginal)
+    ) {
+      setActiveTheme(THEMES[state.themePickerOriginal]);
+    }
+    dispatch(dismissal);
     return true;
   };
   // Stamped when a backdrop-owning surface opens; read by the handler
@@ -1027,7 +1037,10 @@ export function TuiApp({
     state.contextPanelOpen ||
     state.composerSwitch !== null ||
     Boolean(state.uninstall) ||
-    Boolean(state.sessionDelete);
+    Boolean(state.sessionDelete) ||
+    state.themePickerOpen ||
+    state.sessionPickerOpen ||
+    state.slashPaletteOpen;
   useEffect(() => {
     if (backdropOwner) modalOpenedAtRef.current = Date.now();
   }, [backdropOwner]);


### PR DESCRIPTION
Two reports, both about a control that stops answering.

## The composer typed in the terminal's ink, not the theme's

The composer sits on a panel the app paints (`badgeBackground`), and the buffer was drawn with **no foreground at all**. `prompt-shell.tsx` said so in a comment, and called it a feature:

> …it leaves the editor's own (uncoloured) text legible, which matters because the buffer is drawn by `MultiLineEditor` with no foreground of its own.

That holds only while the panel and the terminal agree about which way round light and dark are — and they need not. `classic-light` paints `#dde4f4` there. **Anyone running a light palette in a dark terminal was typing light text onto a light panel** and could not read what they were writing.

The ink is measured now, not assumed: `readableOn` weighs the panel's ground against both ends of the palette's chip pair and takes the better one — the same rule the context chip and the approval buttons already use. On `classic-light` that picks `#0f1216`; on `classic-dark`, `#f1f3f8`.

`MultiLineEditor` gains an optional `textColor`. Absent still means "inherit", which is right for every field drawn straight on the page (the approval retarget field, the MCP modal); only the composer passes it.

## The theme picker took the mouse and gave nothing back

`modalOwnsInput` raises the mouse floor to the modal layer while the picker is open, so every control on screen stops answering. And the picker was **not in the backdrop's list**, so no target took the click that would have closed it either. Its own rows were clickable; everything else, including the way out, was not.

It wasn't modal so much as a hole in the app that only the keyboard could climb out of. The session picker and the slash palette had it too — all three join the backdrop, so a click outside cancels them the same way Esc does.

For the theme picker that is **two steps rather than one**: it previews live, so the palette is put back before the close, or dismissing it would silently *apply* whatever the cursor happened to be resting on.

## One refactor

The decision moved into `resolveBackdropDismissal`, a pure function over state. It was the one part of that handler nothing could reach — the surrounding closure also does grace-period timing, wheel swallowing and the preview revert, none of which a test wants to stand up in order to ask which action a given state should produce.

## Verification

```
npm run lint    clean
npm test        589 passed | 2 failed (591 files)
```

The two failures are the pre-existing sandbox pair (`fs-glob-real`, and an `EACCES` spawning a stub `llama-server`).

One note on the new test: `FORCE_COLOR` has to be set in `vi.hoisted`, because Ink resolves chalk's colour level once at import time and under a test runner that is "none". Without it every frame comes back stripped and the colour assertions pass while proving nothing — the same trap `composer-meta-controls.test.tsx` documents.
