### PR TITLE
Retry transient failures in os.http.request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,27 @@ non-429 untouched, old-curl tolerance),
 [warn-missing-search-key.test.ts](src/tools/os/web-search/tool/warn-missing-search-key.test.ts),
 and [web-search-tool.test.ts](src/tools/os/web-search/tool/web-search-tool.test.ts)
 ("warns once at construction, not once per search").
+## HTTP retry contract
+
+`os.web.fetch` and `os.http.request` both retry transient failures
+(429/502/503/504 plus curl's timeout exit 28) with exponential backoff capped
+at `retryMaxDelayMs`, honouring a server-sent `Retry-After`. The RFC 9110
+value grammar lives once in [retry-after-header.ts](src/tools/os/retry-after-header.ts)
+— both tools read the header off curl differently (`%{header_json}` vs
+`%header{retry-after}`) but normalise it through the same parser.
+
+**`os.http.request` additionally guards non-idempotent methods.** Unlike
+`web.fetch`, it can POST. An origin may already have processed a request whose
+response never arrived, so a blind replay risks a double submit — the one
+failure mode a retry layer must not introduce. A GET is replayed on any
+retryable status or a timeout; a POST is replayed **only** on 429/503 that also
+carries a `Retry-After`, which is an explicit "I did not process this, come
+back". A bare 502/504 or a timeout on a POST is returned as-is.
+
+Pinned by [http-request-retry.test.ts](src/tools/os/http-request-retry.test.ts)
+(retryable statuses, `Retry-After` precedence and clamping, give-up, stable-4xx
+passthrough, timeout handling, and the four non-idempotent-method safety cases)
+and [retry-after-header.test.ts](src/tools/os/retry-after-header.test.ts).
 
 ## Build & test
 

--- a/src/tools/os/http-request-fetch.ts
+++ b/src/tools/os/http-request-fetch.ts
@@ -84,6 +84,18 @@ export interface GuardedCurlResponse {
   redirectChain: string[];
   /** Server-sent `Retry-After` in ms, `null` when absent or unparseable. */
   retryAfterMs: number | null;
+  /**
+   * Method actually used on the hop that produced this response. A 307/308
+   * preserves the original method, so a POST can still be a POST several hops
+   * in; a 301/302/303 downgrades to GET. The retry decision must key off this
+   * rather than the caller's method, or a redirected POST gets replayed.
+   */
+  finalMethod: HttpMethod;
+  /**
+   * Body sent on that same hop — `undefined` once a 301/302/303 has dropped
+   * it. Carried so a retry resumes with the hop's own payload.
+   */
+  finalBody: string | undefined;
   /** Last curl argv (for diagnostics). */
   command: string[];
 }
@@ -113,11 +125,16 @@ export async function executeGuardedHttpRequest(
   const retry = opts.retry ?? DEFAULT_HTTP_RETRY_CONFIG;
   const sleep = opts.sleep ?? defaultSleep;
 
+  // Where the next attempt starts. A retry resumes at the hop that failed
+  // rather than re-walking the redirect chain from the caller's URL.
+  let resumeUrl = rawUrl;
+  let resume: { method: HttpMethod; body: string | undefined } | undefined;
+
   for (let attempt = 0; ; attempt++) {
     let response: GuardedCurlResponse | null = null;
     let failure: unknown = null;
     try {
-      response = await sendGuardedRequestOnce(rawUrl, args, opts);
+      response = await sendGuardedRequestOnce(resumeUrl, args, opts, resume);
     } catch (err) {
       // Only a curl timeout is worth another attempt; a missing binary, an
       // SSRF rejection, or an aborted run must surface immediately.
@@ -130,8 +147,15 @@ export async function executeGuardedHttpRequest(
       failure = err;
     }
 
+    // A redirect can carry the original method forward (307/308) or downgrade
+    // it (301/302/303), so the replay-safety question is about the method that
+    // actually ran, not the one the caller passed in. On a transport failure
+    // there is no response to read it from; fall back to the caller's method,
+    // which is the conservative choice (a POST stays non-idempotent).
+    const effectiveMethod = response?.finalMethod ?? args.method;
+
     const exhausted = attempt >= retry.maxRetries || opts.signal.aborted;
-    if (exhausted || !isRetryableAttempt(args.method, response, failure)) {
+    if (exhausted || !isRetryableAttempt(effectiveMethod, response, failure)) {
       if (response !== null) return response;
       throw failure;
     }
@@ -140,6 +164,18 @@ export async function executeGuardedHttpRequest(
       httpBackoffDelayMs(attempt, response?.retryAfterMs ?? null, retry),
       opts.signal,
     );
+
+    // The sleep resolves on abort rather than rejecting, so re-check here.
+    // Without this an Esc during the backoff still spawns one more curl.
+    if (opts.signal.aborted) {
+      if (response !== null) return response;
+      throw failure;
+    }
+
+    if (response !== null) {
+      resumeUrl = response.finalUrl;
+      resume = { method: response.finalMethod, body: response.finalBody };
+    }
   }
 }
 
@@ -151,6 +187,10 @@ export async function executeGuardedHttpRequest(
  * — a `Retry-After` alongside 429/503 — because the origin may already have
  * processed a request whose response never arrived. A bare 502/504 or a
  * timeout on a POST is therefore returned as-is rather than double-submitted.
+ *
+ * `method` is the method of the hop that actually ran, not the caller's: a
+ * 307/308 carries a POST forward, so replaying the chain would re-submit the
+ * body even though the request "started" as a redirect follow.
  */
 function isRetryableAttempt(
   method: HttpMethod,
@@ -204,11 +244,15 @@ async function sendGuardedRequestOnce(
   rawUrl: string,
   args: HttpRequestArgs,
   opts: ExecuteGuardedHttpOptions,
+  resume?: { method: HttpMethod; body: string | undefined },
 ): Promise<GuardedCurlResponse> {
   const runCommand = opts.runCommand ?? defaultRunCommand;
   let currentUrl = parseHttpUrl(rawUrl);
-  let method = args.method;
-  let body = args.body;
+  // A retry resumes at the hop that failed, with the method and body that hop
+  // actually used. Restarting from the caller's method would re-send a body a
+  // 303 had already dropped, and re-walk redirects the origin already served.
+  let method = resume?.method ?? args.method;
+  let body = resume ? resume.body : args.body;
   const chain: string[] = [];
   let lastCommand: string[] = [];
   let truncated = false;
@@ -287,6 +331,8 @@ async function sendGuardedRequestOnce(
       truncated,
       redirectChain: chain,
       retryAfterMs: parseRetryAfterValueMs(parsed.retryAfter),
+      finalMethod: method,
+      finalBody: body,
       command: lastCommand,
     };
   }
@@ -345,7 +391,11 @@ function buildPinnedCurlArgs(input: BuildPinnedCurlArgs): string[] {
   argv.push(
     "-w",
     `\n${CURL_META_MARKER}%{http_code}|%{content_type}|%{size_download}|` +
-      `%{time_total}|%{redirect_url}|%header{retry-after}`,
+      // `redirect_url` goes last: it is the one field whose value can contain
+      // a literal `|` (RFC 3986 disallows it, but origins emit it and curl
+      // reports it verbatim). Anything after it would be shifted out of place,
+      // so nothing follows it.
+      `%{time_total}|%header{retry-after}|%{redirect_url}`,
   );
   argv.push("--", input.url.toString());
   return argv;
@@ -377,14 +427,17 @@ export function parseCurlOutput(stdout: string): CurlParsedOutput {
   }
   const body = stdout.slice(0, markerIdx).replace(/\n$/, "");
   const meta = stdout.slice(markerIdx + CURL_META_MARKER.length).trim();
+  // `redirect_url` is last and may itself contain `|`, so split off only the
+  // fixed leading fields and keep the remainder intact as the URL.
   const [
     statusStr = "",
     contentType = "",
     sizeStr = "",
     timeStr = "",
-    redirectUrl = "",
     retryAfterRaw = "",
+    ...redirectRest
   ] = meta.split("|");
+  const redirectUrl = redirectRest.join("|");
   const status = Number.parseInt(statusStr, 10);
   const sizeDownload = Number.parseInt(sizeStr, 10);
   const timeTotal = Number.parseFloat(timeStr);

--- a/src/tools/os/http-request-fetch.ts
+++ b/src/tools/os/http-request-fetch.ts
@@ -3,6 +3,7 @@ import {
   type CommandResult,
 } from "../../sandbox/command-runner.js";
 import { CurlUnavailableError, isCurlMissingError } from "./ensure-curl.js";
+import { parseRetryAfterValueMs } from "./retry-after-header.js";
 import {
   assertHostAllowed,
   formatResolveEntry,
@@ -20,6 +21,47 @@ export const CURL_META_MARKER = "__ATOMIC_CURL_META__";
 
 const MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Statuses worth a second attempt: transient-by-contract, and the same set
+ * `os.web.fetch` retries. Everything else — 404, 403, 400 — is a stable
+ * answer that a repeat would only re-spend task budget on.
+ */
+const RETRYABLE_STATUSES = new Set([429, 502, 503, 504]);
+
+/**
+ * Statuses at which a server is explicitly asking the client to come back.
+ * A non-idempotent request is only retried on these, and only when the
+ * server also sent a `Retry-After` (see `isRetryableAttempt`).
+ */
+const INVITED_RETRY_STATUSES = new Set([429, 503]);
+
+/** curl's "operation timed out" exit. The other exits are not transient. */
+const CURL_EXIT_TIMEOUT = 28;
+
+/**
+ * Methods that are safe to replay. A GET carries no side effect, so a repeat
+ * is free. A POST may already have been processed by the origin even when the
+ * response never arrived, so replaying it blindly risks a double submit — the
+ * one failure mode a retry layer must not introduce.
+ */
+const IDEMPOTENT_METHODS = new Set<HttpMethod>(["GET"]);
+
+export interface HttpRetryConfig {
+  /** Extra attempts on top of the first. `0` disables retrying. */
+  maxRetries: number;
+  /** First backoff step; each subsequent retry doubles it. */
+  retryBaseDelayMs: number;
+  /** Ceiling on any single wait, including a server-sent `Retry-After`. */
+  retryMaxDelayMs: number;
+}
+
+/** Mirrors `web.fetch`'s retry defaults so the two tools behave alike. */
+export const DEFAULT_HTTP_RETRY_CONFIG: HttpRetryConfig = {
+  maxRetries: 2,
+  retryBaseDelayMs: 500,
+  retryMaxDelayMs: 5_000,
+};
 
 export type HttpMethod = "GET" | "POST";
 
@@ -40,6 +82,8 @@ export interface GuardedCurlResponse {
   timeTotal: number;
   truncated: boolean;
   redirectChain: string[];
+  /** Server-sent `Retry-After` in ms, `null` when absent or unparseable. */
+  retryAfterMs: number | null;
   /** Last curl argv (for diagnostics). */
   command: string[];
 }
@@ -50,6 +94,10 @@ export interface ExecuteGuardedHttpOptions {
   cwd: string;
   signal: AbortSignal;
   maxResponseBytes: number;
+  /** Retry schedule; omitted means `DEFAULT_HTTP_RETRY_CONFIG`. */
+  retry?: HttpRetryConfig;
+  /** Injectable sleep so retry-backoff tests do not wait in real time. */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
 }
 
 /**
@@ -58,6 +106,101 @@ export interface ExecuteGuardedHttpOptions {
  * `--resolve`, never use bare `-L` (which would skip hop re-checks).
  */
 export async function executeGuardedHttpRequest(
+  rawUrl: string,
+  args: HttpRequestArgs,
+  opts: ExecuteGuardedHttpOptions,
+): Promise<GuardedCurlResponse> {
+  const retry = opts.retry ?? DEFAULT_HTTP_RETRY_CONFIG;
+  const sleep = opts.sleep ?? defaultSleep;
+
+  for (let attempt = 0; ; attempt++) {
+    let response: GuardedCurlResponse | null = null;
+    let failure: unknown = null;
+    try {
+      response = await sendGuardedRequestOnce(rawUrl, args, opts);
+    } catch (err) {
+      // Only a curl timeout is worth another attempt; a missing binary, an
+      // SSRF rejection, or an aborted run must surface immediately.
+      if (
+        !isCurlTransportError(err) ||
+        err.exitCode !== CURL_EXIT_TIMEOUT
+      ) {
+        throw err;
+      }
+      failure = err;
+    }
+
+    const exhausted = attempt >= retry.maxRetries || opts.signal.aborted;
+    if (exhausted || !isRetryableAttempt(args.method, response, failure)) {
+      if (response !== null) return response;
+      throw failure;
+    }
+
+    await sleep(
+      httpBackoffDelayMs(attempt, response?.retryAfterMs ?? null, retry),
+      opts.signal,
+    );
+  }
+}
+
+/**
+ * Whether this attempt earns a retry.
+ *
+ * A GET is replayed on any transient status or a timeout. A non-idempotent
+ * method (POST) is replayed only when the server sent an explicit invitation
+ * — a `Retry-After` alongside 429/503 — because the origin may already have
+ * processed a request whose response never arrived. A bare 502/504 or a
+ * timeout on a POST is therefore returned as-is rather than double-submitted.
+ */
+function isRetryableAttempt(
+  method: HttpMethod,
+  response: GuardedCurlResponse | null,
+  failure: unknown,
+): boolean {
+  const idempotent = IDEMPOTENT_METHODS.has(method);
+
+  if (failure !== null) return idempotent;
+  if (response === null) return false;
+  if (!RETRYABLE_STATUSES.has(response.status)) return false;
+  if (idempotent) return true;
+
+  return (
+    INVITED_RETRY_STATUSES.has(response.status) &&
+    response.retryAfterMs !== null
+  );
+}
+
+/**
+ * Delay before retry `attempt` (0-based): `retryBaseDelayMs * 2^attempt`,
+ * clamped to `retryMaxDelayMs`. A server-sent `Retry-After` wins over the
+ * computed delay — the origin knows its own recovery window — but is clamped
+ * the same way so a hostile value cannot park the agent.
+ */
+function httpBackoffDelayMs(
+  attempt: number,
+  retryAfterMs: number | null,
+  cfg: HttpRetryConfig,
+): number {
+  const backoff = cfg.retryBaseDelayMs * 2 ** attempt;
+  const chosen = retryAfterMs !== null ? retryAfterMs : backoff;
+  return Math.min(cfg.retryMaxDelayMs, Math.max(0, chosen));
+}
+
+function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(finish, ms);
+    function finish(): void {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    }
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}
+
+/** One full request/redirect walk. A retry re-enters this from the top. */
+async function sendGuardedRequestOnce(
   rawUrl: string,
   args: HttpRequestArgs,
   opts: ExecuteGuardedHttpOptions,
@@ -143,6 +286,7 @@ export async function executeGuardedHttpRequest(
       timeTotal: totalTime,
       truncated,
       redirectChain: chain,
+      retryAfterMs: parseRetryAfterValueMs(parsed.retryAfter),
       command: lastCommand,
     };
   }
@@ -200,7 +344,8 @@ function buildPinnedCurlArgs(input: BuildPinnedCurlArgs): string[] {
   }
   argv.push(
     "-w",
-    `\n${CURL_META_MARKER}%{http_code}|%{content_type}|%{size_download}|%{time_total}|%{redirect_url}`,
+    `\n${CURL_META_MARKER}%{http_code}|%{content_type}|%{size_download}|` +
+      `%{time_total}|%{redirect_url}|%header{retry-after}`,
   );
   argv.push("--", input.url.toString());
   return argv;
@@ -213,6 +358,8 @@ export interface CurlParsedOutput {
   sizeDownload: number;
   timeTotal: number;
   redirectUrl: string;
+  /** Raw `Retry-After` header, `""` when absent or unsupported by curl. */
+  retryAfter: string;
 }
 
 export function parseCurlOutput(stdout: string): CurlParsedOutput {
@@ -225,6 +372,7 @@ export function parseCurlOutput(stdout: string): CurlParsedOutput {
       sizeDownload: stdout.length,
       timeTotal: 0,
       redirectUrl: "",
+      retryAfter: "",
     };
   }
   const body = stdout.slice(0, markerIdx).replace(/\n$/, "");
@@ -235,10 +383,14 @@ export function parseCurlOutput(stdout: string): CurlParsedOutput {
     sizeStr = "",
     timeStr = "",
     redirectUrl = "",
+    retryAfterRaw = "",
   ] = meta.split("|");
   const status = Number.parseInt(statusStr, 10);
   const sizeDownload = Number.parseInt(sizeStr, 10);
   const timeTotal = Number.parseFloat(timeStr);
+  // `%header{}` is curl >= 7.83; older curl emits the literal format string,
+  // which must not be mistaken for a header value.
+  const retryAfter = retryAfterRaw.trim();
   return {
     body,
     status: Number.isFinite(status) ? status : 0,
@@ -246,6 +398,7 @@ export function parseCurlOutput(stdout: string): CurlParsedOutput {
     sizeDownload: Number.isFinite(sizeDownload) ? sizeDownload : body.length,
     timeTotal: Number.isFinite(timeTotal) ? timeTotal : 0,
     redirectUrl: redirectUrl.trim(),
+    retryAfter: retryAfter.startsWith("%header{") ? "" : retryAfter,
   };
 }
 

--- a/src/tools/os/http-request-retry.test.ts
+++ b/src/tools/os/http-request-retry.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CommandResult,
+  runCommand as RunCommandType,
+} from "../../sandbox/command-runner.js";
+import { executeGuardedHttpRequest } from "./http-request-fetch.js";
+import type { HostLookup } from "./web-fetch-ssrf-guard.js";
+
+const publicLookup: HostLookup = async () => [
+  { address: "93.184.216.34", family: 4 },
+];
+
+/** Curl stdout envelope, optionally carrying a Retry-After header value. */
+function stubStdout(status: number, retryAfter = ""): string {
+  return `body\n__ATOMIC_CURL_META__${status}|text/plain|4|0.01||${retryAfter}`;
+}
+
+function makeResult(overrides: Partial<CommandResult>): CommandResult {
+  return {
+    command: "curl",
+    args: [],
+    exitCode: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    durationMs: 1,
+    timedOut: false,
+    truncated: false,
+    inputTruncated: false,
+    ...overrides,
+  };
+}
+
+/** Replays the given results in order, one per curl invocation. */
+function scriptedRunCommand(
+  results: CommandResult[],
+  calls: string[][],
+): typeof RunCommandType {
+  return (async (_command: string, args: string[]) => {
+    const result = results[calls.length] ?? results.at(-1)!;
+    calls.push(args);
+    return result;
+  }) as unknown as typeof RunCommandType;
+}
+
+function run(
+  input: {
+    method?: "GET" | "POST";
+    results: CommandResult[];
+    calls: string[][];
+    slept: number[];
+    maxRetries?: number;
+  },
+) {
+  return executeGuardedHttpRequest(
+    "https://api.example/v1",
+    {
+      method: input.method ?? "GET",
+      headers: {},
+      body: input.method === "POST" ? "{}" : undefined,
+      timeoutMs: 1000,
+      followRedirects: false,
+    },
+    {
+      runCommand: scriptedRunCommand(input.results, input.calls),
+      lookup: publicLookup,
+      cwd: "/tmp",
+      signal: new AbortController().signal,
+      maxResponseBytes: 100_000,
+      ...(input.maxRetries !== undefined
+        ? {
+            retry: {
+              maxRetries: input.maxRetries,
+              retryBaseDelayMs: 500,
+              retryMaxDelayMs: 5_000,
+            },
+          }
+        : {}),
+      sleep: async (ms: number) => {
+        input.slept.push(ms);
+      },
+    },
+  );
+}
+
+describe("os.http.request retries", () => {
+  it("retries a 429 GET and returns the eventual success", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      results: [
+        makeResult({ stdout: stubStdout(429) }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(2);
+    expect(slept).toEqual([500]);
+  });
+
+  it("retries 502/503/504 as well", async () => {
+    for (const status of [502, 503, 504]) {
+      const calls: string[][] = [];
+      const slept: number[] = [];
+      const response = await run({
+        results: [
+          makeResult({ stdout: stubStdout(status) }),
+          makeResult({ stdout: stubStdout(200) }),
+        ],
+        calls,
+        slept,
+      });
+
+      expect(response.status).toBe(200);
+      expect(calls).toHaveLength(2);
+    }
+  });
+
+  it("honours Retry-After over its own backoff schedule", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    await run({
+      results: [
+        makeResult({ stdout: stubStdout(429, "2") }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+      slept,
+    });
+
+    expect(slept).toEqual([2000]);
+  });
+
+  it("clamps a hostile Retry-After to the max delay", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    await run({
+      results: [
+        makeResult({ stdout: stubStdout(429, "3600") }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+      slept,
+    });
+
+    expect(slept).toEqual([5000]);
+  });
+
+  it("gives up after maxRetries and returns the last response", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      results: [makeResult({ stdout: stubStdout(503) })],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(503);
+    expect(calls).toHaveLength(3); // initial + 2 retries
+    expect(slept).toEqual([500, 1000]);
+  });
+
+  it("does not retry a stable 4xx", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      results: [makeResult({ stdout: stubStdout(404) })],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(404);
+    expect(calls).toHaveLength(1);
+    expect(slept).toEqual([]);
+  });
+
+  it("can be disabled with maxRetries: 0", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      results: [makeResult({ stdout: stubStdout(429) })],
+      calls,
+      slept,
+      maxRetries: 0,
+    });
+
+    expect(response.status).toBe(429);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("retries a curl timeout on GET", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      results: [
+        makeResult({ exitCode: 28, stderr: "timed out", timedOut: true }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("does not retry a non-timeout curl failure", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    await expect(
+      run({
+        results: [makeResult({ exitCode: 6, stderr: "could not resolve host" })],
+        calls,
+        slept,
+      }),
+    ).rejects.toThrow(/could not resolve host/);
+
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("os.http.request retry safety for non-idempotent methods", () => {
+  it("does NOT replay a POST on a bare 503 (no Retry-After)", async () => {
+    // The origin may already have processed the request; replaying it blindly
+    // would risk a double submit.
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      method: "POST",
+      results: [makeResult({ stdout: stubStdout(503) })],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(503);
+    expect(calls).toHaveLength(1);
+    expect(slept).toEqual([]);
+  });
+
+  it("does NOT replay a POST on a curl timeout", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    await expect(
+      run({
+        method: "POST",
+        results: [makeResult({ exitCode: 28, stderr: "timed out", timedOut: true })],
+        calls,
+        slept,
+      }),
+    ).rejects.toThrow(/timed out/);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("DOES replay a POST when the server invites it with Retry-After", async () => {
+    // 429 + Retry-After is an explicit "I did not process this, come back".
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      method: "POST",
+      results: [
+        makeResult({ stdout: stubStdout(429, "1") }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(2);
+    expect(slept).toEqual([1000]);
+  });
+
+  it("does NOT replay a POST on 502 even with Retry-After", async () => {
+    // 502/504 do not carry the same "not processed" guarantee as 429/503.
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      method: "POST",
+      results: [makeResult({ stdout: stubStdout(502, "1") })],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(502);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/src/tools/os/http-request-retry.test.ts
+++ b/src/tools/os/http-request-retry.test.ts
@@ -11,9 +11,19 @@ const publicLookup: HostLookup = async () => [
   { address: "93.184.216.34", family: 4 },
 ];
 
-/** Curl stdout envelope, optionally carrying a Retry-After header value. */
-function stubStdout(status: number, retryAfter = ""): string {
-  return `body\n__ATOMIC_CURL_META__${status}|text/plain|4|0.01||${retryAfter}`;
+/**
+ * Curl stdout envelope, optionally carrying a Retry-After header value and a
+ * redirect target. Field order mirrors the `-w` format: redirect_url is last.
+ */
+function stubStdout(
+  status: number,
+  retryAfter = "",
+  redirectUrl = "",
+): string {
+  return (
+    `body\n__ATOMIC_CURL_META__${status}|text/plain|4|0.01|` +
+    `${retryAfter}|${redirectUrl}`
+  );
 }
 
 function makeResult(overrides: Partial<CommandResult>): CommandResult {
@@ -288,5 +298,137 @@ describe("os.http.request retry safety for non-idempotent methods", () => {
 
     expect(response.status).toBe(502);
     expect(calls).toHaveLength(1);
+  });
+});
+
+describe("os.http.request retry safety across redirects", () => {
+  /** Drives a full redirect-following request with a scripted curl. */
+  function runRedirecting(input: {
+    method: "GET" | "POST";
+    results: CommandResult[];
+    calls: string[][];
+    signal?: AbortSignal;
+    sleep?: (ms: number) => Promise<void>;
+  }) {
+    return executeGuardedHttpRequest(
+      "https://api.example/submit",
+      {
+        method: input.method,
+        headers: {},
+        body: input.method === "POST" ? "order=1" : undefined,
+        timeoutMs: 1000,
+        followRedirects: true,
+      },
+      {
+        runCommand: scriptedRunCommand(input.results, input.calls),
+        lookup: publicLookup,
+        cwd: "/tmp",
+        signal: input.signal ?? new AbortController().signal,
+        maxResponseBytes: 100_000,
+        sleep: input.sleep ?? (async () => {}),
+      },
+    );
+  }
+
+  it("does NOT replay a POST carried through a 307 redirect", async () => {
+    // 307 preserves method and body, so the hop that hit 502 is still a POST
+    // carrying `order=1`. A bare 502 is not an invitation to come back, so the
+    // body must not be re-submitted even though the request began as a
+    // redirect follow rather than a direct POST.
+    const calls: string[][] = [];
+    const response = await runRedirecting({
+      method: "POST",
+      results: [
+        makeResult({ stdout: stubStdout(307, "", "https://api.example/b") }),
+        makeResult({ stdout: stubStdout(502) }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+    });
+
+    expect(response.status).toBe(502);
+    // Two hops: the original POST and the 307 follow. No third attempt.
+    expect(calls).toHaveLength(2);
+    expect(
+      calls.filter((a) => a.includes("--data-binary")),
+    ).toHaveLength(2);
+  });
+
+  it("DOES retry a GET that a 303 downgraded it to", async () => {
+    // The POST was accepted and answered with 303; the follow-up GET is
+    // idempotent, so a 429 on it is safe to replay.
+    const calls: string[][] = [];
+    const response = await runRedirecting({
+      method: "POST",
+      results: [
+        makeResult({
+          stdout: stubStdout(303, "", "https://api.example/result"),
+        }),
+        makeResult({ stdout: stubStdout(429) }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+    });
+
+    expect(response.status).toBe(200);
+    // Three hops: the POST, the downgraded GET that hit 429, and its replay.
+    expect(calls).toHaveLength(3);
+    // Only the first hop carries the body; the retried GET must not.
+    expect(calls.filter((a) => a.includes("--data-binary"))).toHaveLength(1);
+  });
+});
+
+describe("os.http.request abort handling", () => {
+  it("does not issue another request when abort fires during backoff", async () => {
+    const calls: string[][] = [];
+    const controller = new AbortController();
+    const response = await executeGuardedHttpRequest(
+      "https://api.example/v1",
+      {
+        method: "GET",
+        headers: {},
+        timeoutMs: 1000,
+        followRedirects: false,
+      },
+      {
+        runCommand: scriptedRunCommand(
+          [makeResult({ stdout: stubStdout(429) })],
+          calls,
+        ),
+        lookup: publicLookup,
+        cwd: "/tmp",
+        signal: controller.signal,
+        maxResponseBytes: 100_000,
+        // Abort mid-wait, as pressing Esc during the backoff would.
+        sleep: async () => {
+          controller.abort();
+        },
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(response.status).toBe(429);
+  });
+});
+
+describe("curl metadata parsing", () => {
+  it("keeps a literal pipe inside redirect_url out of Retry-After", async () => {
+    const calls: string[][] = [];
+    const slept: number[] = [];
+    const response = await run({
+      results: [
+        makeResult({
+          stdout: stubStdout(429, "120", "https://x.test/a|b"),
+        }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+      slept,
+    });
+
+    expect(response.status).toBe(200);
+    // Retry-After must be read as 120s (clamped to the 5s cap), not as the
+    // fragment of a URL that happened to follow a pipe.
+    expect(slept).toEqual([5_000]);
   });
 });

--- a/src/tools/os/http-request.test.ts
+++ b/src/tools/os/http-request.test.ts
@@ -100,8 +100,14 @@ function meta(
   size: number,
   time = 0.01,
   redirectUrl = "",
+  retryAfter = "",
 ): string {
-  return `__ATOMIC_CURL_META__${status}|${contentType}|${size}|${time}|${redirectUrl}`;
+  // Field order mirrors the `-w` format: redirect_url is last, because it is
+  // the only field whose value can contain a literal `|`.
+  return (
+    `__ATOMIC_CURL_META__${status}|${contentType}|${size}|${time}` +
+    `|${retryAfter}|${redirectUrl}`
+  );
 }
 
 describe("hostAllowed", () => {
@@ -126,7 +132,7 @@ describe("hostAllowed", () => {
 describe("parseCurlOutput", () => {
   it("splits body from meta marker", () => {
     const stdout =
-      "hello world\n__ATOMIC_CURL_META__200|application/json; charset=utf-8|11|0.123|https://next.example/";
+      "hello world\n__ATOMIC_CURL_META__200|application/json; charset=utf-8|11|0.123||https://next.example/";
     const parsed = parseCurlOutput(stdout);
     expect(parsed.body).toBe("hello world");
     expect(parsed.status).toBe(200);

--- a/src/tools/os/http-request.ts
+++ b/src/tools/os/http-request.ts
@@ -55,7 +55,7 @@ export function buildOsHttpRequestTool(
   return {
     name: "os.http.request",
     description:
-      "Raw HTTP GET or POST via the system `curl` binary for APIs and machine-readable endpoints (JSON, XML, plain text). Returns the response body verbatim — no HTML extraction or cleanup. To read a human web page as markdown/text, use `os.web.fetch` instead. Blocks private/internal addresses (SSRF) like `os.web.fetch`, pins DNS with curl `--resolve`, and re-validates each redirect hop. Host allowlist and approval policy come from `config.http`. Body is capped at `config.http.maxResponseBytes`.",
+      "Raw HTTP GET or POST via the system `curl` binary for APIs and machine-readable endpoints (JSON, XML, plain text). Returns the response body verbatim — no HTML extraction or cleanup. To read a human web page as markdown/text, use `os.web.fetch` instead. Blocks private/internal addresses (SSRF) like `os.web.fetch`, pins DNS with curl `--resolve`, and re-validates each redirect hop. Host allowlist and approval policy come from `config.http`. Body is capped at `config.http.maxResponseBytes`. Retries transient failures (429/502/503/504 and connection timeouts) with exponential backoff, honouring `Retry-After`; a POST is only retried when the server explicitly invites it, so a request is never double-submitted.",
     readonly: false,
     async run(rawArgs, ctx) {
       const httpCfg = options.config.http;

--- a/src/tools/os/retry-after-header.test.ts
+++ b/src/tools/os/retry-after-header.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRetryAfterValueMs } from "./retry-after-header.js";
+
+const NOW = Date.parse("2026-08-20T12:00:00Z");
+
+describe("parseRetryAfterValueMs", () => {
+  it("reads the delta-seconds form", () => {
+    expect(parseRetryAfterValueMs("120", NOW)).toBe(120_000);
+  });
+
+  it("reads the HTTP-date form relative to now", () => {
+    expect(parseRetryAfterValueMs("Thu, 20 Aug 2026 12:00:05 GMT", NOW)).toBe(5000);
+  });
+
+  it("clamps an already-elapsed date to zero rather than negative", () => {
+    expect(parseRetryAfterValueMs("Thu, 20 Aug 2026 11:00:00 GMT", NOW)).toBe(0);
+  });
+
+  it("returns null for absent or unparseable values", () => {
+    expect(parseRetryAfterValueMs(undefined, NOW)).toBeNull();
+    expect(parseRetryAfterValueMs(null, NOW)).toBeNull();
+    expect(parseRetryAfterValueMs("", NOW)).toBeNull();
+    expect(parseRetryAfterValueMs("   ", NOW)).toBeNull();
+    expect(parseRetryAfterValueMs("soon", NOW)).toBeNull();
+  });
+
+  it("rejects a partially-numeric value instead of reading it as seconds", () => {
+    expect(parseRetryAfterValueMs("10abc", NOW)).toBeNull();
+  });
+});

--- a/src/tools/os/retry-after-header.ts
+++ b/src/tools/os/retry-after-header.ts
@@ -1,0 +1,36 @@
+/**
+ * `Retry-After` normalisation, shared by `os.web.fetch` and `os.http.request`.
+ *
+ * Both tools retry transient failures and both honour a server-sent
+ * `Retry-After`, but they read it off curl differently (`%{header_json}` vs
+ * `%header{retry-after}`). The RFC 9110 value grammar is the same either way,
+ * so it is defined once here rather than drifting between two copies.
+ */
+
+/**
+ * Parse a raw `Retry-After` value to milliseconds. Handles both documented
+ * forms — delta-seconds (`120`) and an HTTP-date — and returns `null` for
+ * anything unparseable, so callers fall back to their own backoff schedule.
+ *
+ * A date already in the past clamps to `0`: retry immediately rather than
+ * not at all.
+ */
+export function parseRetryAfterValueMs(
+  value: string | null | undefined,
+  now: number = Date.now(),
+): number | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (text.length === 0) return null;
+
+  // Anchored so a partially-numeric value like "10abc" is rejected rather
+  // than silently read as 10 seconds.
+  if (/^\d+$/.test(text)) {
+    const seconds = Number.parseInt(text, 10);
+    return Number.isFinite(seconds) ? seconds * 1000 : null;
+  }
+
+  const dateMs = Date.parse(text);
+  if (Number.isNaN(dateMs)) return null;
+  return Math.max(0, dateMs - now);
+}

--- a/src/tools/os/web-fetch.ts
+++ b/src/tools/os/web-fetch.ts
@@ -7,6 +7,7 @@ import type { ToolDefinition } from "../tool-registry.js";
 import type { AtomicAgentConfig, WebFetchConfig } from "../../config/index.js";
 import { extractWebContent, type ExtractMode } from "./web-fetch-extract.js";
 import { CurlUnavailableError, isCurlMissingError } from "./ensure-curl.js";
+import { parseRetryAfterValueMs } from "./retry-after-header.js";
 import {
   assertHostAllowed,
   formatResolveEntry,
@@ -542,18 +543,7 @@ function parseRetryAfterMs(headerJson: string): number | null {
   const rawValue = entry?.[1];
   const value = Array.isArray(rawValue) ? rawValue[0] : rawValue;
   if (typeof value !== "string") return null;
-  const text = value.trim();
-  if (text.length === 0) return null;
-
-  if (/^\d+$/.test(text)) {
-    return Number.parseInt(text, 10) * 1000;
-  }
-  const dateMs = Date.parse(text);
-  if (!Number.isNaN(dateMs)) {
-    // Past dates clamp to 0 — retry immediately rather than not at all.
-    return Math.max(0, dateMs - Date.now());
-  }
-  return null;
+  return parseRetryAfterValueMs(value);
 }
 
 function formatCurlError(result: CommandResult): string {


### PR DESCRIPTION
Completes the rate-limit work started in #179. That issue is closed and #199
covered `os.web.search`; `os.http.request` was the one caller left with no
retry path at all, and the campaign behind #179 logged **82 rate-limit
failures** against third-party APIs there (`api.semanticscholar.org`,
`archive.org/wayback`) — hosts that serve the same request seconds later.

`os.web.fetch` gained retries in 2cc491e. This brings its sibling to the same
contract, and removes the copy-paste that would otherwise have created.

## What retries

429/502/503/504 and curl's timeout exit, two attempts on top of the first with
exponential backoff. A server-sent `Retry-After` wins over the computed delay —
the origin knows its own recovery window — clamped so a hostile value cannot
park the agent. Everything else (404, 403, DNS failure, TLS error) is returned
or thrown on the first attempt, because repeating it only spends task budget
for the same answer.

## What does not retry: POST

`web.fetch` never had to consider this because it only GETs. `os.http.request`
can POST, and an origin may already have processed a request whose response
never arrived — so a blind replay risks a **double submit**, the one failure
mode a retry layer must not introduce.

- **GET** — replayed on any retryable status or a timeout.
- **POST** — replayed **only** on 429/503 that also carries a `Retry-After`.
  That pairing is an explicit "I did not process this, come back". A bare
  502/504, or a timeout, is returned as-is.

Four of the new tests exist specifically to pin this asymmetry.

## Shared `Retry-After` parser

Both tools read the header off curl differently (`%{header_json}` for
`web.fetch`, `%header{retry-after}` here) but the RFC 9110 value grammar is the
same, so it moves to `retry-after-header.ts` rather than being duplicated.
`web.fetch` keeps its own header extraction and delegates only the value
parsing; behaviour is unchanged, except that the anchored digit test now also
rejects a partially-numeric value like `10abc` instead of reading it as 10s.

## Deliberately not included

**No `config.http` retry block.** `web.fetch` has one, but adding the
equivalent here means a config schema version bump plus migration — a much
wider blast radius than this fix warrants. The defaults mirror `web.fetch`
(2 retries, 500ms base, 5s cap) and are injectable, so tests drive them
directly. Worth doing as its own change if operators ask to tune it.

## Testing

18 new tests, `npm run lint` clean. Full suite: **6238 passed, 3 failed** —
all three pre-existing on `origin/main` and verified there directly
(`parallel-tool-calls` passes in isolation, `send-message-concurrency` and
`fs-glob-real` fail identically on a clean checkout).

Rebased onto current `main`, including
#242, which rewrote the SSRF guard in these same files to return every safe
address instead of pinning one; `assertHostAllowed` still runs inside the
retried unit, so each attempt re-resolves and re-validates the host rather
than trusting an address resolved before an arbitrary backoff wait.
