### PR TITLE
feat(agent): warn when a test command repeats against an unchanged workspace

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -43,7 +43,9 @@ import { executeStep } from "./step-executor.js";
 import type { LlmStreamParams, StepEvent } from "./step-executor.js";
 import {
   ToolLoopTracker,
+  TEST_REPEAT_WARNING_THRESHOLD,
   formatRepeatNotice,
+  formatTestRepeatNotice,
   formatWanderingRedirect,
   formatForcedLoopReply,
 } from "./loop-detector.js";
@@ -347,7 +349,7 @@ export type AgentLoopEvent =
       /** Graduated severity from the `ToolLoopTracker`. */
       level?: "warn" | "critical" | "breaker";
       /** Which sub-detector fired. */
-      detector?: "generic_repeat" | "no_progress" | "wandering";
+      detector?: "generic_repeat" | "no_progress" | "wandering" | "test_repeat";
     }
   | {
       type: "loop_completed";
@@ -770,13 +772,26 @@ export class AgentLoop {
         // re-injected on every subsequent identical step.
         for (const sig of loopSignals) {
           if (sig.kind !== "warn") continue;
-          if (!loopTracker.shouldEmitWarning(sig.warningKey, sig.count)) {
+          // The test-repeat detector has its own floor: the 2nd
+          // equivalent run is already conclusive, so it must not wait
+          // for the generic warning threshold (default 3).
+          const emit =
+            sig.detector === "test_repeat"
+              ? loopTracker.shouldEmitWarning(
+                  sig.warningKey,
+                  sig.count,
+                  TEST_REPEAT_WARNING_THRESHOLD,
+                )
+              : loopTracker.shouldEmitWarning(sig.warningKey, sig.count);
+          if (!emit) {
             continue;
           }
           pendingNotice =
             sig.detector === "wandering"
               ? formatWanderingRedirect(sig.tool, sig.count)
-              : formatRepeatNotice(sig);
+              : sig.detector === "test_repeat"
+                ? formatTestRepeatNotice(sig)
+                : formatRepeatNotice(sig);
           this.deps.onEvent?.({
             type: "loop_detected",
             tool: sig.tool,

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ToolRegistry } from "../tools/tool-registry.js";
 import {
   compressToolResult,
@@ -962,3 +965,195 @@ describe("executeBatch under plan mode", () => {
 function out2LoopSignals(tracker: ToolLoopTracker): number {
   return tracker.check("os.fs.write", { path: "a" }).count;
 }
+
+describe("test-repeat gate (issue #118)", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "atomic-test-repeat-"));
+    await writeFile(join(dir, "app.py"), "x = 1\n");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** Shell stub returning a scripted summary per invocation. */
+  function shellRegistry(summaries: readonly string[]): {
+    registry: ToolRegistry;
+    calls: () => number;
+  } {
+    let i = 0;
+    const registry = buildRegistry(
+      {
+        "os.shell.run": async () =>
+          okResult(
+            "os.shell.run",
+            summaries[Math.min(i++, summaries.length - 1)]!,
+          ),
+      },
+      false,
+    );
+    return { registry, calls: () => i };
+  }
+
+  function testCtx(tracker: ToolLoopTracker) {
+    return { ...ctx(new AbortController().signal), workingDir: dir, tracker };
+  }
+
+  it("warns on the 2nd equivalent run against an unchanged workspace and still executes it", async () => {
+    const { registry, calls } = shellRegistry(["1 failed", "1 failed again"]);
+    const tracker = new ToolLoopTracker();
+    const context = testCtx(tracker);
+    const call = {
+      tool: "os.shell.run",
+      args: { cmd: "pytest", args: ["-k", "auth"] },
+    };
+
+    const first = await executeBatch(toBatchInputs([call]), registry, context);
+    expect(first.loopSignals).toEqual([]);
+
+    const second = await executeBatch(toBatchInputs([call]), registry, context);
+    const sig = second.loopSignals.find((s) => s.detector === "test_repeat");
+    expect(sig).toBeDefined();
+    expect(sig!.kind).toBe("warn");
+    expect(sig!.count).toBe(2);
+    expect(sig!.target).toBe("pytest -k auth");
+    expect(sig!.previousSummary).toBe("1 failed");
+    // Warn-only: the call still executed and returned the real result.
+    expect(calls()).toBe(2);
+    expect(second.results[0]!.compressed!.status).toBe("ok");
+    expect(second.results[0]!.compressed!.summary).toContain("again");
+  });
+
+  it("warns even when only timeoutMs changed (defeats the raw-args hash)", async () => {
+    const { registry } = shellRegistry(["3 passed"]);
+    const tracker = new ToolLoopTracker();
+    const context = testCtx(tracker);
+
+    await executeBatch(
+      toBatchInputs([
+        { tool: "os.shell.run", args: { cmd: "pytest", timeoutMs: 30_000 } },
+      ]),
+      registry,
+      context,
+    );
+    const second = await executeBatch(
+      toBatchInputs([
+        { tool: "os.shell.run", args: { cmd: "pytest", timeoutMs: 60_000 } },
+      ]),
+      registry,
+      context,
+    );
+    // The generic detector never fires here (different raw args), which
+    // is exactly the gap this detector closes.
+    const sig = second.loopSignals.find((s) => s.detector === "test_repeat");
+    expect(sig).toBeDefined();
+    expect(sig!.previousSummary).toBe("3 passed");
+  });
+
+  it("permits the rerun when any process changed the workspace in between", async () => {
+    const { registry } = shellRegistry(["1 failed"]);
+    const tracker = new ToolLoopTracker();
+    const context = testCtx(tracker);
+    const call = { tool: "os.shell.run", args: { cmd: "pytest" } };
+
+    await executeBatch(toBatchInputs([call]), registry, context);
+    // Out-of-band mutation — an Atomic write tool, a shell command, or an
+    // external editor are indistinguishable at the filesystem level.
+    await writeFile(join(dir, "app.py"), "x = 2 + 2\n");
+    const second = await executeBatch(toBatchInputs([call]), registry, context);
+    expect(
+      second.loopSignals.find((s) => s.detector === "test_repeat"),
+    ).toBeUndefined();
+  });
+
+  it("treats output churn under documented ignores as no progress", async () => {
+    await mkdir(join(dir, "coverage"));
+    const { registry } = shellRegistry(["2 passed"]);
+    const tracker = new ToolLoopTracker();
+    const context = testCtx(tracker);
+    const call = { tool: "os.shell.run", args: { cmd: "pytest" } };
+
+    await executeBatch(toBatchInputs([call]), registry, context);
+    // Only ignored output changed: this is not source progress.
+    await writeFile(join(dir, "coverage", "index.html"), "<html>new</html>");
+    const second = await executeBatch(toBatchInputs([call]), registry, context);
+    expect(
+      second.loopSignals.find((s) => s.detector === "test_repeat"),
+    ).toBeDefined();
+  });
+
+  it("keeps distinct cwd and filter args out of each other's streaks", async () => {
+    await mkdir(join(dir, "api"));
+    await writeFile(join(dir, "api", "mod.py"), "y = 1\n");
+    const { registry } = shellRegistry(["ok"]);
+    const tracker = new ToolLoopTracker();
+    const context = testCtx(tracker);
+
+    await executeBatch(
+      toBatchInputs([{ tool: "os.shell.run", args: { cmd: "pytest" } }]),
+      registry,
+      context,
+    );
+    const otherCwd = await executeBatch(
+      toBatchInputs([
+        { tool: "os.shell.run", args: { cmd: "pytest", cwd: "api" } },
+      ]),
+      registry,
+      context,
+    );
+    const otherFilter = await executeBatch(
+      toBatchInputs([
+        { tool: "os.shell.run", args: { cmd: "pytest", args: ["-k", "x"] } },
+      ]),
+      registry,
+      context,
+    );
+    expect(
+      otherCwd.loopSignals.find((s) => s.detector === "test_repeat"),
+    ).toBeUndefined();
+    expect(
+      otherFilter.loopSignals.find((s) => s.detector === "test_repeat"),
+    ).toBeUndefined();
+  });
+
+  it("never vetoes: every equivalent run still executes (warn-only)", async () => {
+    const { registry, calls } = shellRegistry(["same result"]);
+    const tracker = new ToolLoopTracker();
+    const context = testCtx(tracker);
+
+    for (let t = 0; t < 3; t += 1) {
+      // Distinct timeoutMs keeps the generic no-progress streak silent, so
+      // any signal below is the test-repeat detector's alone.
+      const out = await executeBatch(
+        toBatchInputs([
+          {
+            tool: "os.shell.run",
+            args: { cmd: "pytest", timeoutMs: 1_000 + t },
+          },
+        ]),
+        registry,
+        context,
+      );
+      expect(out.results[0]!.compressed!.status).toBe("ok");
+      for (const sig of out.loopSignals) {
+        expect(sig.kind).toBe("warn");
+      }
+    }
+    expect(calls()).toBe(3);
+  });
+
+  it("leaves unrecognized commands entirely to the generic detector", async () => {
+    const { registry } = shellRegistry(["listing"]);
+    const tracker = new ToolLoopTracker();
+    const context = testCtx(tracker);
+    const call = { tool: "os.shell.run", args: { cmd: "ls", args: ["-la"] } };
+
+    await executeBatch(toBatchInputs([call]), registry, context);
+    const second = await executeBatch(toBatchInputs([call]), registry, context);
+    expect(
+      second.loopSignals.find((s) => s.detector === "test_repeat"),
+    ).toBeUndefined();
+  });
+});

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -18,6 +18,8 @@ import {
   type LoopCheckVerdict,
   type ToolLoopTracker,
 } from "./loop-detector.js";
+import { classifyTestCommand } from "./test-command-key.js";
+import { fingerprintWorkspace } from "./workspace-fingerprint.js";
 
 /**
  * Loop-detection signal surfaced upward from a batch execution. The
@@ -34,6 +36,17 @@ export interface BatchLoopSignal {
   count: number;
   detector: LoopCheckVerdict["detector"];
   warningKey: string;
+  /**
+   * `test_repeat` only: human-readable command label (`pytest -k auth`)
+   * for the notice text.
+   */
+  target?: string;
+  /**
+   * `test_repeat` only: compressed summary of the previous equivalent
+   * run, quoted in the notice so the model sees what re-running
+   * reproduced.
+   */
+  previousSummary?: string;
 }
 
 /**
@@ -566,6 +579,38 @@ function runSyncLoopGate(
       detector: verdict.detector,
       warningKey: verdict.warningKey,
     });
+  }
+
+  // Test-repeat gate (issue #118, companion of #114): a recognized test
+  // command re-run against an unchanged workspace fingerprint is a
+  // stronger no-progress signal than the generic byte-identical repeat —
+  // it survives timeout-only argument variation and timing noise in the
+  // output. Warn-only by design (the issue's acceptance criteria): the
+  // call always proceeds, which is also the intentional-repeat path, and
+  // the generic detectors above stay fully active. The fingerprint walk
+  // runs only here — recognized test commands only — never on ordinary
+  // shell calls. A `null` fingerprint (missing / oversized cwd) disables
+  // detection for this call rather than risking a false warning.
+  const testCommand = classifyTestCommand(tool, args, ctx.workingDir);
+  if (testCommand !== null) {
+    const fingerprint = fingerprintWorkspace(testCommand.cwd);
+    if (fingerprint !== null) {
+      const repeat = ctx.tracker.checkTestRepeat(testCommand.key, fingerprint);
+      ctx.tracker.recordTestRun(testCommand.key, fingerprint, tool, args);
+      if (repeat.repeat) {
+        loopSignals.push({
+          kind: "warn",
+          tool,
+          count: repeat.count,
+          detector: "test_repeat",
+          warningKey: `test_repeat:${testCommand.key}`,
+          target: testCommand.label,
+          ...(repeat.previousSummary !== undefined
+            ? { previousSummary: repeat.previousSummary }
+            : {}),
+        });
+      }
+    }
   }
   return { proceed: true };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -19,15 +19,25 @@ export {
   hashToolCall,
   hashToolOutcome,
   formatRepeatNotice,
+  formatTestRepeatNotice,
   formatVetoInstruction,
   formatForcedLoopReply,
   extractLoopTarget,
   BATCH_LOOP_LABEL,
   LOOP_VETO_DENIED_REASON,
   LOOP_WARNING_BUCKET_SIZE,
+  TEST_REPEAT_WARNING_THRESHOLD,
 } from "./loop-detector.js";
 export type {
   ToolLoopTrackerOptions,
   LoopCheckVerdict,
   LoopCheckLevel,
+  TestRepeatCheck,
 } from "./loop-detector.js";
+export { classifyTestCommand } from "./test-command-key.js";
+export type { RecognizedTestCommand } from "./test-command-key.js";
+export {
+  fingerprintWorkspace,
+  FINGERPRINT_IGNORED_DIRS,
+  FINGERPRINT_IGNORED_FILES,
+} from "./workspace-fingerprint.js";

--- a/src/agent/loop-detector.test.ts
+++ b/src/agent/loop-detector.test.ts
@@ -7,6 +7,7 @@ import {
   extractLoopTarget,
   formatForcedLoopReply,
   formatRepeatNotice,
+  formatTestRepeatNotice,
   formatVetoInstruction,
   formatWanderingRedirect,
   hashToolOutcome,
@@ -569,5 +570,110 @@ describe("hashToolOutcome volatile stripping", () => {
       details: { items: [{ id: 2, name: "x" }], meta: { requestId: "zzz" } },
     });
     expect(hashToolOutcome("t", {}, a)).toBe(hashToolOutcome("t", {}, b));
+  });
+});
+
+describe("test-repeat detector state (issue #118)", () => {
+  const KEY = "/work/project pytest -k auth";
+
+  it("does not flag the first run of a key", () => {
+    const tracker = new ToolLoopTracker();
+    expect(tracker.checkTestRepeat(KEY, "fp-1")).toEqual({
+      repeat: false,
+      count: 1,
+    });
+  });
+
+  it("flags the second equivalent run and quotes the previous summary", () => {
+    const tracker = new ToolLoopTracker();
+    const args = { cmd: "pytest", args: ["-k", "auth"] };
+    tracker.recordTestRun(KEY, "fp-1", "os.shell.run", args);
+    tracker.recordOutcome(
+      "os.shell.run",
+      args,
+      mkResult({ tool: "os.shell.run", summary: "3 passed in 1.2s" }),
+    );
+    const verdict = tracker.checkTestRepeat(KEY, "fp-1");
+    expect(verdict.repeat).toBe(true);
+    expect(verdict.count).toBe(2);
+    expect(verdict.previousSummary).toBe("3 passed in 1.2s");
+  });
+
+  it("clears the repeat and drops the stored summary when the fingerprint changes", () => {
+    const tracker = new ToolLoopTracker();
+    const args = { cmd: "pytest", args: ["-k", "auth"] };
+    tracker.recordTestRun(KEY, "fp-1", "os.shell.run", args);
+    tracker.recordOutcome(
+      "os.shell.run",
+      args,
+      mkResult({ tool: "os.shell.run", summary: "1 failed" }),
+    );
+    // Workspace changed: the rerun is permitted (no repeat) and the
+    // pre-change summary must never be quoted against the new state.
+    const changed = tracker.checkTestRepeat(KEY, "fp-2");
+    expect(changed).toEqual({ repeat: false, count: 1 });
+    tracker.recordTestRun(KEY, "fp-2", "os.shell.run", args);
+    const next = tracker.checkTestRepeat(KEY, "fp-2");
+    expect(next.repeat).toBe(true);
+    expect(next.previousSummary).toBeUndefined();
+  });
+
+  it("keeps counting consecutive equivalent runs", () => {
+    const tracker = new ToolLoopTracker();
+    const args = { cmd: "pytest", args: [] };
+    tracker.recordTestRun(KEY, "fp-1", "os.shell.run", args);
+    tracker.recordTestRun(KEY, "fp-1", "os.shell.run", args);
+    expect(tracker.checkTestRepeat(KEY, "fp-1").count).toBe(3);
+  });
+
+  it("keys are independent: another suite does not inherit the repeat", () => {
+    const tracker = new ToolLoopTracker();
+    const args = { cmd: "pytest", args: [] };
+    tracker.recordTestRun(KEY, "fp-1", "os.shell.run", args);
+    expect(tracker.checkTestRepeat("other-key", "fp-1").repeat).toBe(false);
+  });
+
+  it("shouldEmitWarning honours a per-detector minCount floor", () => {
+    const tracker = new ToolLoopTracker();
+    // Default floor (warningThreshold = 3) suppresses a count of 2 while
+    // the test-repeat floor emits from the 2nd equivalent run.
+    expect(tracker.shouldEmitWarning("warn:generic", 2)).toBe(false);
+    expect(tracker.shouldEmitWarning("test_repeat:k", 2, 2)).toBe(true);
+    // De-dup bucket: the same key stays silent within the bucket.
+    expect(tracker.shouldEmitWarning("test_repeat:k", 3, 2)).toBe(false);
+  });
+});
+
+describe("formatTestRepeatNotice", () => {
+  it("names the command, quotes the previous result, and stays warn-only", () => {
+    const text = formatTestRepeatNotice({
+      count: 2,
+      target: "pytest -k auth",
+      previousSummary: "3 passed in 1.2s",
+    });
+    expect(text).toContain("`pytest -k auth`");
+    expect(text).toContain("2 times");
+    expect(text).toContain("Previous result: 3 passed in 1.2s");
+    expect(text).toContain("nothing was blocked");
+  });
+
+  it("collapses and caps a long multi-line summary", () => {
+    const text = formatTestRepeatNotice({
+      count: 2,
+      previousSummary: `line one\nline two\n${"x".repeat(500)}`,
+    });
+    expect(text).toContain("line one line two");
+    expect(text).not.toContain("\nline two");
+    const resultLine = text
+      .split("\n")
+      .find((l) => l.startsWith("Previous result:"))!;
+    expect(resultLine.length).toBeLessThanOrEqual(320);
+    expect(resultLine.endsWith("...")).toBe(true);
+  });
+
+  it("omits the previous-result line when no summary is known", () => {
+    const text = formatTestRepeatNotice({ count: 2 });
+    expect(text).toContain("the same test command");
+    expect(text).not.toContain("Previous result:");
   });
 });

--- a/src/agent/loop-detector.ts
+++ b/src/agent/loop-detector.ts
@@ -27,6 +27,28 @@ export const LOOP_WARNING_BUCKET_SIZE = 10;
 
 export type LoopCheckLevel = "ok" | "warn" | "critical";
 
+/**
+ * Equivalent-run count at which the test-repeat detector (issue #118)
+ * warns: the 2nd recognized test command against an unchanged workspace
+ * fingerprint is already conclusive (the suite cannot produce new
+ * evidence), unlike the generic byte-repeat where a rerun may be an
+ * intentional retry. Warn-only — never routed into the veto/breaker.
+ */
+export const TEST_REPEAT_WARNING_THRESHOLD = 2;
+
+/**
+ * Verdict of `ToolLoopTracker.checkTestRepeat`: is this recognized test
+ * command an equivalent re-run against an unchanged workspace?
+ */
+export interface TestRepeatCheck {
+  /** True when the key repeats against an identical fingerprint. */
+  repeat: boolean;
+  /** 1 for a fresh/changed-workspace run; N for the Nth equivalent run. */
+  count: number;
+  /** Compressed summary of the previous equivalent run, when recorded. */
+  previousSummary?: string;
+}
+
 export interface ToolLoopTrackerOptions {
   /** Args-only repeat count that fires a `warn`. Min 2. Default 3. */
   warningThreshold?: number;
@@ -57,7 +79,7 @@ export interface LoopCheckVerdict {
    * distinct-args spread (wandering).
    */
   count: number;
-  detector: "generic_repeat" | "no_progress" | "wandering";
+  detector: "generic_repeat" | "no_progress" | "wandering" | "test_repeat";
   /** Stable key for warn de-duplication and breaker signalling. */
   warningKey: string;
   tool: string;
@@ -125,6 +147,22 @@ export class ToolLoopTracker {
   private readonly warningBuckets = new Map<string, number>();
   private consecutiveVetoSignature: string | null = null;
   private consecutiveVetoCount = 0;
+  /**
+   * Test-repeat detector state (issue #118): semantic test-command key →
+   * the workspace fingerprint captured before its latest run, how many
+   * equivalent runs in a row that fingerprint has seen, and the summary
+   * of the previous run's result (patched in by `recordOutcome`).
+   */
+  private readonly testRuns = new Map<
+    string,
+    { fingerprint: string; count: number; lastSummary?: string }
+  >();
+  /**
+   * Call-signature → semantic test key for runs dispatched but not yet
+   * completed, so `recordOutcome` can attach the result summary to the
+   * right `testRuns` entry without re-classifying the command.
+   */
+  private readonly pendingTestKeys = new Map<string, string>();
 
   constructor(options: ToolLoopTrackerOptions = {}) {
     this.warningThreshold = Math.max(2, options.warningThreshold ?? 3);
@@ -253,6 +291,7 @@ export class ToolLoopTracker {
    * signature differs from the one currently being vetoed.
    */
   recordOutcome(tool: string, args: unknown, result: CompressedToolResult): void {
+    this.noteTestOutcome(tool, args, result);
     if (isLoopVetoResult(result)) {
       this.patchLatestPending(tool, args, { vetoed: true });
       this.noteVeto(tool, args);
@@ -268,6 +307,71 @@ export class ToolLoopTracker {
         this.consecutiveVetoCount = 0;
       }
     }
+  }
+
+  /**
+   * Classify a recognized test command's prospective run against the
+   * stored `(key → fingerprint)` state (issue #118). Pure map lookup —
+   * the fingerprint walk happens at the call site, and only for
+   * recognized test commands. Call BEFORE `recordTestRun`.
+   */
+  checkTestRepeat(key: string, fingerprint: string): TestRepeatCheck {
+    const prev = this.testRuns.get(key);
+    if (prev === undefined || prev.fingerprint !== fingerprint) {
+      return { repeat: false, count: 1 };
+    }
+    return {
+      repeat: true,
+      count: prev.count + 1,
+      ...(prev.lastSummary !== undefined
+        ? { previousSummary: prev.lastSummary }
+        : {}),
+    };
+  }
+
+  /**
+   * Record a recognized test command being dispatched: store the
+   * fingerprint captured before this run and remember the call
+   * signature so `recordOutcome` can patch in the result summary. A
+   * changed fingerprint resets the equivalent-run count AND drops the
+   * stored summary — a later warning must cite a result produced
+   * against the current workspace state, never a pre-change one.
+   */
+  recordTestRun(
+    key: string,
+    fingerprint: string,
+    tool: string,
+    args: unknown,
+  ): void {
+    const prev = this.testRuns.get(key);
+    const unchanged = prev !== undefined && prev.fingerprint === fingerprint;
+    this.testRuns.set(key, {
+      fingerprint,
+      count: unchanged ? prev.count + 1 : 1,
+      ...(unchanged && prev.lastSummary !== undefined
+        ? { lastSummary: prev.lastSummary }
+        : {}),
+    });
+    this.pendingTestKeys.set(hashToolCall(tool, args), key);
+  }
+
+  /**
+   * Attach a completed run's summary to its pending test-key entry so
+   * the next equivalent-run warning can quote the previous result.
+   */
+  private noteTestOutcome(
+    tool: string,
+    args: unknown,
+    result: CompressedToolResult,
+  ): void {
+    const signature = hashToolCall(tool, args);
+    const key = this.pendingTestKeys.get(signature);
+    if (key === undefined) return;
+    this.pendingTestKeys.delete(signature);
+    if (isLoopVetoResult(result)) return;
+    const record = this.testRuns.get(key);
+    if (record === undefined) return;
+    this.testRuns.set(key, { ...record, lastSummary: result.summary });
   }
 
   /** Bump the consecutive-veto counter for this call's signature. */
@@ -297,13 +401,19 @@ export class ToolLoopTracker {
   /**
    * Emit a warn at most once per bucket of `warningBucketSize` repeats so
    * the `### notice` is not re-injected every step. Returns true when the
-   * caller should surface this warning.
+   * caller should surface this warning. `minCount` overrides the generic
+   * warning threshold for detectors with their own floor (the test-repeat
+   * detector warns from the 2nd equivalent run, see
+   * `TEST_REPEAT_WARNING_THRESHOLD`).
    */
-  shouldEmitWarning(warningKey: string, count: number): boolean {
-    if (count < this.warningThreshold) return false;
-    const bucket = Math.floor(
-      (count - this.warningThreshold) / this.warningBucketSize,
-    );
+  shouldEmitWarning(
+    warningKey: string,
+    count: number,
+    minCount = this.warningThreshold,
+  ): boolean {
+    const threshold = Math.max(1, minCount);
+    if (count < threshold) return false;
+    const bucket = Math.floor((count - threshold) / this.warningBucketSize);
     const prev = this.warningBuckets.get(warningKey) ?? -1;
     if (bucket <= prev) return false;
     this.warningBuckets.set(warningKey, bucket);
@@ -603,6 +713,47 @@ export function formatVetoInstruction(verdict: {
   detector?: LoopCheckVerdict["detector"];
 }): string {
   return formatLoopGuidance(verdict.tool, verdict.count, "veto", verdict);
+}
+
+/**
+ * Notice injected when a recognized test command was re-run against an
+ * unchanged workspace (issue #118, warn-only). The run has already
+ * executed when the model reads this — the wording is therefore an
+ * after-the-fact nudge, not a block, and explicitly leaves the
+ * intentional-repeat path open (nothing is vetoed; the generic loop
+ * protection stays fully active either way).
+ */
+export function formatTestRepeatNotice(verdict: {
+  count: number;
+  target?: string;
+  previousSummary?: string;
+}): string {
+  const target = sanitizeLoopTarget(verdict.target);
+  const label = target ? `\`${target}\`` : "the same test command";
+  const lines = [
+    `You ran ${label} ${verdict.count} times with no workspace change in between. No project file changed since the previous run, so this run could not produce new evidence.`,
+  ];
+  if (verdict.previousSummary !== undefined) {
+    const summary = sanitizeTestSummary(verdict.previousSummary);
+    if (summary !== undefined) {
+      lines.push(`Previous result: ${summary}`);
+    }
+  }
+  lines.push(
+    "Change the code or the test selection before re-running. If the repeat was intentional (e.g. probing for flakiness), continue — this is a warning, nothing was blocked.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Compact a previous-result summary for inline quoting in a notice:
+ * whitespace collapsed to one line, length-capped. Returns `undefined`
+ * for an empty summary so the caller omits the line entirely.
+ */
+function sanitizeTestSummary(raw: string): string | undefined {
+  const cleaned = raw.replace(/\s+/g, " ").trim();
+  if (cleaned.length === 0) return undefined;
+  return cleaned.length > 300 ? `${cleaned.slice(0, 297)}...` : cleaned;
 }
 
 /**

--- a/src/agent/test-command-key.test.ts
+++ b/src/agent/test-command-key.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { classifyTestCommand } from "./test-command-key.js";
+
+const WD = "/work/project";
+
+function classify(args: unknown, workingDir = WD) {
+  return classifyTestCommand("os.shell.run", args, workingDir);
+}
+
+describe("classifyTestCommand", () => {
+  it("recognizes every classified runner in structured form", () => {
+    const cases: Array<{ cmd: string; args?: string[] }> = [
+      { cmd: "pytest" },
+      { cmd: "python", args: ["-m", "pytest"] },
+      { cmd: "python3", args: ["-m", "pytest"] },
+      { cmd: "cargo", args: ["test"] },
+      { cmd: "go", args: ["test", "./..."] },
+      { cmd: "npm", args: ["test"] },
+      { cmd: "pnpm", args: ["test"] },
+      { cmd: "yarn", args: ["test"] },
+      { cmd: "bun", args: ["test"] },
+    ];
+    for (const c of cases) {
+      expect(classify(c), JSON.stringify(c)).not.toBeNull();
+    }
+  });
+
+  it("recognizes pre-joined command lines in `cmd`", () => {
+    expect(classify({ cmd: "pytest -k auth" })).not.toBeNull();
+    expect(classify({ cmd: "python -m pytest tests/" })).not.toBeNull();
+    expect(classify({ cmd: "cargo test --features foo" })).not.toBeNull();
+    // Pre-joined and structured forms of the same invocation share a key.
+    expect(classify({ cmd: "pytest -k auth" })!.key).toBe(
+      classify({ cmd: "pytest", args: ["-k", "auth"] })!.key,
+    );
+  });
+
+  it("recognizes a path-qualified runner via its basename", () => {
+    const byPath = classify({ cmd: "/usr/local/bin/pytest", args: ["-q"] });
+    expect(byPath).not.toBeNull();
+    expect(byPath!.label).toBe("pytest -q");
+  });
+
+  it("collapses python -m pytest onto the pytest runner", () => {
+    const direct = classify({ cmd: "pytest", args: ["-k", "auth"] });
+    const viaModule = classify({
+      cmd: "python",
+      args: ["-m", "pytest", "-k", "auth"],
+    });
+    expect(viaModule!.key).toBe(direct!.key);
+  });
+
+  it("ignores timeoutMs so timeout-only variation collapses to one key", () => {
+    const short = classify({ cmd: "pytest", args: ["-q"], timeoutMs: 30_000 });
+    const long = classify({ cmd: "pytest", args: ["-q"], timeoutMs: 600_000 });
+    const none = classify({ cmd: "pytest", args: ["-q"] });
+    expect(short!.key).toBe(long!.key);
+    expect(short!.key).toBe(none!.key);
+  });
+
+  it("keeps changed cwd distinct and resolves relative cwd against workingDir", () => {
+    const root = classify({ cmd: "pytest" });
+    const sub = classify({ cmd: "pytest", cwd: "packages/api" });
+    expect(sub!.cwd).toBe(`${WD}/packages/api`);
+    expect(sub!.key).not.toBe(root!.key);
+    // Explicit cwd equal to the working dir matches the implicit one.
+    expect(classify({ cmd: "pytest", cwd: WD })!.key).toBe(root!.key);
+  });
+
+  it("keeps changed suite/filter arguments distinct", () => {
+    const a = classify({ cmd: "pytest", args: ["-k", "auth"] });
+    const b = classify({ cmd: "pytest", args: ["-k", "billing"] });
+    const bare = classify({ cmd: "pytest" });
+    expect(a!.key).not.toBe(b!.key);
+    expect(a!.key).not.toBe(bare!.key);
+    const feat = classify({ cmd: "cargo", args: ["test", "--features", "x"] });
+    const plain = classify({ cmd: "cargo", args: ["test"] });
+    expect(feat!.key).not.toBe(plain!.key);
+  });
+
+  it("preserves argv boundaries in the key", () => {
+    const split = classify({ cmd: "pytest", args: ["-k", "a", "b"] });
+    const joined = classify({ cmd: "pytest", args: ["-k", "a b"] });
+    expect(split!.key).not.toBe(joined!.key);
+  });
+
+  it("accepts a JSON-stringified args array (double-serialising providers)", () => {
+    const jsonForm = classify({ cmd: "pytest", args: '["-k","auth"]' });
+    const arrayForm = classify({ cmd: "pytest", args: ["-k", "auth"] });
+    expect(jsonForm).not.toBeNull();
+    expect(jsonForm!.key).toBe(arrayForm!.key);
+  });
+
+  it("returns null for unrecognized commands and other tools", () => {
+    expect(classify({ cmd: "ls", args: ["-la"] })).toBeNull();
+    expect(classify({ cmd: "cargo", args: ["build"] })).toBeNull();
+    expect(classify({ cmd: "go", args: ["build"] })).toBeNull();
+    expect(classify({ cmd: "npm", args: ["run", "build"] })).toBeNull();
+    expect(classify({ cmd: "vitest", args: ["run"] })).toBeNull();
+    expect(
+      classifyTestCommand("os.fs.read", { path: "pytest" }, WD),
+    ).toBeNull();
+  });
+
+  it("returns null for compound / env-prefixed / malformed forms", () => {
+    // Subshell metacharacters: could be a compound command line.
+    expect(classify({ cmd: "pytest | tee out.log" })).toBeNull();
+    expect(classify({ cmd: "cd api && pytest" })).toBeNull();
+    // Env override on the command line: leading token is not a runner.
+    expect(classify({ cmd: "FOO=1 pytest" })).toBeNull();
+    // Pre-joined cmd combined with separate args is ambiguous.
+    expect(classify({ cmd: "python -m", args: ["pytest"] })).toBeNull();
+    // Malformed args shape.
+    expect(classify({ cmd: "pytest", args: { k: "auth" } })).toBeNull();
+    expect(classify({ cmd: "" })).toBeNull();
+    expect(classify(null)).toBeNull();
+    expect(classify("pytest")).toBeNull();
+  });
+});

--- a/src/agent/test-command-key.ts
+++ b/src/agent/test-command-key.ts
@@ -1,0 +1,158 @@
+import { resolveUserPath } from "../tools/os/expand-home.js";
+import { basenameCommand } from "../tools/os/shell-command-guard/index.js";
+
+/**
+ * Classification of an `os.shell.run` call as a recognized test-suite
+ * invocation (issue #118). Deliberately explicit and conservative: only
+ * the direct common forms are recognized; anything else returns `null`
+ * and stays under the generic `ToolLoopTracker` detectors.
+ *
+ * Recognized runners:
+ *  - `pytest` and `python -m pytest` / `python3 -m pytest`
+ *  - `cargo test` and `go test`
+ *  - `npm test`, `pnpm test`, `yarn test`, `bun test`
+ *
+ * The semantic `key` is built from the resolved working directory, the
+ * runner, and the ordered suite/filter arguments. Execution-only
+ * controls that provably do not change the selected tests — today only
+ * the tool-level `timeoutMs` — are excluded, so a timeout-only
+ * variation collapses to the same key. Everything else (cwd, suite
+ * filters, feature flags, extra args) keeps runs distinct. Environment
+ * overrides expressed on the command line (`FOO=1 pytest`) make the
+ * leading token unrecognizable, so such runs fall back to the generic
+ * detector rather than ever being conflated.
+ */
+export interface RecognizedTestCommand {
+  /** Semantic identity: resolved cwd + runner + ordered filter args. */
+  key: string;
+  /** Human-readable command label for notices (e.g. `pytest -k auth`). */
+  label: string;
+  /** Absolute directory the command runs in (mirrors `os.shell.run`). */
+  cwd: string;
+}
+
+/**
+ * Mirrors the (private) metacharacter set in `src/tools/os/shell.ts`.
+ * A command line carrying any of these runs through a subshell and may
+ * be compound (`pytest | tee`, `cd x && pytest`), so it is never
+ * classified — an exact mirror is not load-bearing, since a mismatch
+ * only means "unrecognized", which degrades to the generic detector.
+ */
+const SHELL_METACHAR_RE = /[|&;<>$`(){}]/;
+
+const NODE_TEST_RUNNERS: ReadonlySet<string> = new Set([
+  "npm",
+  "pnpm",
+  "yarn",
+  "bun",
+]);
+
+/**
+ * Coerce the model-supplied `args` field the way the shell tool does:
+ * missing → `[]`, `string[]` → coerced, JSON-stringified array literal →
+ * parsed. Any other shape returns `null` (the tool would error anyway).
+ */
+function coerceArgs(value: unknown): string[] | null {
+  if (value === undefined || value === null) return [];
+  if (Array.isArray(value)) return value.map((v) => String(v));
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return [];
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (Array.isArray(parsed)) return parsed.map((v) => String(v));
+      } catch {
+        // fall through
+      }
+    }
+  }
+  return null;
+}
+
+/** `~/venv/bin/pytest` → `pytest`, `PYTEST.EXE` → `pytest`. */
+function normalizeRunnerName(token: string): string {
+  const name = basenameCommand(token).toLowerCase();
+  return name.endsWith(".exe") ? name.slice(0, -4) : name;
+}
+
+/**
+ * Classify a prospective tool call as a recognized test command, or
+ * return `null` when it is anything else. Never throws on malformed
+ * args. `workingDir` is the session working directory the shell tool
+ * would resolve a relative/missing `cwd` against.
+ */
+export function classifyTestCommand(
+  tool: string,
+  args: unknown,
+  workingDir: string,
+): RecognizedTestCommand | null {
+  if (tool !== "os.shell.run") return null;
+  if (args === null || typeof args !== "object") return null;
+  const record = args as Record<string, unknown>;
+
+  const cmd = record.cmd;
+  if (typeof cmd !== "string" || cmd.trim().length === 0) return null;
+  // Subshell forms may be compound command lines; stay generic.
+  if (SHELL_METACHAR_RE.test(cmd)) return null;
+
+  const extra = coerceArgs(record.args);
+  if (extra === null) return null;
+
+  // Token view mirrors the shell tool's two execution modes: a
+  // pre-joined command line in `cmd` (no separate args) is split on
+  // whitespace exactly like the guard's tokenised view; the structured
+  // form keeps argv boundaries. A whitespace-carrying `cmd` combined
+  // with separate args is malformed — stay generic.
+  let tokens: string[];
+  if (/\s/.test(cmd.trim())) {
+    if (extra.length > 0) return null;
+    tokens = cmd.trim().split(/\s+/);
+  } else {
+    tokens = [cmd.trim(), ...extra];
+  }
+
+  const name = normalizeRunnerName(tokens[0]!);
+  let runner: string | null = null;
+  let rest: string[] = [];
+  if (name === "pytest") {
+    runner = "pytest";
+    rest = tokens.slice(1);
+  } else if (
+    (name === "python" || name === "python3") &&
+    tokens[1] === "-m" &&
+    tokens[2] === "pytest"
+  ) {
+    runner = "pytest";
+    rest = tokens.slice(3);
+  } else if ((name === "cargo" || name === "go") && tokens[1] === "test") {
+    runner = `${name} test`;
+    rest = tokens.slice(2);
+  } else if (NODE_TEST_RUNNERS.has(name) && tokens[1] === "test") {
+    runner = `${name} test`;
+    rest = tokens.slice(2);
+  }
+  if (runner === null) return null;
+
+  // Same cwd resolution the shell tool applies at dispatch, so the key
+  // matches the directory the command actually runs in.
+  let cwd: string;
+  try {
+    cwd =
+      typeof record.cwd === "string" && record.cwd.length > 0
+        ? resolveUserPath(record.cwd, workingDir)
+        : workingDir;
+  } catch {
+    return null;
+  }
+
+  // `timeoutMs` is deliberately absent: it controls execution, not test
+  // selection, so timeout-only variation collapses to the same key. NUL
+  // separators preserve argv boundaries (["-k","a b"] differs from
+  // ["-k","a","b"]).
+  return {
+    key: [cwd, runner, ...rest].join("\u0000"),
+    label: rest.length > 0 ? `${runner} ${rest.join(" ")}` : runner,
+    cwd,
+  };
+}

--- a/src/agent/workspace-fingerprint.test.ts
+++ b/src/agent/workspace-fingerprint.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fingerprintWorkspace } from "./workspace-fingerprint.js";
+
+describe("fingerprintWorkspace", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "atomic-fp-"));
+    await mkdir(join(dir, "src"));
+    await writeFile(join(dir, "src", "app.py"), "print('a')\n");
+    await writeFile(join(dir, "README.md"), "# readme\n");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("is stable across calls when nothing changes", () => {
+    const first = fingerprintWorkspace(dir);
+    const second = fingerprintWorkspace(dir);
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+  });
+
+  it("changes when a file's content changes (any writer: tool, shell, external)", async () => {
+    const before = fingerprintWorkspace(dir);
+    // The fingerprint observes the filesystem itself, so a write from an
+    // Atomic tool, a shell command, or an external process all look the
+    // same: the file's size/mtime moved.
+    await writeFile(join(dir, "src", "app.py"), "print('changed')\n");
+    expect(fingerprintWorkspace(dir)).not.toBe(before);
+  });
+
+  it("changes on a same-size replacement via mtime", async () => {
+    const path = join(dir, "src", "app.py");
+    await writeFile(path, "print('a')\n");
+    await utimes(path, new Date(1_700_000_000_000), new Date(1_700_000_000_000));
+    const before = fingerprintWorkspace(dir);
+    // Same byte length, different content — only mtime distinguishes it.
+    await writeFile(path, "print('b')\n");
+    await utimes(path, new Date(1_700_000_111_000), new Date(1_700_000_111_000));
+    expect(fingerprintWorkspace(dir)).not.toBe(before);
+  });
+
+  it("changes when a file is added or removed", async () => {
+    const before = fingerprintWorkspace(dir);
+    await writeFile(join(dir, "src", "new_test.py"), "def test(): pass\n");
+    const withFile = fingerprintWorkspace(dir);
+    expect(withFile).not.toBe(before);
+    await rm(join(dir, "src", "new_test.py"));
+    expect(fingerprintWorkspace(dir)).toBe(before);
+  });
+
+  it("ignores churn in cache/output directories (documented ignores)", async () => {
+    await mkdir(join(dir, "coverage"));
+    await mkdir(join(dir, ".pytest_cache"));
+    await mkdir(join(dir, "node_modules"));
+    const before = fingerprintWorkspace(dir);
+    await writeFile(join(dir, "coverage", "index.html"), "<html>1</html>");
+    await writeFile(join(dir, ".pytest_cache", "v"), "cache");
+    await writeFile(join(dir, "node_modules", "pkg.js"), "module");
+    expect(fingerprintWorkspace(dir)).toBe(before);
+  });
+
+  it("ignores root-level coverage artifact files", async () => {
+    const before = fingerprintWorkspace(dir);
+    await writeFile(join(dir, ".coverage"), "data-1");
+    await writeFile(join(dir, ".coverage.host.123"), "data-2");
+    await writeFile(join(dir, "coverage.xml"), "<xml/>");
+    expect(fingerprintWorkspace(dir)).toBe(before);
+  });
+
+  it("returns null for a missing root or a non-directory", async () => {
+    expect(fingerprintWorkspace(join(dir, "does-not-exist"))).toBeNull();
+    expect(fingerprintWorkspace(join(dir, "README.md"))).toBeNull();
+  });
+});

--- a/src/agent/workspace-fingerprint.ts
+++ b/src/agent/workspace-fingerprint.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Workspace fingerprint for the test-repeat detector (issue #118).
+ *
+ * A stat-walk over the resolved test cwd hashing `path + size + mtimeMs`
+ * per file. Because it observes the filesystem itself — not an internal
+ * "write tool called" counter — mutations by Atomic tools, shell
+ * commands, and external processes all change the fingerprint, and a
+ * same-size replacement is caught via mtime.
+ *
+ * The walk is invoked lazily: only when a recognized test command is
+ * about to dispatch (see `runSyncLoopGate`), never on ordinary shell
+ * calls.
+ */
+
+/**
+ * Directory basenames excluded from the fingerprint. Mirrors the
+ * documented `DEFAULT_IGNORE` globs of `os.fs.glob`
+ * (`src/tools/os/fs-glob.ts`): dependency stores, VCS metadata, build
+ * outputs, and tool caches — churn there (a test run repopulating
+ * `.pytest_cache/` or `coverage/`) must not masquerade as source
+ * progress.
+ */
+export const FINGERPRINT_IGNORED_DIRS: ReadonlySet<string> = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "target",
+  "coverage",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  ".cache",
+  "Library",
+  ".rustup",
+  ".cargo",
+  ".npm",
+  ".pnpm-store",
+  ".yarn",
+  ".gradle",
+  ".m2",
+  "__pycache__",
+  "site-packages",
+  "vendor",
+  ".venv",
+  "venv",
+  ".tox",
+  ".pytest_cache",
+  ".mypy_cache",
+  ".ruff_cache",
+  ".terraform",
+  ".idea",
+  ".vscode",
+  ".Trash",
+  ".svn",
+  ".hg",
+]);
+
+/**
+ * File basenames excluded from the fingerprint: root-level artifacts the
+ * recognized runners rewrite on every run even when no source changed.
+ * A `.coverage.*` prefix match covers pytest-cov's parallel-mode files.
+ */
+export const FINGERPRINT_IGNORED_FILES: ReadonlySet<string> = new Set([
+  ".coverage",
+  "coverage.xml",
+  "lcov.info",
+  "junit.xml",
+  ".DS_Store",
+]);
+
+/**
+ * Walk ceiling. A tree still yielding files past this many is too large
+ * to fingerprint reliably in-line, so `fingerprintWorkspace` returns
+ * `null` and the (warn-only) detector simply stays silent for that cwd —
+ * a false negative is preferred over both a false warning and a slow
+ * gate.
+ */
+const MAX_FINGERPRINT_FILES = 25_000;
+
+function isIgnoredFile(name: string): boolean {
+  return FINGERPRINT_IGNORED_FILES.has(name) || name.startsWith(".coverage.");
+}
+
+/**
+ * Fingerprint the workspace rooted at `root`. Deterministic for an
+ * unchanged tree (entries are visited in sorted order); any file
+ * addition, removal, rename, size change, or mtime change under a
+ * non-ignored path yields a different digest.
+ *
+ * Returns `null` when `root` is missing / not a directory / oversized —
+ * callers must treat `null` as "cannot observe the workspace" and skip
+ * repeat detection entirely. Unreadable subdirectories and files that
+ * vanish mid-walk are skipped; symlinks are not followed (cycle safety).
+ */
+export function fingerprintWorkspace(root: string): string | null {
+  try {
+    if (!statSync(root).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  const hash = createHash("sha1");
+  let fileCount = 0;
+  let truncated = false;
+
+  const walk = (dir: string, rel: string): void => {
+    if (truncated) return;
+    let dirents;
+    try {
+      dirents = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    dirents.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    for (const entry of dirents) {
+      if (truncated) return;
+      const name = entry.name;
+      const childRel = rel.length === 0 ? name : `${rel}/${name}`;
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        if (FINGERPRINT_IGNORED_DIRS.has(name)) continue;
+        walk(join(dir, name), childRel);
+        continue;
+      }
+      if (!entry.isFile() || isIgnoredFile(name)) continue;
+      let stats;
+      try {
+        stats = statSync(join(dir, name));
+      } catch {
+        continue;
+      }
+      fileCount += 1;
+      if (fileCount > MAX_FINGERPRINT_FILES) {
+        truncated = true;
+        return;
+      }
+      hash.update(`${childRel}:${stats.size}:${stats.mtimeMs}\n`);
+    }
+  };
+
+  walk(root, "");
+  if (truncated) return null;
+  return hash.digest("hex").slice(0, 16);
+}

--- a/src/tracing/trace/trace-event.ts
+++ b/src/tracing/trace/trace-event.ts
@@ -176,7 +176,7 @@ export interface TraceLoopDetected extends TraceEventBase {
    */
   level?: "warn" | "critical" | "breaker";
   /** Which sub-detector fired. Optional for back-compat. */
-  detector?: "generic_repeat" | "no_progress" | "wandering";
+  detector?: "generic_repeat" | "no_progress" | "wandering" | "test_repeat";
 }
 
 /**


### PR DESCRIPTION
## What was broken

The generic `ToolLoopTracker` hashes exact tool arguments (`hashToolCall`) and normalises `os.shell.run` results by exit code + summary. A coding agent re-running the same test suite against an untouched workspace therefore slips past it whenever:

- an execution-only parameter varies (a different `timeoutMs` produces a different raw args hash), or
- timing noise in the test output ("3 passed in 1.21s" vs "1.24s") breaks the result hash,

so consecutive equivalent runs burn step budget without ever registering as no progress. Byte-identical repeats were partially throttled (warn at 3, veto at 5), but the detector had no notion of "a recognized test command against an unchanged workspace" — confirmed by a collaborator on `main` (`dcf77f1`, v0.4.1) and still absent on v0.4.2.

## The fix (warn-only, per the issue's acceptance criteria)

- **`src/agent/test-command-key.ts`** — explicit, conservative classifier for `pytest` / `python -m pytest` / `cargo test` / `go test` / `npm|pnpm|yarn|bun test` (structured and pre-joined forms). Builds a semantic key from the resolved cwd (same `resolveUserPath` resolution the shell tool applies) + runner + ordered suite/filter args, excluding only `timeoutMs`. Compound/env-prefixed/unrecognized commands return `null` and stay entirely under the existing generic detectors.
- **`src/agent/workspace-fingerprint.ts`** — stat-walk fingerprint (path + size + mtimeMs) of the resolved cwd, so mutations by Atomic tools, shell commands, and external processes are all observed, and a same-size replacement is caught via mtime. Ignore rules mirror `os.fs.glob`'s documented defaults (plus root-level coverage artifacts like `.coverage`), so cache/build/coverage churn does not masquerade as source progress. The walk is lazy: it runs only when a recognized test command is about to dispatch, never on ordinary shell calls; an oversized/missing cwd returns `null` and disables detection rather than risking a false warning.
- **`ToolLoopTracker`** — new pure `checkTestRepeat`/`recordTestRun` state (`key -> {fingerprint, count, lastSummary}`); `recordOutcome` patches in the previous result summary so the warning can quote it.
- **`runSyncLoopGate`** (`batch-executor.ts`) — compares key + fingerprint before dispatch and pushes a warn-level `test_repeat` signal. The call **always proceeds** (which doubles as the intentional-repeat path), rides the existing `shouldEmitWarning` de-dup buckets with its own floor of 2, and is never routed into the veto/breaker path.
- **`agent-loop.ts`** — formats the new notice (command label + previous result summary + explicit "nothing was blocked" wording) into the next step's `### notice`.

## Test evidence

- `npm run lint` (tsc --noEmit): clean.
- `npx vitest run src/agent src/tracing src/tools/os/shell.test.ts`: **20 files, 269 tests passed**, including 30 new tests covering every classified runner, timeout-only variation collapsing to one key, distinct cwd/filter args, Atomic-write and external out-of-band mutations permitting the rerun, same-size replacement via mtime, ignored-dir/coverage-artifact churn still warning, warn-only (all three equivalent runs execute; no veto), and unrecognized commands untouched.
- Reverting only the gate wiring in `batch-executor.ts` makes the 3 end-to-end warn tests fail (`3 failed | 36 passed`), proving the coverage is load-bearing.

Related: #114 (maintainer noted this is under review alongside it).

Fixes #118
