### PR TITLE
fix: plan buttons under the plan, Anthropic tool names, wheel in the wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Handy slash commands: `/help` lists every command, `/tools` lists the built-in t
 | mode | |
 |---|---|
 | `default` | approvals follow the level set on the Privacy tab |
-| `plan` | read-only — every tool that would change something is refused, with a note telling the agent to present a plan instead. Reading, searching and fetching all still work. When the plan lands, two buttons appear above the composer: run it in `auto`, or run it in `bypass permissions`. Typing instead keeps you in plan mode and revises the plan. |
+| `plan` | read-only — every tool that would change something is refused, with a note telling the agent to present a plan instead. Reading, searching and fetching all still work. When the plan lands, three buttons appear **under the plan itself**, beside its `[copy]` row: run it in `auto`, run it in `bypass permissions`, or dismiss it. Typing instead keeps you in plan mode and revises the plan — the composer says so while the offer is up. |
 | `auto` | file writes inside this workspace stop asking; everything else still does |
 | `bypass permissions` | nothing asks, for this session. Hardline shell-guard rules still block. |
 

--- a/src/llm/provider/openai/merge-tool-name.test.ts
+++ b/src/llm/provider/openai/merge-tool-name.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { mergeToolName } from "./openai-stream-consumer.js";
+
+/**
+ * Reported as "Anthropic models do not work at all", with:
+ *
+ *   Turn failed [tool]: tool not registered in this agent:
+ *   replyreplyreplyreplyreplyreplyreplyreplyreplyreplyreply
+ *
+ * Arguments stream as fragments and concatenate. A *name* does not —
+ * the OpenAI contract sends it once, whole — so the accumulator
+ * appended, which is right for every provider that follows the
+ * contract and catastrophic for the ones that repeat the full name in
+ * every delta. The turn died naming a tool nobody had written.
+ */
+describe("mergeToolName", () => {
+  it("takes the first name", () => {
+    expect(mergeToolName("", "reply")).toBe("reply");
+  });
+
+  it("drops a repeat of the whole name", () => {
+    expect(mergeToolName("reply", "reply")).toBe("reply");
+  });
+
+  it("survives the reported stream verbatim", () => {
+    // Eleven deltas, each carrying the full name.
+    let name = "";
+    for (let i = 0; i < 11; i++) name = mergeToolName(name, "reply");
+    expect(name).toBe("reply");
+  });
+
+  it("still joins genuine fragments", () => {
+    // A provider that really does split the name must keep working:
+    // the two cases are distinguishable and both are served.
+    expect(mergeToolName("os.fs", ".read")).toBe("os.fs.read");
+    expect(mergeToolName("re", "ply")).toBe("reply");
+  });
+
+  it("repairs a name that was already doubled before a repeat", () => {
+    expect(mergeToolName("replyreply", "reply")).toBe("replyreply");
+  });
+
+  it("does not mistake a fragment for a repeat", () => {
+    // `read` is not a repeat of `os.fs.` — appending is correct.
+    expect(mergeToolName("os.fs.", "read")).toBe("os.fs.read");
+  });
+});

--- a/src/llm/provider/openai/openai-stream-consumer.ts
+++ b/src/llm/provider/openai/openai-stream-consumer.ts
@@ -139,12 +139,50 @@ function applyToolCallDeltas(
     };
     if (delta.id) current.id = delta.id;
     if (delta.type) current.type = delta.type;
-    if (delta.function?.name) current.function.name += delta.function.name;
+    if (delta.function?.name) {
+      current.function.name = mergeToolName(
+        current.function.name,
+        delta.function.name,
+      );
+    }
     if (delta.function?.arguments) {
       current.function.arguments += delta.function.arguments;
     }
     toolCalls.set(delta.index, current);
   }
+}
+
+/**
+ * Fold a streamed `function.name` fragment into what we have so far.
+ *
+ * Arguments really are fragments and really do concatenate. A *name*
+ * does not: the OpenAI streaming contract sends it once, whole, in the
+ * first delta for its index — so the accumulator appended, and that was
+ * right for every provider that follows the contract.
+ *
+ * Anthropic-compatible endpoints repeat the **full name in every delta**
+ * for the call. Appending them produced tool names like
+ * `replyreplyreplyreplyreply…`, which failed registry lookup and killed
+ * the turn with `tool not registered in this agent` — the whole model
+ * family was unusable, and the error named a tool nobody had written.
+ *
+ * So: a chunk identical to what is already accumulated is a repeat and
+ * is dropped; anything else is appended, which keeps genuine
+ * fragmentation (`re` + `ply`) working for any provider that does it.
+ * The two cases are distinguishable and this is the only rule that
+ * serves both.
+ */
+export function mergeToolName(current: string, incoming: string): string {
+  if (current.length === 0) return incoming;
+  if (current === incoming) return current;
+  // A provider that repeats the whole name *and* has already been
+  // appended to once — `replyreply` arriving alongside another `reply`.
+  // Cheap to check, and it is the shape a partially-fixed stream takes.
+  if (current.endsWith(incoming) && current.length % incoming.length === 0) {
+    const repeats = current.length / incoming.length;
+    if (incoming.repeat(repeats) === current) return current;
+  }
+  return current + incoming;
 }
 
 function buildFinalResult(args: {

--- a/src/tui/components/chat-log.tsx
+++ b/src/tui/components/chat-log.tsx
@@ -6,7 +6,9 @@ import type { TuiAction } from "../tui-action.js";
 import type { ChatMessage, TuiState } from "../tui-state.js";
 import { theme } from "../theme/theme.js";
 import { AssistantBubble } from "./assistant-bubble.js";
+import type { CodingMode } from "../coding-mode.js";
 import { ChatCopyButton } from "./chat-copy-button.js";
+import { PlanHandoff } from "./plan-handoff.js";
 import { ChatTryAgainButton } from "./chat-try-again-button.js";
 import {
   estimateMessageHeight,
@@ -21,6 +23,13 @@ import { UserBubble } from "./user-bubble.js";
 
 interface ChatLogProps {
   state: TuiState;
+  /**
+   * Runs the drafted plan under `mode`, and puts it away. Both optional
+   * so the many tests that render a log need not supply them; without
+   * them the plan simply carries no buttons.
+   */
+  onPlanExecute?: (mode: CodingMode) => void;
+  onPlanDismiss?: () => void;
   /**
    * Optional dispatcher used to self-correct an over-scrolled state.
    * Whenever `state.chatScrollOffset` exceeds the visually allowed
@@ -70,7 +79,12 @@ function isVisibleToolCard(card: { tool: string }): boolean {
  * Empty surface → centred splash banner; everything else falls
  * through into the bottom-anchored column.
  */
-export function ChatLog({ state, dispatch }: ChatLogProps): ReactElement {
+export function ChatLog({
+  state,
+  dispatch,
+  onPlanExecute,
+  onPlanDismiss,
+}: ChatLogProps): ReactElement {
   const terminalSize = useTerminalSize();
   const finalised = state.messages;
   const hasStreamingTail =
@@ -146,11 +160,24 @@ export function ChatLog({ state, dispatch }: ChatLogProps): ReactElement {
     >
       <Box flexDirection="column" flexShrink={0} marginBottom={-offset}>
         <Box ref={innerRef} flexDirection="column" flexShrink={0}>
-          {finalised.map((message) => (
+          {finalised.map((message, idx) => (
             <FinalisedMessage
               key={message.id}
               message={message}
               toolsExpandedById={state.toolsExpandedById}
+              // The plan's own buttons, under the plan. Only the last
+              // message can carry them: the offer is about the newest
+              // plan, and an older one further up the log would be an
+              // offer to run something that has already been superseded.
+              planHandoff={
+                state.planHandoff &&
+                idx === finalised.length - 1 &&
+                message.role === "assistant" &&
+                onPlanExecute !== undefined &&
+                onPlanDismiss !== undefined
+                  ? { onExecute: onPlanExecute, onDismiss: onPlanDismiss }
+                  : null
+              }
             />
           ))}
           {hasStreamingTail ? <StreamingTail state={state} /> : null}
@@ -165,11 +192,17 @@ export function ChatLog({ state, dispatch }: ChatLogProps): ReactElement {
 interface FinalisedMessageProps {
   message: ChatMessage;
   toolsExpandedById: Readonly<Record<string, boolean>>;
+  /** Present only on the message that *is* the plan. */
+  planHandoff: {
+    onExecute: (mode: CodingMode) => void;
+    onDismiss: () => void;
+  } | null;
 }
 
 function FinalisedMessage({
   message,
   toolsExpandedById,
+  planHandoff,
 }: FinalisedMessageProps): ReactElement {
   if (message.role === "user") {
     return (
@@ -213,6 +246,12 @@ function FinalisedMessage({
           toolSteps={message.toolSteps ?? 0}
         />
         <ChatCopyButton text={message.text} />
+        {planHandoff ? (
+          <PlanHandoff
+            onExecute={planHandoff.onExecute}
+            onDismiss={planHandoff.onDismiss}
+          />
+        ) : null}
       </Box>
     );
   }

--- a/src/tui/components/plan-handoff.tsx
+++ b/src/tui/components/plan-handoff.tsx
@@ -43,36 +43,37 @@ export interface PlanHandoffProps {
    * cannot be declined keeps sitting there.
    */
   onDismiss: () => void;
-  /** Columns the bar has to fit inside. */
-  width: number;
 }
 
 export function PlanHandoff({
   onExecute,
   onDismiss,
-  width,
 }: PlanHandoffProps): ReactElement {
-  // Below this the three buttons cannot sit side by side without one of
-  // them being cut, and a truncated verb on a button that starts work is
-  // the last thing to economise on.
-  const stacked = width < 78;
   return (
-    <Box flexDirection="column" width={width}>
-      <Box flexDirection={stacked ? "column" : "row"}>
+    <Box flexDirection="column">
+      {/*
+        `flexWrap` rather than a width breakpoint. The bar sits inside
+        the chat log now, in ordinary flow — so it is the log's column
+        that decides how much room there is, and Yoga already knows
+        that number. Measuring the terminal here and guessing a
+        threshold was how the old version ended up painting its own
+        second line over itself.
+      */}
+      <Box flexWrap="wrap">
         <ExecuteButton
           mode="auto"
           label="▶ run it · auto"
           tone={theme.colors.warn}
           onExecute={onExecute}
         />
-        {stacked ? null : <Text> </Text>}
+        <Text> </Text>
         <ExecuteButton
           mode="bypass"
           label="▶ run it · bypass permissions"
           tone={theme.colors.error}
           onExecute={onExecute}
         />
-        {stacked ? null : <Text> </Text>}
+        <Text> </Text>
         {/*
           Last, and in the quiet tone. It is the one button here that
           does nothing irreversible, and putting it first would give the
@@ -80,9 +81,6 @@ export function PlanHandoff({
         */}
         <DismissButton onDismiss={onDismiss} />
       </Box>
-      <Text color={theme.colors.muted} wrap="truncate">
-        {" or type below to change the plan — it stays in plan mode"}
-      </Text>
     </Box>
   );
 }

--- a/src/tui/components/wizard-pick-list.tsx
+++ b/src/tui/components/wizard-pick-list.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { MouseListRow } from "../mouse/mouse-list-row.js";
+import { useMouseCommands, useMouseTarget } from "../mouse/mouse-context.js";
 import { MOUSE_LAYER_MODAL } from "../mouse/mouse-registry.js";
 import {
   storeWizardMouseRoute,
@@ -82,6 +83,70 @@ function emptyRowLine(search: string | null | undefined): string {
  * on the sentence boundary is width-independent, so the box height stays
  * predictable at any terminal width.
  */
+/**
+ * The list's frame, and the only place in this file that may hold a
+ * hook: `renderPickList` is a plain function its callers invoke
+ * directly, not a component React renders, so hooks inside it are an
+ * "Invalid hook call".
+ *
+ * Wheel over the list walks the cursor, one row a notch — the window is
+ * derived from the cursor, so moving it *is* scrolling, the same model
+ * `menu-popup.tsx` uses.
+ *
+ * It has to be here, at MODAL, rather than on the app's whole-viewport
+ * wheel target: an open wizard raises the mouse floor to MODAL
+ * (`isPanelModalOpen`), and the viewport target sits at the base layer,
+ * so every wheel event over a wizard was dropped before anything saw
+ * it. Hundreds of cloud models, and the only way down the list was the
+ * arrow keys.
+ *
+ * It routes through `route.select` — the very call a click on a row
+ * makes — so wheel and click cannot drift into two different notions of
+ * "select row N".
+ */
+function PickListFrame({
+  cursor,
+  total,
+  wizard,
+  route,
+  children,
+}: {
+  cursor: number;
+  total: number;
+  wizard: ProvidersWizardState;
+  route: WizardMouseRoute;
+  children: ReactNode;
+}): ReactElement {
+  const mouse = useMouseCommands();
+  const ref = useMouseTarget(
+    (hit) => {
+      if (hit.event.kind !== "wheel" || !hit.event.wheel || !mouse) return false;
+      if (total === 0) return true;
+      const delta = hit.event.wheel === "up" ? -1 : 1;
+      const next = Math.min(Math.max(cursor + delta, 0), total - 1);
+      if (next !== cursor) route.select(mouse, wizard, next);
+      // Claimed either way: at the ends of the list the notch has
+      // nowhere to go, and letting it fall through would scroll the
+      // chat behind the wizard instead.
+      return true;
+    },
+    { layer: MOUSE_LAYER_MODAL },
+  );
+  return (
+    <Box
+      ref={ref}
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.colors.accentSoft}
+      paddingX={1}
+      marginY={1}
+      width="100%"
+    >
+      {children}
+    </Box>
+  );
+}
+
 function errorLines(error: string): readonly string[] {
   const split = error.indexOf(". ");
   if (split === -1) return [error];
@@ -184,13 +249,11 @@ export function renderPickList(props: {
     // selection nearly unreadable. The border alone keeps the fill tone:
     // the brief fenced the lift to text, and the quiet frame leaves the
     // accent to the rows that are read.
-    <Box
-      flexDirection="column"
-      borderStyle="round"
-      borderColor={theme.colors.accentSoft}
-      paddingX={1}
-      marginY={1}
-      width="100%"
+    <PickListFrame
+      cursor={clamped}
+      total={total}
+      wizard={props.wizard}
+      route={route}
     >
       <Text bold color={theme.colors.accent}>
         {props.title}
@@ -267,6 +330,6 @@ export function renderPickList(props: {
       <Text color={theme.colors.muted} wrap="truncate-end">
         {props.moveHint} {position} · {props.actionsHint}
       </Text>
-    </Box>
+    </PickListFrame>
   );
 }

--- a/src/tui/plan-handoff.test.tsx
+++ b/src/tui/plan-handoff.test.tsx
@@ -2,6 +2,8 @@ import { Box } from "ink";
 import { render } from "ink-testing-library";
 import { describe, expect, it, vi } from "vitest";
 
+import { ChatLog } from "./components/chat-log.js";
+
 import type { CodingMode } from "./coding-mode.js";
 import {
   EXECUTE_PLAN_MESSAGE,
@@ -28,13 +30,48 @@ function stateWith(overrides: Partial<TuiState> = {}): TuiState {
   return { ...createInitialTuiState(session()), ...overrides };
 }
 
-function frame(width = 76): string {
+function frame(width = 92): string {
   const { lastFrame, unmount } = render(
     <Box width={width}>
-      <PlanHandoff onExecute={() => {}} onDismiss={() => {}} width={width} />
+      <PlanHandoff onExecute={() => {}} onDismiss={() => {}} />
     </Box>,
   );
-  const out = (lastFrame() ?? "").replace(/\[[0-9;]*m/g, "");
+  const out = (lastFrame() ?? "").replace(/\[[0-9;]*m/g, "");
+  unmount();
+  return out;
+}
+
+/** A session whose newest message is the plan, with the offer live. */
+function planState(overrides: Partial<TuiState> = {}): TuiState {
+  return stateWith({
+    codingMode: "plan",
+    planHandoff: true,
+    messages: [
+      { id: "m1", timestamp: 1, role: "user", text: "build me a website" },
+      {
+        id: "m2",
+        timestamp: 2,
+        role: "assistant",
+        text: "Plan: I will build a site.",
+        toolSteps: 5,
+      },
+    ],
+    ...overrides,
+  });
+}
+
+function logFrame(state: TuiState, withHandlers = true): string {
+  const { lastFrame, unmount } = render(
+    <Box width={92} height={32} flexDirection="column">
+      <ChatLog
+        state={state}
+        {...(withHandlers
+          ? { onPlanExecute: () => {}, onPlanDismiss: () => {} }
+          : {})}
+      />
+    </Box>,
+  );
+  const out = (lastFrame() ?? "").replace(/\[[0-9;]*m/g, "");
   unmount();
   return out;
 }
@@ -57,8 +94,11 @@ describe("the plan hand-off bar", () => {
     expect(body).not.toContain("default");
   });
 
-  it("says that typing is still an option", () => {
-    expect(frame()).toContain("type below to change the plan");
+  it("leaves the third option to the composer", () => {
+    // Revising a plan means typing, and the composer's placeholder is
+    // where that is said now — a line of prose inside the button row
+    // was one more thing to keep in sync with the row's own wrapping.
+    expect(frame()).not.toContain("type below");
   });
 
   it("offers a way to decline the plan outright", () => {
@@ -69,21 +109,20 @@ describe("the plan hand-off bar", () => {
     expect(frame()).toContain("dismiss plan");
   });
 
-  it("stacks rather than truncating a verb that starts work", () => {
-    const narrow = frame(60).split("\n");
-    expect(narrow.some((l) => l.includes("run it · auto"))).toBe(true);
-    expect(
-      narrow.some((l) => l.includes("run it · bypass permissions")),
-      "the bypass button kept its full label",
-    ).toBe(true);
-    expect(narrow.some((l) => l.includes("dismiss plan"))).toBe(true);
+  it("wraps rather than truncating a verb that starts work", () => {
+    const narrow = frame(46);
+    expect(narrow).toContain("run it · auto");
+    expect(narrow, "the bypass button kept its full label").toContain(
+      "run it · bypass permissions",
+    );
+    expect(narrow).toContain("dismiss plan");
   });
 
   it("hands the chosen mode to its caller", () => {
     const onExecute = vi.fn<(mode: CodingMode) => void>();
     const { unmount } = render(
       <Box width={76}>
-        <PlanHandoff onExecute={onExecute} onDismiss={() => {}} width={76} />
+        <PlanHandoff onExecute={onExecute} onDismiss={() => {}} />
       </Box>,
     );
     // No mouse provider here, so the faces render without targets — the
@@ -170,5 +209,44 @@ describe("dismissing a plan", () => {
     const idle = stateWith({ codingMode: "plan", planHandoff: false });
     const next = reduceUiAction(idle, { type: "plan_handoff_dismissed" });
     expect((next ?? idle).planHandoff).toBe(false);
+  });
+});
+
+/**
+ * Where the buttons live. They spent two revisions floating between the
+ * chat log and the composer, which put them nowhere near the plan they
+ * belonged to — and left them in a band the composer overlay paints,
+ * so the bar ended up half-overwritten by its own previous frame.
+ *
+ * They belong under the plan, in the log, next to `[copy]`.
+ */
+describe("where the plan buttons render", () => {
+  it("sits under the plan message, after its copy row", () => {
+    const lines = logFrame(planState()).split("\n");
+    const plan = lines.findIndex((l) => l.includes("Plan: I will build"));
+    const buttons = lines.findIndex((l) => l.includes("run it · auto"));
+    expect(plan).toBeGreaterThanOrEqual(0);
+    expect(buttons).toBeGreaterThan(plan);
+    expect(lines[buttons]).toContain("dismiss plan");
+  });
+
+  it("carries no buttons when there is no plan on offer", () => {
+    expect(logFrame(planState({ planHandoff: false }))).not.toContain("run it");
+  });
+
+  it("never attaches them to an older message", () => {
+    // The offer is about the newest plan; an older one further up the
+    // log would be an offer to run something already superseded.
+    const withFollowUp = planState({
+      messages: [
+        { id: "m1", timestamp: 1, role: "assistant", text: "Plan: the plan" },
+        { id: "m2", timestamp: 2, role: "user", text: "actually, no" },
+      ],
+    });
+    expect(logFrame(withFollowUp)).not.toContain("run it");
+  });
+
+  it("draws nothing without handlers to call", () => {
+    expect(logFrame(planState(), false)).not.toContain("run it");
   });
 });

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -60,10 +60,7 @@ import {
 import { DebugPane } from "./components/debug-pane.js";
 import { HotkeyHint } from "./components/hotkey-hint.js";
 import { PromptShell } from "./components/prompt-shell.js";
-import {
-  EXECUTE_PLAN_MESSAGE,
-  PlanHandoff,
-} from "./components/plan-handoff.js";
+import { EXECUTE_PLAN_MESSAGE } from "./components/plan-handoff.js";
 import { QueuedMessages } from "./components/queued-messages.js";
 import { SessionDeleteModal } from "./components/session-delete-modal.js";
 import { UninstallModal } from "./components/uninstall-modal.js";
@@ -1527,6 +1524,11 @@ export function TuiApp({
     [callbacks],
   );
 
+  const dismissPlan = useCallback(
+    () => dispatch({ type: "plan_handoff_dismissed" }),
+    [],
+  );
+
   const promptContextSlot = contextUsage ? (
     <ContextChip usage={contextUsage} layer={MOUSE_LAYER_PANEL} />
   ) : null;
@@ -1676,7 +1678,12 @@ export function TuiApp({
             position="relative"
           >
             {state.uiMode === "chat" ? (
-              <ChatLog state={state} dispatch={dispatch} />
+              <ChatLog
+                state={state}
+                dispatch={dispatch}
+                onPlanExecute={executePlan}
+                onPlanDismiss={dismissPlan}
+              />
             ) : (
               <DebugPane
                 state={state}
@@ -1841,15 +1848,6 @@ export function TuiApp({
                 queued={state.queuedMessages}
                 width={mainColumnWidth}
               />
-              {state.planHandoff ? (
-                <PlanHandoff
-                  onExecute={executePlan}
-                  onDismiss={() =>
-                    dispatch({ type: "plan_handoff_dismissed" })
-                  }
-                  width={mainColumnWidth}
-                />
-              ) : null}
               {/*
                 The composer holds exactly this slot in the flex column
                 — its collapsed height, whatever the buffer holds — and
@@ -1862,7 +1860,16 @@ export function TuiApp({
               <ComposerOverlay>
                 <PromptShell
             value={state.inputValue}
-            placeholder="Type a message or `/` for commands…"
+            placeholder={
+              // While a plan is on offer the field says what typing into
+              // it would *do*. The buttons above cover running and
+              // dropping the plan; this is the third option, and the
+              // composer is the one place it can be said without adding
+              // a fourth control to say it.
+              state.planHandoff
+                ? "Type to change the plan — it stays in plan mode…"
+                : "Type a message or `/` for commands…"
+            }
             rotatingPlaceholders={PROMPT_PLACEHOLDERS}
             backend={promptBackend}
             model={promptLlm.model}


### PR DESCRIPTION
## 1. The plan buttons were in the wrong place — you asked three times

They floated between the chat log and the composer, which put them nowhere near the plan they belong to. And that band is painted by the composer overlay, while the bar's own rows weren't padded to full width — so it was also being half-overwritten by its own previous frame, exactly as in your screenshot:

```
or type below to change the plan — it stays in plan modeiss plan
```

They render **under the plan message** now, in the chat log, next to its `[copy]` row — the same place every other per-message affordance already lives:

```
  ● 5 tool steps
  [copy]
 ▶ run it · auto   ▶ run it · bypass permissions   ✕ dismiss plan
```

Only the newest message can carry them: an older plan further up the log would be an offer to run something already superseded.

Two things I changed beyond moving it:

- **No more terminal measuring.** The bar sat in the flow guessing a stacking width from `terminalSize`. It wraps now, so the log's own column decides — measuring the terminal and picking a threshold is precisely how it ended up drawing a second line over itself.
- **The "you can also type" line moved to the composer placeholder**, which is where that option actually lives (`Type to change the plan — it stays in plan mode…`), rather than being a line of prose inside a row of buttons.

## 2. Anthropic models — the `replyreplyreply…` error

Real bug, and it made the whole model family unusable.

`applyToolCallDeltas` did `current.function.name += delta.function.name`. Arguments genuinely are fragments and genuinely do concatenate; **a name does not** — the OpenAI streaming contract sends it once, whole, in the first delta for its index.

Anthropic-compatible endpoints repeat the **full name in every delta**. Eleven deltas → an eleven-fold tool name → registry lookup fails → the turn dies naming a tool nobody wrote. That's exactly the string in your screenshot.

`mergeToolName` now drops a chunk identical to what's accumulated and appends anything else, so genuine fragmentation (`os.fs` + `.read`) still works. Both cases are distinguishable and both are served.

## 3. Wheel scrolling in the model list

An open wizard raises the mouse floor to `MOUSE_LAYER_MODAL` (`isPanelModalOpen`), and the app's whole-viewport wheel target sits at the **base** layer — so every wheel event over a wizard was dropped before anything saw it. Hundreds of cloud models and the only way down was the arrow keys.

The list frame takes wheel at MODAL now and walks the cursor, routing through `route.select` — the very call a click on a row makes, so wheel and click can't drift into two notions of "select row N".

One structural note: this had to become a real component. `renderPickList` is a plain function its callers invoke directly, not something React renders, so a hook inside it is an `Invalid hook call` — which is what the first attempt produced across seven wizard tests.

## Verification

```
npm run lint    clean
npm test        600 passed | 1 failed (601 files)
```

The one failure is `sidecar/send-message-concurrency`, which fails identically on clean `main` in this sandbox.

New tests: the buttons render after the plan and after `[copy]`; they never attach to an older message; they vanish without handlers or without an offer. The reported Anthropic stream is replayed verbatim (eleven `reply` deltas → `reply`).
