### PR TITLE
fix: follow-ups from review of the four merged fixes

### DIFF
--- a/src/cli/config-command.test.ts
+++ b/src/cli/config-command.test.ts
@@ -244,12 +244,11 @@ describe("configCommand", () => {
       expect(readFileSync(join(stateDir, "config.json"), "utf8")).toBe(before);
     });
 
-    it("set rejects a partly-numeric value instead of truncating it", async () => {
-      // `Number.parseInt` stops at the first character it cannot read, which
-      // would turn each of these into a plausible-looking number and write it
-      // as a success. `1e3` is the worst case: asking for 1000 and silently
-      // getting a token budget of 1.
-      for (const bad of ["1e3", "100_000", "60s", "1,000", "10.9", "8080x"]) {
+    it("set rejects a value that is not a complete number", async () => {
+      // `Number.parseInt` stops at the first character it cannot read, so each
+      // of these would become a plausible-looking number and be written as a
+      // success — `60s` silently becoming a 60ms timeout, `1,000` becoming 1.
+      for (const bad of ["100_000", "60s", "1,000", "10.9", "8080x", "0x10"]) {
         seedSparseConfig({ agent: { maxSteps: 7 } });
         const before = readFileSync(join(stateDir, "config.json"), "utf8");
         stderr = "";
@@ -262,11 +261,35 @@ describe("configCommand", () => {
       }
     });
 
-    it("set still accepts a clean integer, with surrounding space", async () => {
+    it("set accepts any complete literal whose value is a whole number", async () => {
+      // The check is on the value, not the spelling. `10.0` and `1e3` are both
+      // complete literals that name an integer, and `parseInt` already handled
+      // `10.0` correctly — rejecting them would break configs that worked, and
+      // this parser runs at every startup.
+      for (const [input, want] of [
+        [" 1000 ", "1000"],
+        ["10.0", "10"],
+        ["1e3", "1000"],
+        ["+5", "5"],
+      ] as const) {
+        seedSparseConfig({ agent: { maxSteps: 7 } });
+        stdout = "";
+        const code = await configCommand(["set", "agent.tokenBudget", input]);
+        expect(code, `${input} should be accepted`).toBe(0);
+        expect(stdout).toContain(`agent.tokenBudget = ${want}`);
+      }
+    });
+
+    it("set rejects an integer too large to round-trip", async () => {
+      // Past 2^53 the literal is silently stored as a different number.
       seedSparseConfig({ agent: { maxSteps: 7 } });
-      const code = await configCommand(["set", "agent.tokenBudget", " 1000 "]);
-      expect(code).toBe(0);
-      expect(stdout).toContain("agent.tokenBudget = 1000");
+      const code = await configCommand([
+        "set",
+        "agent.tokenBudget",
+        "9007199254740993",
+      ]);
+      expect(code).toBe(1);
+      expect(stderr).toContain("agent.tokenBudget");
     });
 
     it("set rejects a partly-numeric fractional value", async () => {

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -1276,3 +1276,47 @@ describe("tui.whileBusySubmit", () => {
   });
 });
 
+
+describe("numeric coercion of string config values", () => {
+  const base = { version: USER_CONFIG_VERSION };
+
+  it("loads a config whose integer was written as a decimal string", () => {
+    // Regression: a stricter `/^\d+$/` test rejected these, and because this
+    // parser runs on every startup a config.json holding "8080.0" made the
+    // whole CLI unbootable — with no way to repair it from inside the tool,
+    // since `config set` loads the config first. `parseInt` had converted
+    // them correctly all along, so they must keep working.
+    for (const raw of ["10.0", "25.0", "1e3", "+7"]) {
+      expect(() =>
+        parseUserConfigFile({ ...base, agent: { maxSteps: raw } }),
+      ).not.toThrow();
+    }
+    expect(
+      parseUserConfigFile({ ...base, agent: { maxSteps: "10.0" } }).agent
+        .maxSteps,
+    ).toBe(10);
+    expect(
+      parseUserConfigFile({ ...base, agent: { tokenBudget: "1e3" } }).agent
+        .tokenBudget,
+    ).toBe(1000);
+  });
+
+  it("still rejects a value that is not a complete number", () => {
+    for (const raw of ["60s", "100_000", "1,000", "10.9", "0x10", "abc"]) {
+      expect(() =>
+        parseUserConfigFile({ ...base, agent: { maxSteps: raw } }),
+      ).toThrow(/maxSteps/);
+    }
+  });
+
+  it("rejects an integer past the safe range instead of rounding it", () => {
+    // "9007199254740993" would be stored as ...992 — the same quiet
+    // corruption the strict parsing exists to prevent.
+    expect(() =>
+      parseUserConfigFile({
+        ...base,
+        agent: { tokenBudget: "9007199254740993" },
+      }),
+    ).toThrow(/tokenBudget/);
+  });
+});

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -2140,14 +2140,29 @@ export function parseWebSearchFallback(
  * the first character it cannot read, so it turns `"1e3"` into `1`, `"60s"`
  * into `60` and `"100_000"` into `100` — a typo silently becomes a valid
  * setting. That is reachable from `config set <key> <value>`, where every
- * value arrives as a string, so the whole token is checked here and anything
- * that is not a clean integer literal is rejected as `NaN`.
+ * value arrives as a string, so the whole token is parsed here and anything
+ * that is not a complete numeric literal is rejected as `NaN`.
+ *
+ * The test is on the *whole token*, not on its shape: `"10.0"` and `"1e3"`
+ * are both complete literals, and `parseInt` converted the first correctly
+ * (to `10`) while truncating the second. Rejecting every non-`\d+` string
+ * would therefore also reject values that already worked — and since this
+ * parser runs on `loadConfig` at every startup, a `config.json` holding
+ * `"8080.0"` would make the whole CLI unbootable with no way to fix it from
+ * inside the tool. So the value is what decides: parse it in full, then
+ * require it to be an exact integer. `"10.0"` passes, `"1e3"` (1000) passes
+ * as the thousand the user asked for, `"60s"` and `"10.9"` do not.
  */
 function coerceIntLike(raw: unknown): number {
   if (typeof raw === "number") return raw;
   if (typeof raw !== "string") return NaN;
-  const text = raw.trim();
-  return /^[+-]?\d+$/.test(text) ? Number(text) : NaN;
+  const value = coerceFloatLike(raw);
+  // `Number.isInteger` also rejects NaN and the infinities.
+  if (!Number.isInteger(value)) return NaN;
+  // Past 2^53 the literal no longer round-trips: "9007199254740993" would be
+  // silently stored as ...992, which is the same class of quiet corruption
+  // this function exists to stop.
+  return Number.isSafeInteger(value) ? value : NaN;
 }
 
 /**

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -777,22 +777,44 @@ export async function createAgentRuntime(
     return recorder;
   };
 
-  /** Forget a session's recorder once the session is gone. */
+  /** Sessions deleted mid-turn, to be dropped once their turn releases. */
+  const pendingRecorderDrops = new Set<string>();
+
+  /**
+   * Forget a session's recorder once the session is gone.
+   *
+   * A delete that lands mid-turn must not unpin the running turn: the HTTP
+   * route deletes without an `isBusy` check (unlike the TUI, which refuses),
+   * and dropping the pin there would let the next burst evict a recorder the
+   * turn is still writing through — reintroducing the split trace file this
+   * pinning exists to prevent. Such a delete is deferred instead, and the
+   * turn's `finally` completes it; leaving it to cap pressure would strand the
+   * recorder of a session that no longer exists until 64 more arrive.
+   */
   const dropRecorder = (sessionId: string): void => {
+    if (activeTraceSessions.has(sessionId)) {
+      pendingRecorderDrops.add(sessionId);
+      return;
+    }
+    pendingRecorderDrops.delete(sessionId);
     recorders.delete(sessionId);
-    activeTraceSessions.delete(sessionId);
   };
 
   /**
-   * Trim to the cap, oldest-used first, skipping sessions with a live turn.
-   * If every entry is active the map is briefly allowed over the cap: losing
-   * a running session's trace is worse than holding a few extra recorders,
-   * and the excess drains as those turns finish.
+   * Trim to the cap, least-recently-used first, skipping sessions with a live
+   * turn and `exempt` (the entry the caller just created — it has not had a
+   * chance to be pinned yet, and evicting it would throw away the recorder
+   * whose creation triggered this call).
+   *
+   * If everything is pinned the map is allowed over the cap: losing a running
+   * session's trace is worse than holding a few extra recorders, and the
+   * excess drains as those turns finish and release their pins.
    */
-  const evictRecorders = (): void => {
+  const evictRecorders = (exempt?: string): void => {
     if (recorders.size <= MAX_TRACE_RECORDERS) return;
     for (const sessionId of [...recorders.keys()]) {
       if (recorders.size <= MAX_TRACE_RECORDERS) break;
+      if (sessionId === exempt) continue;
       if (activeTraceSessions.has(sessionId)) continue;
       recorders.delete(sessionId);
     }
@@ -2214,7 +2236,11 @@ export async function createAgentRuntime(
       ...(session.metadata ? { metadata: session.metadata } : {}),
     });
     recorders.set(session.id, recorder);
-    evictRecorders();
+    // Exempt the entry just created: the caller pins it only after this
+    // returns, so without this it is the sole unpinned entry when every other
+    // session is mid-turn and would evict itself — losing the whole turn's
+    // trace to a file that already has its `session_started` line.
+    evictRecorders(session.id);
     return recorder;
   };
 
@@ -2254,6 +2280,12 @@ export async function createAgentRuntime(
         return result;
       } finally {
         activeTraceSessions.delete(session.id);
+        // A delete that arrived mid-turn was deferred to keep the pin honest;
+        // complete it now that nothing is writing through the recorder.
+        if (pendingRecorderDrops.has(session.id)) {
+          pendingRecorderDrops.delete(session.id);
+          recorders.delete(session.id);
+        }
         // The turn may have out-waited a burst that could not evict while it
         // was pinned; settle the map now that it can.
         evictRecorders();

--- a/src/runtime/recorder-eviction.test.ts
+++ b/src/runtime/recorder-eviction.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from "vitest";
 function makeRecorderMap(cap: number) {
   const recorders = new Map<string, { id: string }>();
   const active = new Set<string>();
+  const pendingDrops = new Set<string>();
 
   const touch = (id: string) => {
     const found = recorders.get(id);
@@ -28,10 +29,11 @@ function makeRecorderMap(cap: number) {
     return found;
   };
 
-  const evict = () => {
+  const evict = (exempt?: string) => {
     if (recorders.size <= cap) return;
     for (const id of [...recorders.keys()]) {
       if (recorders.size <= cap) break;
+      if (id === exempt) continue;
       if (active.has(id)) continue;
       recorders.delete(id);
     }
@@ -47,12 +49,18 @@ function makeRecorderMap(cap: number) {
       if (existing) return existing;
       const created = { id };
       recorders.set(id, created);
-      evict();
+      evict(id);
       return created;
     },
     drop(id: string) {
+      if (active.has(id)) { pendingDrops.add(id); return; }
+      pendingDrops.delete(id);
       recorders.delete(id);
+    },
+    endTurn(id: string) {
       active.delete(id);
+      if (pendingDrops.has(id)) { pendingDrops.delete(id); recorders.delete(id); }
+      evict();
     },
   };
 }
@@ -105,6 +113,41 @@ describe("trace recorder map eviction (issue #121)", () => {
     m.drop("gone");
     expect(m.recorders.has("gone")).toBe(false);
     expect(m.active.has("gone")).toBe(false);
+  });
+
+  it("a new session is never evicted by its own insertion", () => {
+    // The bug: `ensureRecorder` evicts right after inserting, but the caller
+    // pins the session only after that returns. With every other entry
+    // mid-turn, the newcomer was the sole unpinned entry and deleted itself —
+    // then ran a whole turn writing through a recorder no longer in the map,
+    // leaving a trace file with a lone `session_started` line.
+    const m = makeRecorderMap(64);
+    for (let i = 0; i < 64; i += 1) {
+      m.ensure(`busy-${i}`);
+      m.active.add(`busy-${i}`);
+    }
+    m.ensure("newcomer");
+    expect(m.recorders.has("newcomer")).toBe(true);
+    // Everything else is pinned, so the map is allowed over the cap until
+    // those turns finish.
+    expect(m.recorders.size).toBe(65);
+  });
+
+  it("deleting a session mid-turn does not unpin the running turn", () => {
+    // The HTTP route deletes with no `isBusy` guard, unlike the TUI. Dropping
+    // the pin there would let the next burst evict a recorder the turn is
+    // still writing through.
+    const m = makeRecorderMap(3);
+    m.ensure("running");
+    m.active.add("running");
+    m.drop("running");
+    expect(m.recorders.has("running")).toBe(true);
+    expect(m.active.has("running")).toBe(true);
+
+    // The turn's finally completes the deferred delete, rather than leaving
+    // a dead session's recorder to be pushed out by cap pressure later.
+    m.endTurn("running");
+    expect(m.recorders.has("running")).toBe(false);
   });
 
   it("re-inserting an existing key does not grow the map", () => {

--- a/src/tools/os/http-request-fetch.ts
+++ b/src/tools/os/http-request-fetch.ts
@@ -84,18 +84,6 @@ export interface GuardedCurlResponse {
   redirectChain: string[];
   /** Server-sent `Retry-After` in ms, `null` when absent or unparseable. */
   retryAfterMs: number | null;
-  /**
-   * Method actually used on the hop that produced this response. A 307/308
-   * preserves the original method, so a POST can still be a POST several hops
-   * in; a 301/302/303 downgrades to GET. The retry decision must key off this
-   * rather than the caller's method, or a redirected POST gets replayed.
-   */
-  finalMethod: HttpMethod;
-  /**
-   * Body sent on that same hop — `undefined` once a 301/302/303 has dropped
-   * it. Carried so a retry resumes with the hop's own payload.
-   */
-  finalBody: string | undefined;
   /** Last curl argv (for diagnostics). */
   command: string[];
 }
@@ -125,16 +113,25 @@ export async function executeGuardedHttpRequest(
   const retry = opts.retry ?? DEFAULT_HTTP_RETRY_CONFIG;
   const sleep = opts.sleep ?? defaultSleep;
 
-  // Where the next attempt starts. A retry resumes at the hop that failed
-  // rather than re-walking the redirect chain from the caller's URL.
-  let resumeUrl = rawUrl;
-  let resume: { method: HttpMethod; body: string | undefined } | undefined;
+  // Cumulative across attempts. `sendGuardedRequestOnce` advances `url`,
+  // `method` and `body` before each hop it issues, so a retry — whether after
+  // a retryable status or a timeout — resumes at the hop that actually failed
+  // instead of re-walking redirects the origin has already served.
+  const state: RequestWalkState = {
+    url: rawUrl,
+    method: args.method,
+    body: args.body,
+    chain: [],
+    redirects: 0,
+    totalTime: 0,
+    truncated: false,
+  };
 
   for (let attempt = 0; ; attempt++) {
     let response: GuardedCurlResponse | null = null;
     let failure: unknown = null;
     try {
-      response = await sendGuardedRequestOnce(resumeUrl, args, opts, resume);
+      response = await sendGuardedRequestOnce(args, opts, state);
     } catch (err) {
       // Only a curl timeout is worth another attempt; a missing binary, an
       // SSRF rejection, or an aborted run must surface immediately.
@@ -147,15 +144,12 @@ export async function executeGuardedHttpRequest(
       failure = err;
     }
 
-    // A redirect can carry the original method forward (307/308) or downgrade
-    // it (301/302/303), so the replay-safety question is about the method that
-    // actually ran, not the one the caller passed in. On a transport failure
-    // there is no response to read it from; fall back to the caller's method,
-    // which is the conservative choice (a POST stays non-idempotent).
-    const effectiveMethod = response?.finalMethod ?? args.method;
-
+    // The replay-safety question is about the method of the hop that actually
+    // ran, not the one the caller passed in: a 307/308 carries a POST forward,
+    // and a 303 downgrades it to a bodyless GET that is safe to replay.
+    // `state.method` tracks that on both the response and the failure path.
     const exhausted = attempt >= retry.maxRetries || opts.signal.aborted;
-    if (exhausted || !isRetryableAttempt(effectiveMethod, response, failure)) {
+    if (exhausted || !isRetryableAttempt(state.method, response, failure)) {
       if (response !== null) return response;
       throw failure;
     }
@@ -170,11 +164,6 @@ export async function executeGuardedHttpRequest(
     if (opts.signal.aborted) {
       if (response !== null) return response;
       throw failure;
-    }
-
-    if (response !== null) {
-      resumeUrl = response.finalUrl;
-      resume = { method: response.finalMethod, body: response.finalBody };
     }
   }
 }
@@ -239,26 +228,47 @@ function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+/**
+ * State that survives across retry attempts.
+ *
+ * Everything here is cumulative on purpose. Keeping it inside the per-attempt
+ * function meant a resumed retry rebuilt it from the resume point: the
+ * redirect chain lost its earlier hops, elapsed time under-reported, the
+ * redirect budget reset so a hostile origin got `MAX_REDIRECTS` *per attempt*,
+ * and — because it was only written back on the response path — a transport
+ * failure left `url`/`method` stale and rewound the retry to the caller's URL.
+ */
+interface RequestWalkState {
+  /** Where the next attempt starts: the last hop actually reached. */
+  url: string;
+  /** Method of that hop. A 307/308 keeps a POST; a 301/302/303 drops to GET. */
+  method: HttpMethod;
+  /** Body of that hop — `undefined` once a redirect has dropped it. */
+  body: string | undefined;
+  /** Every hop visited across all attempts, in order. */
+  chain: string[];
+  /** Redirects followed across all attempts, against `MAX_REDIRECTS`. */
+  redirects: number;
+  /** Summed curl time across all attempts. */
+  totalTime: number;
+  /** Sticky once any attempt truncated the response. */
+  truncated: boolean;
+}
+
 /** One full request/redirect walk. A retry re-enters this from the top. */
 async function sendGuardedRequestOnce(
-  rawUrl: string,
   args: HttpRequestArgs,
   opts: ExecuteGuardedHttpOptions,
-  resume?: { method: HttpMethod; body: string | undefined },
+  state: RequestWalkState,
 ): Promise<GuardedCurlResponse> {
   const runCommand = opts.runCommand ?? defaultRunCommand;
-  let currentUrl = parseHttpUrl(rawUrl);
-  // A retry resumes at the hop that failed, with the method and body that hop
-  // actually used. Restarting from the caller's method would re-send a body a
-  // 303 had already dropped, and re-walk redirects the origin already served.
-  let method = resume?.method ?? args.method;
-  let body = resume ? resume.body : args.body;
-  const chain: string[] = [];
+  let currentUrl = parseHttpUrl(state.url);
+  let method = state.method;
+  let body = state.body;
+  const chain = state.chain;
   let lastCommand: string[] = [];
-  let truncated = false;
-  let totalTime = 0;
 
-  for (let hop = 0; ; hop += 1) {
+  for (;;) {
     const pinnedIps = await assertHostAllowed(currentUrl, {
       lookup: opts.lookup,
     });
@@ -271,6 +281,13 @@ async function sendGuardedRequestOnce(
       timeoutMs: args.timeoutMs,
     });
     lastCommand = ["curl", ...curlArgs];
+
+    // Record the hop we are about to make *before* issuing it, so a failure
+    // resumes here rather than rewinding to the caller's URL and re-walking
+    // redirects the origin has already served.
+    state.url = currentUrl.toString();
+    state.method = method;
+    state.body = body;
 
     let result: CommandResult;
     try {
@@ -297,8 +314,8 @@ async function sendGuardedRequestOnce(
     }
 
     const parsed = parseCurlOutput(result.stdout);
-    truncated = truncated || result.truncated;
-    totalTime += parsed.timeTotal;
+    state.truncated = state.truncated || result.truncated;
+    state.totalTime += parsed.timeTotal;
     chain.push(currentUrl.toString());
 
     const shouldFollow =
@@ -307,11 +324,14 @@ async function sendGuardedRequestOnce(
       parsed.redirectUrl.length > 0;
 
     if (shouldFollow) {
-      if (hop >= MAX_REDIRECTS) {
+      // Cumulative across attempts: a per-attempt budget would let a hostile
+      // origin serve MAX_REDIRECTS hops on every retry.
+      if (state.redirects >= MAX_REDIRECTS) {
         throw new Error(
           `os.http.request: too many redirects (> ${MAX_REDIRECTS})`,
         );
       }
+      state.redirects += 1;
       // Curl -L semantics: 301/302/303 drop to GET without body; 307/308 keep method+body.
       if (parsed.status === 301 || parsed.status === 302 || parsed.status === 303) {
         method = "GET";
@@ -327,12 +347,10 @@ async function sendGuardedRequestOnce(
       contentType: parsed.contentType,
       body: parsed.body,
       sizeDownload: parsed.sizeDownload,
-      timeTotal: totalTime,
-      truncated,
-      redirectChain: chain,
+      timeTotal: state.totalTime,
+      truncated: state.truncated,
+      redirectChain: [...chain],
       retryAfterMs: parseRetryAfterValueMs(parsed.retryAfter),
-      finalMethod: method,
-      finalBody: body,
       command: lastCommand,
     };
   }

--- a/src/tools/os/http-request-retry.test.ts
+++ b/src/tools/os/http-request-retry.test.ts
@@ -432,3 +432,128 @@ describe("curl metadata parsing", () => {
     expect(slept).toEqual([5_000]);
   });
 });
+
+describe("os.http.request retry state across attempts", () => {
+  /** Drives a redirect-following request with a scripted curl. */
+  function runWalk(input: {
+    method: "GET" | "POST";
+    results: CommandResult[];
+    calls: string[][];
+  }) {
+    return executeGuardedHttpRequest(
+      "https://a.example/submit",
+      {
+        method: input.method,
+        headers: {},
+        body: input.method === "POST" ? "order=1" : undefined,
+        timeoutMs: 1000,
+        followRedirects: true,
+      },
+      {
+        runCommand: scriptedRunCommand(input.results, input.calls),
+        lookup: publicLookup,
+        cwd: "/tmp",
+        signal: new AbortController().signal,
+        maxResponseBytes: 100_000,
+        sleep: async () => {},
+      },
+    );
+  }
+
+  /** The URL each curl invocation targeted, in order. */
+  function hosts(calls: string[][]): string[] {
+    return calls.map((a) => a[a.length - 1]!);
+  }
+
+  it("a timeout resumes at the failed hop instead of rewinding", async () => {
+    // The resume point was only advanced on the response path, so a timeout
+    // left it stale and the retry re-walked the whole chain from the caller's
+    // URL — re-issuing redirects the origin had already served.
+    const calls: string[][] = [];
+    await expect(
+      runWalk({
+        method: "GET",
+        results: [
+          makeResult({ stdout: stubStdout(302, "", "https://b.example/") }),
+          makeResult({ stdout: stubStdout(302, "", "https://c.example/") }),
+          makeResult({ exitCode: 28, stderr: "timed out", timedOut: true }),
+          makeResult({ stdout: stubStdout(200) }),
+        ],
+        calls,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    expect(hosts(calls)).toEqual([
+      "https://a.example/submit",
+      "https://b.example/",
+      "https://c.example/",
+      "https://c.example/",
+    ]);
+  });
+
+  it("a GET a 303 downgraded to keeps its retry on a timeout", async () => {
+    // On a failure the method fell back to the caller's, so this bodyless GET
+    // was judged as the original POST and denied its replay.
+    const calls: string[][] = [];
+    const response = await runWalk({
+      method: "POST",
+      results: [
+        makeResult({ stdout: stubStdout(303, "", "https://r.example/") }),
+        makeResult({ exitCode: 28, stderr: "timed out", timedOut: true }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(3);
+    // The body is sent once, by the original POST, and never replayed.
+    expect(calls.filter((a) => a.includes("--data-binary"))).toHaveLength(1);
+  });
+
+  it("redirectChain and timeTotal cover every attempt", async () => {
+    const calls: string[][] = [];
+    const response = await runWalk({
+      method: "GET",
+      results: [
+        makeResult({ stdout: stubStdout(302, "", "https://b.example/") }),
+        makeResult({ stdout: stubStdout(429) }),
+        makeResult({ stdout: stubStdout(200) }),
+      ],
+      calls,
+    });
+
+    // Three hops were really made, including the retried one; a chain rebuilt
+    // per attempt reported only the last.
+    expect(response.redirectChain).toEqual([
+      "https://a.example/submit",
+      "https://b.example/",
+      "https://b.example/",
+    ]);
+    expect(response.timeTotal).toBeCloseTo(0.03);
+  });
+
+  it("the redirect budget is cumulative, not per attempt", async () => {
+    // A per-attempt budget let a hostile origin serve MAX_REDIRECTS hops on
+    // every retry — 18 curl invocations against a limit of 5.
+    const calls: string[][] = [];
+    await expect(
+      runWalk({
+        method: "GET",
+        results: [
+          ...Array.from({ length: 5 }, (_, i) =>
+            makeResult({
+              stdout: stubStdout(302, "", `https://h${i}.example/`),
+            }),
+          ),
+          makeResult({ stdout: stubStdout(429) }),
+          makeResult({ stdout: stubStdout(200) }),
+        ],
+        calls,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    // 6 hops to exhaust the budget + 1 resumed retry. Never a fresh budget.
+    expect(calls.length).toBeLessThanOrEqual(8);
+  });
+});

--- a/src/tools/os/read-document/extractors/pdf-extractor.canvas-warnings.test.ts
+++ b/src/tools/os/read-document/extractors/pdf-extractor.canvas-warnings.test.ts
@@ -272,18 +272,41 @@ describe("pdf extractor: optional canvas warnings (issue #117)", () => {
         `const result = await pdfExtractor({ data, path: ${JSON.stringify(
           pdfPath,
         )} });`,
-        'process.stdout.write("\\nEXTRACTED:" + result.text.slice(0, 40));',
+        // Generous slice: the text opens with a `--- page 1 ---` header, and a
+        // tighter bound would cut the marker off if that header ever grows.
+        'process.stdout.write("\\nEXTRACTED:" + result.text.slice(0, 200));',
       ].join("\n"),
     );
 
     try {
-      const { stdout, stderr } = await execFileAsync(
-        process.execPath,
-        ["--import", "tsx", scriptPath],
-        { cwd: repoRoot, encoding: "utf8" },
-      );
-      const output = `${stdout}\n${stderr}`;
+      // The warnings are emitted at import time, before extraction, so they
+      // are in the buffer even when the child later fails. `execFileAsync`
+      // rejects on a non-zero exit, which would skip the assertions entirely
+      // and report "Command failed: … canvas-gate.mjs" instead of naming the
+      // regression — so read the output off the rejection too.
+      let output: string;
+      try {
+        const { stdout, stderr } = await execFileAsync(
+          process.execPath,
+          ["--import", "tsx", scriptPath],
+          { cwd: repoRoot, encoding: "utf8" },
+        );
+        output = `${stdout}\n${stderr}`;
+      } catch (err) {
+        const failed = err as { stdout?: string; stderr?: string };
+        output = `${failed.stdout ?? ""}\n${failed.stderr ?? ""}`;
+        for (const warning of KNOWN_CANVAS_WARNINGS) {
+          expect(output).not.toContain(warning);
+        }
+        throw err;
+      }
+
+      // Guard against a vacuous pass: `EXTRACTED:` alone prints even when the
+      // extractor returns empty text, so assert the marker came through. The
+      // extracted text opens with a `--- page 1 ---` header, so the marker
+      // follows the prefix rather than sitting flush against it.
       expect(output).toContain("EXTRACTED:");
+      expect(output).toContain(TEXT_MARKER);
       for (const warning of KNOWN_CANVAS_WARNINGS) {
         expect(output).not.toContain(warning);
       }


### PR DESCRIPTION
Review of the four fixes merged in #254/#255/#257/#258 found that three of them
were incomplete or broke what they set out to protect. Each defect below is
pinned by a test that fails without its fix.

## config: a stricter parser made working configs unbootable

`coerceIntLike` required `/^[+-]?\d+$/`, which rejects `"10.0"` — a value
`parseInt` had converted *correctly* to 10, not truncated. `parseUserConfigFile`
runs from `loadConfig` at every startup, so a `config.json` holding `"8080.0"`
failed every command, with no way to repair it from inside the tool since
`config set` loads the config first.

The test is now on the value rather than the spelling: parse the whole token,
then require an exact integer. `"10.0"` works again and `"1e3"` yields the 1000
the user asked for, while `"60s"`, `"1,000"` and `"10.9"` stay rejected.
Integers past 2^53 are also rejected, since they no longer round-trip.

## trace: a new session evicted its own recorder

`ensureRecorder` evicts immediately after inserting, but the caller pins the
session only after it returns. With every other entry mid-turn the newcomer was
the sole unpinned entry and deleted itself, then ran a whole turn writing
through a recorder no longer in the map — leaving a trace file holding just its
`session_started` line. Eviction now exempts the entry that triggered it.

`dropRecorder` also unpinned a running turn. The HTTP delete route has no
`isBusy` guard (the TUI refuses instead), so a delete mid-turn re-opened the
split-trace-file corruption the pinning exists to prevent. Such a delete is now
deferred and completed by the turn's `finally`, rather than left to cap
pressure — which would strand a dead session's recorder until 64 more arrived.

## http: resume was only half-wired

The resume point was written back only on the response path, so a timeout left
it stale and the retry rewound to the caller's URL, re-walking redirects the
origin had already served (`a→b→c→timeout` re-issued `a`). The same gap made a
303-downgraded GET fall back to the caller's method and lose its retry, and let
`redirectChain`, `timeTotal`, `truncated` and the redirect budget reset per
attempt — the last of which gave a hostile origin `MAX_REDIRECTS` *per attempt*,
18 curl invocations against a limit of 5.

The walk state is now a single cumulative object advanced before each hop is
issued, so failures move it too. A legitimate chain is unaffected: a retry
resumes at the failed hop, so its redirects are never counted twice.

## test: the canvas gate could report the wrong cause

`execFileAsync` rejects on a non-zero exit, so the warning assertions never ran
and the output holding them was discarded — a regression surfaced as
"Command failed: … canvas-gate.mjs". The warnings are now read off the
rejection as well. `toContain("EXTRACTED:")` was also vacuous, since that
literal prints even for empty text; it now asserts the marker.

## Verification

- Full suite **6291 passed**, `tsc` clean.
- Re-verified by ablation that the canvas gate still fires and names the cause,
  and that the two eviction tests fail against the old helpers.
- Independent review of this branch found no correctness defects. It confirmed
  the cumulative redirect budget does not regress legitimate multi-redirect
  sites, and flagged `finalMethod`/`finalBody` as dead after the refactor —
  removed here.