### PR TITLE
fix(reliability): a dead socket is a transport failure, not a tool bug

### DIFF
--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -1733,3 +1733,57 @@ describe("parallelToolCalls derivation (issue #104)", () => {
     expect(captured.parallelToolCalls).toBe(true);
   });
 });
+
+describe("executeStep raw-network-failure classification", () => {
+  const grammarsDir = join(process.cwd(), "grammars");
+
+  async function runFailingStep(thrown: unknown) {
+    const registry = new ToolRegistry();
+    registry.register(replyTool);
+    const grammar = await buildGrammar(PLAIN_INSTRUCT_PROFILE, grammarsDir);
+    return executeStep(
+      {
+        session: createEmptySessionState({ id: "s-net", workingDir: "/w" }),
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "hi",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async () => {
+          throw thrown;
+        },
+        grammar,
+        profile: PLAIN_INSTRUCT_PROFILE,
+      },
+    );
+  }
+
+  it("surfaces undici's `fetch failed` as TransportError, not ToolExecutionError", async () => {
+    // A surface that does not wrap its own errors (MCP streamable-http,
+    // embeddings, a vendor SDK with its own fetch) throws this shape.
+    // Filing it as a tool failure both mislabels the turn and stops the
+    // provider fallback chain from advancing.
+    const inner = Object.assign(
+      new Error("connect ECONNREFUSED 127.0.0.1:19091"),
+      { code: "ECONNREFUSED" },
+    );
+    const thrown = Object.assign(new TypeError("fetch failed"), {
+      cause: inner,
+    });
+    await expect(runFailingStep(thrown)).rejects.toMatchObject({
+      name: "TransportError",
+      category: "transport",
+    });
+  });
+
+  it("still reports a genuine runtime bug as a tool failure", async () => {
+    await expect(
+      runFailingStep(new TypeError("x.map is not a function")),
+    ).rejects.toMatchObject({ name: "ToolExecutionError", category: "tool" });
+  });
+});

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -1681,6 +1681,15 @@ function toLlmFailure(err: unknown, ctx: StepContext): LlmFailure {
   if (categorised === "cancelled") {
     return new CancelledError(wrapped.message, { cause: err });
   }
+  // A raw socket failure from a surface that does not wrap its own
+  // errors (MCP streamable-http, embeddings, a vendor SDK carrying its
+  // own `fetch`) reaches here as a bare `TypeError: fetch failed`. It is
+  // a provider-boundary problem, not a tool bug: wrapping it as
+  // `ToolExecutionError("unknown", …)` both mislabels the turn for the
+  // user and blocks the fallback chain from advancing.
+  if (categorised === "transport") {
+    return new TransportError(wrapped.message, null, "", { cause: err });
+  }
   return new ToolExecutionError("unknown", wrapped.message, { cause: err });
 }
 

--- a/src/llm/fallback/should-advance.ts
+++ b/src/llm/fallback/should-advance.ts
@@ -29,7 +29,9 @@ const NO: AdvanceDecision = { advance: false, immediate: false };
  *  - `transport` → advance (provider unreachable). Note every cloud
  *    `OpenAiHttpError` classifies as `transport` regardless of status, so
  *    a 404 model-not-found or a 401 dead key advances too — a different
- *    link may have the model or a working key.
+ *    link may have the model or a working key. Untyped socket failures
+ *    (undici's `TypeError: fetch failed` and friends, from surfaces that
+ *    do not wrap their own errors) land here too — see `isNetworkError`.
  *  - `model` → advance. This is a *defective completion* from a reachable
  *    provider (truncated / empty / no_stop), not "model not found"; the
  *    same prompt would reproduce it here, so another link is worth a try.

--- a/src/llm/reliability/classify-failure.test.ts
+++ b/src/llm/reliability/classify-failure.test.ts
@@ -57,3 +57,33 @@ describe("classifyFailure", () => {
     expect(classifyFailure(undefined)).toBe("tool");
   });
 });
+
+describe("classifyFailure — raw network failures", () => {
+  it("maps undici's `fetch failed` to transport, not tool", () => {
+    const inner = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:19091"), {
+      code: "ECONNREFUSED",
+    });
+    const err = Object.assign(new TypeError("fetch failed"), { cause: inner });
+    expect(classifyFailure(err)).toBe("transport");
+  });
+
+  it("maps a socket that died mid-body to transport", () => {
+    expect(classifyFailure(new Error("terminated"))).toBe("transport");
+    expect(classifyFailure(new Error("socket hang up"))).toBe("transport");
+  });
+
+  it("still treats a genuine runtime bug as a tool failure", () => {
+    expect(classifyFailure(new TypeError("x.map is not a function"))).toBe(
+      "tool",
+    );
+  });
+
+  it("keeps cancellation ahead of the network branch", () => {
+    // An aborted request surfaces as ECONNRESET; user intent still wins.
+    const err = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+      code: "ECONNRESET",
+    });
+    expect(classifyFailure(err)).toBe("cancelled");
+  });
+});

--- a/src/llm/reliability/classify-failure.ts
+++ b/src/llm/reliability/classify-failure.ts
@@ -3,6 +3,7 @@ import { OpenAiHttpError } from "../provider/openai/openai-http.js";
 import { ToolCallParseError } from "../grammar/tool-call-grammar.js";
 import type { LlmFailureCategory } from "./failure-category.js";
 import { LlmFailure } from "./llm-failures.js";
+import { isNetworkError } from "./network-error.js";
 
 /**
  * Classify any thrown value into the canonical failure taxonomy.
@@ -13,6 +14,14 @@ import { LlmFailure } from "./llm-failures.js";
  * classifier from legacy surfaces (direct `LlamaServerError` throws,
  * grammar parser errors, abort signals, and anything else treated as
  * a tool-layer problem by default).
+ *
+ * The `isNetworkError` branch sits between the abort check and that
+ * default: an untyped socket failure (MCP streamable-http, embeddings,
+ * a vendor SDK with its own `fetch`) is a `transport` problem even
+ * though no typed client wrapped it. Filing one as `tool` is wrong in
+ * both directions — the user reads "Turn failed [tool]" for someone
+ * else's dead socket, and `shouldAdvance` refuses to fall over to the
+ * next provider because a tool failure is by definition our own bug.
  */
 export function classifyFailure(err: unknown): LlmFailureCategory {
   if (err instanceof LlmFailure) return err.category;
@@ -28,6 +37,9 @@ export function classifyFailure(err: unknown): LlmFailureCategory {
   // TransportError contract.
   if (err instanceof OpenAiHttpError) return "transport";
   if (isAbortError(err)) return "cancelled";
+  // Checked after the abort branch on purpose: an aborted request can
+  // surface as ECONNRESET, and a user pressing Esc is not a fallover.
+  if (isNetworkError(err)) return "transport";
   return "tool";
 }
 

--- a/src/llm/reliability/index.ts
+++ b/src/llm/reliability/index.ts
@@ -12,5 +12,9 @@ export {
 } from "./llm-failures.js";
 export type { LlmFailureOptions } from "./llm-failures.js";
 export { classifyFailure } from "./classify-failure.js";
+export {
+  isNetworkError,
+  readNetworkErrorCode,
+} from "./network-error.js";
 export { detectModelFailure } from "./detect-model-failure.js";
 export type { DetectedModelFailure } from "./detect-model-failure.js";

--- a/src/llm/reliability/network-error.test.ts
+++ b/src/llm/reliability/network-error.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { isNetworkError, readNetworkErrorCode } from "./network-error.js";
+
+/** The shape undici throws from `fetch` when the connection fails. */
+function fetchFailed(cause: unknown): TypeError {
+  return Object.assign(new TypeError("fetch failed"), { cause });
+}
+
+describe("readNetworkErrorCode", () => {
+  it("reads a connection errno off the error itself", () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    expect(readNetworkErrorCode(err)).toBe("ECONNREFUSED");
+  });
+
+  it("reads the errno out of undici's cause chain", () => {
+    const inner = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    });
+    expect(readNetworkErrorCode(fetchFailed(inner))).toBe("ECONNRESET");
+  });
+
+  it("accepts undici's own UND_ERR_* codes", () => {
+    const inner = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    expect(readNetworkErrorCode(fetchFailed(inner))).toBe("UND_ERR_SOCKET");
+  });
+
+  it("ignores stdio errnos — a broken local pipe is not an upstream failure", () => {
+    const err = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    expect(readNetworkErrorCode(err)).toBeUndefined();
+    const eio = Object.assign(new Error("write EIO"), { code: "EIO" });
+    expect(readNetworkErrorCode(eio)).toBeUndefined();
+  });
+
+  it("ignores unrelated codes and non-errors", () => {
+    expect(
+      readNetworkErrorCode(Object.assign(new Error("x"), { code: "ENOENT" })),
+    ).toBeUndefined();
+    expect(readNetworkErrorCode("boom")).toBeUndefined();
+    expect(readNetworkErrorCode(null)).toBeUndefined();
+  });
+
+  it("survives a self-referential cause chain", () => {
+    const err = new Error("loop") as Error & { cause?: unknown };
+    err.cause = err;
+    expect(readNetworkErrorCode(err)).toBeUndefined();
+  });
+});
+
+describe("isNetworkError", () => {
+  it("recognises a bare `fetch failed` with no errno anywhere", () => {
+    expect(isNetworkError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("recognises undici's socket messages", () => {
+    expect(isNetworkError(new Error("terminated"))).toBe(true);
+    expect(isNetworkError(new Error("socket hang up"))).toBe(true);
+    expect(isNetworkError(fetchFailed(new Error("other side closed")))).toBe(
+      true,
+    );
+  });
+
+  it("recognises an errno carried anywhere in the chain", () => {
+    const inner = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:19091"), {
+      code: "ECONNREFUSED",
+    });
+    expect(isNetworkError(fetchFailed(inner))).toBe(true);
+  });
+
+  it("does not claim ordinary runtime bugs", () => {
+    expect(isNetworkError(new TypeError("x.map is not a function"))).toBe(false);
+    expect(isNetworkError(new Error("tool crashed"))).toBe(false);
+    expect(isNetworkError(undefined)).toBe(false);
+  });
+});

--- a/src/llm/reliability/network-error.ts
+++ b/src/llm/reliability/network-error.ts
@@ -1,0 +1,106 @@
+/**
+ * Recognition of raw network failures that reach the runtime *untyped*.
+ *
+ * `LlamaServerClient` and the OpenAI HTTP client both wrap their own
+ * failures into `LlamaServerError` / `OpenAiHttpError`, so the classifier
+ * can read a status off them. Everything else that talks HTTP — MCP
+ * streamable-http transports, embedding calls, vendor SDKs that bring
+ * their own `fetch` — throws whatever `undici` threw: a bare
+ * `TypeError: fetch failed` whose `cause` carries the real errno, or an
+ * `Error: terminated` when the socket dies mid-body.
+ *
+ * Without this recognition those land in `classifyFailure`'s catch-all
+ * and are filed as `tool` failures, which is wrong twice over: the user
+ * is told "Turn failed [tool]" for someone else's dead socket, and
+ * `shouldAdvance` refuses to fall over to the next provider because a
+ * tool failure is by definition our own bug, not the provider's.
+ */
+
+/**
+ * Connection-level errno codes. Deliberately excludes `EPIPE` / `EIO`:
+ * those are overwhelmingly stdio (a closed host pipe, a vanished tty)
+ * rather than an upstream provider, and misreading one as `transport`
+ * would send the fallback chain hunting for a different provider over a
+ * broken *local* stream.
+ */
+const NETWORK_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ECONNABORTED",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EPROTO",
+  "ETIMEDOUT",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+]);
+
+/** undici stamps its own failures with `UND_ERR_*` (`UND_ERR_SOCKET`, …). */
+const UNDICI_CODE_PREFIX = "UND_ERR_";
+
+/**
+ * Messages undici/Node produce for a dead connection when no errno
+ * survives the wrapping. `fetch failed` is the generic outer message;
+ * the rest are the inner ones seen in the wild.
+ */
+const NETWORK_MESSAGES = [
+  /^fetch failed$/i,
+  /^terminated$/i,
+  /socket hang up/i,
+  /other side closed/i,
+  /client network socket disconnected/i,
+  /network socket disconnected/i,
+];
+
+/** Depth cap on the `cause` walk — a chain longer than this is a cycle. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * The errno-style code carried by `err` or anything in its `cause`
+ * chain, when that code names a connection-level failure. Returns
+ * `undefined` for everything else — including codes we deliberately do
+ * not treat as network failures.
+ */
+export function readNetworkErrorCode(err: unknown): string | undefined {
+  for (const link of causeChain(err)) {
+    const code = (link as { code?: unknown }).code;
+    if (typeof code !== "string") continue;
+    if (NETWORK_ERROR_CODES.has(code) || code.startsWith(UNDICI_CODE_PREFIX)) {
+      return code;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * True when `err` is a raw transport failure rather than a defect in our
+ * own code: an errno from the connection layer anywhere in the cause
+ * chain, or one of undici's stock "the socket is gone" messages.
+ *
+ * Callers must check for cancellation FIRST — an aborted request can
+ * surface as `ECONNRESET`, and a user pressing Esc is not a network
+ * failure.
+ */
+export function isNetworkError(err: unknown): boolean {
+  if (readNetworkErrorCode(err) !== undefined) return true;
+  for (const link of causeChain(err)) {
+    const message = (link as { message?: unknown }).message;
+    if (typeof message !== "string") continue;
+    if (NETWORK_MESSAGES.some((re) => re.test(message.trim()))) return true;
+  }
+  return false;
+}
+
+/** `err` followed by its `cause` links, bounded and cycle-safe. */
+function* causeChain(err: unknown): Generator<object> {
+  let current = err;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null) return;
+    yield current;
+    const next = (current as { cause?: unknown }).cause;
+    if (next === current) return;
+    current = next;
+  }
+}


### PR DESCRIPTION
## What Sentry shows

Three of the top tool-error issues in [`cli`](https://atomic-agent.sentry.io/issues/?project=4511727478636544) are not tool errors:

| Issue | Events | Users | Tags |
|---|---|---|---|
| `CLI-4N` | 108 | 13 | `category=tool`, `tool=unknown`, `cause_type=TypeError`, **zero stack frames** |
| `CLI-4T` | 44 | 20 | `category=tool`, `tool=unknown`, `cause_type=TypeError`, frames end in `undici … Object.errorRequest ← Socket.onHttpSocketClose` |
| `CLI-4A` | 173 | 31 | `category=tool`, `tool=unknown`, `cause_type=Error` |

Plus `CLI-G`, `CLI-F`, `CLI-2K`, `CLI-4F`, `CLI-2S`, `CLI-W` in the same shape — **~700 events** filed as "our tool broke" for what the stack says is a connection that died.

## Root cause

`classifyFailure` ends in a catch-all `return "tool"`, and `toLlmFailure` wraps the remainder into `ToolExecutionError("unknown", …)`. Everything that is not a typed `LlamaServerError` / `OpenAiHttpError` lands there — i.e. every raw `undici` failure from a surface that does not wrap its own errors (MCP streamable-http, embeddings, vendor SDKs with their own `fetch`). Those arrive as a bare `TypeError: fetch failed` with the real errno buried in `cause`.

The misfiling costs twice over:

1. the user is told `Turn failed [tool]` for someone else's dead socket;
2. `shouldAdvance` refuses to advance on `tool` (by definition our own bug, not the provider's), so **a genuine network failure never falls over to the next provider** — precisely what the fallback chain exists for.

## The change

`src/llm/reliability/network-error.ts` — `isNetworkError` / `readNetworkErrorCode` walk the `cause` chain (bounded, cycle-safe) for connection-level errnos (`ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`, `EAI_AGAIN`, `UND_ERR_*`, …) or undici's stock socket messages (`fetch failed`, `terminated`, `socket hang up`, `other side closed`). `classifyFailure` returns `transport` for those; `toLlmFailure` wraps them as `TransportError` carrying the original as `cause`.

Two deliberate boundaries:

- **`EPIPE` / `EIO` are excluded.** Those are overwhelmingly stdio — a closed host pipe, a vanished tty — and reading one as `transport` would send the chain hunting for a different provider over a broken *local* stream. (They are their own defect; separate PR.)
- **The check sits after the cancellation branch.** An aborted request can surface as `ECONNRESET`, and a user pressing Esc is not a fallover. Pinned by a test.

## Tests

`network-error.test.ts` (10 new), plus `classify-failure.test.ts` and `step-executor.test.ts` cases proving a `fetch failed` from the completion path surfaces as `TransportError` while `TypeError: x.map is not a function` still surfaces as `ToolExecutionError`.

`npm run lint` clean; `npm test` 6330 passed / 1 failed — the failure is `src/sidecar/send-message-concurrency.test.ts`, which fails identically on untouched `main` in this environment.