### PR TITLE
fix(agent): an empty completion gets one repair before the turn dies

### DIFF
--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -787,7 +787,7 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(loopFailedCategory).toBe("model");
   });
 
-  it("classifies an empty completion as ModelError and skips parse retry", async () => {
+  it("repairs an empty completion once, then classifies it as ModelError", async () => {
     const registry = buildDefaultToolRegistry();
     let llmCalls = 0;
     const stepErrors: Array<{ category: string }> = [];
@@ -816,7 +816,11 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     });
     expect(result.reason).toBe("failed");
     expect(result.session.status).toBe("failed");
-    expect(llmCalls).toBe(1);
+    // An empty grammar body now goes through the one-shot repair (a
+    // rebuilt prompt, not a replay) before the turn is written off — two
+    // calls, never three. A second empty completion is still terminal
+    // and still classifies as `model`.
+    expect(llmCalls).toBe(2);
     expect(stepErrors[0]?.category).toBe("model");
   });
 

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -1733,3 +1733,77 @@ describe("parallelToolCalls derivation (issue #104)", () => {
     expect(captured.parallelToolCalls).toBe(true);
   });
 });
+
+describe("executeStep empty-completion repair", () => {
+  const grammarsDir = join(process.cwd(), "grammars");
+
+  /**
+   * Runs one grammar-transport step over a scripted list of completion
+   * bodies: the first is the initial call, the second the repair.
+   */
+  async function runGrammarStep(bodies: string[]) {
+    const registry = new ToolRegistry();
+    registry.register(replyTool);
+    const grammar = await buildGrammar(PLAIN_INSTRUCT_PROFILE, grammarsDir);
+    let calls = 0;
+    const outcome = await executeStep(
+      {
+        session: createEmptySessionState({ id: "s-empty", workingDir: "/w" }),
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "hi",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async () => {
+          const content = bodies[calls] ?? "";
+          calls += 1;
+          return {
+            content,
+            reasoningContent: "",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: content.length,
+            },
+            cacheHitTokens: 0,
+            slotId: 0,
+            modelId: "mock",
+          };
+        },
+        grammar,
+        profile: PLAIN_INSTRUCT_PROFILE,
+      },
+    );
+    return { outcome, calls };
+  }
+
+  it("repairs an empty body instead of ending the turn", async () => {
+    // ModelError(reason=empty) is the largest failure bucket in
+    // production (Sentry CLI-2W/2X/2Z/5J/4R, ~500 events). An empty
+    // grammar body is exactly what the one-shot repair recovers for
+    // every other malformed completion.
+    const { outcome, calls } = await runGrammarStep([
+      "",
+      JSON.stringify([{ tool: "reply", args: { text: "recovered" } }]),
+    ]);
+    expect(calls).toBe(2);
+    expect(outcome.toolCalls).toHaveLength(1);
+    expect(outcome.toolCalls[0]!.tool).toBe("reply");
+    expect(outcome.toolResults[0]!.status).toBe("ok");
+  });
+
+  it("still fails with ModelError when the repair is empty too", async () => {
+    await expect(runGrammarStep(["", ""])).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+    });
+  });
+});

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -412,23 +412,40 @@ async function executeStepInner(
   // the model may have thought but failed to emit a required tool call, and
   // the existing repair path can recover with a stricter one-shot prompt.
   const initialModelFailure = detectModelFailure(completion);
-  if (
-    initialModelFailure !== null &&
-    !isNativeToolsEmptyCompletionHandledByParser(
-      parseDepsFor(completion, deps),
+  if (initialModelFailure !== null) {
+    const initialParseDeps = parseDepsFor(completion, deps);
+    const repairable = isGrammarEmptyCompletionWorthRepairing(
+      initialParseDeps,
       initialModelFailure.reason,
-      completion,
-    )
-  ) {
-    deps.logger?.warn("model-side completion defect", {
-      sessionId: ctx.session.id,
-      stepIndex: ctx.stepIndex,
-      reason: initialModelFailure.reason,
-    });
-    throw new ModelError(
-      initialModelFailure.reason,
-      initialModelFailure.message,
     );
+    if (
+      !repairable &&
+      !isNativeToolsEmptyCompletionHandledByParser(
+        initialParseDeps,
+        initialModelFailure.reason,
+        completion,
+      )
+    ) {
+      deps.logger?.warn("model-side completion defect", {
+        sessionId: ctx.session.id,
+        stepIndex: ctx.stepIndex,
+        reason: initialModelFailure.reason,
+      });
+      throw new ModelError(
+        initialModelFailure.reason,
+        initialModelFailure.message,
+      );
+    }
+    if (repairable) {
+      // Fall through to the parser: an empty body fails to parse, which
+      // routes into the one-shot repair below. The repair's own
+      // `detectModelFailure` still throws `ModelError` if the second
+      // completion is empty too, so "twice empty" remains terminal.
+      deps.logger?.warn("empty completion, repairing once", {
+        sessionId: ctx.session.id,
+        stepIndex: ctx.stepIndex,
+      });
+    }
   }
 
   // Notice text injected into the NEXT step's `transientNotice` when
@@ -1031,6 +1048,36 @@ function isNativeToolsEmptyCompletionHandledByParser(
       ? completion.reasoningContent.trim()
       : "";
   return reasoning.length > 0;
+}
+
+/**
+ * Is this an empty completion the one-shot repair should get a crack at?
+ *
+ * On the grammar transports an empty body is not the dead end
+ * `detectModelFailure`'s doc assumes. The prompt is not replayed
+ * verbatim: the repair path rebuilds it through
+ * `buildToolCallRepairPrompt` with a corrective notice and a bounded
+ * token cap, which is a materially different request — and the same
+ * machinery already recovers every *other* unparseable body (a truncated
+ * array, a stray prelude, prose where JSON belongs). Only "the model
+ * emitted literally nothing" was singled out to end the turn outright,
+ * and that is the single largest failure bucket in production.
+ *
+ * `native_tools` is deliberately excluded: that transport has its own
+ * salvage path (`isNativeToolsEmptyCompletionHandledByParser`), and a
+ * native completion with nothing in any channel routes through
+ * `ModelError` by design — see `step-executor.test.ts`, "native_tools:
+ * routes 'no tool_calls and no content' through ModelError".
+ *
+ * `truncated` and `no_stop` are excluded too, and for the original
+ * reason: the model already spent its budget on this prefix, so a second
+ * pass hits the same wall.
+ */
+function isGrammarEmptyCompletionWorthRepairing(
+  deps: Pick<StepDependencies, "toolTransport">,
+  reason: string,
+): boolean {
+  return reason === "empty" && deps.toolTransport !== "native_tools";
 }
 
 /**


### PR DESCRIPTION
## What Sentry shows

`ModelError` with `reason=empty` is the largest single failure bucket in the project — and it is still firing on `0.4.1`:

| Issue | Events | Users | Tags |
|---|---|---|---|
| `CLI-2W` | 157 | 64 | `category=model`, `reason=empty` |
| `CLI-2X` | 131 | 41 | `category=model`, `reason=empty` |
| `CLI-2Z` | 90 | 35 | `category=model`, `reason=empty` |
| `CLI-5J` | 73 | 27 | `category=model`, `reason=empty` |
| `CLI-4R` | 53 | 25 | `category=model`, `reason=empty` |

Plus `CLI-B` and `CLI-H` in the same shape — **~500+ events across 200+ users**, every one of them a turn that ended because the model returned nothing once.

## Root cause

`detectModelFailure` flags `empty`, and `executeStepInner` throws `ModelError` on the spot — before the parser ever sees the body, and therefore before the one-shot repair path that recovers *every other* malformed completion (a truncated array, a stray prelude, prose where JSON belongs, a batch that failed validation).

Only `native_tools` was exempted, via `isNativeToolsEmptyCompletionHandledByParser`. On the grammar transports a single empty body ends the turn with no recovery attempt at all.

The rationale in `detect-model-failure.ts` — "re-running the same prompt just reproduces the wall" — holds for `truncated` and `no_stop`, where the model already spent its budget on this prefix. It does not hold for `empty`: the repair path does not replay the prompt. It rebuilds it through `buildToolCallRepairPrompt` with a corrective notice and a bounded token cap (`REPAIR_MAX_TOKENS`), which is a materially different request.

## The change

`isGrammarEmptyCompletionWorthRepairing` lets an empty body on a non-`native_tools` transport fall through to the parser, which fails to parse it and routes into the existing one-shot repair. Nothing new is built — this is the same machinery, reached by one more case.

"Twice empty" stays terminal: the repair's own `detectModelFailure` check throws `ModelError("empty")` exactly as before.

Two things deliberately unchanged:

- **`native_tools` keeps its current contract.** A native completion with nothing in any channel routes through `ModelError` by design, pinned by "native_tools: routes 'no tool_calls and no content' through ModelError, not parse_retry". That is a documented decision, not an oversight, so this PR does not reverse it.
- **`truncated` / `no_stop` still fail fast**, for the original reason.

## The gap this does *not* close

`should-advance.ts` documents `model → advance`: a defective completion should fall over to the next provider. That policy is structurally unreachable today. `runWithFallback` resolves as soon as the stream **opens** (`llm-fallback-seam.ts`), while the emptiness is only detectable after the stream is consumed — so `advanceFrom` never sees a model defect and the chain never switches on one.

Closing that means either validating completions inside the fallback attempt (impossible for the streaming seam without buffering) or giving the step executor a way to report a defect back to the chain. Both are larger than this fix and change the seam's contract, so I left them out rather than half-doing them here.

## This reverses a deliberate decision — please push back if the trade is wrong

`agent-loop.test.ts` pinned the old behaviour explicitly, under the name *"classifies an empty completion as ModelError and skips parse retry"* (`llmCalls === 1`). That test is **updated, not worked around**: it now pins two calls and never three, and the failure it ends on is still `category: model`.

If the original call was correctness-driven — some reason an empty grammar body cannot be repaired that I have missed — this PR is wrong and should be closed. If it was load-driven, the trade is one bounded `REPAIR_MAX_TOKENS` (1024) completion against a turn that currently just dies, on the largest error bucket in production.

## Tests

Two new cases: an empty body followed by a good repair completes the step (2 LLM calls, `reply` executed); an empty body followed by an empty repair still throws `ModelError { reason: "empty" }`. Verified non-vacuous — the first fails against `main` with the `ModelError` thrown at the pre-parser check.
