### PR TITLE
fix(error-reporting): stacks Sentry can actually read

### DIFF
--- a/src/error-reporting/error-scrubber.test.ts
+++ b/src/error-reporting/error-scrubber.test.ts
@@ -199,4 +199,41 @@ describe("scrubError", () => {
     const ev = scrubError(err, { source: "uncaughtException" });
     expect(ev.causeType).toBeUndefined();
   });
+
+  it("falls back to the wrapper's frames when the cause has none", () => {
+    // A cause with an unparseable stack used to take the wrapper's
+    // frames down with it and ship an event with NO stack at all — how
+    // a 108-event issue ended up undiagnosable.
+    const cause = new Error("fetch failed");
+    cause.stack = "TypeError: fetch failed";
+    const wrapper = Object.assign(new Error("wrapped"), {
+      name: "ToolExecutionError",
+      cause,
+    });
+    wrapper.stack = [
+      "ToolExecutionError: wrapped",
+      "    at toLlmFailure (/app/step-executor.js:1561:10)",
+      "    at executeStep (/app/step-executor.js:303:20)",
+    ].join("\n");
+    const ev = scrubError(wrapper, { source: "llm_failure" });
+    expect(ev.frames.map((f) => f.filename)).toEqual([
+      "step-executor.js",
+      "step-executor.js",
+    ]);
+  });
+
+  it("still prefers the cause's frames when it has them", () => {
+    const cause = new Error("boom");
+    cause.stack = [
+      "Error: boom",
+      "    at realThrowSite (/app/prime-stream.js:24:3)",
+    ].join("\n");
+    const wrapper = Object.assign(new Error("wrapped"), { cause });
+    wrapper.stack = [
+      "Error: wrapped",
+      "    at wrapIt (/app/step-executor.js:1561:10)",
+    ].join("\n");
+    const ev = scrubError(wrapper, { source: "llm_failure" });
+    expect(ev.frames.map((f) => f.filename)).toEqual(["prime-stream.js"]);
+  });
 });

--- a/src/error-reporting/error-scrubber.ts
+++ b/src/error-reporting/error-scrubber.ts
@@ -194,6 +194,30 @@ export function extractSafeTransportHost(err: unknown): string | undefined {
 }
 
 /**
+ * Choose the frames to report: the cause's, when it has any, else the
+ * wrapper's own.
+ *
+ * Preferring the cause is right — a generic wrapper's `.stack` points at
+ * the `new ToolExecutionError(...)` call site, not the throw site. But
+ * preferring it *unconditionally* meant that a cause with no parseable
+ * frames took the wrapper's frames down with it, and the event shipped
+ * with an empty stack. That is not hypothetical: it is how a
+ * 108-event issue ended up with no stack trace at all and no way to
+ * tell where it came from. Some causes genuinely have nothing — a
+ * `DOMException` from an abort, an error rebuilt from a serialized
+ * worker message, anything constructed without `Error.captureStackTrace`.
+ * A wrapper frame is worth strictly more than nothing.
+ */
+function pickFrames(
+  err: Error,
+  causeError: Error | undefined,
+): SentryStackFrame[] {
+  const causeFrames = causeError ? sanitizeStack(causeError.stack) : [];
+  if (causeFrames.length > 0) return causeFrames;
+  return sanitizeStack(err.stack);
+}
+
+/**
  * Read the underlying `Error` off `err.cause`, when present. Only an
  * `Error` instance is returned — a non-Error cause carries no `.stack` /
  * `.name` worth extracting.
@@ -236,7 +260,7 @@ export function scrubError(
   const event: ScrubbedErrorEvent = {
     errorType,
     source: opts.source,
-    frames: sanitizeStack(causeError?.stack ?? err.stack),
+    frames: pickFrames(err, causeError),
   };
   if (causeType) event.causeType = causeType;
   if (category) event.category = category;

--- a/src/error-reporting/sentry-envelope.test.ts
+++ b/src/error-reporting/sentry-envelope.test.ts
@@ -10,7 +10,15 @@ const META = { installId: "install-1", release: "1.2.3", platform: "darwin" };
 function parseEventPayload(body: string): {
   tags: Record<string, string>;
   fingerprint: string[];
-  exception: { values: Array<{ type: string; value: string }> };
+  exception: {
+    values: Array<{
+      type: string;
+      value: string;
+      stacktrace: {
+        frames: Array<{ filename: string; lineno?: number; in_app: boolean }>;
+      };
+    }>;
+  };
 } {
   const lines = body.trim().split("\n");
   return JSON.parse(lines[2]!);
@@ -80,5 +88,65 @@ describe("buildEnvelope", () => {
     // Different original causes must not collapse into the same
     // fingerprint just because they share the generic "unknown" tool tag.
     expect(payloadA.fingerprint).not.toEqual(payloadB.fingerprint);
+  });
+
+  it("sends frames oldest-first, the way Sentry reads a stack", () => {
+    // V8 puts the throw site at index 0; Sentry's protocol wants it
+    // LAST. Sending V8 order rendered every stack upside-down and made
+    // Sentry read the culprit off the outermost caller — which is why
+    // the issue list was a wall of `async run` / `async runOneTurn`.
+    const ev: ScrubbedErrorEvent = {
+      errorType: "TransportError",
+      source: "llm_failure",
+      frames: [
+        { filename: "prime-stream.ts", lineno: 24, function: "primeStream" },
+        { filename: "llm-fallback-seam.ts", lineno: 160 },
+        { filename: "step-executor.ts", lineno: 272 },
+      ],
+    };
+    const payload = parseEventPayload(buildEnvelope(DSN, ev, META).body);
+    const frames = payload.exception.values[0]!.stacktrace.frames;
+    expect(frames.map((f) => f.filename)).toEqual([
+      "step-executor.ts",
+      "llm-fallback-seam.ts",
+      "prime-stream.ts",
+    ]);
+    // The crash site is the last frame — that is what Sentry names as
+    // the culprit.
+    expect(frames.at(-1)!.filename).toBe("prime-stream.ts");
+  });
+
+  it("marks our own frames in_app and node internals not", () => {
+    const ev: ScrubbedErrorEvent = {
+      errorType: "Error",
+      source: "uncaughtException",
+      frames: [
+        { filename: "node:internal/streams/writable", lineno: 1 },
+        { filename: "stdio-protocol.js", lineno: 114 },
+      ],
+    };
+    const payload = parseEventPayload(buildEnvelope(DSN, ev, META).body);
+    const frames = payload.exception.values[0]!.stacktrace.frames;
+    expect(frames.map((f) => [f.filename, f.in_app])).toEqual([
+      ["stdio-protocol.js", true],
+      ["node:internal/streams/writable", false],
+    ]);
+  });
+
+  it("does not reorder the caller's array (the fingerprint reads frames[0])", () => {
+    const frames = [
+      { filename: "inner.ts", lineno: 1 },
+      { filename: "outer.ts", lineno: 2 },
+    ];
+    const ev: ScrubbedErrorEvent = {
+      errorType: "TransportError",
+      source: "llm_failure",
+      frames,
+    };
+    const payload = parseEventPayload(buildEnvelope(DSN, ev, META).body);
+    // Reversing in place would flip the fingerprint's topFrame and
+    // re-group every existing issue.
+    expect(frames[0]!.filename).toBe("inner.ts");
+    expect(payload.fingerprint.at(-1)).toBe("inner.ts");
   });
 });

--- a/src/error-reporting/sentry-envelope.ts
+++ b/src/error-reporting/sentry-envelope.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import type { ParsedSentryDsn } from "./sentry-config.js";
-import type { ScrubbedErrorEvent } from "./error-scrubber.js";
+import type {
+  ScrubbedErrorEvent,
+  SentryStackFrame,
+} from "./error-scrubber.js";
 
 /** Constant context stamped on every envelope. */
 export interface EnvelopeMeta {
@@ -88,7 +91,9 @@ export function buildEnvelope(
         {
           type: ev.errorType,
           value: ev.message ?? ev.errorType,
-          stacktrace: { frames: ev.frames },
+          // `ev.frames` stays innermost-first for the fingerprint above;
+          // the wire format wants the opposite. See `toSentryFrameOrder`.
+          stacktrace: { frames: toSentryFrameOrder(ev.frames) },
         },
       ],
     },
@@ -103,6 +108,49 @@ export function buildEnvelope(
   const payload = JSON.stringify(event);
   const body = `${envelopeHeader}\n${itemHeader}\n${payload}\n`;
   return { eventId, body };
+}
+
+/** A stack frame as Sentry's ingest protocol wants it. */
+interface WireStackFrame {
+  function?: string;
+  filename: string;
+  lineno?: number;
+  colno?: number;
+  in_app: boolean;
+}
+
+/**
+ * Reorder and annotate frames for the wire.
+ *
+ * Two protocol details, both of which we were getting wrong:
+ *
+ *  - **Order.** Sentry lists a stack oldest frame FIRST, so the crash
+ *    site is the LAST entry — the opposite of V8, which puts the throw
+ *    site at index 0. Sending V8 order rendered every stack upside-down
+ *    in the UI and, worse, made Sentry read the culprit off the wrong
+ *    end: that is why the issue list is a wall of `async run`,
+ *    `async executeStep`, `async runOneTurn` — the outermost caller of
+ *    unrelated bugs — instead of the frame that actually threw.
+ *
+ *  - **`in_app`.** Nothing ever set it, so every frame was a system
+ *    frame (`in_app_frame_mix: "system-only"` on all of our issues) and
+ *    Sentry's culprit/grouping heuristics had nothing of ours to
+ *    prefer. Anything that is not a `node:` internal is ours — the
+ *    scrubber has already reduced paths to basenames, and the bundle
+ *    is a single file, so there is no dependency directory left to
+ *    distinguish.
+ *
+ * `ev.frames` is left untouched (a copy is reversed): the fingerprint
+ * reads `frames[0]` as the innermost frame, and flipping that would
+ * re-group every existing issue.
+ */
+function toSentryFrameOrder(frames: SentryStackFrame[]): WireStackFrame[] {
+  return frames
+    .map((frame) => ({
+      ...frame,
+      in_app: !frame.filename.startsWith("node:"),
+    }))
+    .reverse();
 }
 
 /** Build the `X-Sentry-Auth` header value for an envelope POST. */


### PR DESCRIPTION
## What Sentry shows

This one is visible on every issue in the project rather than in any single bucket:

- **Every culprit is the wrong frame.** The issue list reads `async run(atomic-agent)`, `async executeStep(atomic-agent)`, `async runOneTurn(atomic-agent)` — the outermost caller, shared by unrelated bugs. `CLI-76` (596 events) and `CLI-75` (142 events, a different error class entirely) both show `async run`.
- **All 328 issues carry `in_app_frame_mix: "system-only"`.** Sentry believes we have no application code.
- **`CLI-4N` (108 events) ships with an empty stack.** Zero frames, `cause_type=TypeError`, `tool=unknown` — nothing to act on at all.

I pulled a raw event to confirm the ordering. `frames[0]` is `node:internal/stream_base_commons#afterWriteDispatched`; the **last** frame is `Xle.renderInteractiveFrame`. That is V8 order — and Sentry named `renderInteractiveFrame` as the culprit, i.e. it read the last entry.

## Root causes

1. **Frame order.** Sentry's protocol lists a stack *oldest frame first*, so the crash site is the **last** entry. V8 is the opposite: the throw site is index 0. `buildEnvelope` passed `ev.frames` straight through, so every stack renders upside-down and Sentry derives the culprit from the outermost caller. That is the whole explanation for the wall of `async run` culprits.
2. **`in_app` was never set**, so nothing is an application frame and Sentry's culprit/grouping heuristics have nothing of ours to prefer.
3. **`scrubError` preferred `cause.stack` unconditionally.** Preferring the cause is right — a wrapper's stack points at the `new ToolExecutionError(...)` call site, not the throw site. But when the cause has no parseable frames (a `DOMException` from an abort, an error rebuilt from a serialized message, anything constructed without `Error.captureStackTrace`), it took the wrapper's frames down with it and shipped nothing. That is `CLI-4N`.

## The change

- `toSentryFrameOrder` reverses **a copy** and marks every non-`node:` frame `in_app: true`. The copy matters: `ev.frames[0]` is the fingerprint's innermost-frame discriminator, and reversing in place would re-group every existing issue. Pinned by a test.
- `pickFrames` falls back to the wrapper's own frames when the cause yields none.

**Grouping is unaffected.** The fingerprint is explicit (`["{{ default }}", errorType, category, discriminator, topFrame]`) and every input to it is unchanged, so existing issues keep their identity and history — only their rendering and culprit improve.

## What this does *not* do

Chained exceptions. Sentry can render `exception.values` as a wrapper→cause chain, which would show both stacks instead of picking one. It is a schema change for modest gain here (a wrapper's own frames are usually just its constructor call site), so I left it out.

## Tests

Three new envelope cases (frame order, `in_app` split, caller's array not mutated + fingerprint stability) and two scrubber cases (fallback when the cause has no frames; the cause still wins when it does).

`npm run lint` clean; full-suite result in the PR checks — the only failure in this environment is `src/sidecar/send-message-concurrency.test.ts`, which fails identically on untouched `main`.
