### PR TITLE
fix(memory): bound four unbounded-growth paths and warn on heap pressure (#121)

### DIFF
--- a/src/approval/approval-gate.test.ts
+++ b/src/approval/approval-gate.test.ts
@@ -452,3 +452,91 @@ describe("ApprovalGate", () => {
     expect(canGrantShape(httpReq)).toBe(false);
   });
 });
+
+// Regression: issue #121 — `request()` subscribed to the caller's abort
+// signal with `{ once: true }` and never detached. `once` only removes the
+// listener when the event actually fires, and on the normal approve/deny
+// path it never does. The signal is the turn-lifetime one threaded into
+// every gated tool, so a turn with N gated calls left N listeners (each
+// closing over its request, including the shell command preview) attached
+// until the whole turn was torn down.
+describe("ApprovalGate abort-listener lifecycle (issue #121)", () => {
+  /** An AbortSignal wrapper that counts currently-attached listeners. */
+  function countingSignal(): { signal: AbortSignal; live: () => number; abort: () => void } {
+    const controller = new AbortController();
+    const real = controller.signal;
+    let live = 0;
+    const proxy = {
+      get aborted() {
+        return real.aborted;
+      },
+      addEventListener(type: string, fn: EventListener, opts?: AddEventListenerOptions) {
+        live += 1;
+        real.addEventListener(type, fn, opts);
+      },
+      removeEventListener(type: string, fn: EventListener) {
+        live -= 1;
+        real.removeEventListener(type, fn);
+      },
+    } as unknown as AbortSignal;
+    return { signal: proxy, live: () => live, abort: () => controller.abort() };
+  }
+
+  it("detaches the abort listener after an approval, across many calls on one signal", async () => {
+    const { signal, live } = countingSignal();
+    const gate = new ApprovalGate({
+      emit: (req) =>
+        setImmediate(() => gate.resolve({ approvalId: req.approvalId, approved: true })),
+    });
+    // One turn-lifetime signal, many gated tool calls.
+    for (let i = 0; i < 20; i += 1) {
+      const decision = await gate.request(
+        { sessionId: "s", tool: "os.shell.run", category: "shell", reason: "r", preview: `cmd ${i}` },
+        { signal },
+      );
+      expect(decision.approved).toBe(true);
+    }
+    expect(live()).toBe(0);
+    expect(gate.pendingCount()).toBe(0);
+  });
+
+  it("detaches the abort listener after a denial too", async () => {
+    const { signal, live } = countingSignal();
+    const gate = new ApprovalGate({
+      emit: (req) => setImmediate(() => gate.reject(req.approvalId, "nope")),
+    });
+    for (let i = 0; i < 5; i += 1) {
+      const decision = await gate.request(
+        { sessionId: "s", tool: "os.shell.run", category: "shell", reason: "r" },
+        { signal },
+      );
+      expect(decision.approved).toBe(false);
+    }
+    expect(live()).toBe(0);
+  });
+
+  it("still rejects when the signal aborts while a request is pending", async () => {
+    const { signal, abort } = countingSignal();
+    const gate = new ApprovalGate({ emit: () => setImmediate(abort) });
+    await expect(
+      gate.request(
+        { sessionId: "s", tool: "os.shell.run", category: "shell", reason: "r" },
+        { signal },
+      ),
+    ).rejects.toThrow(/aborted/);
+    expect(gate.pendingCount()).toBe(0);
+  });
+
+  it("rejects immediately when handed an already-aborted signal", async () => {
+    const { signal, abort } = countingSignal();
+    abort();
+    const gate = new ApprovalGate({ emit: () => {} });
+    await expect(
+      gate.request(
+        { sessionId: "s", tool: "os.shell.run", category: "shell", reason: "r" },
+        { signal },
+      ),
+    ).rejects.toThrow(/aborted/);
+    expect(gate.pendingCount()).toBe(0);
+  });
+});

--- a/src/approval/approval-gate.ts
+++ b/src/approval/approval-gate.ts
@@ -89,6 +89,15 @@ export class ApprovalGateError extends Error {
 interface PendingEntry {
   resolve: (decision: ApprovalDecision) => void;
   request: ApprovalRequest;
+  /**
+   * Detaches the caller's abort listener. `{ once: true }` only fires —
+   * and so only self-removes — when the signal actually aborts, which
+   * never happens on the normal approve/deny path. Without this the
+   * listener stays attached to a signal that lives for the whole turn,
+   * so every gated tool call in a turn leaks one listener plus the
+   * closure over its `request` (which carries the command preview).
+   */
+  detach: () => void;
 }
 
 /**
@@ -194,20 +203,26 @@ export class ApprovalGate {
     const auto = this.autoApproval(request);
     if (auto) return Promise.resolve({ approvalId, approved: true, reason: auto });
     return new Promise<ApprovalDecision>((resolve, reject) => {
-      this.pending.set(approvalId, { resolve, request });
-      signal?.addEventListener(
-        "abort",
-        () => {
-          this.pending.delete(approvalId);
-          reject(
-            new ApprovalGateError(
-              "approval aborted before a decision was made",
-              approvalId,
-            ),
-          );
-        },
-        { once: true },
-      );
+      const onAbort = (): void => {
+        this.pending.delete(approvalId);
+        reject(
+          new ApprovalGateError(
+            "approval aborted before a decision was made",
+            approvalId,
+          ),
+        );
+      };
+      const detach = (): void => {
+        signal?.removeEventListener("abort", onAbort);
+      };
+      this.pending.set(approvalId, { resolve, request, detach });
+      // An already-aborted signal never fires `abort`, so check before
+      // subscribing rather than hanging until the turn is torn down.
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
       this.emitter(request);
     });
   }
@@ -244,6 +259,7 @@ export class ApprovalGate {
     const entry = this.pending.get(decision.approvalId);
     if (!entry) return false;
     this.pending.delete(decision.approvalId);
+    entry.detach();
     if (decision.approved && decision.grant) {
       this.recordGrant(entry.request, decision.grant);
     }

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -743,6 +743,17 @@ export async function createAgentRuntime(
         logger,
       })
     : null;
+  /**
+   * Trace recorders keyed by session id, bounded so a long-lived runtime
+   * that serves many sessions (sidecar, HTTP server, background tasks)
+   * cannot grow this map without limit — there is no session-teardown
+   * hook to delete from it. Insertion order makes `Map` an LRU by
+   * construction: the oldest session id is evicted once over the cap.
+   * A recorder holds only counters and a `pendingCalls` map that is
+   * drained per step, so eviction costs nothing but a re-`beginSession`
+   * if that session ever speaks again.
+   */
+  const MAX_TRACE_RECORDERS = 64;
   const recorders = new Map<string, TraceRecorder>();
   /**
    * Per-turn context used to route `loopDeps.onEvent` calls back to
@@ -2152,6 +2163,11 @@ export async function createAgentRuntime(
       ...(session.metadata ? { metadata: session.metadata } : {}),
     });
     recorders.set(session.id, recorder);
+    while (recorders.size > MAX_TRACE_RECORDERS) {
+      const oldest = recorders.keys().next();
+      if (oldest.done) break;
+      recorders.delete(oldest.value);
+    }
     return recorder;
   };
 

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -746,15 +746,57 @@ export async function createAgentRuntime(
   /**
    * Trace recorders keyed by session id, bounded so a long-lived runtime
    * that serves many sessions (sidecar, HTTP server, background tasks)
-   * cannot grow this map without limit — there is no session-teardown
-   * hook to delete from it. Insertion order makes `Map` an LRU by
-   * construction: the oldest session id is evicted once over the cap.
-   * A recorder holds only counters and a `pendingCalls` map that is
-   * drained per step, so eviction costs nothing but a re-`beginSession`
-   * if that session ever speaks again.
+   * cannot grow this map without limit.
+   *
+   * `Map` preserves *insertion* order, which is not the same as recency:
+   * re-reading a key does not move it. Evicting `keys().next()` therefore
+   * targets the oldest-*created* session, which in a long-lived runtime is
+   * usually the operator's own still-running one. `touchRecorder` re-inserts
+   * on every access so the order really is least-recently-used, and
+   * `dropRecorder` removes a session's recorder when the session itself goes
+   * away — cheaper and more correct than waiting for the cap to push it out.
+   *
+   * Eviction is not free: `beginSession` is written to run once per NDJSON
+   * file, so re-creating an evicted recorder appends a second
+   * `session_started` and restarts `seq` at 0 in a file that already has
+   * events. Anything sorting or de-duplicating by `seq` then mis-orders.
+   * That is why an actively-running session is never evicted.
    */
   const MAX_TRACE_RECORDERS = 64;
   const recorders = new Map<string, TraceRecorder>();
+  /** Sessions with a turn in flight. Never evicted; see `evictRecorders`. */
+  const activeTraceSessions = new Set<string>();
+
+  /** Look a recorder up and mark it most-recently-used. */
+  const touchRecorder = (sessionId: string): TraceRecorder | undefined => {
+    const recorder = recorders.get(sessionId);
+    if (recorder !== undefined) {
+      recorders.delete(sessionId);
+      recorders.set(sessionId, recorder);
+    }
+    return recorder;
+  };
+
+  /** Forget a session's recorder once the session is gone. */
+  const dropRecorder = (sessionId: string): void => {
+    recorders.delete(sessionId);
+    activeTraceSessions.delete(sessionId);
+  };
+
+  /**
+   * Trim to the cap, oldest-used first, skipping sessions with a live turn.
+   * If every entry is active the map is briefly allowed over the cap: losing
+   * a running session's trace is worse than holding a few extra recorders,
+   * and the excess drains as those turns finish.
+   */
+  const evictRecorders = (): void => {
+    if (recorders.size <= MAX_TRACE_RECORDERS) return;
+    for (const sessionId of [...recorders.keys()]) {
+      if (recorders.size <= MAX_TRACE_RECORDERS) break;
+      if (activeTraceSessions.has(sessionId)) continue;
+      recorders.delete(sessionId);
+    }
+  };
   /**
    * Per-turn context used to route `loopDeps.onEvent` calls back to
    * the correct session. Two sessions running concurrently each have
@@ -785,7 +827,7 @@ export async function createAgentRuntime(
   const emitAgentLoopEvent = (event: AgentLoopEvent): void => {
     const ctx = turnContext.getStore();
     if (ctx) {
-      const recorder = recorders.get(ctx.sessionId);
+      const recorder = touchRecorder(ctx.sessionId);
       recorder?.onAgentEvent(event);
       turnController.emit(ctx.sessionId, event);
     }
@@ -1130,6 +1172,15 @@ export async function createAgentRuntime(
   // column-only `listRecentWorkingDirs` projection, so the store must
   // exist by the time `registerOsTools` wires the closure below.
   const sessionStore = new SessionStore();
+  // Drop a session's trace recorder when the session itself is deleted, so
+  // the map shrinks on teardown instead of relying on the cap to push
+  // entries out. Wrapped here rather than at each call site (the TUI and the
+  // HTTP route both delete sessions) so every caller gets it.
+  const deleteSession = sessionStore.delete.bind(sessionStore);
+  sessionStore.delete = (id: string): void => {
+    dropRecorder(id);
+    deleteSession(id);
+  };
 
   const toolRegistry = new ToolRegistry();
   toolRegistry.register(finishTool);
@@ -1544,7 +1595,7 @@ export async function createAgentRuntime(
     // `turn_finished`, so a missing recorder is a normal "tracing
     // disabled for this session" outcome, not an error.
     emitTrace: (event: ReflectionTraceEvent) => {
-      const recorder = recorders.get(event.sessionId);
+      const recorder = touchRecorder(event.sessionId);
       if (!recorder) return;
       recorder.recordReflection({
         outcome: event.outcome,
@@ -1612,7 +1663,7 @@ export async function createAgentRuntime(
       // Per-session trace emission — same resolve-by-sessionId
       // pattern as reflection / vote.
       emitTrace: (event) => {
-        const recorder = recorders.get(event.sessionId);
+        const recorder = touchRecorder(event.sessionId);
         if (!recorder) return;
         recorder.recordLinkGenerator({
           outcome: event.outcome,
@@ -1687,7 +1738,7 @@ export async function createAgentRuntime(
       // recorder is a normal "tracing disabled for this session"
       // outcome, not an error.
       emitTrace: (event) => {
-        const recorder = recorders.get(event.sessionId);
+        const recorder = touchRecorder(event.sessionId);
         if (!recorder) return;
         if (event.type === "applied") {
           recorder.recordVoteApplied({
@@ -1839,7 +1890,7 @@ export async function createAgentRuntime(
       // not exist yet on the very first turn; a missing recorder is a
       // normal "tracing disabled" outcome.
       emitTrace: (event) => {
-        const recorder = recorders.get(event.sessionId);
+        const recorder = touchRecorder(event.sessionId);
         if (!recorder) return;
         recorder.recordQueryRewriter({ outcome: event.outcome });
       },
@@ -2152,7 +2203,7 @@ export async function createAgentRuntime(
 
   const ensureRecorder = (session: SessionState): TraceRecorder | null => {
     if (!traceBus) return null;
-    const existing = recorders.get(session.id);
+    const existing = touchRecorder(session.id);
     if (existing) return existing;
     const recorder = createTraceRecorder({
       sessionId: session.id,
@@ -2163,11 +2214,7 @@ export async function createAgentRuntime(
       ...(session.metadata ? { metadata: session.metadata } : {}),
     });
     recorders.set(session.id, recorder);
-    while (recorders.size > MAX_TRACE_RECORDERS) {
-      const oldest = recorders.keys().next();
-      if (oldest.done) break;
-      recorders.delete(oldest.value);
-    }
+    evictRecorders();
     return recorder;
   };
 
@@ -2190,14 +2237,27 @@ export async function createAgentRuntime(
     runOptions: { maxSteps?: number; signal?: AbortSignal } = {},
   ): Promise<RunTurnResult> => {
     ensureRecorder(session);
+    // Pin this session for the duration of the turn. Without it a burst of
+    // new sessions can push this one's recorder out mid-turn, after which
+    // `emitAgentLoopEvent`'s `recorders.get(...)?.` silently drops every
+    // remaining event of the turn and any tool call whose `pendingCalls`
+    // entry went with it is logged with empty args.
+    activeTraceSessions.add(session.id);
     return turnContext.run({ sessionId: session.id }, async () => {
-      const result = await loop.runTurn(session, {
-        userMessage,
-        maxSteps: runOptions.maxSteps ?? config.agent.maxSteps,
-        signal: runOptions.signal ?? new AbortController().signal,
-      });
-      sessionStore.save(result.session);
-      return result;
+      try {
+        const result = await loop.runTurn(session, {
+          userMessage,
+          maxSteps: runOptions.maxSteps ?? config.agent.maxSteps,
+          signal: runOptions.signal ?? new AbortController().signal,
+        });
+        sessionStore.save(result.session);
+        return result;
+      } finally {
+        activeTraceSessions.delete(session.id);
+        // The turn may have out-waited a burst that could not evict while it
+        // was pinned; settle the map now that it can.
+        evictRecorders();
+      }
     });
   };
 

--- a/src/runtime/heap-guard.test.ts
+++ b/src/runtime/heap-guard.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyHeap,
+  createHeapGuard,
+  readProcessHeap,
+  HEAP_WARN_RATIO,
+  HEAP_CRITICAL_RATIO,
+  type HeapReading,
+} from "./heap-guard.js";
+
+const GB = 1_073_741_824;
+const reading = (usedGb: number, limitGb = 4): HeapReading => ({
+  usedBytes: usedGb * GB,
+  limitBytes: limitGb * GB,
+});
+
+describe("classifyHeap", () => {
+  it("stays quiet with headroom", () => {
+    const s = classifyHeap(reading(1));
+    expect(s.severity).toBe("ok");
+    expect(s.message).toBeNull();
+  });
+
+  it("warns at the warn ratio and names the remedy", () => {
+    const s = classifyHeap(reading(4 * HEAP_WARN_RATIO));
+    expect(s.severity).toBe("warn");
+    expect(s.message).toContain("max-old-space-size");
+  });
+
+  it("escalates at the critical ratio", () => {
+    const s = classifyHeap(reading(4 * HEAP_CRITICAL_RATIO));
+    expect(s.severity).toBe("critical");
+    expect(s.message).toMatch(/critical/);
+  });
+
+  it("reports the real numbers in MB, matching the #121 crash", () => {
+    // The reported crash: 4083 MB used against a ~4288 MB ceiling.
+    const s = classifyHeap({ usedBytes: 4083 * 1_048_576, limitBytes: 4288 * 1_048_576 });
+    expect(s.severity).toBe("critical");
+    expect(s.message).toContain("4083 MB");
+    expect(s.message).toContain("4288 MB");
+  });
+
+  it("does not divide by zero when no ceiling is reported", () => {
+    const s = classifyHeap({ usedBytes: 5 * GB, limitBytes: 0 });
+    expect(s.severity).toBe("ok");
+    expect(s.ratio).toBe(0);
+  });
+});
+
+describe("createHeapGuard", () => {
+  it("reports each escalation once, not on every poll", () => {
+    let used = 1;
+    const guard = createHeapGuard(() => reading(used));
+    expect(guard.check()).toBeNull(); // ok
+    used = 3.2; // ~80% -> warn
+    expect(guard.check()?.severity).toBe("warn");
+    expect(guard.check()).toBeNull(); // still warn, stay quiet
+    expect(guard.check()).toBeNull();
+    used = 3.8; // ~95% -> critical
+    expect(guard.check()?.severity).toBe("critical");
+    expect(guard.check()).toBeNull();
+  });
+
+  it("re-arms after memory is released", () => {
+    let used = 3.2;
+    const guard = createHeapGuard(() => reading(used));
+    expect(guard.check()?.severity).toBe("warn");
+    used = 1; // recovered
+    expect(guard.check()).toBeNull();
+    used = 3.2; // climbs again -> warn again
+    expect(guard.check()?.severity).toBe("warn");
+  });
+});
+
+describe("readProcessHeap", () => {
+  it("reads a real, sane ceiling from this process", () => {
+    const r = readProcessHeap();
+    expect(r.limitBytes).toBeGreaterThan(0);
+    expect(r.usedBytes).toBeGreaterThan(0);
+    expect(r.usedBytes).toBeLessThan(r.limitBytes);
+  });
+});

--- a/src/runtime/heap-guard.ts
+++ b/src/runtime/heap-guard.ts
@@ -1,0 +1,111 @@
+import v8 from "node:v8";
+
+/**
+ * Heap headroom watchdog.
+ *
+ * Issue #121: a long session died with `FATAL ERROR: Ineffective
+ * mark-compacts near heap limit` at 4083 MB — Node's *default* ceiling
+ * (~4288 MB), because the SEA build sets no `--max-old-space-size`. The
+ * process vanished with no warning and took ~40 minutes of work with it.
+ *
+ * V8 cannot raise its own ceiling after startup (`setFlagsFromString`
+ * is a no-op for `--max-old-space-size` once the heap exists), so this
+ * cannot prevent the crash. What it can do is make the crash *legible*:
+ * warn while there is still headroom to save work and restart with a
+ * bigger ceiling.
+ *
+ * Pure except for the injected `readHeap`, so the thresholds are unit
+ * testable without allocating gigabytes.
+ */
+
+export interface HeapReading {
+  usedBytes: number;
+  limitBytes: number;
+}
+
+export type HeapSeverity = "ok" | "warn" | "critical";
+
+export interface HeapStatus {
+  severity: HeapSeverity;
+  usedBytes: number;
+  limitBytes: number;
+  /** Fraction of the ceiling in use, 0..1. */
+  ratio: number;
+  /** Operator-facing line; `null` while `ok`. */
+  message: string | null;
+}
+
+/** Fraction of the heap ceiling at which we start warning. */
+export const HEAP_WARN_RATIO = 0.75;
+/** Fraction at which a crash is imminent and the wording escalates. */
+export const HEAP_CRITICAL_RATIO = 0.9;
+
+export function readProcessHeap(): HeapReading {
+  const s = v8.getHeapStatistics();
+  return { usedBytes: s.used_heap_size, limitBytes: s.heap_size_limit };
+}
+
+function mb(bytes: number): string {
+  return `${Math.round(bytes / 1_048_576)} MB`;
+}
+
+/**
+ * Classify one heap reading. `limitBytes <= 0` (a runtime that does not
+ * report a ceiling) is treated as "ok" rather than dividing by zero.
+ */
+export function classifyHeap(reading: HeapReading): HeapStatus {
+  const { usedBytes, limitBytes } = reading;
+  if (!Number.isFinite(limitBytes) || limitBytes <= 0) {
+    return { severity: "ok", usedBytes, limitBytes, ratio: 0, message: null };
+  }
+  const ratio = usedBytes / limitBytes;
+  if (ratio >= HEAP_CRITICAL_RATIO) {
+    return {
+      severity: "critical",
+      usedBytes,
+      limitBytes,
+      ratio,
+      message:
+        `memory critical: ${mb(usedBytes)} of ${mb(limitBytes)} used. ` +
+        `The agent may be killed by the runtime without warning — finish or ` +
+        `save this turn, then restart with a bigger heap: ` +
+        `NODE_OPTIONS=--max-old-space-size=8192`,
+    };
+  }
+  if (ratio >= HEAP_WARN_RATIO) {
+    return {
+      severity: "warn",
+      usedBytes,
+      limitBytes,
+      ratio,
+      message:
+        `memory high: ${mb(usedBytes)} of ${mb(limitBytes)} used. ` +
+        `Long sessions with large file reads can exhaust the default heap; ` +
+        `restarting with NODE_OPTIONS=--max-old-space-size=8192 raises it.`,
+    };
+  }
+  return { severity: "ok", usedBytes, limitBytes, ratio, message: null };
+}
+
+/**
+ * Stateful wrapper that reports only when severity *rises*, so a session
+ * sitting at 76% does not repeat the same line on every poll. Dropping
+ * back below a threshold re-arms it.
+ */
+export function createHeapGuard(
+  readHeap: () => HeapReading = readProcessHeap,
+): { check: () => HeapStatus | null } {
+  const rank: Record<HeapSeverity, number> = { ok: 0, warn: 1, critical: 2 };
+  let reported: HeapSeverity = "ok";
+  return {
+    check(): HeapStatus | null {
+      const status = classifyHeap(readHeap());
+      if (rank[status.severity] > rank[reported]) {
+        reported = status.severity;
+        return status;
+      }
+      if (rank[status.severity] < rank[reported]) reported = status.severity;
+      return null;
+    },
+  };
+}

--- a/src/runtime/recorder-eviction.test.ts
+++ b/src/runtime/recorder-eviction.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Regression: issue #121 — `bootstrap.ts` kept a `TraceRecorder` per session
+ * id in a Map that had no `delete`/`clear` anywhere, so a long-lived runtime
+ * serving many sessions (sidecar, HTTP server, background tasks) grew it
+ * forever. There is no session-teardown hook to delete from, so the map is
+ * now bounded and evicts oldest-first.
+ *
+ * `recorders` is a closure-private detail of `createAgentRuntime`, so this
+ * pins the eviction rule itself — insertion-ordered `Map` used as an LRU —
+ * which is what the bootstrap code relies on.
+ */
+function evictOldest<T>(map: Map<string, T>, cap: number): void {
+  while (map.size > cap) {
+    const oldest = map.keys().next();
+    if (oldest.done) break;
+    map.delete(oldest.value);
+  }
+}
+
+describe("trace recorder map eviction (issue #121)", () => {
+  it("stays at the cap no matter how many sessions arrive", () => {
+    const cap = 64;
+    const map = new Map<string, { id: string }>();
+    for (let i = 0; i < 5_000; i += 1) {
+      map.set(`s-${i}`, { id: `s-${i}` });
+      evictOldest(map, cap);
+    }
+    expect(map.size).toBe(cap);
+  });
+
+  it("evicts oldest-first and always keeps the newest entry", () => {
+    const cap = 3;
+    const map = new Map<string, number>();
+    for (let i = 0; i < 10; i += 1) {
+      map.set(`s-${i}`, i);
+      evictOldest(map, cap);
+    }
+    expect([...map.keys()]).toEqual(["s-7", "s-8", "s-9"]);
+    // The just-inserted session must never be the one thrown away.
+    expect(map.has("s-9")).toBe(true);
+  });
+
+  it("re-inserting an existing key does not evict the live entry", () => {
+    // `ensureRecorder` returns early on a hit, so a repeat session id never
+    // reaches the eviction loop; if it ever does, size must not grow.
+    const cap = 2;
+    const map = new Map<string, number>([["a", 1], ["b", 2]]);
+    map.set("a", 3);
+    evictOldest(map, cap);
+    expect(map.size).toBe(2);
+    expect(map.get("a")).toBe(3);
+  });
+});

--- a/src/runtime/recorder-eviction.test.ts
+++ b/src/runtime/recorder-eviction.test.ts
@@ -4,52 +4,114 @@ import { describe, it, expect } from "vitest";
  * Regression: issue #121 — `bootstrap.ts` kept a `TraceRecorder` per session
  * id in a Map that had no `delete`/`clear` anywhere, so a long-lived runtime
  * serving many sessions (sidecar, HTTP server, background tasks) grew it
- * forever. There is no session-teardown hook to delete from, so the map is
- * now bounded and evicts oldest-first.
+ * forever. The map is now bounded, evicts least-recently-*used* first, and
+ * never evicts a session with a turn in flight.
  *
  * `recorders` is a closure-private detail of `createAgentRuntime`, so this
- * pins the eviction rule itself — insertion-ordered `Map` used as an LRU —
- * which is what the bootstrap code relies on.
+ * mirrors the three helpers it uses (`touchRecorder`, `dropRecorder`,
+ * `evictRecorders`) and pins the rules they implement. An earlier version of
+ * this file re-implemented plain insertion-order eviction and so agreed with
+ * the bug it was meant to catch: `Map` preserves insertion order, which is
+ * not recency, so the oldest-*created* session was evicted even while it was
+ * the one actively running.
  */
-function evictOldest<T>(map: Map<string, T>, cap: number): void {
-  while (map.size > cap) {
-    const oldest = map.keys().next();
-    if (oldest.done) break;
-    map.delete(oldest.value);
-  }
+function makeRecorderMap(cap: number) {
+  const recorders = new Map<string, { id: string }>();
+  const active = new Set<string>();
+
+  const touch = (id: string) => {
+    const found = recorders.get(id);
+    if (found !== undefined) {
+      recorders.delete(id);
+      recorders.set(id, found);
+    }
+    return found;
+  };
+
+  const evict = () => {
+    if (recorders.size <= cap) return;
+    for (const id of [...recorders.keys()]) {
+      if (recorders.size <= cap) break;
+      if (active.has(id)) continue;
+      recorders.delete(id);
+    }
+  };
+
+  return {
+    recorders,
+    active,
+    touch,
+    evict,
+    ensure(id: string) {
+      const existing = touch(id);
+      if (existing) return existing;
+      const created = { id };
+      recorders.set(id, created);
+      evict();
+      return created;
+    },
+    drop(id: string) {
+      recorders.delete(id);
+      active.delete(id);
+    },
+  };
 }
 
 describe("trace recorder map eviction (issue #121)", () => {
   it("stays at the cap no matter how many sessions arrive", () => {
-    const cap = 64;
-    const map = new Map<string, { id: string }>();
-    for (let i = 0; i < 5_000; i += 1) {
-      map.set(`s-${i}`, { id: `s-${i}` });
-      evictOldest(map, cap);
-    }
-    expect(map.size).toBe(cap);
+    const m = makeRecorderMap(64);
+    for (let i = 0; i < 5_000; i += 1) m.ensure(`s-${i}`);
+    expect(m.recorders.size).toBe(64);
   });
 
-  it("evicts oldest-first and always keeps the newest entry", () => {
-    const cap = 3;
-    const map = new Map<string, number>();
-    for (let i = 0; i < 10; i += 1) {
-      map.set(`s-${i}`, i);
-      evictOldest(map, cap);
-    }
-    expect([...map.keys()]).toEqual(["s-7", "s-8", "s-9"]);
-    // The just-inserted session must never be the one thrown away.
-    expect(map.has("s-9")).toBe(true);
+  it("keeps the newest entry and drops the least recently used", () => {
+    const m = makeRecorderMap(3);
+    for (let i = 0; i < 10; i += 1) m.ensure(`s-${i}`);
+    expect([...m.recorders.keys()]).toEqual(["s-7", "s-8", "s-9"]);
   });
 
-  it("re-inserting an existing key does not evict the live entry", () => {
-    // `ensureRecorder` returns early on a hit, so a repeat session id never
-    // reaches the eviction loop; if it ever does, size must not grow.
-    const cap = 2;
-    const map = new Map<string, number>([["a", 1], ["b", 2]]);
-    map.set("a", 3);
-    evictOldest(map, cap);
-    expect(map.size).toBe(2);
-    expect(map.get("a")).toBe(3);
+  it("a session that keeps working is not evicted by newer arrivals", () => {
+    // The bug: insertion order never refreshed on a hit, so the oldest
+    // *created* session — usually the operator's own long-running one — was
+    // the first thrown away no matter how recently it had spoken.
+    const m = makeRecorderMap(3);
+    m.ensure("operator");
+    for (let i = 0; i < 20; i += 1) {
+      m.ensure(`sidecar-${i}`);
+      m.ensure("operator"); // still working
+    }
+    expect(m.recorders.has("operator")).toBe(true);
+  });
+
+  it("never evicts a session with a turn in flight", () => {
+    // Losing a running session's recorder mid-turn silently drops the rest
+    // of that turn's events, so an active session outranks the cap.
+    const m = makeRecorderMap(3);
+    m.ensure("busy");
+    m.active.add("busy");
+    for (let i = 0; i < 50; i += 1) m.ensure(`other-${i}`);
+    expect(m.recorders.has("busy")).toBe(true);
+
+    // Once the turn ends it becomes evictable like anything else.
+    m.active.delete("busy");
+    for (let i = 0; i < 50; i += 1) m.ensure(`later-${i}`);
+    expect(m.recorders.has("busy")).toBe(false);
+  });
+
+  it("deleting a session drops its recorder immediately", () => {
+    const m = makeRecorderMap(64);
+    m.ensure("gone");
+    expect(m.recorders.has("gone")).toBe(true);
+    m.drop("gone");
+    expect(m.recorders.has("gone")).toBe(false);
+    expect(m.active.has("gone")).toBe(false);
+  });
+
+  it("re-inserting an existing key does not grow the map", () => {
+    const m = makeRecorderMap(2);
+    m.ensure("a");
+    m.ensure("b");
+    m.ensure("a");
+    expect(m.recorders.size).toBe(2);
   });
 });

--- a/src/session/conversation-turn.test.ts
+++ b/src/session/conversation-turn.test.ts
@@ -374,3 +374,74 @@ describe("conversation-turn helpers", () => {
     });
   });
 });
+
+// Regression: issue #121 — `packConversation` re-rendered and re-tokenised
+// every historical turn on every agent step, so a long turn burned O(N^2)
+// transient strings (~10MB across 25 steps). Costs are now memoised per
+// turn object; these tests pin the behaviour that memoisation must not change.
+describe("packConversation memoisation (issue #121)", () => {
+  function longTurns(steps: number): ConversationTurn[] {
+    const turns: ConversationTurn[] = [userTurn("go")];
+    for (let i = 0; i < steps; i += 1) {
+      turns.push(
+        assistantToolCallTurn({ tool: "os.fs.read", args: { path: `/x/${i}` } }),
+      );
+      turns.push(
+        toolResultTurn({
+          tool: "os.fs.read",
+          status: "ok",
+          summary: `body-${i} ${"s".repeat(2_000)}`,
+        }),
+      );
+    }
+    return turns;
+  }
+
+  it("returns identical results on repeated calls over the same turns", () => {
+    const turns = longTurns(20);
+    const first = packConversation(turns, 4_000);
+    const second = packConversation(turns, 4_000);
+    expect(second.droppedCount).toBe(first.droppedCount);
+    expect(second.droppedSummary).toBe(first.droppedSummary);
+    expect(second.visibleTurns).toEqual(first.visibleTurns);
+  });
+
+  it("keeps the fresh/aged distinction — a turn cached as fresh is not reused when aged", () => {
+    // `os.http.request` renders uncapped while fresh and capped once aged,
+    // so the same turn object has two different costs. Caching must key on
+    // the flag, not collapse the two.
+    const body = "h".repeat(5_000);
+    const httpResult = toolResultTurn({
+      tool: "os.http.request",
+      status: "ok",
+      summary: body,
+    });
+    const freshTurns: ConversationTurn[] = [userTurn("go"), httpResult];
+    const agedTurns: ConversationTurn[] = [
+      userTurn("go"),
+      httpResult,
+      assistantReplyTurn("done"),
+      userTurn("again"),
+    ];
+    // Pack fresh first so the fresh cost is the one cached first.
+    packConversation(freshTurns, 100_000);
+    const aged = packConversation(agedTurns, 100_000);
+    const agedRender = renderTurnForPrompt(httpResult, { inCurrentMacroTurn: false });
+    expect(agedRender.length).toBeLessThan(body.length);
+    expect(aged.visibleTurns).toHaveLength(4);
+  });
+
+  it("still drops under budget pressure and pins the last user turn", () => {
+    // Two macro-turns: the first is droppable, the second is pinned. A
+    // single-macro-turn fixture would pin everything and drop nothing.
+    const turns: ConversationTurn[] = [
+      ...longTurns(30),
+      assistantReplyTurn("first answer"),
+      ...longTurns(5),
+    ];
+    const out = packConversation(turns, 2_000);
+    expect(out.droppedCount).toBeGreaterThan(0);
+    expect(out.droppedSummary).toMatch(/^summary: \d+ older turns dropped/);
+    expect(out.visibleTurns.length).toBeGreaterThan(0);
+  });
+});

--- a/src/session/conversation-turn.ts
+++ b/src/session/conversation-turn.ts
@@ -257,10 +257,9 @@ export function packConversation(
   // fresh (e.g. `os.http.request`) get under-estimated and the packed
   // section overshoots `maxTokens`.
   const currentStart = findCurrentMacroTurnStart(turns);
-  const rendered = turns.map((turn, i) =>
-    renderTurnForPrompt(turn, { inCurrentMacroTurn: i >= currentStart }),
+  const tokenCosts = turns.map((turn, i) =>
+    tokenCostForTurn(turn, i >= currentStart),
   );
-  const tokenCosts = rendered.map((line) => estimateTokens(line) + 1);
   const total = tokenCosts.reduce((a, b) => a + b, 0);
   if (total <= maxTokens) {
     return { visibleTurns: [...turns], droppedSummary: null, droppedCount: 0 };
@@ -303,6 +302,42 @@ export function packConversation(
     droppedSummary: renderDroppedSummary(droppedSlice),
     droppedCount: droppedSlice.length,
   };
+}
+
+/**
+ * Memoised token cost of a single rendered turn.
+ *
+ * `packConversation` runs once per agent step and previously re-rendered
+ * (and re-`JSON.stringify`-ed) every historical turn on each call, only to
+ * throw the strings away after summing their token cost — O(N) work per
+ * step, so O(N^2) transient allocation across a long turn. Issue #121
+ * reported ~10MB of churn for a 25-step turn.
+ *
+ * Turns are immutable once appended, so the cost is keyed on the turn
+ * object itself. `inCurrentMacroTurn` changes what the renderer emits for
+ * fresh-bypass tools (`os.http.request`, fresh `gog` shell), so it is part
+ * of the key rather than folded away. The `WeakMap` lets dropped turns be
+ * collected with the sessions that own them.
+ */
+const TURN_TOKEN_COST_CACHE = new WeakMap<
+  object,
+  { fresh?: number; aged?: number }
+>();
+
+function tokenCostForTurn(
+  turn: ConversationTurn,
+  inCurrentMacroTurn: boolean,
+): number {
+  const key = turn as unknown as object;
+  const slot = TURN_TOKEN_COST_CACHE.get(key);
+  const cached = inCurrentMacroTurn ? slot?.fresh : slot?.aged;
+  if (cached !== undefined) return cached;
+  const cost = estimateTokens(renderTurnForPrompt(turn, { inCurrentMacroTurn })) + 1;
+  const nextSlot = slot ?? {};
+  if (inCurrentMacroTurn) nextSlot.fresh = cost;
+  else nextSlot.aged = cost;
+  TURN_TOKEN_COST_CACHE.set(key, nextSlot);
+  return cost;
 }
 
 /**

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -43,6 +43,7 @@ import {
   type LocalTurnGateFacts,
 } from "./local-turn-gate.js";
 import { turnsToMessages } from "./turns-to-messages.js";
+import { createHeapGuard } from "../runtime/heap-guard.js";
 import type { SessionPickerEntry, TuiState } from "./tui-state.js";
 
 const DEBUG_BUNDLE_TRACE_LIMIT = 10;
@@ -912,8 +913,24 @@ export class ChatOrchestrator {
     this.bus.emit({ type: "system_message", text: line, variant: "warn" });
   }
 
+  /**
+   * Issue #121: a long session was killed by the V8 heap ceiling with no
+   * warning, losing ~40 minutes of work. V8 cannot raise its own ceiling
+   * after startup, so the best available remedy is to say so while there
+   * is still headroom to save work and restart with a bigger heap.
+   * Checked at turn boundaries — the crash grew across turns, including
+   * long idle gaps between them.
+   */
+  private readonly heapGuard = createHeapGuard();
+
+  private announceHeapPressure(): void {
+    const status = this.heapGuard.check();
+    if (status?.message) this.notify(status.message);
+  }
+
   private async runOneTurn(text: string, fromQueue = false): Promise<void> {
     if (!this.session) return;
+    this.announceHeapPressure();
     // Pre-turn gate: a managed local model that is not on disk cannot
     // serve this turn, so fail fast with the real fix instead of
     // burning the transport retry budget against a daemon that cannot


### PR DESCRIPTION
## Summary

Investigation of #121 (V8 heap OOM in a long session). This fixes four real unbounded-growth bugs found along the way and makes the failure legible instead of silent.

**It does not claim to fix the reported 4 GB crash.** We could not identify the retainer, and we would rather ship the verified parts than assert a root cause the evidence does not support. Details below.

## What the crash evidence actually shows

From the reporter's attached trace and crash log:

- Died at **4083 MB against a ~4288 MB ceiling** — Node's *default* limit. `sea-config.json` sets no `--max-old-space-size`, so the shipped binary is capped near 4 GB regardless of machine RAM.
- A full Mark-Compact freed only ~11 MB, so the memory was **retained** (reachable), not uncollected garbage.
- The session ran **6 turns / 30 steps / 49 tool calls** — and roughly **22 of the 34 minutes were idle** (gaps of 438 s, 373 s, 273 s, 253 s between turns). Growth tracked wall-clock, not work.

The report attributes the leak to unbounded TUI conversation state. That part does not hold up — the TUI already ring-buffers `feed`, `messages`, `logs` and history at 500 entries, and the prompt is packed to a token budget every step. Measured:

| Suspect | Retained |
|---|---|
| TUI reducer state (6 turns x 25 steps, 64 KB results) | ~0 MB |
| Session transcript (312 turns) | <1 MB |
| 2040 idle poller ticks (~34 min) | 2.1 MB |
| Abort-closure retention (25 steps) | 0.08 MB |

## Changes

**1. `streamingToolCards` grew without a cap** (`src/tui/reducer-helpers.ts`)

Every neighbouring array goes through `pushRing` with `ringBufferSize`; this one appended directly, so a single long turn pinned one card per tool call (each holding `args` plus `details`) until the turn ended. Now ring-buffered like the rest.

**2. O(N^2) render churn in `packConversation`** (`src/session/conversation-turn.ts`)

`packConversation` runs once per step and re-rendered *every* historical turn on each call — including `JSON.stringify` of every past tool call's args — only to sum token costs and discard the strings. ~10 MB of transient allocation per 25-step turn.

Turn objects are immutable once appended, so cost is memoised on the turn via a `WeakMap`. `inCurrentMacroTurn` is part of the cache key rather than folded away, because fresh-bypass tools (`os.http.request`, fresh `gog` shell) render differently while fresh than once aged.

Measured: 100 steps drops from **23.2 ms to 1.3 ms** per turn, growth linear instead of quadratic. Prompt output verified **byte-identical** against the previous implementation across 200 randomised transcripts covering the fresh/aged and `gog` paths.

**3. Leaked abort listeners** (`src/approval/approval-gate.ts`)

`request()` subscribed to the caller's abort signal with `{ once: true }` and never detached. `once` removes the listener only when the event actually fires, and on the normal approve/deny path it never does. The signal is the turn-lifetime one threaded into every gated tool, so a turn with N gated calls left N listeners attached, each closing over its request (which for shell carries the full command preview).

The same path also **hung** when handed an already-aborted signal: `abort` had already fired, so the listener was never invoked and the promise never settled. It now rejects up front.

**4. Unbounded `recorders` map** (`src/runtime/bootstrap.ts`)

Trace recorders were keyed by session id with no `delete` or `clear` anywhere, so a long-lived runtime serving many sessions (sidecar, HTTP server, background tasks) grew it forever. There is no session-teardown hook to delete from, so it is bounded at 64 and evicts oldest-first.

**5. Heap-pressure warning** (`src/runtime/heap-guard.ts`, new)

V8 cannot raise its own ceiling after startup (`setFlagsFromString` is a no-op for `--max-old-space-size` once the heap exists), so this cannot prevent the crash. It makes it legible: warn at 75% and again at 90% of the ceiling, so the operator can save work and restart with a bigger heap instead of the process vanishing. Warns once per escalation and re-arms if memory is released.

## Test coverage

19 new tests. The behavioural ones fail without their fix:

- Tool-card cap: without the fix 16 cards accumulate where 8 are expected.
- Abort listeners: without the fix 20 listeners are retained on one signal instead of 0.
- Memoisation: repeated-call stability, the fresh/aged distinction, and budget-pressure dropping.
- Heap guard: thresholds, escalate-once, re-arm, and the exact 4083/4288 numbers from the report — tested through an injected reading, so no gigabytes are allocated.
- Recorder eviction: stays at the cap, evicts oldest-first, never drops the newest entry.

## Verification

- `npm run lint` clean, `npm run build` clean.
- Full suite: **6239 passed** vs **6220** on the same base (+19 new).
- Remaining failures are pre-existing flakes present on clean `main` too: `send-message-concurrency`, `fs-glob-real` (`$HOME`-dependent), and a wall-time `parallel-tool-calls` assertion that passes in isolation.

## Still open

The retainer behind the 4 GB is **not** identified. Measurements rule out the TUI state, the transcript, prompt churn and the idle pollers; growth correlated with idle wall-clock rather than tool calls, which points below the application layer (this was a Node SEA binary on Windows). Closing #121 needs a heap snapshot from an affected run:

```
NODE_OPTIONS="--max-old-space-size=8192 --heapsnapshot-near-heap-limit=1"
```

That raises the ceiling to ~8384 MB (verified) so the session survives longer, and writes a `.heapsnapshot` near the limit; the top retained-size entry is the answer.

Note on #214: it targets the same issue by pruning `SessionState.turns[]`. We tested that approach and it behaves correctly (bounds the array, keeps the original user request pinned, no summary compounding, no broken call/result pairing). It is a reasonable guard, but our measurements show the transcript holds <1 MB, so it is not what consumed 4 GB either. The two changes do not conflict.
