### PR TITLE
fix(llm): keep the errno when a transport failure is rewrapped

### DIFF
--- a/src/error-reporting/error-scrubber.test.ts
+++ b/src/error-reporting/error-scrubber.test.ts
@@ -50,6 +50,53 @@ describe("extractSafeCode", () => {
     expect(extractSafeCode({ code: "failed to read /home/x" })).toEqual({});
     expect(extractSafeCode(null)).toEqual({});
   });
+
+  it("reads status and errno through the wrapper chain", () => {
+    // What actually reaches the scrubber: TransportError wrapping a
+    // LlamaServerError wrapping undici's TypeError. Only the innermost
+    // link knows it was a refused connection.
+    const undici = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("connect ECONNREFUSED"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+    const llama = Object.assign(new Error("network"), {
+      name: "LlamaServerError",
+      status: null,
+      cause: undici,
+    });
+    const transport = Object.assign(new Error("network"), {
+      name: "TransportError",
+      cause: llama,
+    });
+    expect(extractSafeCode(transport)).toEqual({ code: "ECONNREFUSED" });
+  });
+
+  it("prefers a status the wrapper carries over its cause's", () => {
+    const cause = Object.assign(new Error("inner"), { status: 500 });
+    const wrapper = Object.assign(new Error("outer"), { status: 404, cause });
+    expect(extractSafeCode(wrapper)).toEqual({ httpStatus: 404 });
+  });
+
+  it("back-fills the status a GrammarError wrapper does not carry", () => {
+    // GrammarError has no status field at all, which is why not one
+    // grammar issue in Sentry has an `http_status` tag today.
+    const llama = Object.assign(new Error("http 501"), {
+      name: "LlamaServerError",
+      status: 501,
+    });
+    const grammar = Object.assign(new Error("rejected"), {
+      name: "GrammarError",
+      cause: llama,
+    });
+    expect(extractSafeCode(grammar)).toEqual({ httpStatus: 501 });
+  });
+
+  it("survives a self-referential cause chain", () => {
+    const err = new Error("loop") as Error & { cause?: unknown };
+    err.cause = err;
+    expect(extractSafeCode(err)).toEqual({});
+  });
 });
 
 describe("extractSafeReason", () => {

--- a/src/error-reporting/error-scrubber.ts
+++ b/src/error-reporting/error-scrubber.ts
@@ -90,6 +90,16 @@ const SAFE_IDENTIFIER_RE = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,63}$/;
 
 const MAX_FRAMES = 30;
 
+/**
+ * Enum shape for an errno-style code. A value that does not match could
+ * be freeform text (and therefore user data), so it is dropped rather
+ * than sent.
+ */
+const SAFE_CODE_RE = /^[A-Z][A-Z0-9_]*$/;
+
+/** Depth cap on every `cause` walk in this module — longer is a cycle. */
+const MAX_CAUSE_DEPTH = 5;
+
 // `    at fn (/abs/path/file.js:12:34)` or `    at /abs/path/file.js:12:34`
 const FRAME_RE = /^\s*at (?:(.+?) \()?(.+?):(\d+):(\d+)\)?\s*$/;
 
@@ -139,18 +149,44 @@ export function sanitizeStack(stack: string | undefined): SentryStackFrame[] {
   return frames;
 }
 
-/** Extract only safe, enum-like scalar codes from an error. */
+/**
+ * Extract only safe, enum-like scalar codes from an error.
+ *
+ * The walk continues into `err.cause` because the error that reaches
+ * this function is usually a wrapper: `TransportError` carries no status
+ * of its own on the network path, and `GrammarError` carries none at all
+ * — the HTTP status lives on the `LlamaServerError` underneath, and the
+ * errno one level below that. Reading only the top object is why the
+ * largest issue in error reporting has neither an `http_status` nor a
+ * `code` tag on a single event.
+ *
+ * Each field is taken from the outermost link that has it, so a wrapper
+ * that DOES carry a status still wins over its cause.
+ */
 export function extractSafeCode(err: unknown): {
   httpStatus?: number;
   code?: string;
 } {
-  if (typeof err !== "object" || err === null) return {};
   const out: { httpStatus?: number; code?: string } = {};
-  const status = (err as { status?: unknown }).status;
-  if (typeof status === "number") out.httpStatus = status;
-  const code = (err as { code?: unknown }).code;
-  if (typeof code === "string" && /^[A-Z][A-Z0-9_]*$/.test(code)) {
-    out.code = code;
+  let current: unknown = err;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null) break;
+    const status = (current as { status?: unknown }).status;
+    if (out.httpStatus === undefined && typeof status === "number") {
+      out.httpStatus = status;
+    }
+    const code = (current as { code?: unknown }).code;
+    if (
+      out.code === undefined &&
+      typeof code === "string" &&
+      SAFE_CODE_RE.test(code)
+    ) {
+      out.code = code;
+    }
+    if (out.httpStatus !== undefined && out.code !== undefined) break;
+    const next = (current as { cause?: unknown }).cause;
+    if (next === current) break;
+    current = next;
   }
   return out;
 }

--- a/src/llm/errno-code.test.ts
+++ b/src/llm/errno-code.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { readErrnoCode } from "./errno-code.js";
+
+describe("readErrnoCode", () => {
+  it("reads the errno off the error itself", () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:19091"), {
+      code: "ECONNREFUSED",
+    });
+    expect(readErrnoCode(err)).toBe("ECONNREFUSED");
+  });
+
+  it("digs the errno out from under undici's `fetch failed`", () => {
+    const inner = Object.assign(new Error("read ECONNRESET"), {
+      code: "ECONNRESET",
+    });
+    const outer = Object.assign(new TypeError("fetch failed"), {
+      cause: inner,
+    });
+    expect(readErrnoCode(outer)).toBe("ECONNRESET");
+  });
+
+  it("accepts undici's own UND_ERR_* codes", () => {
+    const inner = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    expect(
+      readErrnoCode(Object.assign(new TypeError("fetch failed"), { cause: inner })),
+    ).toBe("UND_ERR_SOCKET");
+  });
+
+  it("drops a freeform code — it could carry user data", () => {
+    const err = Object.assign(new Error("x"), {
+      code: "failed to read /home/alex/notes.md",
+    });
+    expect(readErrnoCode(err)).toBeUndefined();
+  });
+
+  it("returns undefined for errors with no code and for non-objects", () => {
+    expect(readErrnoCode(new Error("plain"))).toBeUndefined();
+    expect(readErrnoCode("ECONNREFUSED")).toBeUndefined();
+    expect(readErrnoCode(null)).toBeUndefined();
+  });
+
+  it("survives a self-referential cause chain", () => {
+    const err = new Error("loop") as Error & { cause?: unknown };
+    err.cause = err;
+    expect(readErrnoCode(err)).toBeUndefined();
+  });
+});

--- a/src/llm/errno-code.ts
+++ b/src/llm/errno-code.ts
@@ -1,0 +1,43 @@
+/**
+ * The errno a failed request left behind.
+ *
+ * Node reports connection-level failures as an errno on the thrown
+ * error (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, …) — and `undici`
+ * buries it one level down, under the generic `TypeError: fetch failed`
+ * it hands to `fetch` callers. Both HTTP clients here rebuild the
+ * failure into their own typed error, which is where that errno used to
+ * be dropped: `LlamaServerError(message, null, url)` says only "the
+ * network failed", never *how*.
+ *
+ * That distinction is the whole diagnosis. `ECONNREFUSED` is "the daemon
+ * was never started" — a setup problem. `ECONNRESET` mid-generation is
+ * "the daemon died under us" — an OOM or a crash. `EAI_AGAIN` is DNS,
+ * `ETIMEDOUT` is a hung box or a proxy. They need opposite fixes and
+ * they all currently arrive looking identical.
+ */
+
+/** Node errnos are `E`-prefixed screaming snake; undici uses `UND_ERR_*`. */
+const ERRNO_SHAPE = /^[A-Z][A-Z0-9_]*$/;
+
+/** Depth cap on the `cause` walk — a longer chain is a cycle. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * The first errno-shaped `code` on `err` or in its `cause` chain.
+ *
+ * The shape check is not cosmetic: an arbitrary `code` field could be
+ * freeform text, and this value is destined for an error report where
+ * only enum-like scalars are allowed to travel.
+ */
+export function readErrnoCode(err: unknown): string | undefined {
+  let current: unknown = err;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null) return undefined;
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && ERRNO_SHAPE.test(code)) return code;
+    const next = (current as { cause?: unknown }).cause;
+    if (next === current) return undefined;
+    current = next;
+  }
+  return undefined;
+}

--- a/src/llm/llama-server-client.test.ts
+++ b/src/llm/llama-server-client.test.ts
@@ -113,6 +113,42 @@ describe("LlamaServerClient.complete", () => {
     });
   });
 
+  it("keeps the errno and the original error on a network failure", async () => {
+    // Without these, every unreachable-daemon failure is indistinguishable
+    // from every died-mid-generation one: same name, same null status,
+    // same empty message in an error report.
+    const cause = Object.assign(
+      new Error("connect ECONNREFUSED 127.0.0.1:9999"),
+      { code: "ECONNREFUSED" },
+    );
+    const client = new LlamaServerClient({
+      baseUrl: "http://127.0.0.1:9999",
+      fetchImpl: createMockFetch(async () => {
+        throw Object.assign(new TypeError("fetch failed"), { cause });
+      }),
+      completionRetries: 1,
+    });
+    await expect(client.complete({ prompt: "x" })).rejects.toMatchObject({
+      name: "LlamaServerError",
+      status: null,
+      code: "ECONNREFUSED",
+    });
+  });
+
+  it("leaves `code` undefined when the transport left no errno", async () => {
+    const client = new LlamaServerClient({
+      baseUrl: "http://127.0.0.1:9999",
+      fetchImpl: createMockFetch(async () => {
+        throw new Error("something opaque");
+      }),
+      completionRetries: 1,
+    });
+    await expect(client.complete({ prompt: "x" })).rejects.toMatchObject({
+      name: "LlamaServerError",
+      code: undefined,
+    });
+  });
+
   it("retries transient 5xx responses and eventually succeeds", async () => {
     let calls = 0;
     const client = new LlamaServerClient({

--- a/src/llm/llama-server-client.ts
+++ b/src/llm/llama-server-client.ts
@@ -1,5 +1,6 @@
 import { getConfig } from "../config/index.js";
 import { llamaEndpointUrl } from "./llama-endpoint-url.js";
+import { readErrnoCode } from "./errno-code.js";
 import type {
   CompletionRequest,
   CompletionResult,
@@ -52,9 +53,21 @@ export class LlamaServerError extends Error {
      * `isRetryableLlamaError`.
      */
     public readonly timedOut = false,
+    /**
+     * Errno of the underlying failure (`ECONNREFUSED`, `ECONNRESET`,
+     * `ETIMEDOUT`, `UND_ERR_*`, …) when the transport left one behind.
+     * This is the difference between "the daemon was never started" and
+     * "the daemon died under us" — two problems with opposite fixes
+     * that both surface as `status === null`.
+     */
+    public readonly code: string | undefined = undefined,
+    options?: { cause?: unknown },
   ) {
     super(message);
     this.name = "LlamaServerError";
+    if (options?.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
   }
 }
 
@@ -192,7 +205,9 @@ export class LlamaServerClient {
     } catch (err) {
       if (err instanceof LlamaServerError) throw err;
       const message = err instanceof Error ? err.message : String(err);
-      throw new LlamaServerError(message, null, url);
+      throw new LlamaServerError(message, null, url, false, readErrnoCode(err), {
+        cause: err,
+      });
     } finally {
       clearTimeout(timer);
     }
@@ -268,7 +283,9 @@ export class LlamaServerClient {
     } catch (err) {
       if (err instanceof LlamaServerError) throw err;
       const message = err instanceof Error ? err.message : String(err);
-      throw new LlamaServerError(message, null, url);
+      throw new LlamaServerError(message, null, url, false, readErrnoCode(err), {
+        cause: err,
+      });
     }
     const { response, cleanup, timedOut } = opened;
     let finalResult: CompletionResult = {
@@ -401,10 +418,18 @@ export class LlamaServerClient {
         null,
         url,
         true,
+        undefined,
+        { cause: err },
       );
     }
     const message = err instanceof Error ? err.message : String(err);
-    return new LlamaServerError(message, null, url);
+    // Keep the errno and the original error. Rebuilding the failure
+    // without them is what left the biggest bucket in error reporting
+    // undiagnosable: ~1,900 events that say "the network failed" and
+    // nothing about how.
+    return new LlamaServerError(message, null, url, false, readErrnoCode(err), {
+      cause: err,
+    });
   }
 
   private prepareRequest(

--- a/src/llm/provider/openai/openai-http.ts
+++ b/src/llm/provider/openai/openai-http.ts
@@ -1,4 +1,5 @@
 import { buildOpenAiAuthHeaders } from "./openai-auth-headers.js";
+import { readErrnoCode } from "../../errno-code.js";
 
 export type OpenAiHttpDeps = {
   baseUrl: string;
@@ -40,9 +41,21 @@ export class OpenAiHttpError extends Error {
     public readonly retryAfterMs: number | null = null,
     /** Provider id for user-facing wording; falls back to the host. */
     public readonly providerLabel = "",
+    /**
+     * Errno of the underlying failure (`ECONNREFUSED`, `ENOTFOUND`,
+     * `UND_ERR_*`, …) when the transport left one behind. A cloud
+     * provider that is unreachable and one that refused the request
+     * both arrive with `status === null`; this is what tells them
+     * apart in a postmortem.
+     */
+    public readonly code: string | undefined = undefined,
+    options?: { cause?: unknown },
   ) {
     super(message);
     this.name = "OpenAiHttpError";
+    if (options?.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
   }
 }
 
@@ -237,10 +250,13 @@ export async function openAiFetch(
         true,
         null,
         deps.label,
+        undefined,
+        { cause: err },
       );
     }
     // fetch threw without an HTTP response: DNS failure, refused
-    // connection, TLS error, socket reset.
+    // connection, TLS error, socket reset. Which of those it was lives
+    // in the errno — keep it, and the original error with it.
     const detail = err instanceof Error ? err.message : String(err);
     throw new OpenAiHttpError(
       `openai provider network error: ${detail}`,
@@ -249,6 +265,8 @@ export async function openAiFetch(
       false,
       null,
       deps.label,
+      readErrnoCode(err),
+      { cause: err },
     );
   } finally {
     clearTimeout(timer);


### PR DESCRIPTION
## What Sentry shows

The four largest issues in the project, plus seven more in the same shape:

| Issue | Events | Users | `transport_host` | `http_status` | `code` |
|---|---|---|---|---|---|
| `CLI-76` | 596 | **176** | `127.0.0.1:19091` (417), `:8080` (146) | empty on 555/596 | **none** |
| `CLI-74` | 404 | 116 | `127.0.0.1:19091` (212), `:8080` (185) | empty on 392/404 | **none** |
| `CLI-4B` | 231 | 64 | `127.0.0.1:19091` (193) | empty on 223/231 | **none** |
| `CLI-4C` | 229 | 77 | `127.0.0.1:19091` (173) | — | **none** |

With `CLI-7C`, `CLI-79`, `CLI-7J`, `CLI-8P`, `CLI-7D`, `CLI-81`, `CLI-7K`: **~1,900 events**, all `TransportError` over `cause_type=LlamaServerError`, and **not one event in the project carries a `code` tag**.

So the biggest bucket we have says "the network failed" and nothing else.

## Root cause

`LlamaServerClient.wrapTransportError` rebuilt the failure as `new LlamaServerError(message, null, url)`. The original error — and with it the errno — was dropped. The scrubber has allowlisted a `code` tag since day one (`extractSafeCode`); nothing ever populated it.

That errno is the entire diagnosis:

| errno | what actually happened | what fixes it |
|---|---|---|
| `ECONNREFUSED` | the daemon was never started | setup / onboarding |
| `ECONNRESET` | the daemon died mid-generation | OOM, context size, a crash to chase |
| `EAI_AGAIN` | DNS | user's network |
| `ETIMEDOUT` | hung box, or a proxy in the way | timeouts / proxy config |

Four different bugs with four different fixes, arriving as one indistinguishable pile — which is why these issues have sat unresolved while staying at the top of the list.

## The change

- **`readErrnoCode`** (`src/llm/errno-code.ts`) walks the `cause` chain for an errno-shaped `code`. That walk is required, not defensive: undici buries the errno under the generic `TypeError: fetch failed` it hands to `fetch` callers.
- **`LlamaServerError`** and **`OpenAiHttpError`** gained a `code` field and now keep the original error as `cause`, on every rewrap path (including the two bare catch-alls that also dropped it).
- **`extractSafeCode`** follows `cause` as well, taking each field from the outermost link that has it (a wrapper with its own status still wins). This also back-fills `http_status` for `GrammarError`, which carries no status of its own — which is why not one grammar issue in Sentry has that tag today, and why PR-6-shaped questions about 4xx mix are currently unanswerable.

**Privacy is unchanged.** The `/^[A-Z][A-Z0-9_]*$/` shape check still gates every code that travels: an errno is an enum, not text. Nothing new leaves the machine except a value from that alphabet.

## Deliberately not in scope

Retry policy. Now that `ECONNREFUSED` is distinguishable, *not* burning three attempts on a daemon that is not running is worth doing — but that is a behaviour change and this is a diagnosis fix.

## Tests

`errno-code.test.ts` (6), two `LlamaServerClient` cases (errno + cause preserved through an undici-shaped failure; `code` stays `undefined` when the transport left none), and four `extractSafeCode` cases including the real three-deep wrapper chain and the `GrammarError` status back-fill.

`npm run lint` clean; `npm test` 6326 passed / 1 failed — `src/sidecar/send-message-concurrency.test.ts`, which fails identically on untouched `main` in this environment.

## Note on overlap

If #262 lands first, `readErrnoCode` and that PR's `readNetworkErrorCode` are close enough to collapse into one helper — happy to do that in whichever merges second.