### PR TITLE
feat(tui): a collapsible rail — « folds it, » brings it back, /sidebar for the keyboard

### DIFF
--- a/src/tui/commands/slash-command-handler.test.ts
+++ b/src/tui/commands/slash-command-handler.test.ts
@@ -103,6 +103,15 @@ describe("dispatchSlashCommand", () => {
     expect(dispatchSlashCommand("/new").triggerNewWindow).toBe(false);
   });
 
+  it("dispatches the rail fold toggle for /sidebar", () => {
+    // Pure state, so the toggle rides `actions` like /expand does —
+    // no trigger flag, no callback.
+    const result = dispatchSlashCommand("/sidebar");
+    expect(result.actions).toEqual([{ type: "sidebar_collapse_toggled" }]);
+    expect(result.forwardAsMessage).toBe(false);
+    expect(result.clearBuffer).toBe(true);
+  });
+
   it("opens the Memory tab for bare /memory", () => {
     const result = dispatchSlashCommand("/memory");
     expect(result.triggerMemoryDump).toBe(false);

--- a/src/tui/commands/slash-command-handler.ts
+++ b/src/tui/commands/slash-command-handler.ts
@@ -268,6 +268,11 @@ export function dispatchSlashCommand(buffer: string): SlashDispatchResult {
       return pureActions([], { triggerSessionNew: true });
     case "window":
       return pureActions([], { triggerNewWindow: true });
+    case "sidebar":
+      // Pure state, so no trigger flag: the toggle rides `actions` the
+      // way `/expand` and `/collapse` do, and the keyboard gets the
+      // same flip the rail's « control gives the mouse.
+      return pureActions([{ type: "sidebar_collapse_toggled" }]);
     case "tools":
       return dispatchToolsSub(parsed.args);
     case "skills":

--- a/src/tui/components/sidebar.test.tsx
+++ b/src/tui/components/sidebar.test.tsx
@@ -81,6 +81,32 @@ describe("Sidebar", () => {
     expect(text).not.toContain("LLM");
   });
 
+  it("keeps the fold mark on the lockup row even without mouse support", () => {
+    // Rendered outside MouseProvider the chip is inert, but it stays on
+    // screen as the signpost to /sidebar — same degradation as `+ new`.
+    // On the lockup row, not a row of its own: `SIDEBAR_CHROME_ROWS`
+    // (pinned by sidebar-fit.test.tsx) must not move.
+    const { lastFrame } = render(
+      <Sidebar
+        width={32}
+        sessions={SESSIONS}
+        sessionsCursor={0}
+        currentSessionId="abcdef1234"
+        tasks={TASKS}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={false}
+      />,
+    );
+    const lines = strip(lastFrame() ?? "").split("\n");
+    const foldRow = lines.findIndex((line) => line.includes("«"));
+    // Row 0 is the rail's breathing row; the lockup's top row — the
+    // rail's top-right corner — is where the hinge sits, one row above
+    // the wordmark beside the mark's centre.
+    expect(foldRow).toBe(1);
+    expect(lines[foldRow + 1]).toContain("atomic-agent");
+  });
+
   it("shows the empty state when there are no sessions", () => {
     const { lastFrame } = render(
       <Sidebar

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -243,7 +243,10 @@ function RailBrand({
   sessionId: string | null;
 }): ReactElement {
   const art = RAIL_MARK;
-  const textWidth = Math.max(0, inner - MARK_COLUMNS - 1);
+  const textWidth = Math.max(
+    0,
+    inner - MARK_COLUMNS - 1 - COLLAPSE_COLUMNS,
+  );
   return (
     <Box flexDirection="column">
       <RailBlank />
@@ -269,6 +272,17 @@ function RailBrand({
             {clip(`v${getAppVersion()}`, textWidth)}
           </Text>
         </Box>
+        <Box flexGrow={1} />
+        {/*
+          The fold control rides the lockup's top row rather than a row
+          of its own, so the rail's chrome-row count — the promise
+          `SIDEBAR_CHROME_ROWS` makes to `sidebar-fit.test.tsx` — does
+          not move. The column wrapper keeps the click target one cell
+          tall; a bare child in this row stretches to the mark's three.
+        */}
+        <Box flexDirection="column" flexShrink={0}>
+          <CollapseRailButton />
+        </Box>
       </Box>
       {sessionId ? (
         <RailLine inner={inner} color={theme.colors.railMuted}>
@@ -281,6 +295,34 @@ function RailBrand({
 
 /** Width of {@link RAIL_MARK}, kept beside it so the lockup can measure. */
 const MARK_COLUMNS = 6;
+
+/** Cells the fold chip occupies at the lockup row's right edge: ` « `. */
+const COLLAPSE_COLUMNS = 3;
+
+/**
+ * Folds the rail away — the top-right corner of the rail, which is the
+ * hinge a collapsible drawer is grabbed by in any desktop application.
+ * The status bar grows the matching `»` while the rail is folded, and
+ * `/sidebar` is the keyboard route to the same flip. With mouse support
+ * off the glyph still renders as a signpost to that command, inert the
+ * same way `+ new` is.
+ */
+function CollapseRailButton(): ReactElement {
+  const mouse = useMouseCommands();
+  const label = <Chip label={theme.glyphs.railCollapse} />;
+  if (!mouse) return label;
+  return (
+    <MouseTarget
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        mouse.dispatch({ type: "sidebar_collapse_toggled" });
+        return true;
+      }}
+    >
+      {label}
+    </MouseTarget>
+  );
+}
 
 /**
  * Starts a fresh thread. It sits on the Sessions header because that is

--- a/src/tui/components/status-bar.tsx
+++ b/src/tui/components/status-bar.tsx
@@ -21,6 +21,14 @@ interface StatusBarProps {
    * copies of them read as a rendering bug rather than as chrome.
    */
   brand?: boolean;
+  /**
+   * Draw the `»` that reopens a rail the operator folded away. True only
+   * while the fold is the operator's own (`sidebarCollapsed`) AND the
+   * terminal could seat the rail — when the size gate is what hid it,
+   * there is nothing a click could restore, so no control is offered.
+   * `TuiApp` computes the condition; the bar stays presentational.
+   */
+  railRestore?: boolean;
 }
 
 /**
@@ -46,12 +54,14 @@ interface StatusBarProps {
 export function StatusBar({
   state,
   brand = true,
+  railRestore = false,
 }: StatusBarProps): ReactElement {
   const section = getCurrentSection(state);
   const title = currentSessionTitle(state);
   const { columns } = useTerminalSize();
   return (
     <Box>
+      {railRestore ? <RailRestoreButton /> : null}
       {brand ? (
         <>
           <Text color={theme.colors.accentSoft} bold>
@@ -172,6 +182,34 @@ function Breadcrumb({
         mouse.dispatch({ type: "menu_path_set", path: null });
         mouse.dispatch({ type: "menu_cursor_set", cursor: 0 });
         mouse.dispatch({ type: "menu_opened" });
+        return true;
+      }}
+    >
+      {label}
+    </MouseTarget>
+  );
+}
+
+/**
+ * The way back after the rail's `«` folded it away. It sits at the head
+ * of the bar — the cell nearest the corner the rail vacated — so the
+ * fold and the unfold read as two positions of the same hinge. One
+ * click brings the rail back; without mouse support the glyph stays as
+ * a signpost to `/sidebar`, inert like every other chip.
+ */
+function RailRestoreButton(): ReactElement {
+  const mouse = useMouseCommands();
+  const label = (
+    <Text>
+      <Chip label={theme.glyphs.railRestore} />{" "}
+    </Text>
+  );
+  if (!mouse) return label;
+  return (
+    <MouseTarget
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        mouse.dispatch({ type: "sidebar_collapse_toggled" });
         return true;
       }}
     >

--- a/src/tui/menu/menu-registry.test.ts
+++ b/src/tui/menu/menu-registry.test.ts
@@ -217,6 +217,13 @@ const V0_2_2_SLASH_COMMANDS = [
     name: "context",
     description: "show where this session's context window went",
   },
+  // The rail's fold toggle: the mouse has the « control, this is the
+  // keyboard's route to the same flip.
+  {
+    name: "sidebar",
+    description:
+      "hide or show the session rail (the rail's « does the same)",
+  },
   {
     name: "uninstall",
     description:

--- a/src/tui/menu/menu-registry.ts
+++ b/src/tui/menu/menu-registry.ts
@@ -556,6 +556,18 @@ export const MENU: readonly MenuNode[] = [
   },
   {
     kind: "action",
+    id: "setup.sidebar",
+    label: "Hide or show the sidebar",
+    group: "setup",
+    slash: {
+      name: "sidebar",
+      description:
+        "hide or show the session rail (the rail's « does the same)",
+      rank: 38,
+    },
+  },
+  {
+    kind: "action",
     id: "setup.analytics",
     label: "Analytics",
     group: "setup",

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -502,6 +502,31 @@ describe("TuiApp mouse", () => {
     });
   });
 
+  it("folds the rail from its « mark and restores it from the bar's »", async () => {
+    // The two positions of one hinge: « in the rail's top-right corner
+    // folds it away, » at the head of the status bar brings it back.
+    const app = mountApp();
+    await waitUntil(() => app.frame().includes("SESSIONS"), "the rail on screen");
+    await clickUntil(
+      app.mouse,
+      () => locate(app.frame(), "«"),
+      () => !app.frame().includes("SESSIONS"),
+      "click the fold mark",
+    );
+    expect(app.frame()).not.toContain("SESSIONS");
+    // The restore mark sits on the top row, so a top-down locate cannot
+    // confuse it with a transcript's own » lines further down.
+    await waitUntil(() => app.frame().includes("»"), "the restore mark");
+    await clickUntil(
+      app.mouse,
+      () => locate(app.frame(), "»"),
+      () => app.frame().includes("SESSIONS"),
+      "click the restore mark",
+    );
+    expect(app.frame()).toContain("SESSIONS");
+    app.unmount();
+  });
+
   it("puts a start-page tip in the composer when it is clicked", async () => {
     // The rows are suggestions, not buttons: the command lands in the
     // buffer with a trailing space and Enter stays the operator's.

--- a/src/tui/reduce-sidebar-actions.test.ts
+++ b/src/tui/reduce-sidebar-actions.test.ts
@@ -143,6 +143,44 @@ describe("reduce sidebar + chat scroll actions", () => {
     expect(next.sidebarTasksCursor).toBe(0);
   });
 
+  it("toggles sidebarCollapsed and back", () => {
+    const initial = createInitialTuiState(SESSION);
+    expect(initial.sidebarCollapsed).toBe(false);
+    const folded = reduceTuiState(initial, {
+      type: "sidebar_collapse_toggled",
+    });
+    expect(folded.sidebarCollapsed).toBe(true);
+    const restored = reduceTuiState(folded, {
+      type: "sidebar_collapse_toggled",
+    });
+    expect(restored.sidebarCollapsed).toBe(false);
+  });
+
+  it("returns focus to the editor when the rail is folded from under it", () => {
+    const initial = createInitialTuiState(SESSION);
+    const onRail = { ...initial, chatFocus: "sidebar" as const };
+    const folded = reduceTuiState(onRail, {
+      type: "sidebar_collapse_toggled",
+    });
+    expect(folded.sidebarCollapsed).toBe(true);
+    expect(folded.chatFocus).toBe("editor");
+  });
+
+  it("leaves editor focus alone when the rail is folded or restored", () => {
+    const initial = createInitialTuiState(SESSION);
+    const folded = reduceTuiState(initial, {
+      type: "sidebar_collapse_toggled",
+    });
+    expect(folded.chatFocus).toBe("editor");
+    // Restoring never steals focus either — the operator asked for the
+    // rail back on screen, not for the keyboard to move there.
+    const restored = reduceTuiState(
+      { ...folded, chatFocus: "editor" as const },
+      { type: "sidebar_collapse_toggled" },
+    );
+    expect(restored.chatFocus).toBe("editor");
+  });
+
   it("sets sidebarSection on sidebar_section_focused", () => {
     const initial = createInitialTuiState(SESSION);
     const next = reduceTuiState(initial, {

--- a/src/tui/reduce-ui-actions.ts
+++ b/src/tui/reduce-ui-actions.ts
@@ -303,6 +303,22 @@ export function reduceUiAction(
       };
     case "chat_focus_set":
       return { ...state, chatFocus: action.focus };
+    case "sidebar_collapse_toggled": {
+      const collapsed = !state.sidebarCollapsed;
+      // Folding the rail away takes its focus stop with it, so the
+      // keyboard goes home to the editor in the same action — a
+      // separate frame with focus on an undrawn surface is exactly the
+      // strand the resize effect in `tui-app.tsx` exists to fix, and
+      // this is the one flip the reducer can see coming itself.
+      return {
+        ...state,
+        sidebarCollapsed: collapsed,
+        chatFocus:
+          collapsed && state.chatFocus === "sidebar"
+            ? "editor"
+            : state.chatFocus,
+      };
+    }
     case "sidebar_section_focused":
       return { ...state, sidebarSection: action.section };
     case "sidebar_cursor_moved": {

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -159,6 +159,10 @@ export interface TuiGlyphs {
   readonly menuCursor: string;
   /** Hamburger, for the rail's menu button. */
   readonly menuGlyph: string;
+  /** Folds the rail away; sits in its top-right corner. */
+  readonly railCollapse: string;
+  /** Reopens the folded rail; sits at the head of the status bar. */
+  readonly railRestore: string;
   readonly dotSeparator: string;
   readonly pipeSeparator: string;
 }
@@ -203,6 +207,8 @@ const GLYPHS: TuiGlyphs = {
   chevronRight: "▸",
   menuCursor: "▶",
   menuGlyph: "☰",
+  railCollapse: "«",
+  railRestore: "»",
   dotSeparator: "·",
   pipeSeparator: "|",
 };

--- a/src/tui/tui-action.ts
+++ b/src/tui/tui-action.ts
@@ -270,6 +270,8 @@ export type TuiAction =
   | { type: "chat_focus_toggled" }
   /** Set keyboard focus explicitly (used when the sidebar collapses below the width threshold). */
   | { type: "chat_focus_set"; focus: "editor" | "sidebar" }
+  /** Fold the rail away or bring it back (the rail's `«`, the bar's `»`, `/sidebar`). */
+  | { type: "sidebar_collapse_toggled" }
   /** Pick which sidebar pane (Sessions / Tasks) is the current Tab-cycle stop. */
   | { type: "sidebar_section_focused"; section: "sessions" | "tasks" }
   /** Move the sidebar's session-list cursor by N rows (clamped). */

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -784,6 +784,14 @@ export function TuiApp({
   const terminalSize = useTerminalSize();
   const sidebarVisible =
     state.uiMode === "chat" &&
+    !state.sidebarCollapsed &&
+    isSidebarVisible(terminalSize.columns, terminalSize.rows);
+  // The `»` restore control is offered only while the fold is the
+  // operator's own choice AND the terminal could seat the rail: when
+  // the size gate is what hid it, a click could restore nothing.
+  const sidebarRestorable =
+    state.uiMode === "chat" &&
+    state.sidebarCollapsed &&
     isSidebarVisible(terminalSize.columns, terminalSize.rows);
   // The rail takes a share of the terminal rather than a flat 30
   // columns, and its two panes get a row budget cut from the terminal
@@ -897,9 +905,12 @@ export function TuiApp({
             state.localModelsPanel.removeConfirmId !== null)
         )));
 
-  // When the sidebar collapses below the width or height threshold
+  // When the sidebar drops below the width or height threshold
   // (terminal resized smaller), focus must follow back to the editor so
-  // Tab does not strand the operator on an invisible surface.
+  // Tab does not strand the operator on an invisible surface. The
+  // dependency is the derived `sidebarVisible`, so every flip is
+  // covered — the operator's own fold (`sidebarCollapsed`) included,
+  // though the reducer already reclaims focus on that path itself.
   useEffect(() => {
     if (!sidebarVisible && state.chatFocus === "sidebar") {
       dispatch({ type: "chat_focus_set", focus: "editor" });
@@ -1679,7 +1690,11 @@ export function TuiApp({
         bug rather than as chrome.
       */}
       <Box flexShrink={0}>
-        <StatusBar state={state} brand={!sidebarVisible} />
+        <StatusBar
+          state={state}
+          brand={!sidebarVisible}
+          railRestore={sidebarRestorable}
+        />
       </Box>
       {/*
         The design separates the top bar and the hint strip from the

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -587,6 +587,16 @@ export interface TuiState {
    */
   sidebarSection: "sessions" | "tasks";
   /**
+   * The operator's own choice to fold the rail away — the `«` control
+   * on the rail, the `»` on the status bar, or `/sidebar`. Session-only,
+   * never persisted, and independent of the terminal-size gate: render
+   * time combines both (`!sidebarCollapsed && isSidebarVisible(...)`),
+   * so a rail folded by hand stays folded through resizes, and the
+   * restore control only appears when the terminal could actually seat
+   * the rail again.
+   */
+  sidebarCollapsed: boolean;
+  /**
    * Highlighted row in the sidebar's session list. `0` = newest session,
    * `recentSessions.length - 1` = oldest. Independent of
    * `sessionPickerCursor` so opening / closing the modal picker does not
@@ -801,6 +811,7 @@ export function createInitialTuiState(
     recentSessions: [],
     chatFocus: "editor",
     sidebarSection: "sessions",
+    sidebarCollapsed: false,
     sidebarCursor: 0,
     sidebarTasksCursor: 0,
     chatScrollOffset: 0,


### PR DESCRIPTION
The left rail can now be folded away. A `«` chip sits in the rail's top-right corner — the hinge a collapsible drawer is grabbed by — and one click folds the rail; while it is folded, a `»` chip at the head of the status bar brings it back. `/sidebar` (also in the operator menu under Setup) toggles the same flip for keyboard users.

- `sidebarCollapsed` is session-only UI state, never persisted, and independent of the terminal-size gate: visibility is `!sidebarCollapsed && isSidebarVisible(...)`, so a hand-folded rail stays folded through resizes, and the `»` restore control only renders when the terminal could actually seat the rail — never when the size gate is what hid it.
- Folding while the rail owns keyboard focus returns focus to the editor in the same reducer action; the existing resize effect keeps covering the size-gate path.
- The fold chip rides the brand lockup's top row, so `SIDEBAR_CHROME_ROWS` stays 14 and `sidebar-fit.test.tsx`'s geometry pin holds. With mouse support off both chips render inert, as signposts to `/sidebar` — the `+ new` degradation.
- `/sidebar` carries its toggle on `actions` like `/expand` does (pure state, no trigger flag or callback).

Tests: reducer round trip + focus reclaim, `/sidebar` dispatch, inert-render placement, and an app-level mouse test that folds the rail from `«` and restores it from `»`. Palette snapshot in `menu-registry.test.ts` extended with the new command. `npm run lint` clean; full `src/tui` suite green (2478 tests).
