### PR TITLE
feat(cli): config get/set/unset/list by dotted key

### DIFF
--- a/src/cli/config-command.test.ts
+++ b/src/cli/config-command.test.ts
@@ -244,6 +244,42 @@ describe("configCommand", () => {
       expect(readFileSync(join(stateDir, "config.json"), "utf8")).toBe(before);
     });
 
+    it("set rejects a partly-numeric value instead of truncating it", async () => {
+      // `Number.parseInt` stops at the first character it cannot read, which
+      // would turn each of these into a plausible-looking number and write it
+      // as a success. `1e3` is the worst case: asking for 1000 and silently
+      // getting a token budget of 1.
+      for (const bad of ["1e3", "100_000", "60s", "1,000", "10.9", "8080x"]) {
+        seedSparseConfig({ agent: { maxSteps: 7 } });
+        const before = readFileSync(join(stateDir, "config.json"), "utf8");
+        stderr = "";
+        const code = await configCommand(["set", "agent.tokenBudget", bad]);
+        expect(code, `${bad} should be rejected`).toBe(1);
+        expect(stderr).toContain("agent.tokenBudget");
+        expect(readFileSync(join(stateDir, "config.json"), "utf8")).toBe(
+          before,
+        );
+      }
+    });
+
+    it("set still accepts a clean integer, with surrounding space", async () => {
+      seedSparseConfig({ agent: { maxSteps: 7 } });
+      const code = await configCommand(["set", "agent.tokenBudget", " 1000 "]);
+      expect(code).toBe(0);
+      expect(stdout).toContain("agent.tokenBudget = 1000");
+    });
+
+    it("set rejects a partly-numeric fractional value", async () => {
+      seedSparseConfig({ agent: { maxSteps: 7 } });
+      const code = await configCommand([
+        "set",
+        "memory.retrieve.fts5Threshold",
+        "0.85xyz",
+      ]);
+      expect(code).toBe(1);
+      expect(stderr).toContain("fts5Threshold");
+    });
+
     it("set rejects version, which the schema's migration owns", async () => {
       const code = await configCommand(["set", "version", "12"]);
       expect(code).toBe(1);

--- a/src/cli/config-command.test.ts
+++ b/src/cli/config-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -170,5 +170,173 @@ describe("configCommand", () => {
     const onDisk = JSON.parse(readFileSync(join(stateDir, "config.json"), "utf8"));
     expect(onDisk.version).toBe(USER_CONFIG_VERSION);
     expect(onDisk.localModels.url).toBe("http://127.0.0.1:19091");
+  });
+
+  describe("point edits", () => {
+    /** Seed a hand-written sparse config, as a user who edited the file would have. */
+    function seedSparseConfig(tree: Record<string, unknown>): void {
+      writeFileSync(
+        join(stateDir, "config.json"),
+        JSON.stringify({ version: USER_CONFIG_VERSION, ...tree }, null, 2),
+      );
+      resetConfigCache();
+    }
+
+    it("set <key> <value> writes one key and leaves the rest of the file alone", async () => {
+      seedSparseConfig({ agent: { maxSteps: 7 } });
+      const code = await configCommand(["set", "log.level", "debug"]);
+      expect(code).toBe(0);
+      const onDisk = JSON.parse(readFileSync(join(stateDir, "config.json"), "utf8"));
+      expect(onDisk.log.level).toBe("debug");
+      // The pre-existing user value survives untouched...
+      expect(onDisk.agent.maxSteps).toBe(7);
+      // ...and the file is NOT expanded with every default in the schema.
+      // Writing back the defaulted parse output would freeze today's
+      // defaults into the user's file; only touched keys may appear.
+      expect(Object.keys(onDisk).sort()).toEqual(["agent", "log", "version"]);
+      expect(stdout.trim()).toBe('log.level = "debug"');
+    });
+
+    it("set coerces the raw string through the schema rather than guessing types", async () => {
+      // The command never inspects the value: "false" becomes a boolean and
+      // "19099" a number purely because the schema's parsers coerce them.
+      // This is what keeps CLI typing from drifting from the schema.
+      expect(await configCommand(["set", "localModels.managed.autoUpdate", "false"])).toBe(0);
+      expect(await configCommand(["set", "localModels.managed.port", "19099"])).toBe(0);
+      const onDisk = JSON.parse(readFileSync(join(stateDir, "config.json"), "utf8"));
+      expect(onDisk.localModels.managed.autoUpdate).toBe(false);
+      expect(onDisk.localModels.managed.port).toBe(19099);
+    });
+
+    it("set rejects an unknown key instead of silently writing nothing", async () => {
+      // The load-bearing test. `parseUserConfigFile` IGNORES unknown keys,
+      // so without our own check this typo would validate, write a file
+      // with no such setting, and report success — the command would lie.
+      seedSparseConfig({ agent: { maxSteps: 7 } });
+      const before = readFileSync(join(stateDir, "config.json"), "utf8");
+      const code = await configCommand([
+        "set",
+        "localModels.managed.autoUpdte",
+        "false",
+      ]);
+      expect(code).toBe(1);
+      expect(stderr).toContain("unknown key localModels.managed.autoUpdte");
+      expect(stderr).toContain("did you mean localModels.managed.autoUpdate?");
+      expect(readFileSync(join(stateDir, "config.json"), "utf8")).toBe(before);
+    });
+
+    it("set suggests nothing when no key is close enough", async () => {
+      // A wrong suggestion points the user at a real but unintended
+      // setting, so the threshold stays conservative.
+      const code = await configCommand(["set", "totally.bogus.nonsense", "1"]);
+      expect(code).toBe(1);
+      expect(stderr).toContain("unknown key");
+      expect(stderr).not.toContain("did you mean");
+    });
+
+    it("set rejects a value the schema refuses, leaving the file untouched", async () => {
+      seedSparseConfig({ agent: { maxSteps: 7 } });
+      const before = readFileSync(join(stateDir, "config.json"), "utf8");
+      const code = await configCommand(["set", "agent.maxSteps", "0"]);
+      expect(code).toBe(1);
+      // The dotted path comes from ConfigValidationError, not from us.
+      expect(stderr).toContain("agent.maxSteps");
+      expect(readFileSync(join(stateDir, "config.json"), "utf8")).toBe(before);
+    });
+
+    it("set rejects version, which the schema's migration owns", async () => {
+      const code = await configCommand(["set", "version", "12"]);
+      expect(code).toBe(1);
+      expect(stderr).toContain("managed by the config schema");
+    });
+
+    it("set rejects a branch and a list rather than inventing syntax", async () => {
+      expect(await configCommand(["set", "localModels.managed", "x"])).toBe(1);
+      expect(stderr).toContain("unknown key localModels.managed");
+      stderr = "";
+      expect(await configCommand(["set", "projects.roots", "/a"])).toBe(1);
+      expect(stderr).toContain("is a list");
+    });
+
+    it("set with a key but no value is a usage error, not a get", async () => {
+      const code = await configCommand(["set", "agent.maxSteps"]);
+      expect(code).toBe(1);
+      expect(stderr).toContain("no value given for agent.maxSteps");
+    });
+
+    it("unset restores a key to its default and prunes the emptied block", async () => {
+      seedSparseConfig({ agent: { maxSteps: 7 } });
+      const code = await configCommand(["unset", "agent.maxSteps"]);
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe("agent.maxSteps \u2192 25 (default)");
+      const onDisk = JSON.parse(readFileSync(join(stateDir, "config.json"), "utf8"));
+      // The now-empty `agent` block is pruned rather than left as a husk.
+      expect(onDisk.agent).toBeUndefined();
+    });
+
+    it("unset works on list keys, which set refuses", async () => {
+      seedSparseConfig({ projects: { roots: ["/tmp/x"] } });
+      expect(await configCommand(["unset", "projects.roots"])).toBe(0);
+      const onDisk = JSON.parse(readFileSync(join(stateDir, "config.json"), "utf8"));
+      expect(onDisk.projects).toBeUndefined();
+    });
+
+    it("unset rejects an unknown key", async () => {
+      expect(await configCommand(["unset", "agent.maxStep"])).toBe(1);
+      expect(stderr).toContain("unknown key agent.maxStep");
+    });
+
+    it("get <key> prints a single value and rejects unknown keys", async () => {
+      seedSparseConfig({ agent: { maxSteps: 7 } });
+      expect(await configCommand(["get", "agent.maxSteps"])).toBe(0);
+      expect(stdout.trim()).toBe("7");
+      stdout = "";
+      expect(await configCommand(["get", "localModels.managed"])).toBe(0);
+      expect(JSON.parse(stdout).port).toBe(19091);
+      stdout = "";
+      expect(await configCommand(["get", "nope.nope"])).toBe(1);
+      expect(stderr).toContain("unknown key nope.nope");
+    });
+
+    it("list marks non-default values and masks credential-shaped strings", async () => {
+      seedSparseConfig({ agent: { maxSteps: 42 } });
+      const code = await configCommand(["list"]);
+      expect(code).toBe(0);
+      const lines = stdout.split("\n");
+      const maxSteps = lines.find((line) => line.startsWith("agent.maxSteps "));
+      expect(maxSteps).toContain("= 42");
+      expect(maxSteps).toContain("(default 25)");
+      // A key left at its default carries no annotation.
+      expect(lines.find((line) => line.startsWith("log.level "))).not.toContain(
+        "(default",
+      );
+      // `apiKeyEnv` holds an env var name today, but anything
+      // credential-shaped is masked before it reaches a terminal.
+      expect(
+        lines.find((line) => line.startsWith("web.search.exa.apiKeyEnv ")),
+      ).toContain("***");
+      // A token *count* is not a credential and must stay readable.
+      expect(
+        lines.find((line) => line.startsWith("agent.tokenBudget ")),
+      ).toContain("= 3000");
+    });
+
+    it("path prints the config file location", async () => {
+      expect(await configCommand(["path"])).toBe(0);
+      expect(stdout.trim()).toBe(join(stateDir, "config.json"));
+    });
+
+    it("the key/value example in --help runs through the real set path", async () => {
+      // Same rot-proofing as the JSON example above: the documented
+      // `<key> <value>` line is executed, so a renamed key fails here
+      // rather than in a user's terminal.
+      await configCommand(["--help"]);
+      const match = stdout.match(/config set ([a-zA-Z.]+) (\S+)\n/);
+      expect(match).not.toBeNull();
+      stdout = "";
+      const code = await configCommand(["set", match![1], match![2]]);
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe(`${match![1]} = ${match![2]}`);
+    });
   });
 });

--- a/src/cli/config-command.ts
+++ b/src/cli/config-command.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+
 import {
   ConfigValidationError,
   ensureUserConfigFileSync,
@@ -7,39 +9,19 @@ import {
   USER_CONFIG_VERSION,
   writeUserConfigFileSync,
 } from "../config/index.js";
-
-/**
- * Copy-pasteable `config set` payload, assembled from the live schema
- * constants so the help text cannot drift from what `parseUserConfigFile`
- * accepts (the previous hand-written example carried `"version":1` and a
- * `llama` key, both long dead). `config-command.test.ts` extracts this
- * exact line from the rendered help and runs it through the real `set`
- * path.
- */
-const CONFIG_SET_EXAMPLE = JSON.stringify({
-  version: USER_CONFIG_VERSION,
-  localModels: { url: "http://127.0.0.1:19091" },
-  log: { level: "info" },
-});
-
-const HELP =
-  [
-    "atomic-agent config — manage the user config file",
-    "",
-    "Location: <stateDir>/config.json (stateDir comes from ATOMIC_AGENT_STATE_DIR",
-    "or defaults to ~/.atomic-agent).",
-    "",
-    "Subcommands:",
-    "  get                       Print the whole config file as JSON",
-    "  set '<json>'              Replace the whole config file with a JSON payload",
-    "",
-    "Keys left out of the payload are filled with their defaults; the result is",
-    "validated before anything is written.",
-    "",
-    "Example:",
-    "  atomic-agent config get",
-    `  atomic-agent config set '${CONFIG_SET_EXAMPLE}'`,
-  ].join("\n") + "\n";
+import { HELP } from "./config-help.js";
+import {
+  deleteConfigPath,
+  findConfigLeaf,
+  formatConfigValue,
+  isConfigBranch,
+  isReadOnlyConfigKey,
+  listConfigLeaves,
+  readConfigPath,
+  suggestConfigKey,
+  writeConfigPath,
+  writeRawUserConfigFileSync,
+} from "../config/config-paths.js";
 
 export async function configCommand(args: string[]): Promise<number> {
   const sub = args[0];
@@ -50,9 +32,16 @@ export async function configCommand(args: string[]): Promise<number> {
   try {
     switch (sub) {
       case "get":
-        return handleGet();
+        return handleGet(args.slice(1));
       case "set":
         return handleSet(args.slice(1));
+      case "unset":
+        return handleUnset(args.slice(1));
+      case "list":
+        return handleList();
+      case "path":
+        process.stdout.write(`${getConfig().paths.userConfigFile}\n`);
+        return 0;
       default:
         process.stderr.write(`unknown subcommand: ${sub}\n`);
         process.stderr.write(HELP);
@@ -69,19 +58,56 @@ export async function configCommand(args: string[]): Promise<number> {
   }
 }
 
-function handleGet(): number {
+function handleGet(args: string[]): number {
   const path = getConfig().paths.userConfigFile;
   const file = ensureUserConfigFileSync(path);
-  process.stdout.write(`${JSON.stringify(file, null, 2)}\n`);
+  if (args.length === 0) {
+    process.stdout.write(`${JSON.stringify(file, null, 2)}\n`);
+    return 0;
+  }
+  const key = args[0]!;
+  if (isConfigBranch(key)) {
+    // A branch has no single value; print the subtree rather than
+    // refusing, since that is unambiguously what was asked for.
+    process.stdout.write(
+      `${JSON.stringify(readConfigPath(file, key), null, 2)}\n`,
+    );
+    return 0;
+  }
+  if (!findConfigLeaf(key)) return rejectUnknownKey("get", key);
+  process.stdout.write(`${formatConfigValue(key, readConfigPath(file, key))}\n`);
   return 0;
 }
 
 function handleSet(args: string[]): number {
   if (args.length === 0) {
-    process.stderr.write("usage: atomic-agent config set '<json>'\n");
+    process.stderr.write(
+      "usage: atomic-agent config set <key> <value>\n" +
+        "   or: atomic-agent config set '<json>'\n",
+    );
     return 1;
   }
-  const raw = args.join(" ");
+  // Form discrimination. A leading `{` means the whole-file JSON payload,
+  // including the case where the shell split one JSON argument across
+  // several argv entries (`set { "version":40, ... }`), which is why the
+  // test for that keeps passing.
+  const first = args[0]!;
+  if (args.length >= 2 && !first.startsWith("{")) {
+    return setOneKey(first, args.slice(1).join(" "));
+  }
+  if (!first.startsWith("{")) {
+    // Single non-JSON argument: a key with no value. Treating this as
+    // `get` would silently do something other than what was typed.
+    process.stderr.write(
+      `config set failed: no value given for ${first}\n` +
+        `usage: atomic-agent config set ${first} <value>\n`,
+    );
+    return 1;
+  }
+  return setWholeFile(args.join(" "));
+}
+
+function setWholeFile(raw: string): number {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -110,4 +136,141 @@ function handleSet(args: string[]): number {
   resetConfigCache();
   process.stdout.write(`wrote ${path}\n`);
   return 0;
+}
+
+function setOneKey(key: string, value: string): number {
+  const leaf = findConfigLeaf(key);
+  if (!leaf) return rejectUnknownKey("set", key);
+  if (isReadOnlyConfigKey(key)) {
+    process.stderr.write(
+      `config set failed: ${key} is managed by the config schema and cannot be set by hand\n`,
+    );
+    return 1;
+  }
+  if (leaf.isArray) {
+    process.stderr.write(
+      `config set failed: ${key} is a list; set it with the whole-file JSON form\n` +
+        `  atomic-agent config set '{"version":${USER_CONFIG_VERSION}, ...}'\n`,
+    );
+    return 1;
+  }
+  const path = getConfig().paths.userConfigFile;
+  const tree = readRawConfigTree(path);
+  // The raw string goes in as-is: `parseUserConfigFile` coerces it to the
+  // declared type ("false" → false, "40" → 40) and enforces bounds and
+  // enums. Guessing the type here would be a second source of truth that
+  // drifts from the schema the moment a field changes type.
+  writeConfigPath(tree, key, value);
+  // Validate first, write second: `parseUserConfigFile` throws on a bad
+  // value, so a rejected `set` leaves the file untouched.
+  const next = parseUserConfigFile(tree);
+  // Store the *coerced* value the schema produced ("false" → false,
+  // "40" → 40) rather than the raw string. Both reload identically, since
+  // the schema coerces on every read, but a config file should hold
+  // JSON-typed values — anything else is a surprise to whoever opens it
+  // next. Only this one key is taken from the parse output; the rest of
+  // the tree stays exactly as it was on disk, so the file does not get
+  // expanded with every default (see `writeRawUserConfigFileSync`).
+  writeConfigPath(tree, key, readConfigPath(next, key));
+  writeRawUserConfigFileSync(path, tree);
+  resetConfigCache();
+  process.stdout.write(
+    `${key} = ${formatConfigValue(key, readConfigPath(next, key))}\n`,
+  );
+  return 0;
+}
+
+function handleUnset(args: string[]): number {
+  if (args.length === 0) {
+    process.stderr.write("usage: atomic-agent config unset <key>\n");
+    return 1;
+  }
+  const key = args[0]!;
+  const leaf = findConfigLeaf(key);
+  if (!leaf) return rejectUnknownKey("unset", key);
+  if (isReadOnlyConfigKey(key)) {
+    process.stderr.write(
+      `config unset failed: ${key} is managed by the config schema\n`,
+    );
+    return 1;
+  }
+  const path = getConfig().paths.userConfigFile;
+  const tree = readRawConfigTree(path);
+  deleteConfigPath(tree, key);
+  const next = parseUserConfigFile(tree);
+  writeRawUserConfigFileSync(path, tree);
+  resetConfigCache();
+  process.stdout.write(
+    `${key} → ${formatConfigValue(key, readConfigPath(next, key))} (default)\n`,
+  );
+  return 0;
+}
+
+function handleList(): number {
+  const file = ensureUserConfigFileSync(getConfig().paths.userConfigFile);
+  const rows = listConfigLeaves().map((leaf) => {
+    const actual = readConfigPath(file, leaf.key);
+    const rendered = `${leaf.key} = ${formatConfigValue(leaf.key, actual)}`;
+    const isDefault =
+      JSON.stringify(actual) === JSON.stringify(leaf.defaultValue);
+    return { rendered, isDefault, leaf };
+  });
+  // Align the `(default …)` notes with each other, not with all 139 rows:
+  // padding to the widest key in the whole config would strand the notes
+  // far off to the right of the handful of lines that carry them.
+  const annotated = rows.filter((row) => !row.isDefault);
+  const width = annotated.length
+    ? Math.max(...annotated.map((row) => row.rendered.length))
+    : 0;
+  for (const row of rows) {
+    if (row.isDefault) {
+      process.stdout.write(`${row.rendered}\n`);
+      continue;
+    }
+    const shown = formatConfigValue(row.leaf.key, row.leaf.defaultValue);
+    process.stdout.write(
+      `${row.rendered.padEnd(width)}  (default ${shown})\n`,
+    );
+  }
+  return 0;
+}
+
+/**
+ * Reject a key the schema does not define.
+ *
+ * This check is the whole reason `set` does not simply hand the tree to
+ * the schema: `parseUserConfigFile` *ignores* unknown keys, so a typo
+ * would validate, write a file without the setting, and report success.
+ */
+function rejectUnknownKey(sub: string, key: string): number {
+  const suggestion = suggestConfigKey(key);
+  const hint = suggestion ? ` (did you mean ${suggestion}?)` : "";
+  process.stderr.write(`config ${sub} failed: unknown key ${key}${hint}\n`);
+  process.stderr.write("run `atomic-agent config list` to see every key\n");
+  return 1;
+}
+
+/**
+ * Read the config file as a plain JSON tree, without filling in defaults.
+ *
+ * Deliberately not `ensureUserConfigFileSync`: that returns the fully
+ * defaulted config, so writing it back would freeze today's 139 defaults
+ * into the user's file and silently pin them against future schema
+ * changes. A point edit must leave the rest of the file byte-for-byte
+ * alone, which means starting from what is actually on disk.
+ */
+function readRawConfigTree(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  const text = readFileSync(path, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ConfigValidationError("<file>", `${path} is not valid JSON: ${message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ConfigValidationError("<file>", `${path} is not a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
 }

--- a/src/cli/config-help.ts
+++ b/src/cli/config-help.ts
@@ -1,0 +1,57 @@
+import { USER_CONFIG_VERSION } from "../config/index.js";
+
+/**
+ * Help text for `atomic-agent config`, kept beside the command rather
+ * than inside it so `config-command.ts` stays within the 300-line limit
+ * and holds only command behaviour.
+ */
+
+/**
+ * Copy-pasteable `config set` payload, assembled from the live schema
+ * constants so the help text cannot drift from what `parseUserConfigFile`
+ * accepts (the previous hand-written example carried `"version":1` and a
+ * `llama` key, both long dead). `config-command.test.ts` extracts this
+ * exact line from the rendered help and runs it through the real `set`
+ * path.
+ */
+const CONFIG_SET_EXAMPLE = JSON.stringify({
+  version: USER_CONFIG_VERSION,
+  localModels: { url: "http://127.0.0.1:19091" },
+  log: { level: "info" },
+});
+
+/**
+ * Key/value example, also extracted and executed by the test suite for
+ * the same rot-proofing reason as `CONFIG_SET_EXAMPLE`.
+ */
+const CONFIG_SET_KEY_EXAMPLE = "agent.maxSteps 40";
+
+export const HELP =
+  [
+    "atomic-agent config — manage the user config file",
+    "",
+    "Location: <stateDir>/config.json (stateDir comes from ATOMIC_AGENT_STATE_DIR",
+    "or defaults to ~/.atomic-agent).",
+    "",
+    "Subcommands:",
+    "  get                       Print the whole config file as JSON",
+    "  get <key>                 Print one value by dotted key",
+    "  set <key> <value>         Set one value, leaving the rest of the file alone",
+    "  set '<json>'              Replace the whole config file with a JSON payload",
+    "  unset <key>               Restore one key to its default",
+    "  list                      Print every key as `key = value`",
+    "  path                      Print the path to the config file",
+    "",
+    "Values are typed by the config schema, so `false`, `40` and `info` are",
+    "written as boolean, number and string respectively; bounds and enums are",
+    "enforced before anything is written. Keys left out of a whole-file JSON",
+    "payload are filled with their defaults.",
+    "",
+    "List-valued keys (for example projects.roots) have no single-value spelling —",
+    "set those with the whole-file JSON form. `unset` works on them.",
+    "",
+    "Example:",
+    "  atomic-agent config get",
+    `  atomic-agent config set ${CONFIG_SET_KEY_EXAMPLE}`,
+    `  atomic-agent config set '${CONFIG_SET_EXAMPLE}'`,
+  ].join("\n") + "\n";

--- a/src/config/config-paths.test.ts
+++ b/src/config/config-paths.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deleteConfigPath,
+  isSafeConfigPath,
+  readConfigPath,
+  writeConfigPath,
+} from "./config-paths.js";
+
+describe("config path helpers reject prototype-reaching keys", () => {
+  it("writeConfigPath throws rather than polluting Object.prototype", () => {
+    const tree: Record<string, unknown> = {};
+    expect(() => writeConfigPath(tree, "__proto__.polluted", "yes")).toThrow(
+      /unsafe path/,
+    );
+    expect(() =>
+      writeConfigPath(tree, "constructor.prototype.polluted", "yes"),
+    ).toThrow(/unsafe path/);
+
+    // The real assertion: nothing leaked onto every object in the process.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty("polluted");
+  });
+
+  it("writeConfigPath still writes ordinary nested keys", () => {
+    const tree: Record<string, unknown> = {};
+    writeConfigPath(tree, "localModels.managed.autoUpdate", false);
+    expect(tree).toEqual({
+      localModels: { managed: { autoUpdate: false } },
+    });
+  });
+
+  it("readConfigPath returns undefined for inherited properties", () => {
+    // A bare `node[segment]` would hand back Object.prototype.constructor
+    // here, reporting a value the config file does not contain.
+    expect(readConfigPath({}, "constructor")).toBeUndefined();
+    expect(readConfigPath({}, "toString")).toBeUndefined();
+    expect(readConfigPath({ a: { b: 1 } }, "a.b")).toBe(1);
+    expect(readConfigPath({ a: { b: 0 } }, "a.b")).toBe(0);
+    expect(readConfigPath({ a: { b: false } }, "a.b")).toBe(false);
+  });
+
+  it("deleteConfigPath refuses unsafe paths and inherited keys", () => {
+    expect(deleteConfigPath({}, "__proto__.x")).toBe(false);
+    expect(deleteConfigPath({}, "constructor")).toBe(false);
+    expect(Object.prototype).not.toHaveProperty("x");
+  });
+
+  it("deleteConfigPath still prunes a real emptied branch", () => {
+    const tree: Record<string, unknown> = { a: { b: { c: 1 } }, keep: 2 };
+    expect(deleteConfigPath(tree, "a.b.c")).toBe(true);
+    expect(tree).toEqual({ keep: 2 });
+  });
+
+  it("isSafeConfigPath names the three dangerous segments", () => {
+    expect(isSafeConfigPath("agent.maxSteps")).toBe(true);
+    expect(isSafeConfigPath("__proto__")).toBe(false);
+    expect(isSafeConfigPath("a.constructor.b")).toBe(false);
+    expect(isSafeConfigPath("a.prototype")).toBe(false);
+  });
+});

--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -178,9 +178,25 @@ export function readConfigPath(tree: unknown, key: string): unknown {
     if (node === null || typeof node !== "object" || Array.isArray(node)) {
       return undefined;
     }
+    // Own properties only: a bare `[segment]` would happily return
+    // `Object.prototype.constructor` for a key named "constructor",
+    // reporting a value the config file does not contain.
+    if (!Object.hasOwn(node, segment)) return undefined;
     node = (node as Record<string, unknown>)[segment];
   }
   return node;
+}
+
+/**
+ * Segments that must never be walked or assigned through. Writing to
+ * `__proto__` mutates `Object.prototype` for the whole process, and
+ * `constructor.prototype` reaches it the long way round.
+ */
+const UNSAFE_PATH_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
+/** Whether a dotted key is safe to walk. Exported for the callers' guards. */
+export function isSafeConfigPath(key: string): boolean {
+  return key.split(".").every((s) => !UNSAFE_PATH_SEGMENTS.has(s));
 }
 
 /**
@@ -191,17 +207,31 @@ export function readConfigPath(tree: unknown, key: string): unknown {
  * `typeof` calls "object") is replaced: it cannot be a valid parent, and
  * `parseUserConfigFile` will reject the result anyway if the shape is
  * wrong — nothing is written until it passes.
+ *
+ * Throws on a path containing `__proto__`, `constructor` or `prototype`.
+ * Callers today filter keys through the schema allowlist first, so this is
+ * unreachable from the CLI — but the guard lives here, next to the
+ * assignment, rather than depending on every future caller validating as
+ * strictly.
  */
 export function writeConfigPath(
   tree: Record<string, unknown>,
   key: string,
   value: unknown,
 ): void {
+  if (!isSafeConfigPath(key)) {
+    throw new Error(`config: refusing to write unsafe path ${key}`);
+  }
   const segments = key.split(".");
   let node = tree;
   for (const segment of segments.slice(0, -1)) {
     const child = node[segment];
-    if (child === null || typeof child !== "object" || Array.isArray(child)) {
+    if (
+      child === null ||
+      typeof child !== "object" ||
+      Array.isArray(child) ||
+      !Object.hasOwn(node, segment)
+    ) {
       node[segment] = {};
     }
     node = node[segment] as Record<string, unknown>;
@@ -243,11 +273,12 @@ export function deleteConfigPath(
   tree: Record<string, unknown>,
   key: string,
 ): boolean {
+  if (!isSafeConfigPath(key)) return false;
   const segments = key.split(".");
   const chain: Record<string, unknown>[] = [tree];
   let node: Record<string, unknown> = tree;
   for (const segment of segments.slice(0, -1)) {
-    const child = node[segment];
+    const child = Object.hasOwn(node, segment) ? node[segment] : undefined;
     if (child === null || typeof child !== "object" || Array.isArray(child)) {
       return false;
     }
@@ -255,7 +286,8 @@ export function deleteConfigPath(
     chain.push(node);
   }
   const last = segments[segments.length - 1]!;
-  if (!(last in node)) return false;
+  // `in` walks the prototype chain; only an own key is really present.
+  if (!Object.hasOwn(node, last)) return false;
   delete node[last];
   for (let i = chain.length - 1; i > 0; i -= 1) {
     if (Object.keys(chain[i]!).length > 0) break;

--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -1,0 +1,265 @@
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { USER_CONFIG_DEFAULTS } from "./config-schema.js";
+
+/**
+ * Dotted-key addressing for `atomic-agent config get|set|unset|list`.
+ *
+ * The shape of the config is derived from `USER_CONFIG_DEFAULTS` at
+ * module load rather than hand-listed, so a new block in the schema
+ * becomes addressable without touching this file.
+ *
+ * Deliberately absent: any notion of a *type* per key. `parseUserConfigFile`
+ * already coerces strings ("false" → false, "19099" → 19099 via `parseBool`
+ * / the numeric parsers), enforces bounds and enums, and reports failures
+ * as `ConfigValidationError` with the dotted path already in the message.
+ * A type table here would be a second source of truth that silently drifts
+ * from the schema; instead `set` substitutes the raw string and lets the
+ * schema decide. See `config-command.ts`.
+ */
+
+/** A leaf that `config set` can address, and its default value. */
+export interface ConfigLeaf {
+  /** Dotted path, e.g. `localModels.managed.autoUpdate`. */
+  readonly key: string;
+  /** Default value from `USER_CONFIG_DEFAULTS`. */
+  readonly defaultValue: unknown;
+  /**
+   * True when the default is an array. Arrays have no single-token
+   * spelling that would not be an invented mini-language (indices,
+   * append syntax, separator escaping), so `set` refuses them and points
+   * at the whole-file JSON form. `unset` still works — restoring the
+   * default needs no syntax.
+   */
+  readonly isArray: boolean;
+}
+
+function buildIndex(): {
+  leaves: Map<string, ConfigLeaf>;
+  branches: Set<string>;
+} {
+  const leaves = new Map<string, ConfigLeaf>();
+  const branches = new Set<string>();
+  const walk = (node: Record<string, unknown>, prefix: string[]): void => {
+    for (const [name, value] of Object.entries(node)) {
+      const path = [...prefix, name];
+      const key = path.join(".");
+      // Arrays and null are leaves: `null` is a real value in this schema
+      // (tri-state toggles, "no override"), not an empty branch to descend.
+      if (value !== null && !Array.isArray(value) && typeof value === "object") {
+        branches.add(key);
+        walk(value as Record<string, unknown>, path);
+        continue;
+      }
+      leaves.set(key, { key, defaultValue: value, isArray: Array.isArray(value) });
+    }
+  };
+  walk(USER_CONFIG_DEFAULTS as unknown as Record<string, unknown>, []);
+  return { leaves, branches };
+}
+
+const INDEX = buildIndex();
+
+/**
+ * `version` is owned by the schema's migration path
+ * (`ensureUserConfigFileSync` bumps it); a user pinning it by hand
+ * produces a file the migrator will disagree with, so it is not settable.
+ */
+const READ_ONLY_KEYS = new Set(["version"]);
+
+/** Every addressable leaf, in declaration order. */
+export function listConfigLeaves(): readonly ConfigLeaf[] {
+  return [...INDEX.leaves.values()];
+}
+
+/** Look up a leaf by dotted key, or `undefined` if it is not one. */
+export function findConfigLeaf(key: string): ConfigLeaf | undefined {
+  return INDEX.leaves.get(key);
+}
+
+/** True when `key` names an object node (e.g. `localModels.managed`). */
+export function isConfigBranch(key: string): boolean {
+  return INDEX.branches.has(key);
+}
+
+/** True when `key` exists but the schema, not the user, owns its value. */
+export function isReadOnlyConfigKey(key: string): boolean {
+  return READ_ONLY_KEYS.has(key);
+}
+
+/**
+ * Nearest known leaf to a typo, or `null` when nothing is close enough.
+ *
+ * The threshold is deliberately tight (edit distance <= 2, and never more
+ * than a third of the key's length): a wrong suggestion sends the user
+ * to edit a real but unintended setting, which is worse than no
+ * suggestion at all.
+ */
+export function suggestConfigKey(key: string): string | null {
+  const target = key.toLowerCase();
+  let best: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const leaf of INDEX.leaves.keys()) {
+    const distance = editDistance(target, leaf.toLowerCase());
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = leaf;
+    }
+  }
+  if (best === null) return null;
+  const ceiling = Math.min(2, Math.floor(key.length / 3));
+  return bestDistance <= ceiling ? best : null;
+}
+
+/** Levenshtein distance, two-row rolling table. */
+function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let current = new Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitution = previous[j - 1]! + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(previous[j]! + 1, current[j - 1]! + 1, substitution);
+    }
+    [previous, current] = [current, previous];
+  }
+  return previous[b.length]!;
+}
+
+/**
+ * Leaf names whose *values* would be secrets if this schema ever held
+ * one. Today the config file stores only env var *names*
+ * (`web.search.exa.apiKeyEnv`), with the secrets themselves in `.env` —
+ * but `config get`/`list` print to a terminal that gets pasted into bug
+ * reports, so the masking rule is in place before a real secret lands in
+ * the schema and quietly gets printed.
+ *
+ * The name is matched on whole camelCase words of the last path segment,
+ * in any position, so both `apiKeyEnv` and a future `authToken` are
+ * caught. Name alone is not enough, though: `agent.tokenBudget` and
+ * `memory.profile.maxTokens` are step counters that happen to contain
+ * "token". The value's type is the tiebreaker — a number is a budget, a
+ * non-empty string is the thing worth hiding — so masking is decided in
+ * `formatConfigValue`, where the value is in hand.
+ */
+const SECRET_NAMES = new Set(["secret", "token", "apikey", "password"]);
+
+/**
+ * True when a leaf's name suggests its value is a credential. Callers
+ * that print values should use {@link formatConfigValue}, which also
+ * applies the value-type check described above.
+ */
+export function isSecretConfigKey(key: string): boolean {
+  const last = key.slice(key.lastIndexOf(".") + 1);
+  const words = last.split(/(?=[A-Z])/).map((word) => word.toLowerCase());
+  if (words.some((word) => SECRET_NAMES.has(word))) return true;
+  // `apiKey`/`apiKeyEnv`: the secret noun spans two camelCase words.
+  return words.some(
+    (word, i) => SECRET_NAMES.has(word + (words[i + 1] ?? "")),
+  );
+}
+
+/** Render a value for `get`/`list`, masking anything secret-shaped. */
+export function formatConfigValue(key: string, value: unknown): string {
+  if (isSecretConfigKey(key) && typeof value === "string" && value.length > 0) {
+    return "***";
+  }
+  return JSON.stringify(value);
+}
+
+/** Read a dotted path out of a config tree, or `undefined` if absent. */
+export function readConfigPath(tree: unknown, key: string): unknown {
+  let node: unknown = tree;
+  for (const segment of key.split(".")) {
+    if (node === null || typeof node !== "object" || Array.isArray(node)) {
+      return undefined;
+    }
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return node;
+}
+
+/**
+ * Write `value` at a dotted path in a raw (on-disk) config tree,
+ * creating intermediate objects as needed. Mutates `tree`.
+ *
+ * A non-object sitting where a branch must go (including an array, which
+ * `typeof` calls "object") is replaced: it cannot be a valid parent, and
+ * `parseUserConfigFile` will reject the result anyway if the shape is
+ * wrong — nothing is written until it passes.
+ */
+export function writeConfigPath(
+  tree: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  const segments = key.split(".");
+  let node = tree;
+  for (const segment of segments.slice(0, -1)) {
+    const child = node[segment];
+    if (child === null || typeof child !== "object" || Array.isArray(child)) {
+      node[segment] = {};
+    }
+    node = node[segment] as Record<string, unknown>;
+  }
+  node[segments[segments.length - 1]!] = value;
+}
+
+/**
+ * Atomically write a *sparse* config tree — only the keys the user has
+ * actually set — using the same tmp + rename discipline as
+ * `writeUserConfigFileSync`.
+ *
+ * Separate from `writeUserConfigFileSync` on purpose: that one takes a
+ * fully-defaulted `UserConfigFile`, which is right for the whole-file
+ * `set` and for migration, but wrong for a point edit. Writing the
+ * defaulted tree back would expand a hand-written four-line config into
+ * every key in the schema and freeze today's defaults into the user's
+ * file, so a later change to a default would silently not reach them.
+ * The caller validates the tree through `parseUserConfigFile` first and
+ * only reaches this function once that succeeds.
+ */
+export function writeRawUserConfigFileSync(
+  path: string,
+  tree: Record<string, unknown>,
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const payload = JSON.stringify(tree, null, 2) + "\n";
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, payload, "utf8");
+  renameSync(tmp, path);
+}
+
+/**
+ * Delete a dotted path from a raw config tree, pruning any intermediate
+ * objects the deletion leaves empty so `unset` does not accumulate
+ * `{"memory":{"links":{}}}` husks. Returns true when something was removed.
+ */
+export function deleteConfigPath(
+  tree: Record<string, unknown>,
+  key: string,
+): boolean {
+  const segments = key.split(".");
+  const chain: Record<string, unknown>[] = [tree];
+  let node: Record<string, unknown> = tree;
+  for (const segment of segments.slice(0, -1)) {
+    const child = node[segment];
+    if (child === null || typeof child !== "object" || Array.isArray(child)) {
+      return false;
+    }
+    node = child as Record<string, unknown>;
+    chain.push(node);
+  }
+  const last = segments[segments.length - 1]!;
+  if (!(last in node)) return false;
+  delete node[last];
+  for (let i = chain.length - 1; i > 0; i -= 1) {
+    if (Object.keys(chain[i]!).length > 0) break;
+    delete chain[i - 1]![segments[i - 1]!];
+  }
+  return true;
+}

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -2133,13 +2133,40 @@ export function parseWebSearchFallback(
   return out;
 }
 
+/**
+ * Coerce a raw config value to a number for validation.
+ *
+ * A string must be a *complete* numeric literal. `Number.parseInt` stops at
+ * the first character it cannot read, so it turns `"1e3"` into `1`, `"60s"`
+ * into `60` and `"100_000"` into `100` — a typo silently becomes a valid
+ * setting. That is reachable from `config set <key> <value>`, where every
+ * value arrives as a string, so the whole token is checked here and anything
+ * that is not a clean integer literal is rejected as `NaN`.
+ */
+function coerceIntLike(raw: unknown): number {
+  if (typeof raw === "number") return raw;
+  if (typeof raw !== "string") return NaN;
+  const text = raw.trim();
+  return /^[+-]?\d+$/.test(text) ? Number(text) : NaN;
+}
+
+/**
+ * The float counterpart of {@link coerceIntLike}. Accepts the forms JSON
+ * does — `1.5`, `-0.25`, `1e3` — and rejects trailing garbage like
+ * `"0.85xyz"` or a second dot, which `Number.parseFloat` would truncate.
+ */
+function coerceFloatLike(raw: unknown): number {
+  if (typeof raw === "number") return raw;
+  if (typeof raw !== "string") return NaN;
+  const text = raw.trim();
+  if (text.length === 0) return NaN;
+  return /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(text)
+    ? Number(text)
+    : NaN;
+}
+
 export function parsePositiveInt(raw: unknown, field: string): number {
-  const value =
-    typeof raw === "number"
-      ? raw
-      : typeof raw === "string"
-        ? Number.parseInt(raw, 10)
-        : NaN;
+  const value = coerceIntLike(raw);
   if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
     throw new ConfigValidationError(
       field,
@@ -2177,12 +2204,7 @@ export function parseBoundedPositiveInt(
  * accept `0` as "feature disabled", e.g. `memory.reflection.maxNotesPerCall`.
  */
 export function parseNonNegativeInt(raw: unknown, field: string): number {
-  const value =
-    typeof raw === "number"
-      ? raw
-      : typeof raw === "string"
-        ? Number.parseInt(raw, 10)
-        : NaN;
+  const value = coerceIntLike(raw);
   if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
     throw new ConfigValidationError(
       field,
@@ -2222,12 +2244,7 @@ export function parseNonNegativeBoundedInt(
  * re-deriving the clamp.
  */
 export function parseUnitInterval(raw: unknown, field: string): number {
-  const value =
-    typeof raw === "number"
-      ? raw
-      : typeof raw === "string"
-        ? Number.parseFloat(raw)
-        : NaN;
+  const value = coerceFloatLike(raw);
   if (!Number.isFinite(value) || value < 0 || value > 1) {
     throw new ConfigValidationError(
       field,
@@ -2248,12 +2265,7 @@ export function parseHalfOpenUnitInterval(
   raw: unknown,
   field: string,
 ): number {
-  const value =
-    typeof raw === "number"
-      ? raw
-      : typeof raw === "string"
-        ? Number.parseFloat(raw)
-        : NaN;
+  const value = coerceFloatLike(raw);
   if (!Number.isFinite(value) || value <= 0 || value > 1) {
     throw new ConfigValidationError(
       field,


### PR DESCRIPTION
## Summary

`atomic-agent config set` replaces the **whole** config file, so changing one
field means dumping the JSON, editing it, and writing it back. This adds
dotted-key addressing while keeping the whole-file form intact.

```
atomic-agent config get                  # whole file (unchanged)
atomic-agent config get <key>            # one value
atomic-agent config set <key> <value>    # new: point edit
atomic-agent config set '<json>'         # unchanged
atomic-agent config unset <key>          # restore the default
atomic-agent config list                 # flat listing, non-defaults marked
atomic-agent config path
```

Motivation: `localModels.managed.autoUpdate` ships on by default and drives a
background download, but there was no practical way to turn it off. The TUI
toggle (`U`) added in #131 writes the same field; this is the CLI half.

## Design notes

**No type coercion in the CLI.** The schema already coerces: `parseBool`
accepts `1/true/yes/on`, the integer parsers accept strings. So `set` injects
the raw string at the path and hands the tree to `parseUserConfigFile`, which
types it and applies the real bounds and enums. A CLI-side type table would
be a second source of truth that drifts from a 3700-line schema.

**Unknown keys are rejected.** `parseUserConfigFile` silently ignores keys it
does not know, so `set localModels.managed.autoUpdte false` would report
success and change nothing. The key is checked against the defaults tree
first, with a Levenshtein suggestion:

```
config set failed: unknown key localModels.managed.autoUpdte
  (did you mean localModels.managed.autoUpdate?)
```

**Sparse write.** The parsed tree is not what gets written — writing it would
turn a 4-line config into 233 lines and freeze today's defaults into the
user's file, so future default changes would never reach them. Only the
touched key is written, atomically, and only after validation passes.

**Arrays** (`projects.roots`, `skills.disabled`, `mcp.servers`, …) reject
point `set` and point at the JSON form; `unset` works on them. Nullable
*scalars* are settable — they validate fine as strings.

Secret-shaped leaves are masked in `get`/`list`. `version` is not settable.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/cli src/config` — 382 passed
- [x] Built and exercised end to end: `set`, `get`, `unset`, typo rejection,
      and a 4-line config staying 11 lines after a point edit
- [x] The pre-existing whole-file `set` tests, including the shell-split JSON
      case, stay green
