### PR TITLE
feat(web-search): persist the search cache and provider cooldown across restarts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,20 +234,44 @@ from silently deciding answer quality:
    than configured. Warning **once at construction** (not per search) is
    deliberate: a long autonomous run would drown in a per-query warning.
 
-`cacheTtlMinutes` stays at 15. The cache is per-process, in-memory, capped at
-256 entries, and keyed on the exact query string, so a longer TTL neither
-survives the per-task restarts a campaign does nor catches the near-miss
-rephrasings that actually burn quota — while it would serve staler results for
-time-sensitive lookups. A restart-surviving cache is the real fix and is not
-built.
+The result cache and the #241 provider cooldown **survive the process**
+(#256): given a `stateDir`, [transport/search-cache.ts](src/tools/os/web-search/transport/search-cache.ts)
+and [transport/provider-cooldown.ts](src/tools/os/web-search/transport/provider-cooldown.ts)
+mirror both to `<stateDir>/web-search-cache.json` /
+`web-search-cooldown.json`, so a campaign that runs one agent process per
+task inherits the last process's answers, parks, and strikes instead of
+starting cold and re-spending quota — the demand-side half of #179 that a
+longer TTL cannot reach, because a per-task process dies long before any
+TTL binds. Key, TTL (`cacheTtlMinutes`, default 60), the 256-entry FIFO
+cap, and the park/escalation ladder are unchanged — only the storage
+moved. Rows already expired and cooldown records staler than two doubling
+ceilings are dropped on load, a park that lapsed while nothing ran reads
+as expired, every write goes through tmp-file + rename, and a missing or
+corrupt file starts cold while a failed write is swallowed — persistence
+is an optimisation and must never fail a search. Concurrent processes
+race benignly (last writer wins; no locking). `web.search.persistCache:
+false` (config v46) opts back into the in-memory pair for workloads that
+want a cold cache per run. The key is still the exact query string, so
+near-miss rephrasings still miss — query normalisation is deferred by
+#256 for separate measurement.
 
 Pinned by [retry-after.test.ts](src/tools/os/web-search/transport/retry-after.test.ts),
 [search-http.test.ts](src/tools/os/web-search/transport/search-http.test.ts)
 (retry-then-succeed, `Retry-After` precedence, give-up-after-maxRetries,
 non-429 untouched, old-curl tolerance),
 [warn-missing-search-key.test.ts](src/tools/os/web-search/tool/warn-missing-search-key.test.ts),
-and [web-search-tool.test.ts](src/tools/os/web-search/tool/web-search-tool.test.ts)
-("warns once at construction, not once per search").
+[web-search-tool.test.ts](src/tools/os/web-search/tool/web-search-tool.test.ts)
+("warns once at construction, not once per search"; the persistent-cache
+describe: cross-instance hit, `persistCache: false`, no `stateDir`),
+[search-cache.test.ts](src/tools/os/web-search/transport/search-cache.test.ts)
+and [provider-cooldown.test.ts](src/tools/os/web-search/transport/provider-cooldown.test.ts)
+(round-trip, load-time expiry/eviction, ladder-across-restart, corrupt and
+malformed files), and the `#256` seam case in
+[bootstrap.test.ts](src/runtime/bootstrap.test.ts), which boots the real
+runtime against a pre-seeded `stateDir` and proves `os.web.search` answers
+from the file — so deleting the `stateDir` wiring in `createAgentRuntime`
+or `registerOsTools` fails loudly instead of silently shipping the
+in-memory behaviour.
 ## HTTP retry contract
 
 `os.web.fetch` and `os.http.request` both retry transient failures

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -461,6 +461,29 @@ describe("parseUserConfigFile", () => {
     ).toThrow(/web.search.cacheTtlMinutes/);
   });
 
+  it("fills persistCache default true when migrating from v45 (#256)", () => {
+    const parsed = parseUserConfigFile({ version: 45 });
+    expect(parsed.version).toBe(USER_CONFIG_VERSION);
+    expect(parsed.web.search.persistCache).toBe(true);
+  });
+
+  it("honours an explicit persistCache opt-out", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      web: { search: { persistCache: false } },
+    });
+    expect(parsed.web.search.persistCache).toBe(false);
+  });
+
+  it("rejects a non-boolean persistCache", () => {
+    expect(() =>
+      parseUserConfigFile({
+        version: USER_CONFIG_VERSION,
+        web: { search: { persistCache: "yes please" } },
+      }),
+    ).toThrow(/web.search.persistCache/);
+  });
+
   it("rejects an invalid fallback entry", () => {
     expect(() =>
       parseUserConfigFile({

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -96,6 +96,16 @@ export interface WebSearchConfig {
    */
   cacheTtlMinutes: number;
   /**
+   * Persist the result cache and the provider cooldown under `stateDir`
+   * (v46, #256), so a campaign that runs one process per task inherits
+   * both instead of starting cold and re-spending quota on queries the
+   * last process already answered. Key/TTL/eviction semantics are
+   * unchanged — only the storage moves. Default `true`; set `false` for
+   * workloads that genuinely want a cold cache per run (reproducing a
+   * benchmark, for one).
+   */
+  persistCache: boolean;
+  /**
    * Ordered fallback providers tried (after the primary) when a search is
    * blocked / empty / throws. Default `["duckduckgo"]` — the keyless Exa
    * primary degrades to DuckDuckGo's keyless HTML endpoint. Both are
@@ -1599,7 +1609,13 @@ export interface UserConfigFile {
 // implied. (It was drafted as a second v44, but v44 was already spent on
 // `customModels` in the same release — the stamp ships as v45 so the two
 // additive changes keep distinct numbers.)
-export const USER_CONFIG_VERSION = 45;
+// v46: web.search gains `persistCache` (#256) — persist the search result
+// cache and the provider cooldown under `stateDir` so a per-task process
+// starts warm instead of re-spending quota. Additive: an older file parses
+// with the default `true`, which is the new product behaviour; `false`
+// keeps both structures in-memory (the pre-v46 behaviour) for workloads
+// that want a cold cache per run.
+export const USER_CONFIG_VERSION = 46;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1733,6 +1749,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   42,
   43,
   44,
+  45,
   USER_CONFIG_VERSION,
 ];
 
@@ -1783,6 +1800,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       maxResults: 8,
       timeoutMs: 15_000,
       cacheTtlMinutes: 60,
+      persistCache: true,
       fallback: ["duckduckgo"],
       searxng: {
         instanceUrl: null,
@@ -3264,6 +3282,10 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
           "web.search.cacheTtlMinutes",
           0,
           1440,
+        ),
+        persistCache: parseBool(
+          webSearch.persistCache ?? USER_CONFIG_DEFAULTS.web.search.persistCache,
+          "web.search.persistCache",
         ),
         fallback: parseWebSearchFallback(
           webSearch.fallback ?? USER_CONFIG_DEFAULTS.web.search.fallback,

--- a/src/runtime/bootstrap.test.ts
+++ b/src/runtime/bootstrap.test.ts
@@ -11,6 +11,10 @@ import {
   USER_CONFIG_DEFAULTS,
   writeUserConfigFileSync,
 } from "../config/index.js";
+import {
+  buildSearchCacheKey,
+  createPersistentSearchCache,
+} from "../tools/os/web-search/transport/index.js";
 import type {
   BotFactory,
   BotInstance,
@@ -295,6 +299,77 @@ describe("createAgentRuntime", () => {
       ).rejects.toThrow(/approval denied/);
       expect(prompts).toHaveLength(1);
       expect(prompts[0]?.category).toBe("trust_config");
+    } finally {
+      await runtime.shutdown();
+    }
+  });
+
+  it("threads stateDir into os.web.search: a cache seeded by the last process answers without the network (#256)", async () => {
+    // Pins the enablement seam itself — the `stateDir: config.paths.stateDir`
+    // argument in createAgentRuntime and the pass-through in registerOsTools.
+    // Every other #256 test constructs the persistent cache or the tool
+    // directly, so deleting either wiring line would leave them all green
+    // while the shipped runtime silently regressed to the pre-#256 in-memory
+    // cache — the invisible-degradation failure mode #256 exists to close.
+    // Same idea as the trust_config case above pinning `trustConfigPaths`.
+    //
+    // The provider is a searxng instance on a closed local port, so a broken
+    // seam fails fast with a connection error instead of a live provider call;
+    // the passing path never leaves the cache file.
+    writeUserConfigFileSync(getUserConfigPath(stateDir), {
+      ...USER_CONFIG_DEFAULTS,
+      web: {
+        ...USER_CONFIG_DEFAULTS.web,
+        search: {
+          ...USER_CONFIG_DEFAULTS.web.search,
+          provider: "searxng",
+          fallback: [],
+          searxng: { instanceUrl: "http://127.0.0.1:9" },
+        },
+      },
+    });
+    resetConfigCache();
+
+    // What the previous per-task process left behind in stateDir.
+    const query = "query answered by the previous process";
+    const seeded = createPersistentSearchCache({
+      ttlMs: 60_000,
+      filePath: join(stateDir, "web-search-cache.json"),
+    });
+    seeded.set(
+      buildSearchCacheKey(
+        "searxng",
+        query,
+        USER_CONFIG_DEFAULTS.web.search.maxResults,
+      ),
+      [
+        {
+          title: "Seeded by the last process",
+          url: "https://example.com/seeded",
+          snippet: "still warm",
+        },
+      ],
+    );
+
+    const runtime = await createAgentRuntime({
+      workingDir,
+      approvalLevel: 5,
+      overrides: { browserBackend: backend, skipLlamaHealthCheck: true },
+    });
+    try {
+      const result = await runtime.toolRegistry.invoke(
+        "os.web.search",
+        { query },
+        {
+          workingDir,
+          sessionId: "s-search-persist",
+          stepIndex: 0,
+          signal: new AbortController().signal,
+        },
+      );
+      expect(result.status).toBe("ok");
+      expect(result.details.fromCache).toBe(true);
+      expect(result.summary).toContain("https://example.com/seeded");
     } finally {
       await runtime.shutdown();
     }

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -1223,6 +1223,8 @@ export async function createAgentRuntime(
     trustConfigPaths: getTrustConfigPaths(config.paths),
     // Lets `os.web.search` persist its result cache and provider cooldown
     // across processes (#256); `web.search.persistCache: false` opts out.
+    // Pinned by the `#256` seam case in bootstrap.test.ts — the direct
+    // persistence tests cannot see this line.
     stateDir: config.paths.stateDir,
   });
   registerSkillTools(toolRegistry, skillRegistry, dangerous);

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -1221,6 +1221,9 @@ export async function createAgentRuntime(
     // where it lives. Pinned by the level-4 `trust_config` case in
     // bootstrap.test.ts.
     trustConfigPaths: getTrustConfigPaths(config.paths),
+    // Lets `os.web.search` persist its result cache and provider cooldown
+    // across processes (#256); `web.search.persistCache: false` opts out.
+    stateDir: config.paths.stateDir,
   });
   registerSkillTools(toolRegistry, skillRegistry, dangerous);
   toolRegistry.register(buildToolViewTool());

--- a/src/tools/os/index.ts
+++ b/src/tools/os/index.ts
@@ -94,6 +94,13 @@ export interface RegisterOsToolsOptions extends DangerousToolOptions {
    * surface lives. Omitted / empty disables the `trust_config` guard.
    */
   trustConfigPaths?: readonly string[];
+  /**
+   * Absolute state directory (`config.paths.stateDir`), resolved by the
+   * bootstrap and threaded into `os.web.search` so its result cache and
+   * provider cooldown can survive the process (#256). Omitted keeps both
+   * in-memory, which is what existing embedders and tests get.
+   */
+  stateDir?: string;
 }
 
 export function registerOsTools(
@@ -131,7 +138,9 @@ export function registerOsTools(
       config: options.config,
     }),
   );
-  registry.register(buildOsWebSearchTool({ config: options.config }));
+  registry.register(
+    buildOsWebSearchTool({ config: options.config, stateDir: options.stateDir }),
+  );
   registry.register(buildOsWebFetchTool({ config: options.config }));
   registry.register(osClipboardReadTool);
   registry.register(osClipboardWriteTool);

--- a/src/tools/os/web-search/tool/web-search-tool.test.ts
+++ b/src/tools/os/web-search/tool/web-search-tool.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AtomicAgentConfig } from "../../../../config/index.js";
 import type { runCommand as RunCommandType } from "../../../../sandbox/command-runner.js";
@@ -20,6 +24,7 @@ function makeConfig(
         maxResults: 8,
         timeoutMs: 15_000,
         cacheTtlMinutes: 15,
+        persistCache: true,
         fallback: [],
         searxng: { instanceUrl: null },
         exa: {
@@ -188,6 +193,87 @@ describe("os.web.search", () => {
 
     expect(result.status).toBe("error");
     expect(result.details.provider).toBe("duckduckgo");
+  });
+});
+
+describe("os.web.search persistent cache (#256)", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "web-search-state-"));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("a second tool instance (fresh process, same stateDir) serves the cached result", async () => {
+    const firstRun = vi.fn(makeRunCommand(RESULT_HTML));
+    const first = buildOsWebSearchTool({
+      config: makeConfig(),
+      stateDir,
+      runCommand: firstRun,
+      lookup: publicLookup,
+    });
+    const miss = await first.run({ query: "same query" }, makeCtx());
+    expect(miss.status).toBe("ok");
+    expect(miss.details.fromCache).toBe(false);
+    expect(existsSync(join(stateDir, "web-search-cache.json"))).toBe(true);
+
+    // A new builder call is what a new per-task process looks like from
+    // the cache's point of view: nothing shared but the stateDir.
+    const secondRun = vi.fn(makeRunCommand(RESULT_HTML));
+    const second = buildOsWebSearchTool({
+      config: makeConfig(),
+      stateDir,
+      runCommand: secondRun,
+      lookup: publicLookup,
+    });
+    const hit = await second.run({ query: "same query" }, makeCtx());
+    expect(hit.status).toBe("ok");
+    expect(hit.details.fromCache).toBe(true);
+    expect(secondRun).not.toHaveBeenCalled();
+  });
+
+  it("web.search.persistCache: false keeps the cache in-memory", async () => {
+    const first = buildOsWebSearchTool({
+      config: makeConfig({ persistCache: false }),
+      stateDir,
+      runCommand: makeRunCommand(RESULT_HTML),
+      lookup: publicLookup,
+    });
+    await first.run({ query: "same query" }, makeCtx());
+    expect(existsSync(join(stateDir, "web-search-cache.json"))).toBe(false);
+
+    const secondRun = vi.fn(makeRunCommand(RESULT_HTML));
+    const second = buildOsWebSearchTool({
+      config: makeConfig({ persistCache: false }),
+      stateDir,
+      runCommand: secondRun,
+      lookup: publicLookup,
+    });
+    const result = await second.run({ query: "same query" }, makeCtx());
+    expect(result.details.fromCache).toBe(false);
+    expect(secondRun).toHaveBeenCalled();
+  });
+
+  it("without a stateDir the cache stays in-memory (embedders and tests)", async () => {
+    const first = buildOsWebSearchTool({
+      config: makeConfig(),
+      runCommand: makeRunCommand(RESULT_HTML),
+      lookup: publicLookup,
+    });
+    await first.run({ query: "same query" }, makeCtx());
+
+    const secondRun = vi.fn(makeRunCommand(RESULT_HTML));
+    const second = buildOsWebSearchTool({
+      config: makeConfig(),
+      runCommand: secondRun,
+      lookup: publicLookup,
+    });
+    const result = await second.run({ query: "same query" }, makeCtx());
+    expect(result.details.fromCache).toBe(false);
+    expect(secondRun).toHaveBeenCalled();
   });
 });
 

--- a/src/tools/os/web-search/tool/web-search-tool.ts
+++ b/src/tools/os/web-search/tool/web-search-tool.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { compressToolResult } from "../../../../compressor/result-compressor.js";
 import type { AtomicAgentConfig } from "../../../../config/index.js";
 import {
@@ -6,16 +8,33 @@ import {
 import type { ToolDefinition } from "../../../tool-registry.js";
 import type { HostLookup } from "../../web-fetch-ssrf-guard.js";
 import { runWebSearchWithFallback } from "../providers/index.js";
-import { createProviderCooldown } from "../transport/provider-cooldown.js";
-import { createSearchCache } from "../transport/search-cache.js";
+import {
+  createPersistentProviderCooldown,
+  createProviderCooldown,
+} from "../transport/provider-cooldown.js";
+import {
+  createPersistentSearchCache,
+  createSearchCache,
+} from "../transport/search-cache.js";
 import type { WebSearchResult } from "../web-search-provider.js";
 import { checkMissingSearchKey } from "./warn-missing-search-key.js";
 
 const TOOL_NAME = "os.web.search";
 const MAX_RESULTS_CAP = 20;
 
+/** `<stateDir>/` files backing the persistent cache and cooldown (#256). */
+const CACHE_FILE_NAME = "web-search-cache.json";
+const COOLDOWN_FILE_NAME = "web-search-cooldown.json";
+
 export interface OsWebSearchOptions {
   config: Pick<AtomicAgentConfig, "web">;
+  /**
+   * Absolute state directory backing the persistent result cache and
+   * provider cooldown (#256). Omitted — or opted out via
+   * `web.search.persistCache: false` — both stay in-memory and die with
+   * the process, the pre-#256 behaviour.
+   */
+  stateDir?: string;
   runCommand?: typeof defaultRunCommand;
   lookup?: HostLookup;
   /** Process env source for the missing-key check; injectable for tests. */
@@ -30,15 +49,31 @@ interface WebSearchArgs {
 }
 
 export function buildOsWebSearchTool(options: OsWebSearchOptions): ToolDefinition {
-  // Per-runtime cache lives in this closure (NOT a global singleton). It
-  // persists across tool invocations so repeated identical queries skip the
-  // HTTP round-trip — the primary defence against provider rate-limiting.
+  // The cache lives in this closure (NOT a global singleton). It persists
+  // across tool invocations so repeated identical queries skip the HTTP
+  // round-trip — the primary defence against provider rate-limiting. Given
+  // a `stateDir` (unless `web.search.persistCache` opts out) it is also
+  // mirrored to disk, so a per-task process starts warm instead of
+  // re-spending quota on queries the last process already answered (#256).
   const cfg0 = options.config.web.search;
-  const cache = createSearchCache({ ttlMs: cfg0.cacheTtlMinutes * 60_000 });
-  // Same lifetime and same reason as the cache: a rate limit is a fact
-  // about the last few minutes of this process, so it lives in this
-  // closure rather than in a global or on disk.
-  const cooldown = createProviderCooldown();
+  const persistDir = cfg0.persistCache ? options.stateDir : undefined;
+  const ttlMs = cfg0.cacheTtlMinutes * 60_000;
+  const cache =
+    persistDir === undefined
+      ? createSearchCache({ ttlMs })
+      : createPersistentSearchCache({
+          ttlMs,
+          filePath: join(persistDir, CACHE_FILE_NAME),
+        });
+  // Same lifetime and same reason as the cache: parks and strikes are
+  // facts about the last few minutes, whether those minutes belonged to
+  // this process or to the one that just exited (#256).
+  const cooldown =
+    persistDir === undefined
+      ? createProviderCooldown()
+      : createPersistentProviderCooldown({
+          filePath: join(persistDir, COOLDOWN_FILE_NAME),
+        });
 
   // Emitted once at construction, not per search: a keyless primary provider
   // degrades every subsequent query, and one line at startup is what turns

--- a/src/tools/os/web-search/transport/index.ts
+++ b/src/tools/os/web-search/transport/index.ts
@@ -15,18 +15,22 @@ export {
 } from "./retry-after.js";
 export type { SearchRetryPolicy } from "./retry-after.js";
 export {
+  createPersistentProviderCooldown,
   createProviderCooldown,
   formatCooldown,
 } from "./provider-cooldown.js";
 export type {
+  PersistentProviderCooldownOptions,
   ProviderCooldown,
   ProviderCooldownOptions,
 } from "./provider-cooldown.js";
 export {
   buildSearchCacheKey,
+  createPersistentSearchCache,
   createSearchCache,
 } from "./search-cache.js";
 export type {
+  PersistentSearchCacheOptions,
   SearchCache,
   SearchCacheOptions,
 } from "./search-cache.js";

--- a/src/tools/os/web-search/transport/provider-cooldown.test.ts
+++ b/src/tools/os/web-search/transport/provider-cooldown.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  createPersistentProviderCooldown,
   createProviderCooldown,
   formatCooldown,
 } from "./provider-cooldown.js";
@@ -84,6 +89,107 @@ describe("createProviderCooldown", () => {
   it("treats a negative Retry-After as no advice at all", () => {
     const cooldown = createProviderCooldown();
     expect(cooldown.park("exa", T0, -5000)).toBe(60_000);
+  });
+});
+
+describe("createPersistentProviderCooldown (#256)", () => {
+  const T0 = 1_000_000;
+  /** Default doubling ceiling: fifteen minutes. */
+  const MAX_MS = 15 * 60_000;
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "provider-cooldown-"));
+    filePath = join(dir, "web-search-cooldown.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("a second process inherits a live park", () => {
+    const first = createPersistentProviderCooldown({ filePath, now: () => T0 });
+    first.park("exa", T0, null);
+
+    const second = createPersistentProviderCooldown({
+      filePath,
+      now: () => T0 + 30_000,
+    });
+    expect(second.isParked("exa", T0 + 30_000)).toBe(true);
+    expect(second.remainingMs("exa", T0 + 30_000)).toBe(30_000);
+    expect(second.isParked("duckduckgo", T0 + 30_000)).toBe(false);
+  });
+
+  it("a park that lapsed while nothing ran reads as expired, but the strikes survive", () => {
+    const first = createPersistentProviderCooldown({ filePath, now: () => T0 });
+    first.park("exa", T0, null);
+
+    // Restart after the one-minute park has lapsed: not parked, yet the
+    // next 429 escalates to two minutes instead of restarting the ladder —
+    // exactly the in-process "keeps escalating across an expired park"
+    // semantic, now across a process boundary.
+    const second = createPersistentProviderCooldown({
+      filePath,
+      now: () => T0 + 61_000,
+    });
+    expect(second.isParked("exa", T0 + 61_000)).toBe(false);
+    expect(second.park("exa", T0 + 61_000, null)).toBe(120_000);
+  });
+
+  it("drops a record whose park ended more than two ceilings ago", () => {
+    const first = createPersistentProviderCooldown({ filePath, now: () => T0 });
+    first.park("exa", T0, null);
+    first.park("exa", T0, null);
+
+    // until = T0 + 120_000; evidence this stale is yesterday's quota.
+    const later = T0 + 120_000 + 2 * MAX_MS + 1;
+    const second = createPersistentProviderCooldown({
+      filePath,
+      now: () => later,
+    });
+    expect(second.isParked("exa", later)).toBe(false);
+    expect(second.park("exa", later, null)).toBe(60_000);
+  });
+
+  it("clear removes the record from disk as well", () => {
+    const first = createPersistentProviderCooldown({ filePath, now: () => T0 });
+    first.park("exa", T0, null);
+    first.park("exa", T0, null);
+    first.clear("exa");
+
+    const second = createPersistentProviderCooldown({ filePath, now: () => T0 });
+    expect(second.isParked("exa", T0)).toBe(false);
+    expect(second.park("exa", T0, null)).toBe(60_000);
+  });
+
+  it("starts cold on a corrupt file instead of throwing, and park repairs it", () => {
+    writeFileSync(filePath, "{not json[", "utf8");
+    const first = createPersistentProviderCooldown({ filePath, now: () => T0 });
+    expect(first.isParked("exa", T0)).toBe(false);
+
+    first.park("exa", T0, null);
+    const second = createPersistentProviderCooldown({ filePath, now: () => T0 });
+    expect(second.isParked("exa", T0)).toBe(true);
+  });
+
+  it("skips malformed entries without dropping the valid ones", () => {
+    writeFileSync(
+      filePath,
+      JSON.stringify({
+        duckduckgo: { until: "soon", strikes: 1 },
+        searxng: null,
+        exa: { until: T0 + 60_000, strikes: 1 },
+      }),
+      "utf8",
+    );
+    const cooldown = createPersistentProviderCooldown({
+      filePath,
+      now: () => T0,
+    });
+    expect(cooldown.isParked("exa", T0)).toBe(true);
+    expect(cooldown.isParked("duckduckgo", T0)).toBe(false);
+    expect(cooldown.isParked("searxng", T0)).toBe(false);
   });
 });
 

--- a/src/tools/os/web-search/transport/provider-cooldown.ts
+++ b/src/tools/os/web-search/transport/provider-cooldown.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
 import type { WebSearchProviderName } from "../web-search-provider.js";
 
 /**
@@ -21,10 +24,16 @@ import type { WebSearchProviderName } from "../web-search-provider.js";
  * provider that can actually answer. When the park expires it is tried
  * again, and one success clears the record.
  *
- * **Per-runtime, like the result cache.** Not a global singleton and not
- * persisted: a quota window is a fact about the last few minutes, and a
- * cooldown restored from disk at start-up would park a provider on
- * yesterday's evidence.
+ * **Per-runtime by default, persisted on request (#256).** Not a global
+ * singleton: the tool owns one instance in its closure. The in-memory
+ * variant dies with the process — right for a long-lived session, but a
+ * campaign that runs one process per task then pays a fresh 429 at every
+ * start to rediscover a quota the last process hit minutes ago.
+ * `createPersistentProviderCooldown` writes the same entries through to
+ * disk so the next process inherits them. A quota window is still a fact
+ * about the last few minutes: a park that lapsed while nothing ran reads
+ * as expired, and a record whose park ended more than `2 * maxMs` ago is
+ * dropped on load rather than parking a provider on yesterday's evidence.
  */
 export interface ProviderCooldown {
   /** True while `name` is parked — the orchestrator skips it. */
@@ -49,6 +58,16 @@ export interface ProviderCooldownOptions {
   baseMs?: number;
   /** Ceiling on the doubling. */
   maxMs?: number;
+}
+
+export interface PersistentProviderCooldownOptions extends ProviderCooldownOptions {
+  /** Absolute path of the JSON file mirroring the cooldown on disk. */
+  filePath: string;
+  /**
+   * Injectable clock for the load-time age-out. The live methods keep
+   * taking `now` per call, exactly as the in-memory variant does.
+   */
+  now?: () => number;
 }
 
 /**
@@ -84,9 +103,37 @@ interface CooldownEntry {
 export function createProviderCooldown(
   options: ProviderCooldownOptions = {},
 ): ProviderCooldown {
+  return buildCooldown(options, new Map<WebSearchProviderName, CooldownEntry>(), undefined);
+}
+
+/**
+ * The same cooldown, mirrored to a JSON file so a new process inherits
+ * parks and strikes instead of paying a 429 to relearn them (#256).
+ * Park/escalation semantics are exactly those of `createProviderCooldown`;
+ * only the storage changes. Entries are loaded on creation (records whose
+ * park ended more than `2 * maxMs` ago are dropped as stale evidence) and
+ * written through on every `park`/`clear` via tmp-file + rename. A missing
+ * or corrupt file starts cold; a failed write is swallowed. Concurrent
+ * processes race benignly: last writer wins.
+ */
+export function createPersistentProviderCooldown(
+  options: PersistentProviderCooldownOptions,
+): ProviderCooldown {
+  const maxMs = options.maxMs ?? DEFAULT_MAX_MS;
+  const now = options.now ?? Date.now;
+  const entries = loadCooldownFile(options.filePath, now(), maxMs);
+  return buildCooldown(options, entries, () =>
+    saveCooldownFile(options.filePath, entries),
+  );
+}
+
+function buildCooldown(
+  options: ProviderCooldownOptions,
+  entries: Map<WebSearchProviderName, CooldownEntry>,
+  persist: (() => void) | undefined,
+): ProviderCooldown {
   const baseMs = options.baseMs ?? DEFAULT_BASE_MS;
   const maxMs = options.maxMs ?? DEFAULT_MAX_MS;
-  const entries = new Map<WebSearchProviderName, CooldownEntry>();
 
   function remainingMs(name: WebSearchProviderName, now: number): number {
     const entry = entries.get(name);
@@ -120,12 +167,69 @@ export function createProviderCooldown(
           : Math.min(MAX_HONOURED_RETRY_AFTER_MS, Math.max(0, retryAfterMs));
       const parkMs = Math.max(escalated, advertised);
       entries.set(name, { until: now + parkMs, strikes });
+      persist?.();
       return parkMs;
     },
     clear(name) {
-      entries.delete(name);
+      if (entries.delete(name)) persist?.();
     },
   };
+}
+
+function loadCooldownFile(
+  filePath: string,
+  now: number,
+  maxMs: number,
+): Map<WebSearchProviderName, CooldownEntry> {
+  const entries = new Map<WebSearchProviderName, CooldownEntry>();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    // Missing on the very first run, or corrupt. A cold cooldown is the
+    // pre-#256 behaviour, so it is always a safe recovery.
+    return entries;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return entries;
+  }
+  for (const [name, raw] of Object.entries(parsed)) {
+    const entry = raw as Partial<CooldownEntry> | null;
+    if (
+      typeof entry?.until !== "number" ||
+      !Number.isFinite(entry.until) ||
+      typeof entry.strikes !== "number" ||
+      !Number.isFinite(entry.strikes)
+    ) {
+      continue;
+    }
+    // Strikes outlive an expired park in-process (see `park`), and they
+    // survive a restart the same way — but not forever. A record whose
+    // park ended more than two ceilings ago is yesterday's evidence, and
+    // restoring it would restart the ladder near the top against a quota
+    // that has long since reset.
+    if (entry.until + 2 * maxMs <= now) continue;
+    entries.set(name as WebSearchProviderName, {
+      until: entry.until,
+      strikes: entry.strikes,
+    });
+  }
+  return entries;
+}
+
+function saveCooldownFile(
+  filePath: string,
+  entries: Map<WebSearchProviderName, CooldownEntry>,
+): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    const tmp = `${filePath}.tmp-${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(Object.fromEntries(entries)), "utf8");
+    renameSync(tmp, filePath);
+  } catch {
+    // Persistence is best-effort: a read-only stateDir or a full disk
+    // costs the next process its warm start, never this search.
+  }
 }
 
 /** `90000` -> `1m 30s`, for the line the model reads. */

--- a/src/tools/os/web-search/transport/search-cache.test.ts
+++ b/src/tools/os/web-search/transport/search-cache.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { buildSearchCacheKey, createSearchCache } from "./search-cache.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildSearchCacheKey,
+  createPersistentSearchCache,
+  createSearchCache,
+} from "./search-cache.js";
 import type { WebSearchResult } from "../web-search-provider.js";
 
 const RESULTS: WebSearchResult[] = [
@@ -61,5 +69,132 @@ describe("search-cache", () => {
     expect(a).not.toBe(b);
     expect(a).toBe(c); // case-insensitive, trimmed
     expect(a).not.toBe(d);
+  });
+});
+
+describe("createPersistentSearchCache (#256)", () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "search-cache-"));
+    filePath = join(dir, "web-search-cache.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("round-trips entries: a second instance from the same file serves the hit", () => {
+    const first = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 0,
+    });
+    first.set("k", RESULTS);
+
+    const second = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 500,
+    });
+    expect(second.get("k")).toEqual(RESULTS);
+  });
+
+  it("drops rows already past their expiresAt on load", () => {
+    const first = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 0,
+    });
+    first.set("k", RESULTS);
+
+    const second = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 1001,
+    });
+    expect(second.size).toBe(0);
+    expect(second.get("k")).toBeUndefined();
+  });
+
+  it("enforces the entry cap on load, evicting oldest first", () => {
+    const first = createPersistentSearchCache({
+      ttlMs: 1000,
+      maxEntries: 3,
+      filePath,
+      now: () => 0,
+    });
+    first.set("a", RESULTS);
+    first.set("b", RESULTS);
+    first.set("c", RESULTS);
+
+    const second = createPersistentSearchCache({
+      ttlMs: 1000,
+      maxEntries: 2,
+      filePath,
+      now: () => 0,
+    });
+    expect(second.size).toBe(2);
+    expect(second.get("a")).toBeUndefined();
+    expect(second.get("b")).toEqual(RESULTS);
+    expect(second.get("c")).toEqual(RESULTS);
+  });
+
+  it("starts cold on a missing file", () => {
+    const cache = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 0,
+    });
+    expect(cache.size).toBe(0);
+    expect(cache.get("k")).toBeUndefined();
+  });
+
+  it("starts cold on a corrupt file instead of throwing, and set repairs it", () => {
+    writeFileSync(filePath, "{not json[", "utf8");
+    const cache = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 0,
+    });
+    expect(cache.size).toBe(0);
+
+    cache.set("k", RESULTS);
+    const repaired = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 0,
+    });
+    expect(repaired.get("k")).toEqual(RESULTS);
+  });
+
+  it("skips malformed rows without dropping the valid ones", () => {
+    writeFileSync(
+      filePath,
+      JSON.stringify([
+        { key: 42, expiresAt: 1000, value: RESULTS },
+        { key: "no-expiry", value: RESULTS },
+        { key: "ok", expiresAt: 1000, value: RESULTS },
+      ]),
+      "utf8",
+    );
+    const cache = createPersistentSearchCache({
+      ttlMs: 1000,
+      filePath,
+      now: () => 0,
+    });
+    expect(cache.size).toBe(1);
+    expect(cache.get("ok")).toEqual(RESULTS);
+  });
+
+  it("writes nothing when ttlMs is 0 (caching disabled)", () => {
+    const cache = createPersistentSearchCache({
+      ttlMs: 0,
+      filePath,
+      now: () => 0,
+    });
+    cache.set("k", RESULTS);
+    expect(existsSync(filePath)).toBe(false);
   });
 });

--- a/src/tools/os/web-search/transport/search-cache.ts
+++ b/src/tools/os/web-search/transport/search-cache.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
 import type { WebSearchResult } from "../web-search-provider.js";
 
 const DEFAULT_MAX_ENTRIES = 256;
@@ -9,6 +12,11 @@ export interface SearchCacheOptions {
   maxEntries?: number;
   /** Injectable clock for deterministic tests. */
   now?: () => number;
+}
+
+export interface PersistentSearchCacheOptions extends SearchCacheOptions {
+  /** Absolute path of the JSON file mirroring the cache on disk. */
+  filePath: string;
 }
 
 export interface SearchCache {
@@ -41,10 +49,45 @@ export function buildSearchCacheKey(
  * against DuckDuckGo's burst rate-limiting.
  */
 export function createSearchCache(options: SearchCacheOptions): SearchCache {
+  return buildCache(options, new Map<string, CacheEntry>(), undefined);
+}
+
+/**
+ * The same cache, mirrored to a JSON file so it survives the process
+ * (#256). Key, TTL, and eviction semantics are exactly those of
+ * `createSearchCache` — only the storage changes: entries are loaded on
+ * creation (rows already past their `expiresAt` are dropped, the entry
+ * cap is enforced oldest-first) and written through on every `set` via
+ * tmp-file + rename, so a crash never leaves a torn file. A missing or
+ * corrupt file starts the cache cold; a failed write is swallowed —
+ * persistence is an optimisation, and a full disk must never fail a
+ * search. Concurrent processes race benignly: last writer wins.
+ */
+export function createPersistentSearchCache(
+  options: PersistentSearchCacheOptions,
+): SearchCache {
   const ttlMs = Math.max(0, options.ttlMs);
   const maxEntries = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
   const now = options.now ?? Date.now;
-  const store = new Map<string, CacheEntry>();
+  // ttlMs 0 disables caching entirely, so there is nothing worth
+  // loading and nothing that would ever be written.
+  const store =
+    ttlMs === 0
+      ? new Map<string, CacheEntry>()
+      : loadCacheFile(options.filePath, now(), maxEntries);
+  const persist =
+    ttlMs === 0 ? undefined : () => saveCacheFile(options.filePath, store);
+  return buildCache(options, store, persist);
+}
+
+function buildCache(
+  options: SearchCacheOptions,
+  store: Map<string, CacheEntry>,
+  persist: (() => void) | undefined,
+): SearchCache {
+  const ttlMs = Math.max(0, options.ttlMs);
+  const maxEntries = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const now = options.now ?? Date.now;
 
   return {
     get(key) {
@@ -69,9 +112,70 @@ export function createSearchCache(options: SearchCacheOptions): SearchCache {
         if (oldest === undefined) break;
         store.delete(oldest);
       }
+      persist?.();
     },
     get size() {
       return store.size;
     },
   };
+}
+
+/** On-disk row shape: insertion order in the array is FIFO age order. */
+interface PersistedCacheRow {
+  key: string;
+  expiresAt: number;
+  value: WebSearchResult[];
+}
+
+function loadCacheFile(
+  filePath: string,
+  now: number,
+  maxEntries: number,
+): Map<string, CacheEntry> {
+  const store = new Map<string, CacheEntry>();
+  let rows: unknown;
+  try {
+    rows = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    // Missing on the very first run, or corrupt (torn by an interrupted
+    // write predating the tmp+rename, or hand-edited). Either way the
+    // correct recovery is a cold cache, not a crash.
+    return store;
+  }
+  if (!Array.isArray(rows)) return store;
+  for (const row of rows as Partial<PersistedCacheRow>[]) {
+    if (
+      typeof row?.key !== "string" ||
+      typeof row.expiresAt !== "number" ||
+      !Number.isFinite(row.expiresAt) ||
+      !Array.isArray(row.value)
+    ) {
+      continue;
+    }
+    if (row.expiresAt <= now) continue;
+    store.set(row.key, { expiresAt: row.expiresAt, value: row.value });
+  }
+  while (store.size > maxEntries) {
+    const oldest = store.keys().next().value;
+    if (oldest === undefined) break;
+    store.delete(oldest);
+  }
+  return store;
+}
+
+function saveCacheFile(filePath: string, store: Map<string, CacheEntry>): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    const rows: PersistedCacheRow[] = [...store].map(([key, entry]) => ({
+      key,
+      expiresAt: entry.expiresAt,
+      value: entry.value,
+    }));
+    const tmp = `${filePath}.tmp-${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(rows), "utf8");
+    renameSync(tmp, filePath);
+  } catch {
+    // Persistence is best-effort: a read-only stateDir or a full disk
+    // costs the next process its warm start, never this search.
+  }
 }


### PR DESCRIPTION
## What was broken

`os.web.search` kept both its result cache and the #241 provider cooldown in the tool's closure, so both died with the process. A campaign that runs one agent process per task started every task cold: queries answered minutes ago were re-bought from the provider, and a fresh process had to pay a 429 to rediscover a quota the last process had already parked — the exact request the park exists to avoid. Search quota was the single largest source of tool failure behind #179 (1341 429s, 44% of failures), and the per-task workload is the one case that #199's retry and #241's parking cannot reach, because nothing survived a restart. `cacheTtlMinutes` cannot fix this either: lifetime, not expiry, was the binding constraint.

## What this does

Both structures are now mirrored under `stateDir`, next to the other durable state:

- **`web-search-cache.json`** — `createPersistentSearchCache` keeps the key/TTL/FIFO-eviction semantics of `createSearchCache` exactly; only the storage changes. Rows already past `expiresAt` are dropped on load, the 256-entry cap is enforced oldest-first, and every `set` writes through via tmp-file + rename so a crash never leaves a torn file.
- **`web-search-cooldown.json`** — `createPersistentProviderCooldown` inherits parks *and* strikes, so the escalation ladder continues across a restart instead of walking back into the same wall. A park that lapsed while nothing ran simply reads as expired; a record whose park ended more than `2 × maxMs` (30 min) ago is dropped on load rather than parking a provider on yesterday's evidence.
- **Plumbing** — `buildOsWebSearchTool` takes an optional `stateDir`; the bootstrap passes `config.paths.stateDir` through `registerOsTools`. No `stateDir` (embedders, tests) keeps the old in-memory behaviour. **This seam is itself pinned**: a `bootstrap.test.ts` case boots the real runtime against a `stateDir` pre-seeded by a "previous process" and requires `os.web.search` to answer from the file — deleting the `stateDir` line in `createAgentRuntime` or the pass-through in `registerOsTools` fails that test in ~100 ms (verified by mutation on both lines) instead of silently shipping the pre-#256 in-memory behaviour with every other test green.
- **Opt-out** — `web.search.persistCache` (config v46, default `true`); `false` keeps both in-memory for workloads that genuinely want a cold cache per run, e.g. reproducing a benchmark.
- **Docs** — the "not persisted" invariant comment in `provider-cooldown.ts` is updated, and the AGENTS.md "Web search reliability" section no longer claims the cache "is per-process, in-memory" and that "a restart-surviving cache … is not built"; it now documents the persistent pair, the opt-out, and the new pinning tests.

A missing or corrupt file starts cold, never throws; a failed write is swallowed — persistence must never fail a search. Concurrent processes race benignly (atomic rename, last writer wins; no locking in v1). Query-key normalisation stays out, as the issue defers it for separate measurement.

## Test evidence

- `npm run lint` (tsc --noEmit): clean.
- `npx vitest run src/config src/tools/os/web-search src/tools/os/os-tools.test.ts src/runtime/bootstrap.test.ts` — 25 files, 408 tests, all passing.
- Also ran every other suite that touches `parseUserConfigFile` (config-command, skill, llm-config, custom-models-schema, persist-mcp-server, local-backend-readiness, tui-command.mouse, scorecard-7a): 185 tests, all passing.

New coverage that fails without the fix:

- `bootstrap.test.ts`: the enablement seam — real runtime, pre-seeded `stateDir`, `os.web.search` must answer `fromCache: true` from the file without any network (the configured provider is a closed local port, so a broken seam fails fast instead of making a live call). Mutation-verified against both wiring lines.
- `search-cache.test.ts`: cross-instance round-trip from the same file; expired rows dropped on load; cap enforced on load oldest-first; missing/corrupt file starts cold and `set` repairs it; malformed rows skipped without dropping valid ones; `ttlMs: 0` writes nothing.
- `provider-cooldown.test.ts`: a second process inherits a live park; a lapsed park reads as expired but the next 429 escalates to 2 min (ladder survives the restart); records staler than two ceilings are dropped; `clear` clears the disk too; corrupt file starts cold; malformed entries skipped.
- `web-search-tool.test.ts`: a second tool instance with the same `stateDir` serves the repeated query from cache without calling the provider; `persistCache: false` writes no file and starts cold; no `stateDir` keeps the in-memory behaviour.
- `config-schema.test.ts`: v45→v46 migration defaults `persistCache` to `true`; explicit opt-out honoured; non-boolean rejected.

Fixes #256
