### PR TITLE
feat(tui): the mode menu drops from the chip, and says everything in full

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Handy slash commands: `/help` lists every command, `/tools` lists the built-in t
 |---|---|
 | `default` | approvals follow the level set on the Privacy tab |
 | `plan` | read-only — every tool that would change something is refused, with a note telling the agent to present a plan instead. Reading, searching and fetching all still work. |
-| `accept edits` | file writes inside this workspace stop asking; everything else still does |
+| `auto` | file writes inside this workspace stop asking; everything else still does |
 | `bypass permissions` | nothing asks, for this session. Hardline shell-guard rules still block. |
 
 All four are session state and none are written to `config.json` — a `bypass` that survived a restart would be a standing grant nobody remembers making. `default` restores the level you actually configured, so a session that passed through `bypass` and back lands where it started. The cycle order keeps `plan` and `bypass` two presses apart in either direction.

--- a/src/tui/coding-mode-menu.test.tsx
+++ b/src/tui/coding-mode-menu.test.tsx
@@ -36,7 +36,7 @@ function apply(state: TuiState, action: Parameters<typeof reduceUiAction>[1]): T
  * measures to nothing and every assertion below would read an empty
  * string.
  */
-function frame(cursor: number, columns = 70, rows = 12): string {
+function frame(cursor: number, columns = 76, rows = 12): string {
   const { lastFrame, unmount } = render(
     <Box flexDirection="column" position="relative" width={columns} height={rows}>
       {Array.from({ length: rows }, (_unused, row) => (
@@ -60,19 +60,44 @@ function frame(cursor: number, columns = 70, rows = 12): string {
  * The chip used to advance the ring on click. That made the one control
  * that changes what the agent is *allowed to do* the only one with no
  * confirmation and no explanation — two stray clicks took you from
- * `plan` to `accept edits` with nothing on screen saying what either
+ * `plan` to `auto` with nothing on screen saying what either
  * meant.
  */
 describe("the coding-mode menu", () => {
-  it("lists every mode with what it means", () => {
+  it("shows every description in full, never truncated", () => {
+    // The whole reason the menu exists. A description with its end
+    // shaved off reads as a rendering bug and still does not answer the
+    // question — so the menu is sized from its content rather than the
+    // content being cut to fit the menu.
     const body = frame(0);
     for (const mode of CODING_MODES) {
       const look = codingModeLook(mode);
       expect(body, `${mode} label`).toContain(look.label);
-      // The explanation is the whole reason the menu exists; a row
-      // showing only a name would be the chip again, with extra steps.
-      expect(body, `${mode} detail`).toContain(look.detail.slice(0, 18));
+      expect(body, `${mode} detail`).toContain(look.detail);
     }
+    expect(body).not.toContain("…");
+  });
+
+  it("stacks the description rather than cutting it when the pane is narrow", () => {
+    // Too narrow for two columns is not a licence to truncate: the
+    // detail moves to its own indented line and stays whole.
+    const body = frame(0, 40, 14);
+    for (const mode of CODING_MODES) {
+      expect(body, `${mode} detail`).toContain(codingModeLook(mode).detail);
+    }
+    expect(body).not.toContain("…");
+  });
+
+  it("hangs off the right edge, where the chip is", () => {
+    // The chip sits at the far end of the composer's bar. A menu that
+    // dropped from the opposite corner would read as belonging to
+    // something else.
+    const columns = 90;
+    const lines = frame(0, columns, 12).split("\n");
+    const top = lines.find((l) => l.includes("╭"));
+    expect(top).toBeDefined();
+    const right = (top as string).indexOf("╮");
+    expect(right).toBeGreaterThanOrEqual(columns - 2);
   });
 
   it("marks the mode in force", () => {
@@ -81,7 +106,7 @@ describe("the coding-mode menu", () => {
 
   it("keeps the four rows even when the pane is too short for chrome", () => {
     // Title and footer are ornament; the rows are the content.
-    const short = frame(0, 70, 6);
+    const short = frame(0, 76, 6);
     for (const mode of CODING_MODES) {
       expect(short, `${mode} survived`).toContain(codingModeLook(mode).label);
     }
@@ -101,11 +126,11 @@ describe("driving the menu", () => {
     // The menu opens as a statement of where you are before it is a list
     // of where you could go.
     const state = apply(
-      stateWith({ codingMode: "accept-edits" }),
+      stateWith({ codingMode: "auto" }),
       { type: "coding_mode_menu_opened" },
     );
     expect(state.codingModeMenu?.cursor).toBe(
-      CODING_MODES.indexOf("accept-edits"),
+      CODING_MODES.indexOf("auto"),
     );
   });
 

--- a/src/tui/coding-mode.test.ts
+++ b/src/tui/coding-mode.test.ts
@@ -17,7 +17,7 @@ describe("the coding-mode ring", () => {
     expect([...CODING_MODES]).toEqual([
       "default",
       "plan",
-      "accept-edits",
+      "auto",
       "bypass",
     ]);
     // The ring *wraps*, which is what makes severity order wrong: it
@@ -75,14 +75,14 @@ describe("what a mode means to the runtime", () => {
     }
   });
 
-  it("raises to workspace writes for accept-edits, and never lowers", () => {
-    expect(resolveCodingMode("accept-edits", 1).approvalLevel).toBe(2);
-    expect(resolveCodingMode("accept-edits", 2).approvalLevel).toBe(2);
-    // Someone already at 4 asking for accept-edits is asking for at
+  it("raises to workspace writes for auto, and never lowers", () => {
+    expect(resolveCodingMode("auto", 1).approvalLevel).toBe(2);
+    expect(resolveCodingMode("auto", 2).approvalLevel).toBe(2);
+    // Someone already at 4 asking for auto is asking for at
     // least that. Clamping them down to 2 would surprise them in the
     // direction that costs prompts.
-    expect(resolveCodingMode("accept-edits", 4).approvalLevel).toBe(4);
-    expect(resolveCodingMode("accept-edits", 5).approvalLevel).toBe(5);
+    expect(resolveCodingMode("auto", 4).approvalLevel).toBe(4);
+    expect(resolveCodingMode("auto", 5).approvalLevel).toBe(5);
   });
 
   it("opens the ladder all the way for bypass", () => {

--- a/src/tui/coding-mode.ts
+++ b/src/tui/coding-mode.ts
@@ -19,12 +19,12 @@ import {
  * approval level and a plan-mode flag; nothing else in the app learns a
  * new concept, and the Privacy tab keeps working exactly as it did.
  */
-export type CodingMode = "default" | "accept-edits" | "plan" | "bypass";
+export type CodingMode = "default" | "plan" | "auto" | "bypass";
 
 /**
  * Cycle order, and it is not the order of severity.
  *
- * Severity order — `plan, default, accept-edits, bypass` — reads well
+ * Severity order — `plan, default, auto, bypass` — reads well
  * and is wrong, because the ring *wraps*: on four modes it leaves
  * `bypass` one backward press from `plan`, which is exactly where a
  * careful operator parks. Two keys apart is the most a four-ring
@@ -36,7 +36,7 @@ export type CodingMode = "default" | "accept-edits" | "plan" | "bypass";
 export const CODING_MODES: readonly CodingMode[] = [
   "default",
   "plan",
-  "accept-edits",
+  "auto",
   "bypass",
 ];
 
@@ -44,13 +44,18 @@ export interface CodingModeLook {
   /** What the chip prints. */
   readonly label: string;
   /**
-   * The second column of the menu: what picking this row would mean, in
-   * few enough words to sit beside the label without wrapping.
+   * The second column of the menu: what picking this row would mean.
+   *
+   * Kept short enough that the menu can be sized to show all four in
+   * full — the popup measures these rather than truncating them, so a
+   * long one here does not get an ellipsis, it makes the whole menu
+   * wider. An explanation with its end cut off is worse than no
+   * explanation: it reads as a bug and it still does not answer the
+   * question.
    *
    * Separate from `summary` on purpose. The summary is a sentence the
    * chat log prints once, after the fact; this is a label read *while
-   * deciding*, next to three alternatives, and the two jobs want very
-   * different lengths.
+   * deciding*, next to three alternatives.
    */
   readonly detail: string;
   /** Which palette role paints the chip's ground. */
@@ -62,27 +67,27 @@ export interface CodingModeLook {
 const LOOKS: Readonly<Record<CodingMode, CodingModeLook>> = {
   plan: {
     label: "plan",
-    detail: "reads only — proposes, changes nothing",
+    detail: "reads only, then proposes",
     tone: "accent",
     summary:
       "plan mode — the agent reads and proposes, and every tool that would change something is refused",
   },
   default: {
     label: "default",
-    detail: "asks before anything risky",
+    detail: "asks before risky steps",
     tone: "success",
     summary: "default — approvals follow the level set on the Privacy tab",
   },
-  "accept-edits": {
-    label: "accept edits",
-    detail: "writes in this folder without asking",
+  auto: {
+    label: "auto",
+    detail: "edits this folder freely",
     tone: "warn",
     summary:
-      "accept edits — file writes inside this workspace stop asking; everything else still does",
+      "auto — file writes inside this workspace stop asking; everything else still does",
   },
   bypass: {
     label: "bypass permissions",
-    detail: "never asks — nothing is gated",
+    detail: "never asks at all",
     tone: "error",
     summary:
       "bypass permissions — nothing asks, for the rest of this session. Hardline shell-guard rules still block.",
@@ -108,10 +113,10 @@ export interface ResolvedCodingMode {
  * started from, not on a hardcoded 1, or the control would quietly
  * tighten every operator who had chosen otherwise.
  *
- * `accept-edits` raises to level 2 (workspace file writes stop asking)
- * but never *lowers*: an operator already at 4 who asks for accept-edits
- * is asking for at least that, and clamping them down to 2 would be a
- * surprise in the direction that costs them prompts.
+ * `auto` raises to level 2 (workspace file writes stop asking) but never
+ * *lowers*: an operator already at 4 who asks for auto is asking for at
+ * least that, and clamping them down to 2 would be a surprise in the
+ * direction that costs them prompts.
  */
 export function resolveCodingMode(
   mode: CodingMode,
@@ -124,7 +129,7 @@ export function resolveCodingMode(
       // moot — and leaving it alone is what lets `default` restore it
       // without remembering anything extra.
       return { approvalLevel: baseLevel, planMode: true };
-    case "accept-edits":
+    case "auto":
       return {
         approvalLevel: clampApprovalLevel(Math.max(baseLevel, 2)),
         planMode: false,

--- a/src/tui/commands/slash-command-handler.ts
+++ b/src/tui/commands/slash-command-handler.ts
@@ -1,4 +1,8 @@
-import { CODING_MODES, codingModeLook } from "../coding-mode.js";
+import {
+  CODING_MODES,
+  codingModeLook,
+  type CodingMode,
+} from "../coding-mode.js";
 import type { WhileBusySubmitMode } from "../../config/index.js";
 import type { TuiAction } from "../tui-action.js";
 import { normalizeLocalLlmBaseUrl } from "../persist-user-local-models-config.js";
@@ -373,9 +377,13 @@ function dispatchSteerSub(args: string): SlashDispatchResult {
  * one path that skips it — a name typed in full is already a decision,
  * and making it open a menu to confirm what it just said would be a
  * second question about a settled matter. Names are matched on the
- * chip's own label as well as the identifier, because "accept edits" is
- * what the operator can see and `accept-edits` is what the code calls
- * it, and being told the visible name is wrong would be absurd.
+ * chip's own label as well as the identifier, because the label is what
+ * the operator can see and being told the visible name is wrong would
+ * be absurd.
+ *
+ * `accept-edits` still resolves to `auto`: it was the name this mode
+ * shipped under, and a rename is not a reason to reject a word somebody
+ * already learned.
  */
 function dispatchModeSub(args: string): SlashDispatchResult {
   const raw = args.trim().toLowerCase();
@@ -386,11 +394,15 @@ function dispatchModeSub(args: string): SlashDispatchResult {
     return pureActions([{ type: "coding_mode_menu_opened" }]);
   }
   const wanted = raw.replace(/[\s_]+/g, "-");
-  const match = CODING_MODES.find(
-    (mode) =>
-      mode === wanted ||
-      codingModeLook(mode).label.replace(/\s+/g, "-") === wanted,
-  );
+  const RETIRED_NAMES: Readonly<Record<string, CodingMode>> = {
+    "accept-edits": "auto",
+  };
+  const match =
+    CODING_MODES.find(
+      (mode) =>
+        mode === wanted ||
+        codingModeLook(mode).label.replace(/\s+/g, "-") === wanted,
+    ) ?? RETIRED_NAMES[wanted];
   if (!match) {
     return pureActions([], {
       systemMessage: `unknown mode: ${args.trim()} — try ${CODING_MODES.join(", ")}`,

--- a/src/tui/components/coding-mode-chip.tsx
+++ b/src/tui/components/coding-mode-chip.tsx
@@ -17,7 +17,7 @@ import { theme } from "../theme/theme.js";
  * to do, so it wants the end position, where the eye stops.
  *
  * **Colour carries the meaning, not just the word.** `default` is the
- * palette's success tone, `accept edits` its warn, `bypass permissions`
+ * palette's success tone, `auto` its warn, `bypass permissions`
  * its error. That is not decoration: a chip a person stops reading after
  * the first week still has to say "you are not in normal mode" from
  * across the room, and on a strip this dense the word alone does not.

--- a/src/tui/components/coding-mode-popup.tsx
+++ b/src/tui/components/coding-mode-popup.tsx
@@ -16,10 +16,39 @@ import { MOUSE_LAYER_MODAL } from "../mouse/mouse-registry.js";
 import { chromeTheme } from "../theme/theme.js";
 import { fitToWidth } from "./fit-to-width.js";
 
-/** Popup width, clamped to the pane on narrow windows. */
-const PREFERRED_WIDTH = 52;
-/** Column reserved for the mode name, so the details form a column. */
-const LABEL_WIDTH = 22;
+/**
+ * Width of the label column: the longest mode name plus the marker,
+ * the check and the two gutter spaces around them. Measured rather
+ * than guessed, so renaming a mode cannot silently clip it.
+ */
+const LABEL_WIDTH =
+  Math.max(...CODING_MODES.map((mode) => codingModeLook(mode).label.length)) + 6;
+
+/**
+ * The narrowest the menu may get before it stops laying the detail
+ * beside the label. Below this the two columns are fighting, and a
+ * stacked row reads better than a squeezed one.
+ */
+const MIN_TWO_COLUMN_WIDTH = 34;
+
+/**
+ * Columns the menu needs to show every row in full: the label column
+ * plus the longest detail plus its leading space.
+ *
+ * The menu is sized from its content instead of the content being cut to
+ * a fixed width. An explanation with its end shaved off is worse than no
+ * explanation — it reads as a rendering bug, and it still does not answer
+ * the question the menu exists to answer.
+ */
+export function codingMenuContentWidth(): number {
+  // +1 for the space before the detail, +1 for a trailing gutter so the
+  // longest line does not sit flush against the right border, +2 for
+  // the border columns themselves.
+  const detail =
+    Math.max(...CODING_MODES.map((mode) => codingModeLook(mode).detail.length)) +
+    2;
+  return LABEL_WIDTH + detail + 2;
+}
 
 export interface CodingModePopupProps {
   /** Highlighted row, an index into {@link CODING_MODES}. */
@@ -44,7 +73,7 @@ export interface CodingModePopupProps {
  * The chip used to cycle the ring on click. That made the one control in
  * the app that changes what the agent is *allowed to do* also the only
  * one with no confirmation and no explanation: two stray clicks took you
- * from `plan` to `accept edits`, and nothing on screen said what either
+ * from `plan` to `auto`, and nothing on screen said what either
  * of them meant. A menu costs one extra click and buys the four
  * sentences that make the choice a choice.
  *
@@ -62,20 +91,34 @@ export function CodingModePopup({
   availableColumns,
   onActivate,
 }: CodingModePopupProps): ReactElement {
-  const width = Math.max(24, Math.min(PREFERRED_WIDTH, availableColumns - 2));
+  // Content-sized, then clamped to the pane. Wanting more room than the
+  // terminal has is the one case the detail cannot be shown beside the
+  // label, and `stacked` is what handles it — by giving the detail its
+  // own line, never by truncating it.
+  const wanted = codingMenuContentWidth();
+  const width = Math.max(24, Math.min(wanted, availableColumns - 2));
+  const stacked = width < Math.min(wanted, MIN_TWO_COLUMN_WIDTH)
+    || width < wanted;
   // Interior columns between the two border columns. Ink's `paddingX` is
   // not painted by our rows — it leaves real gaps — so the one-column
   // gutter is baked into every string instead.
   const inner = width - 2;
   // Title and footer are ornament: on a pane too short for them the four
   // rows are what has to survive, because they are the actual content.
-  const chromeSlots = Math.min(2, Math.max(0, availableRows - 2 - CODING_MODES.length));
+  const bodyRows = CODING_MODES.length * (stacked ? 2 : 1);
+  const chromeSlots = Math.min(2, Math.max(0, availableRows - 2 - bodyRows));
   const showTitle = chromeSlots >= 1;
   const showFooter = chromeSlots >= 2;
-  const height = 2 + chromeSlots + CODING_MODES.length;
+  const height = 2 + chromeSlots + bodyRows;
   return (
     <PopupFrame
       offsetTop={Math.max(0, availableRows - height)}
+      // Right-aligned, because the control that opens it is: the chip
+      // sits at the far end of the composer's bar, and a menu that
+      // dropped from the opposite corner would read as belonging to
+      // something else. `ComposerSwitchPopup` hangs left for exactly the
+      // same reason — its controls are at the bar's left end.
+      offsetLeft={Math.max(0, availableColumns - width)}
       width={width}
     >
       {showTitle ? (
@@ -90,6 +133,7 @@ export function CodingModePopup({
           inner={inner}
           selected={idx === cursor}
           active={mode === active}
+          stacked={stacked}
           onActivate={onActivate}
         />
       ))}
@@ -109,10 +153,12 @@ export function CodingModePopup({
  */
 function PopupFrame({
   offsetTop,
+  offsetLeft,
   width,
   children,
 }: {
   offsetTop: number;
+  offsetLeft: number;
   width: number;
   children: ReactNode;
 }): ReactElement {
@@ -127,6 +173,7 @@ function PopupFrame({
       ref={ref}
       position="absolute"
       marginTop={offsetTop}
+      marginLeft={offsetLeft}
       borderStyle="round"
       borderColor={chromeTheme.colors.railMuted}
       backgroundColor={chromeTheme.colors.railBackground}
@@ -143,36 +190,52 @@ function ModeRow({
   inner,
   selected,
   active,
+  stacked,
   onActivate,
 }: {
   mode: CodingMode;
   inner: number;
   selected: boolean;
   active: boolean;
+  /** Detail on its own line, for a pane too narrow for two columns. */
+  stacked: boolean;
   onActivate: (mode: CodingMode) => void;
 }): ReactElement {
   const look = codingModeLook(mode);
   const marker = selected ? chromeTheme.glyphs.menuCursor : " ";
   const check = active ? `${chromeTheme.glyphs.check} ` : "";
-  const label = fitToWidth(
-    ` ${marker} ${check}${look.label}`,
-    Math.min(LABEL_WIDTH, inner),
-  );
-  const detail = fitToWidth(
-    ` ${look.detail}`,
-    Math.max(0, inner - label.length),
-  );
-  const body = (
-    <>
-      {/*
-        Selection is weight plus the marker, not a second colour: on a
-        painted panel a colour swap either fights the ground or is too
-        faint to see, and the marker is the part that survives NO_COLOR.
-      */}
+  const labelText = ` ${marker} ${check}${look.label}`;
+  /*
+    Selection is weight plus the marker, not a second colour: on a
+    painted panel a colour swap either fights the ground or is too faint
+    to see, and the marker is the part that survives NO_COLOR.
+  */
+  const body = stacked ? (
+    <Box flexDirection="column">
       <Text color={chromeTheme.colors.railForeground} bold={selected}>
-        {label}
+        {fitToWidth(labelText, inner)}
       </Text>
-      <Text color={chromeTheme.colors.railMuted}>{detail}</Text>
+      {/*
+        Indented under the label rather than beside it. The detail is
+        still shown in full — that is the whole point of stacking rather
+        than truncating — and `fitToWidth` here only pads it out to the
+        panel's ground.
+      */}
+      <Text color={chromeTheme.colors.railMuted}>
+        {fitToWidth(`     ${look.detail}`, inner)}
+      </Text>
+    </Box>
+  ) : (
+    <>
+      <Text color={chromeTheme.colors.railForeground} bold={selected}>
+        {fitToWidth(labelText, Math.min(LABEL_WIDTH, inner))}
+      </Text>
+      <Text color={chromeTheme.colors.railMuted}>
+        {fitToWidth(
+          ` ${look.detail}`,
+          Math.max(0, inner - Math.min(LABEL_WIDTH, inner)),
+        )}
+      </Text>
     </>
   );
   const mouse = useMouseCommands();

--- a/src/tui/menu/menu-registry.test.ts
+++ b/src/tui/menu/menu-registry.test.ts
@@ -54,7 +54,7 @@ const V0_2_2_SLASH_COMMANDS = [
   {
     name: "mode",
     description:
-      "open the coding-mode menu: default · plan · accept edits · bypass permissions · `/mode <name>` sets one directly",
+      "open the coding-mode menu: default · plan · auto · bypass permissions · `/mode <name>` sets one directly",
   },
   {
     name: "quit",

--- a/src/tui/menu/menu-registry.ts
+++ b/src/tui/menu/menu-registry.ts
@@ -451,7 +451,7 @@ export const MENU: readonly MenuNode[] = [
     slash: {
       name: "mode",
       description:
-        "open the coding-mode menu: default · plan · accept edits · bypass permissions · `/mode <name>` sets one directly",
+        "open the coding-mode menu: default · plan · auto · bypass permissions · `/mode <name>` sets one directly",
       rank: 6,
     },
   },

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -613,7 +613,7 @@ export interface TuiState {
    * Clicking the chip used to advance the ring directly, which made the
    * one control that changes what the agent is allowed to do the only
    * control in the app with no confirmation and no explanation — two
-   * stray clicks took you from `plan` to `accept edits` with nothing on
+   * stray clicks took you from `plan` to `auto` with nothing on
    * screen saying what either meant.
    */
   codingModeMenu: { readonly cursor: number } | null;


### PR DESCRIPTION
Three notes from using the menu.

## It dropped from the wrong corner

The menu hung at the **left** edge of the content pane while the chip that opens it sits at the far **right** of the composer's bar — so the thing that appeared was nowhere near the thing that was clicked. It is right-aligned now.

`ComposerSwitchPopup` keeps hanging left for exactly the same reason: *its* controls are at the bar's left end. The rule is "under the control", not "on a side".

## `accept edits` → `auto`

Shorter, and it is the word people already use. `/mode accept-edits` still resolves — a rename is not a reason to reject a name somebody already learned.

## The descriptions were being cut

Every one ended in an ellipsis at the widths the menu actually opened at, which is the worst of both worlds: it reads as a rendering bug **and** it still does not answer the question the menu exists to answer.

Two changes, and the order matters:

1. The text got shorter — `reads only — proposes, changes nothing` → `reads only, then proposes`.
2. **The menu is now sized from its content**, rather than the content being cut to fit the menu. `codingMenuContentWidth()` measures the longest label and the longest detail; `LABEL_WIDTH` is derived from the mode names instead of hardcoded, so renaming a mode cannot silently clip it again.

Shortening alone would have been a fix that lasted until the next edit.

```
╭───────────────────────────────────────────────────╮
│ CODING MODE                                       │
│   ✓ default             asks before risky steps   │
│ ▶ plan                  reads only, then proposes │
│   auto                  edits this folder freely  │
│   bypass permissions    never asks at all         │
│ ↑↓ move · enter apply · esc cancel                │
╰───────────────────────────────────────────────────╯
```

On a pane too narrow for two columns the detail moves to its own indented line instead of being truncated — still whole, just stacked. That is the one case the old code had no answer for, and truncation is what it reached for.

## Verification

Tested at 76 and 40 columns: every description appears **in full** at both, and no frame contains an ellipsis. Plus a test that the popup's right edge lands at the pane's right edge.

```
npm run lint    clean
npm test        592 passed | 2 failed (594 files)
```

Two pre-existing sandbox failures (`fs-glob-real`, and a `sidecar` concurrency test that fails identically on clean `main`).
