### PR TITLE
fix(io): a closed pipe or a vanished tty must not crash the agent

### DIFF
--- a/src/error-reporting/broken-pipe.test.ts
+++ b/src/error-reporting/broken-pipe.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { isBrokenPipeError } from "./broken-pipe.js";
+
+describe("isBrokenPipeError", () => {
+  it("recognises a closed host pipe", () => {
+    const err = Object.assign(new Error("write EPIPE"), {
+      code: "EPIPE",
+      syscall: "write",
+    });
+    expect(isBrokenPipeError(err)).toBe(true);
+  });
+
+  it("recognises a tty that went away", () => {
+    const err = Object.assign(new Error("write EIO"), { code: "EIO" });
+    expect(isBrokenPipeError(err)).toBe(true);
+  });
+
+  it("recognises a stream torn down under us", () => {
+    for (const code of ["ERR_STREAM_DESTROYED", "ERR_STREAM_WRITE_AFTER_END"]) {
+      expect(isBrokenPipeError(Object.assign(new Error(code), { code }))).toBe(
+        true,
+      );
+    }
+  });
+
+  it("reads the code out of a cause chain", () => {
+    const inner = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    const outer = Object.assign(new Error("failed to emit event"), {
+      cause: inner,
+    });
+    expect(isBrokenPipeError(outer)).toBe(true);
+  });
+
+  it("does not claim ordinary failures", () => {
+    expect(isBrokenPipeError(new Error("boom"))).toBe(false);
+    expect(
+      isBrokenPipeError(Object.assign(new Error("x"), { code: "ECONNRESET" })),
+    ).toBe(false);
+    expect(isBrokenPipeError("EPIPE")).toBe(false);
+    expect(isBrokenPipeError(null)).toBe(false);
+  });
+
+  it("survives a self-referential cause chain", () => {
+    const err = new Error("loop") as Error & { cause?: unknown };
+    err.cause = err;
+    expect(isBrokenPipeError(err)).toBe(false);
+  });
+});

--- a/src/error-reporting/broken-pipe.ts
+++ b/src/error-reporting/broken-pipe.ts
@@ -1,0 +1,41 @@
+/**
+ * "The other end of our stdio went away."
+ *
+ * Two shapes reach us in production, both as *uncaught exceptions* from
+ * an asynchronous write:
+ *
+ *  - `EPIPE` — the sidecar's host (the desktop app) exited, so the next
+ *    NDJSON event write hits a closed pipe;
+ *  - `EIO`   — the controlling tty is gone (terminal window closed,
+ *    SIGHUP, a detached tmux pane), so the TUI's frame write fails.
+ *
+ * Neither is a defect in the agent. Left unhandled they kill a healthy
+ * process with a raw stack trace and ship a Sentry event for a peer that
+ * is simply no longer there.
+ */
+const BROKEN_PIPE_CODES = new Set([
+  "EPIPE",
+  "EIO",
+  "ERR_STREAM_DESTROYED",
+  "ERR_STREAM_WRITE_AFTER_END",
+]);
+
+/** Depth cap on the `cause` walk — a longer chain is a cycle. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * True when `err` (or anything in its `cause` chain) is a write failure
+ * against a stdio stream whose far end has closed.
+ */
+export function isBrokenPipeError(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null) return false;
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && BROKEN_PIPE_CODES.has(code)) return true;
+    const next = (current as { cause?: unknown }).cause;
+    if (next === current) return false;
+    current = next;
+  }
+  return false;
+}

--- a/src/error-reporting/error-reporter.test.ts
+++ b/src/error-reporting/error-reporter.test.ts
@@ -51,4 +51,20 @@ describe("captureError", () => {
     expect(captured[0].errorType).toBe("NonError");
     expect(captured[0].message).toBeUndefined();
   });
+  it("drops a process-global broken pipe — the reader left, nothing broke", () => {
+    const { client, captured } = fakeClient();
+    const err = Object.assign(new Error("write EPIPE"), {
+      code: "EPIPE",
+      syscall: "write",
+    });
+    captureError(client, err, { source: "uncaughtException" });
+    expect(captured).toHaveLength(0);
+  });
+
+  it("still reports an EPIPE raised at a call site, where it may be ours", () => {
+    const { client, captured } = fakeClient();
+    const err = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    captureError(client, err, { source: "tool_exec" });
+    expect(captured).toHaveLength(1);
+  });
 });

--- a/src/error-reporting/error-reporter.ts
+++ b/src/error-reporting/error-reporter.ts
@@ -1,7 +1,9 @@
+import { isBrokenPipeError } from "./broken-pipe.js";
 import { scrubError } from "./error-scrubber.js";
 import type { SentryClient } from "./sentry-client.js";
 
 let globalHandlersInstalled = false;
+let stdioGuardsInstalled = false;
 
 /**
  * Capture an error through the (possibly `null`) client. No-ops when
@@ -17,6 +19,11 @@ export function captureError(
 ): void {
   if (!client) return;
   if (opts.category === "cancelled") return;
+  // A process-global EPIPE/EIO is the host pipe or the tty going away,
+  // not a defect: nothing in the agent misbehaved, its reader left. Only
+  // the global sources are filtered — an EPIPE surfaced by a tool still
+  // reports, because there it may well be a bug in ours.
+  if (isGlobalSource(opts.source) && isBrokenPipeError(err)) return;
   const error =
     err instanceof Error
       ? err
@@ -53,9 +60,18 @@ export function installGlobalErrorHandlers(
   const soleUncaughtHandler =
     process.listenerCount("uncaughtException") === 0;
 
+  installStdioErrorGuards(soleUncaughtHandler);
+
   process.on("uncaughtException", (err) => {
     const client = getClient();
     captureError(client, err, { source: "uncaughtException" });
+    // Belt-and-braces for the synchronous path the stream guards below
+    // cannot intercept: a dead pipe is not a crash, so it neither prints
+    // a stack (there is nowhere to print it) nor exits non-zero.
+    if (isBrokenPipeError(err)) {
+      if (soleUncaughtHandler) process.exit(0);
+      return;
+    }
     if (soleUncaughtHandler) {
       // Preserve Node's default fatal behavior: flush best-effort (only
       // when a client is present), print the stack to local stderr, then
@@ -79,7 +95,45 @@ export function installGlobalErrorHandlers(
   });
 }
 
-/** Test-only reset of the idempotency guard. */
+/**
+ * Attach `error` listeners to `process.stdout` / `process.stderr`.
+ *
+ * Without a listener, a write failure on either stream is thrown as an
+ * uncaught exception — which is how a closed host pipe (`EPIPE`) or a
+ * terminal that went away (`EIO`, e.g. SIGHUP or a detached tmux pane)
+ * takes down an otherwise healthy agent, stack trace and all. These are
+ * the two loudest crashes in production and neither is a defect.
+ *
+ * `ownsProcess` mirrors the `uncaughtException` policy: when this
+ * runtime is the top-level process we shut down cleanly (exit 0 — the
+ * pipe closed, same as `head` hanging up), and when a host embeds us we
+ * only swallow the error and let the host decide. A non-broken-pipe
+ * stream error is re-thrown so genuine bugs stay visible.
+ */
+export function installStdioErrorGuards(ownsProcess: boolean): void {
+  if (stdioGuardsInstalled) return;
+  stdioGuardsInstalled = true;
+
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on("error", (err: unknown) => {
+      if (!isBrokenPipeError(err)) {
+        queueMicrotask(() => {
+          throw err;
+        });
+        return;
+      }
+      if (ownsProcess) process.exit(0);
+    });
+  }
+}
+
+/** Test-only reset of the idempotency guards. */
 export function resetGlobalErrorHandlersForTests(): void {
   globalHandlersInstalled = false;
+  stdioGuardsInstalled = false;
+}
+
+/** Sources that report a process-global failure rather than a call site. */
+function isGlobalSource(source: string): boolean {
+  return source === "uncaughtException" || source === "unhandledRejection";
 }

--- a/src/error-reporting/index.ts
+++ b/src/error-reporting/index.ts
@@ -29,5 +29,7 @@ export type {
 export {
   captureError,
   installGlobalErrorHandlers,
+  installStdioErrorGuards,
   resetGlobalErrorHandlersForTests,
 } from "./error-reporter.js";
+export { isBrokenPipeError } from "./broken-pipe.js";

--- a/src/sidecar/stdio-protocol.test.ts
+++ b/src/sidecar/stdio-protocol.test.ts
@@ -195,3 +195,76 @@ describe("StdioProtocol", () => {
     expect(received).toHaveLength(1);
   });
 });
+
+describe("StdioProtocol output that died under us", () => {
+  /** A writable whose far end has gone: every write raises EPIPE. */
+  function brokenOutput() {
+    const output = new PassThrough();
+    output.setEncoding("utf8");
+    const original = output.write.bind(output);
+    let broken = false;
+    return {
+      output,
+      break() {
+        broken = true;
+        output.emit(
+          "error",
+          Object.assign(new Error("write EPIPE"), {
+            code: "EPIPE",
+            syscall: "write",
+          }),
+        );
+      },
+      install() {
+        output.write = ((chunk: string) => {
+          if (broken) {
+            throw Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+          }
+          return original(chunk);
+        }) as typeof output.write;
+      },
+    };
+  }
+
+  it("does not rethrow when the host pipe errors — the peer left, we did not break", () => {
+    const input = new PassThrough();
+    const broken = brokenOutput();
+    const protocol = new StdioProtocol({ input, output: broken.output });
+    expect(protocol.isOutputClosed()).toBe(false);
+    expect(() => broken.break()).not.toThrow();
+    expect(protocol.isOutputClosed()).toBe(true);
+  });
+
+  it("silently stops emitting once the output is closed", () => {
+    const input = new PassThrough();
+    const broken = brokenOutput();
+    broken.install();
+    const protocol = new StdioProtocol({ input, output: broken.output });
+    broken.break();
+    // The runtime keeps fanning events out at its own pace; none of them
+    // may resurrect the dead pipe or throw out of `emitEvent`.
+    expect(() => protocol.emitEvent("log", { message: "after" })).not.toThrow();
+    expect(() => protocol.respond("c1", { ok: true })).not.toThrow();
+  });
+
+  it("swallows a synchronous EPIPE from a destroyed stream", () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.destroy();
+    const protocol = new StdioProtocol({ input, output });
+    expect(() => protocol.emitEvent("log", { message: "x" })).not.toThrow();
+  });
+
+  it("leaves a non-broken-pipe stream error alone", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    new StdioProtocol({ input, output });
+    const thrown = new Promise<unknown>((resolve) => {
+      process.once("uncaughtException", resolve);
+    });
+    output.emit("error", new Error("genuinely broken"));
+    await expect(thrown).resolves.toMatchObject({
+      message: "genuinely broken",
+    });
+  });
+});

--- a/src/sidecar/stdio-protocol.ts
+++ b/src/sidecar/stdio-protocol.ts
@@ -8,6 +8,7 @@ import type {
   SidecarResponse,
 } from "./sidecar-events.js";
 import { isHostRequest } from "./sidecar-events.js";
+import { isBrokenPipeError } from "../error-reporting/broken-pipe.js";
 
 export interface StdioProtocolOptions {
   input: Readable;
@@ -26,6 +27,7 @@ export class StdioProtocol {
   private buffer = "";
   private requestHandler: RequestHandler | null = null;
   private closed = false;
+  private outputClosed = false;
 
   constructor(private readonly options: StdioProtocolOptions) {
     options.input.setEncoding("utf8");
@@ -33,6 +35,17 @@ export class StdioProtocol {
     options.input.on("end", () => {
       this.flushTail();
       this.closed = true;
+    });
+    // The host end of the pipe can vanish at any moment — the desktop
+    // app quits, the CLI that spawned us is killed. Node surfaces that
+    // as an ASYNCHRONOUS `error` on the stream, and a stream with no
+    // `error` listener throws it as an uncaught exception: a healthy
+    // agent dying with a raw EPIPE stack because its peer went away
+    // first. Listening (and latching `outputClosed`) turns that into
+    // "stop emitting", which is all a vanished host can mean.
+    options.output.on("error", (err) => this.onOutputError(err));
+    options.output.on("close", () => {
+      this.outputClosed = true;
     });
   }
 
@@ -78,6 +91,15 @@ export class StdioProtocol {
     return this.closed;
   }
 
+  /**
+   * True once the host stopped reading — the pipe errored, was
+   * destroyed, or ended. Every subsequent `emitEvent` / `respond` is a
+   * silent no-op; there is nobody left to read the frame.
+   */
+  isOutputClosed(): boolean {
+    return this.outputClosed;
+  }
+
   private ingest(chunk: string): void {
     this.buffer += chunk;
     let newlineIndex = this.buffer.indexOf("\n");
@@ -114,9 +136,31 @@ export class StdioProtocol {
     }
   }
 
+  /**
+   * Latch the output as closed. Only a broken-pipe style failure is
+   * swallowed — anything else is a real stream bug and is re-thrown on
+   * the next tick so it is not lost, matching Node's default behaviour
+   * for an unhandled stream error.
+   */
+  private onOutputError(err: unknown): void {
+    this.outputClosed = true;
+    if (isBrokenPipeError(err)) return;
+    queueMicrotask(() => {
+      throw err;
+    });
+  }
+
   private writeMessage(message: SidecarMessage): void {
+    if (this.outputClosed || this.options.output.destroyed) return;
     const line = `${JSON.stringify(message)}\n`;
-    this.options.output.write(line);
+    try {
+      this.options.output.write(line);
+    } catch (err) {
+      // A synchronous throw from `write` (already-destroyed stream)
+      // reaches us here rather than through the `error` event.
+      this.outputClosed = true;
+      if (!isBrokenPipeError(err)) throw err;
+    }
   }
 }
 


### PR DESCRIPTION
## What Sentry shows

Three issues, **~190 events across 80+ users**, all `source=uncaughtException` — i.e. each one ends with a raw stack printed to a stream nobody is reading and `process.exit(1)`:

| Issue | Events | Users | `code` | Frames (innermost → outermost) |
|---|---|---|---|---|
| `CLI-4K` | 88 | **76** | `EIO` (87) / `EPIPE` (1) | `afterWriteDispatched ← Writable.write ← throttledLog ← renderInteractiveFrame` |
| `CLI-5B` | 71 | 4 | `EPIPE` | `Writable.write ← StdioProtocol.writeMessage ← StdioProtocol.emitEvent ← createAgentRuntime.handlers.metricSinks` |
| `CLI-5A` | 27 | 2 | `EPIPE` | `Writable.write ← StdioProtocol.writeMessage ← StdioProtocol.emitEvent ← Object.eventSink` |

`CLI-4K` is the widest-reaching crash in the project by user count.

## Root cause

`StdioProtocol.writeMessage` wrote to the host pipe unguarded and never listened for `error` on `output`. When the desktop host exits, the next event write raises `EPIPE` **asynchronously** — and a stream with no `error` listener rethrows it as an uncaught exception.

The TUI case is the same class one layer up: when the controlling tty goes away (terminal window closed, SIGHUP, a detached tmux pane) the frame write raises `EIO`.

Neither is a defect. Nothing in the agent misbehaved — its peer went away.

## The change

- **`StdioProtocol`** listens for `error`/`close` on its output, latches `outputClosed` (exposed as `isOutputClosed()`), and makes every later `emitEvent`/`respond` a silent no-op — the only thing a vanished host can mean. A synchronous throw from `write` on an already-destroyed stream is caught the same way. A stream error that is **not** a broken pipe is re-thrown on the next tick, so genuine stream bugs stay as loud as they were.
- **`installStdioErrorGuards`** applies the same treatment to `process.stdout` / `process.stderr` — this is what covers the TUI. It reuses the existing `soleUncaughtHandler` test: when this runtime owns the process, a broken pipe exits **0** (the pipe closed, same as `head` hanging up) rather than exiting 1 with a stack; when a host embeds us, we only swallow and let the host decide. Same conservative crash semantics the file already documents.
- **`captureError`** drops broken-pipe errors from the two process-global sources (`uncaughtException` / `unhandledRejection`). An `EPIPE` surfaced at a call site still reports — there it may well be ours.
- `isBrokenPipeError` (`src/error-reporting/broken-pipe.ts`) recognises `EPIPE` / `EIO` / `ERR_STREAM_DESTROYED` / `ERR_STREAM_WRITE_AFTER_END` through a bounded, cycle-safe `cause` walk.

## Tests

`broken-pipe.test.ts` (6), four new `StdioProtocol` cases (the pipe erroring does not rethrow; emitting after the close is a silent no-op; a synchronous EPIPE from a destroyed stream is swallowed; a non-broken-pipe stream error still surfaces), and two `captureError` cases (global EPIPE dropped, call-site EPIPE still reported).

`npm run lint` clean; `npm test` 6326 passed / 1 failed — `src/sidecar/send-message-concurrency.test.ts`, which fails identically on untouched `main` in this environment.

## Note

`installStdioErrorGuards` itself is not unit-tested: exercising it means attaching listeners to the real `process.stdout` inside the test worker and emitting a fake error at vitest's own reporter. The predicate it depends on is covered, and the wiring is five lines.