### PR TITLE
feat(tui): clickable links in every chat message, including mid-stream

### DIFF
--- a/src/tui/build-terminal-launch.ts
+++ b/src/tui/build-terminal-launch.ts
@@ -10,6 +10,14 @@ export interface TerminalLaunch {
   readonly args: readonly string[];
   /** Human name of the terminal being opened, for the chat confirmation. */
   readonly label: string;
+  /**
+   * win32 only: the args are already quoted for cmd.exe and must reach
+   * CreateProcess byte-for-byte. Node's default argv quoting cannot
+   * protect a `cmd /c start` line — it only quotes on whitespace, and
+   * cmd's operators (`&`, `^`, `|`) need double quotes, not backslash
+   * escapes. Set by `open-url.ts`; every terminal launch leaves it off.
+   */
+  readonly windowsVerbatimArguments?: boolean;
 }
 
 export interface TerminalLaunchInput {

--- a/src/tui/components/assistant-bubble.test.tsx
+++ b/src/tui/components/assistant-bubble.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import { AssistantBubble } from "./assistant-bubble.js";
+
+// A bare URL wrapped in OSC 8 with the URL itself as the visible label.
+const OSC8_CURSOR =
+  "\u001b]8;;https://cursor.com\u001b\\https://cursor.com\u001b]8;;\u001b\\";
+
+describe("AssistantBubble", () => {
+  it("wraps a bare URL in OSC 8 while the reply is still streaming", () => {
+    const { lastFrame } = render(
+      <AssistantBubble text="see https://cursor.com now" streaming />,
+    );
+    expect(lastFrame() ?? "").toContain(OSC8_CURSOR);
+  });
+
+  it("keeps the same URL clickable once the reply finalises into markdown", () => {
+    const { lastFrame } = render(
+      <AssistantBubble text="see https://cursor.com now" toolSteps={0} />,
+    );
+    expect(lastFrame() ?? "").toContain(OSC8_CURSOR);
+  });
+
+  it("renders streaming text without OSC 8 when there is no URL", () => {
+    const { lastFrame } = render(
+      <AssistantBubble text="thinking about it" streaming />,
+    );
+    const text = lastFrame() ?? "";
+    expect(text).toContain("thinking about it");
+    expect(text).not.toContain("\u001b]8;;");
+  });
+});

--- a/src/tui/components/assistant-bubble.tsx
+++ b/src/tui/components/assistant-bubble.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
+import { LinkifiedText } from "../render/linkify-text.js";
 import { MarkdownRenderer } from "../render/markdown-renderer.js";
 import { theme } from "../theme/theme.js";
 
@@ -24,7 +25,9 @@ interface AssistantBubbleProps {
  * Markdown rendering is gated on `!streaming`: partial markdown
  * (half-opened `**`, fenced block missing its closing ```, dangling
  * list marker) lexes into ugly literals that flicker as the stream
- * arrives. Plain text while streaming, markdown once finalised.
+ * arrives. Plain text while streaming, markdown once finalised — but
+ * the plain-text phase still routes through `LinkifiedText`, so a URL
+ * is clickable the moment it appears, not only after the turn ends.
  */
 export function AssistantBubble({
   text,
@@ -49,7 +52,13 @@ export function AssistantBubble({
         paddingRight={1}
         flexDirection="column"
       >
-        {streaming ? <Text>{text}</Text> : <MarkdownRenderer text={text} />}
+        {streaming ? (
+          <Text>
+            <LinkifiedText text={text} />
+          </Text>
+        ) : (
+          <MarkdownRenderer text={text} />
+        )}
       </Box>
       {showFooter ? (
         <Box marginLeft={3}>

--- a/src/tui/components/chat-link-buttons.test.tsx
+++ b/src/tui/components/chat-link-buttons.test.tsx
@@ -1,0 +1,238 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+import type { ReactElement, ReactNode } from "react";
+import type { TuiMouseEvent } from "../mouse/mouse-event.js";
+import { MouseProvider } from "../mouse/mouse-context.js";
+import { MouseTargetRegistry } from "../mouse/mouse-registry.js";
+import type { TuiAppCallbacks } from "../tui-app.js";
+import { createInitialTuiState, type TuiSessionInfo } from "../tui-state.js";
+import {
+  ChatLinkButtons,
+  extractMessageUrls,
+  linkChipLabel,
+} from "./chat-link-buttons.js";
+
+const SESSION: TuiSessionInfo = {
+  sessionId: "links",
+  workingDir: "/tmp/links",
+  llamaUrl: "http://127.0.0.1:8080",
+  browserChannel: "chrome",
+  browserHeadless: false,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+function strip(value: string): string {
+  return value.replace(/\[[0-9;]*m/g, "");
+}
+
+/** Screen position of `needle` — same trick as `chat-copy-button.test.tsx`. */
+function locate(frame: string, needle: string): { x: number; y: number } {
+  for (const [y, line] of frame.split("\n").entries()) {
+    const x = line.indexOf(needle);
+    if (x !== -1) return { x, y };
+  }
+  throw new Error(`"${needle}" is not on screen:\n${frame}`);
+}
+
+function click(x: number, y: number): TuiMouseEvent {
+  return {
+    kind: "press",
+    button: "left",
+    wheel: null,
+    x,
+    y,
+    shift: false,
+    alt: false,
+    ctrl: false,
+  };
+}
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitUntil(
+  condition: () => boolean,
+  what: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await delay(25);
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
+
+interface Harness {
+  frame: () => string;
+  clickAt: (needle: string) => void;
+  unmount: () => void;
+}
+
+function callbacksWith(opened: string[]): TuiAppCallbacks {
+  return {
+    onApprovalDecision: () => {},
+    onAbort: () => {},
+    onQuit: () => {},
+    onMessageSubmitted: () => {},
+    onOpenUrlRequested: (url) => opened.push(url),
+  };
+}
+
+function mount(
+  children: ReactNode,
+  {
+    withMouse = true,
+    opened = [],
+  }: { withMouse?: boolean; opened?: string[] } = {},
+): Harness {
+  const registry = new MouseTargetRegistry();
+  const state = createInitialTuiState(SESSION);
+  const tree: ReactElement = withMouse ? (
+    <MouseProvider
+      registry={registry}
+      dispatch={() => {}}
+      callbacks={callbacksWith(opened)}
+      getState={() => state}
+    >
+      {children}
+    </MouseProvider>
+  ) : (
+    <>{children}</>
+  );
+  const { lastFrame, unmount } = render(tree);
+  const frame = (): string => strip(lastFrame() ?? "");
+  return {
+    frame,
+    clickAt: (needle) => {
+      const at = locate(frame(), needle);
+      registry.dispatch(click(at.x, at.y));
+    },
+    unmount,
+  };
+}
+
+/**
+ * Clicks the chip until the click actually lands — the target is
+ * registered by a post-frame effect, exactly as in
+ * `chat-copy-button.test.tsx`.
+ */
+async function clickChip(
+  app: Harness,
+  needle: string,
+  opened: readonly string[],
+): Promise<void> {
+  await waitUntil(() => app.frame().includes(needle), "the idle chip");
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (opened.length > 0) return;
+    app.clickAt(needle);
+    await delay(25);
+  }
+  throw new Error("click never took effect on the link chip");
+}
+
+describe("extractMessageUrls", () => {
+  it("collects normalised targets in message order", () => {
+    expect(
+      extractMessageUrls("see https://a.io then www.b.io for details"),
+    ).toEqual(["https://a.io", "https://www.b.io"]);
+  });
+
+  it("dedupes on the normalised target", () => {
+    expect(
+      extractMessageUrls("https://a.io twice https://a.io"),
+    ).toEqual(["https://a.io"]);
+  });
+
+  it("is empty for a message without URLs", () => {
+    expect(extractMessageUrls("no links in here")).toEqual([]);
+  });
+});
+
+describe("linkChipLabel", () => {
+  it("labels with the bare hostname, www shorn", () => {
+    expect(linkChipLabel("https://www.example.com/deep/path?q=1")).toBe(
+      "example.com",
+    );
+  });
+
+  it("ellipsises an overlong hostname", () => {
+    const label = linkChipLabel(
+      "https://an.absurdly.long.subdomain.chain.example-hosting.io/x",
+    );
+    expect(label.endsWith("…")).toBe(true);
+    expect(label.length).toBeLessThanOrEqual(24);
+  });
+});
+
+describe("ChatLinkButtons", () => {
+  it("renders one chip per URL, labelled by hostname", () => {
+    const app = mount(
+      <ChatLinkButtons text="docs at https://cursor.com and www.example.com" />,
+    );
+    expect(app.frame()).toContain("[open cursor.com]");
+    expect(app.frame()).toContain("[open example.com]");
+    app.unmount();
+  });
+
+  it("renders nothing for a message without URLs", () => {
+    const app = mount(<ChatLinkButtons text="just prose" />);
+    expect(app.frame()).not.toContain("[open");
+    app.unmount();
+  });
+
+  it("renders a single chip for a repeated URL", () => {
+    const app = mount(
+      <ChatLinkButtons text="https://a.io and again https://a.io" />,
+    );
+    expect(app.frame().split("[open a.io]").length).toBe(2);
+    app.unmount();
+  });
+
+  it("caps at three chips and notes the overflow", () => {
+    const app = mount(
+      <ChatLinkButtons text="https://a.io https://b.io https://c.io https://d.io https://e.io" />,
+    );
+    const frame = app.frame();
+    expect(frame).toContain("[open a.io]");
+    expect(frame).toContain("[open c.io]");
+    expect(frame).not.toContain("[open d.io]");
+    expect(frame).toContain("+2 more");
+    app.unmount();
+  });
+
+  it("still renders without a mouse provider", () => {
+    const app = mount(<ChatLinkButtons text="see https://cursor.com" />, {
+      withMouse: false,
+    });
+    expect(app.frame()).toContain("[open cursor.com]");
+    app.unmount();
+  });
+
+  it("fires the callback with the normalised https URL and badges", async () => {
+    const opened: string[] = [];
+    const app = mount(<ChatLinkButtons text="try www.example.com now" />, {
+      opened,
+    });
+    await clickChip(app, "[open example.com]", opened);
+    expect(opened).toEqual(["https://www.example.com"]);
+    await waitUntil(
+      () => app.frame().includes("[opening…]"),
+      "the opening badge",
+    );
+    app.unmount();
+  });
+
+  it("opens the URL its own chip names, not a neighbour's", async () => {
+    const opened: string[] = [];
+    const app = mount(
+      <ChatLinkButtons text="https://a.io then https://b.io" />,
+      { opened },
+    );
+    await clickChip(app, "[open b.io]", opened);
+    expect(opened).toEqual(["https://b.io"]);
+    app.unmount();
+  });
+});

--- a/src/tui/components/chat-link-buttons.tsx
+++ b/src/tui/components/chat-link-buttons.tsx
@@ -1,0 +1,171 @@
+import { Box, Text } from "ink";
+import { type ReactElement } from "react";
+import { useTransientStatus } from "../hooks/use-transient-status.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
+import { splitUrlSegments } from "../render/linkify-text.js";
+import { theme } from "../theme/theme.js";
+
+interface ChatLinkButtonsProps {
+  /**
+   * The message source. URLs are re-detected here with the same
+   * detector the bubbles render with, so a chip exists exactly for the
+   * text that shows as a link.
+   */
+  readonly text: string;
+  /** How long `[opening…]` stays up before the label reverts. */
+  readonly revertAfterMs?: number;
+}
+
+/** Idle / just-fired. The badge doubles as the double-click guard. */
+type OpenStatus = "idle" | "opening";
+
+const DEFAULT_REVERT_MS = 2_000;
+
+/**
+ * At most this many chips per message. The footer is a single row that
+ * already carries `[copy]` (and `[try again]` on user messages), and a
+ * reply quoting a dozen references would otherwise push chips past the
+ * terminal's right edge, where Yoga clips them into unclickable
+ * half-labels. The first three URLs win — they are the ones the author
+ * led with — and the remainder is summed up in a muted `+N more` note
+ * so the cap is visible rather than silent. The in-text OSC 8 links
+ * still cover every URL on terminals that support them.
+ */
+const MAX_LINK_CHIPS = 3;
+
+/**
+ * Hostnames longer than this ellipsise mid-label. Long enough for any
+ * mainstream host, short enough that three chips fit an 80-column row.
+ */
+const MAX_LABEL_CHARS = 24;
+
+/**
+ * The ordered, deduped, normalised URL targets of a message. Dedupe is
+ * on the exact normalised href — `https://a.io` and `https://a.io/` are
+ * two entries, which is the honest reading of a message that spells
+ * them differently.
+ */
+export function extractMessageUrls(text: string): readonly string[] {
+  const seen = new Set<string>();
+  const urls: string[] = [];
+  for (const segment of splitUrlSegments(text)) {
+    if (segment.url === null || seen.has(segment.url)) continue;
+    seen.add(segment.url);
+    urls.push(segment.url);
+  }
+  return urls;
+}
+
+/**
+ * The chip's label: the hostname alone, `www.` shorn — `[open
+ * example.com]` says where a click lands without repeating the URL the
+ * message just showed. Falls back to the raw text for a target the URL
+ * parser refuses (unreachable for detector output, but a label function
+ * must not throw).
+ */
+export function linkChipLabel(url: string): string {
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    host = url;
+  }
+  const bare = host.startsWith("www.") ? host.slice(4) : host;
+  if (bare.length <= MAX_LABEL_CHARS) return bare;
+  return `${bare.slice(0, MAX_LABEL_CHARS - 1)}…`;
+}
+
+/**
+ * The per-message "open that in the browser" affordance, beside
+ * `[copy]`.
+ *
+ * **Why a chip when the URL text is already an OSC 8 link.** OSC 8 is a
+ * terminal feature, and plenty of terminals — including the stock
+ * macOS Terminal.app — ignore it entirely: the styled URL looks
+ * clickable and does nothing. These chips route through the app's own
+ * mouse layer instead, the same machinery `[copy]` rides, so one click
+ * opens the default browser in *every* terminal the TUI runs in. The
+ * in-text links stay for the terminals that do support them.
+ *
+ * **Why the badge.** The browser can take a beat to front itself, and a
+ * click with no feedback reads as a dead button and gets clicked again
+ * — two tabs for one intent. `[opening…]` closes the gap and, as with
+ * `[try again]`, ignores clicks while up so a double-press cannot fire
+ * twice.
+ *
+ * **Without a mouse provider** (component tests, `--no-mouse`) the
+ * chips still render as legible hints but register no targets — the
+ * same degradation as `ChatCopyButton`.
+ */
+export function ChatLinkButtons({
+  text,
+  revertAfterMs = DEFAULT_REVERT_MS,
+}: ChatLinkButtonsProps): ReactElement | null {
+  const urls = extractMessageUrls(text);
+  if (urls.length === 0) return null;
+  const shown = urls.slice(0, MAX_LINK_CHIPS);
+  const hidden = urls.length - shown.length;
+  return (
+    <Box flexDirection="row">
+      {shown.map((url) => (
+        <LinkChip key={url} url={url} revertAfterMs={revertAfterMs} />
+      ))}
+      {hidden > 0 ? (
+        <Box marginLeft={1} flexShrink={0}>
+          <Text color={theme.colors.muted} dimColor>
+            +{hidden} more
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function LinkChip({
+  url,
+  revertAfterMs,
+}: {
+  readonly url: string;
+  readonly revertAfterMs: number;
+}): ReactElement {
+  const mouse = useMouseCommands();
+  const [status, flash] = useTransientStatus<OpenStatus>(
+    "idle",
+    revertAfterMs,
+  );
+
+  const label = (
+    <Text color={theme.colors.muted} dimColor={status === "idle"}>
+      {status === "idle" ? `[open ${linkChipLabel(url)}]` : "[opening…]"}
+    </Text>
+  );
+
+  // One space off the previous chip, on the same row — the footer stays
+  // a single line whatever the role, so `estimateMessageHeight` does
+  // not have to branch (see `ChatTryAgainButton` for why an under-count
+  // is not merely cosmetic in Ink 7).
+  return (
+    <Box marginLeft={1} flexDirection="row">
+      {mouse ? (
+        <MouseTarget
+          flexShrink={0}
+          onMouse={(hit) => {
+            if (!isPrimaryPress(hit.event)) return false;
+            // Claim the press either way — the click landed on this
+            // chip, and letting it fall through would hand it to the
+            // viewport wheel target behind the chat log.
+            if (status !== "idle") return true;
+            mouse.callbacks.onOpenUrlRequested?.(url);
+            flash("opening");
+            return true;
+          }}
+        >
+          {label}
+        </MouseTarget>
+      ) : (
+        label
+      )}
+    </Box>
+  );
+}

--- a/src/tui/components/chat-log.tsx
+++ b/src/tui/components/chat-log.tsx
@@ -8,6 +8,7 @@ import { theme } from "../theme/theme.js";
 import { AssistantBubble } from "./assistant-bubble.js";
 import type { CodingMode } from "../coding-mode.js";
 import { ChatCopyButton } from "./chat-copy-button.js";
+import { ChatLinkButtons } from "./chat-link-buttons.js";
 import { PlanHandoff } from "./plan-handoff.js";
 import { ChatTryAgainButton } from "./chat-try-again-button.js";
 import {
@@ -211,6 +212,7 @@ function FinalisedMessage({
         <Box flexDirection="row">
           <ChatCopyButton text={message.text} />
           <ChatTryAgainButton text={message.text} />
+          <ChatLinkButtons text={message.text} />
         </Box>
       </Box>
     );
@@ -245,7 +247,14 @@ function FinalisedMessage({
           text={message.text}
           toolSteps={message.toolSteps ?? 0}
         />
-        <ChatCopyButton text={message.text} />
+        {/* Link chips ride the copy row on user and assistant messages
+            only: those carry the URLs someone means to follow. System
+            bubbles are TUI runtime output, and their occasional URL is
+            documentation, not a destination. */}
+        <Box flexDirection="row">
+          <ChatCopyButton text={message.text} />
+          <ChatLinkButtons text={message.text} />
+        </Box>
         {planHandoff ? (
           <PlanHandoff
             onExecute={planHandoff.onExecute}

--- a/src/tui/components/chat-message-height.ts
+++ b/src/tui/components/chat-message-height.ts
@@ -28,7 +28,8 @@ const ASSISTANT_FOOTER_ROWS = 1;
 /**
  * `FinalisedMessage` hangs a button footer under every finalised bubble,
  * whatever the role: `[copy]` everywhere, `[try again]` beside it on
- * user messages. The two share a row, so this stays one row and
+ * user messages, and up to three `[open <host>]` chips when the message
+ * carries URLs. They all share a row, so this stays one row and
  * unconditional — the day a role earns a second footer line this
  * estimate has to learn about roles, and an under-count is not cosmetic:
  * Ink 7 paints an over-tall frame's later lines over its earlier ones

--- a/src/tui/open-terminal-window.ts
+++ b/src/tui/open-terminal-window.ts
@@ -35,6 +35,8 @@ export type TerminalSpawn = (
     detached: boolean;
     stdio: readonly ["ignore", "ignore", "pipe"];
     cwd?: string;
+    /** Only present when the launch pre-quoted its own cmd.exe line. */
+    windowsVerbatimArguments?: boolean;
   },
 ) => SpawnedTerminal;
 
@@ -68,6 +70,9 @@ export async function openTerminalWindow(
       // reading reported "opened" for every one of those.
       stdio: ["ignore", "ignore", "pipe"] as const,
       ...(options.cwd ? { cwd: options.cwd } : {}),
+      ...(launch.windowsVerbatimArguments
+        ? { windowsVerbatimArguments: true }
+        : {}),
     });
   } catch (err) {
     return { ok: false, reason: `${launch.cmd}: ${errorMessage(err)}` };

--- a/src/tui/open-url.test.ts
+++ b/src/tui/open-url.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SpawnedTerminal, TerminalSpawn } from "./open-terminal-window.js";
+import {
+  buildOpenUrlCommand,
+  canonicalHttpUrl,
+  openUrlInBrowser,
+} from "./open-url.js";
+
+/** Child stub that replays one lifecycle event — as in `open-terminal-window.test.ts`. */
+function fakeChild(event: "error" | "exit" | "none", payload?: Error | number) {
+  const unref = vi.fn();
+  const child: SpawnedTerminal = {
+    once(name: string, listener: (...args: never[]) => void) {
+      if (name === event) {
+        queueMicrotask(() =>
+          (listener as unknown as (arg?: Error | number) => void)(payload),
+        );
+      }
+      return child;
+    },
+    unref,
+  };
+  return { child, unref };
+}
+
+describe("buildOpenUrlCommand", () => {
+  it("uses `open` on darwin", () => {
+    expect(buildOpenUrlCommand("https://example.com/docs", "darwin")).toEqual({
+      cmd: "open",
+      args: ["https://example.com/docs"],
+      label: "default browser",
+    });
+  });
+
+  it("uses `xdg-open` on linux", () => {
+    expect(buildOpenUrlCommand("https://example.com/docs", "linux")).toEqual({
+      cmd: "xdg-open",
+      args: ["https://example.com/docs"],
+      label: "default browser",
+    });
+  });
+
+  it("falls back to `xdg-open` on the BSDs", () => {
+    expect(buildOpenUrlCommand("https://a.io/", "freebsd")?.cmd).toBe(
+      "xdg-open",
+    );
+  });
+
+  it("quotes the whole start line verbatim on win32", () => {
+    // The URL rides inside double quotes so cmd.exe cannot read `&` as
+    // a command separator — the query below must arrive intact.
+    const launch = buildOpenUrlCommand(
+      "https://example.com/search?a=1&b=2",
+      "win32",
+    );
+    expect(launch).toEqual({
+      cmd: "cmd.exe",
+      args: ["/c", 'start "" "https://example.com/search?a=1&b=2"'],
+      label: "default browser",
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it("refuses non-http(s) schemes outright", () => {
+    expect(buildOpenUrlCommand("file:///etc/passwd", "darwin")).toBeNull();
+    expect(buildOpenUrlCommand("javascript:alert(1)", "linux")).toBeNull();
+    expect(buildOpenUrlCommand("vscode://open", "win32")).toBeNull();
+    expect(buildOpenUrlCommand("not a url at all", "darwin")).toBeNull();
+  });
+});
+
+describe("canonicalHttpUrl", () => {
+  it("accepts http and https and re-serialises canonically", () => {
+    expect(canonicalHttpUrl("https://example.com")).toBe(
+      "https://example.com/",
+    );
+    expect(canonicalHttpUrl("http://a.io/x")).toBe("http://a.io/x");
+  });
+
+  it("percent-encodes double quotes so cmd quoting cannot be broken", () => {
+    const href = canonicalHttpUrl('https://a.io/pa"th');
+    expect(href).not.toBeNull();
+    expect(href).not.toContain('"');
+    expect(href).toContain("%22");
+  });
+
+  it("returns null for other schemes and for garbage", () => {
+    expect(canonicalHttpUrl("file:///tmp/x")).toBeNull();
+    expect(canonicalHttpUrl("javascript:alert(1)")).toBeNull();
+    expect(canonicalHttpUrl("")).toBeNull();
+  });
+});
+
+describe("openUrlInBrowser", () => {
+  it("spawns the opener detached and reports ok on exit 0", async () => {
+    const { child, unref } = fakeChild("exit", 0);
+    const spawn = vi.fn(() => child) as unknown as TerminalSpawn;
+    const result = await openUrlInBrowser("https://example.com/", {
+      platform: "darwin",
+      spawn,
+    });
+    expect(result).toEqual({ ok: true, label: "default browser" });
+    expect(spawn).toHaveBeenCalledWith("open", ["https://example.com/"], {
+      detached: true,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a non-http(s) URL without spawning anything", async () => {
+    const spawn = vi.fn() as unknown as TerminalSpawn;
+    const result = await openUrlInBrowser("file:///etc/passwd", {
+      platform: "linux",
+      spawn,
+    });
+    expect(result).toEqual({
+      ok: false,
+      reason: "not an http(s) URL: file:///etc/passwd",
+    });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("returns a missing opener as a reason instead of throwing", async () => {
+    const { child } = fakeChild(
+      "error",
+      new Error("spawn xdg-open ENOENT"),
+    );
+    const spawn = vi.fn(() => child) as unknown as TerminalSpawn;
+    const result = await openUrlInBrowser("https://a.io/", {
+      platform: "linux",
+      spawn,
+    });
+    expect(result).toEqual({
+      ok: false,
+      reason: "xdg-open: spawn xdg-open ENOENT",
+    });
+  });
+
+  it("survives a synchronous throw from spawn", async () => {
+    const spawn = vi.fn(() => {
+      throw new Error("EACCES");
+    }) as unknown as TerminalSpawn;
+    const result = await openUrlInBrowser("https://a.io/", {
+      platform: "darwin",
+      spawn,
+    });
+    expect(result).toEqual({ ok: false, reason: "open: EACCES" });
+  });
+});

--- a/src/tui/open-url.ts
+++ b/src/tui/open-url.ts
@@ -1,0 +1,106 @@
+import type { TerminalLaunch } from "./build-terminal-launch.js";
+import {
+  openTerminalWindow,
+  type OpenTerminalWindowResult,
+  type TerminalSpawn,
+} from "./open-terminal-window.js";
+
+/**
+ * Opens a URL in the operator's default browser — the `[open …]` chips
+ * under chat messages. The in-text OSC 8 links depend on the terminal
+ * honouring an escape sequence many terminals ignore; this path must
+ * not, so it goes through the one opener every platform ships: the OS
+ * URL handler.
+ */
+
+export type OpenUrlResult = OpenTerminalWindowResult;
+
+/**
+ * Resolves "open this URL in the default browser" into a `{cmd, args}`
+ * launch for `platform`. Returns `null` for anything that is not plain
+ * http(s) — `file:`, `javascript:` and friends reach OS handlers that
+ * do far more than browse, and a chat chip must never become a general
+ * command runner. Pure so every branch is testable without spawning.
+ */
+export function buildOpenUrlCommand(
+  url: string,
+  platform: NodeJS.Platform,
+): TerminalLaunch | null {
+  const href = canonicalHttpUrl(url);
+  if (href === null) return null;
+  switch (platform) {
+    case "darwin":
+      return { cmd: "open", args: [href], label: "default browser" };
+    case "win32":
+      // `start` is a cmd.exe builtin, so it needs the cmd shell — and
+      // cmd parses `&`, `^` and `|` in unquoted text as operators, so a
+      // query string handed over as a bare argv entry is a truncated
+      // URL plus an executed command. The whole `start` line therefore
+      // travels as ONE pre-quoted verbatim argument with the URL inside
+      // double quotes, where cmd interprets nothing but `%`
+      // (`canonicalHttpUrl` guarantees no `"` and no whitespace survive
+      // in `href`, so the quoting cannot be broken out of). The leading
+      // `""` fills `start`'s window-title slot — without it the quoted
+      // URL itself would be read as the title and nothing would open.
+      return {
+        cmd: "cmd.exe",
+        args: ["/c", `start "" "${href}"`],
+        label: "default browser",
+        windowsVerbatimArguments: true,
+      };
+    default:
+      // linux and the BSDs: xdg-open is the freedesktop opener and
+      // resolves the default browser however the desktop defines it.
+      return { cmd: "xdg-open", args: [href], label: "default browser" };
+  }
+}
+
+/**
+ * Parses and re-serialises through WHATWG `URL`, refusing every scheme
+ * but http(s). The round-trip also percent-encodes `"` and whitespace,
+ * which is what lets the win32 branch above interpolate the result into
+ * a double-quoted cmd.exe string.
+ */
+export function canonicalHttpUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  return parsed.toString();
+}
+
+export interface OpenUrlOptions {
+  /** Defaults to `process.platform`; injectable for the unit tests. */
+  readonly platform?: NodeJS.Platform;
+  readonly spawn?: TerminalSpawn;
+  readonly settleMs?: number;
+}
+
+/**
+ * Build + spawn in one call. The detached spawn and the "exit 0 /
+ * non-zero with stderr / still running" settle protocol are delegated
+ * to `openTerminalWindow` — `open`, `xdg-open` and `cmd /c start` are
+ * short-lived launchers with exactly the lifecycle that helper decodes,
+ * and it already guarantees the two things this caller needs: the child
+ * is unref'd so it outlives the agent, and every failure comes back as
+ * a value instead of a throw.
+ */
+export async function openUrlInBrowser(
+  url: string,
+  options: OpenUrlOptions = {},
+): Promise<OpenUrlResult> {
+  const launch = buildOpenUrlCommand(
+    url,
+    options.platform ?? process.platform,
+  );
+  if (launch === null) {
+    return { ok: false, reason: `not an http(s) URL: ${url}` };
+  }
+  return await openTerminalWindow(launch, {
+    ...(options.spawn ? { spawn: options.spawn } : {}),
+    ...(options.settleMs !== undefined ? { settleMs: options.settleMs } : {}),
+  });
+}

--- a/src/tui/render/linkify-text.test.tsx
+++ b/src/tui/render/linkify-text.test.tsx
@@ -1,7 +1,7 @@
 import { Text } from "ink";
 import { render } from "ink-testing-library";
 import { describe, expect, it } from "vitest";
-import { LinkifiedText, splitUrlSegments } from "./linkify-text.js";
+import { hrefFor, LinkifiedText, splitUrlSegments } from "./linkify-text.js";
 
 describe("splitUrlSegments", () => {
   it("returns an empty list for empty input", () => {
@@ -37,6 +37,60 @@ describe("splitUrlSegments", () => {
       "http://b.io",
     ]);
   });
+
+  it("detects a scheme-less www URL and normalises only the target", () => {
+    expect(splitUrlSegments("try www.example.com today")).toEqual([
+      { text: "try ", url: null },
+      { text: "www.example.com", url: "https://www.example.com" },
+      { text: " today", url: null },
+    ]);
+  });
+
+  it("detects a www URL at the very start of the string", () => {
+    expect(splitUrlSegments("www.a.io wins")[0]).toEqual({
+      text: "www.a.io",
+      url: "https://www.a.io",
+    });
+  });
+
+  it("does not fire on a mid-word www run", () => {
+    expect(splitUrlSegments("awww.cute but not a link")).toEqual([
+      { text: "awww.cute but not a link", url: null },
+    ]);
+  });
+
+  it("leaves a www that belongs to a larger hostname to its host", () => {
+    // `www.` preceded by a dot is the middle of `api.www.host`, not a
+    // link starting at `www.`.
+    expect(
+      splitUrlSegments("api.www.example.com").every((s) => s.url === null),
+    ).toBe(true);
+  });
+
+  it("trims trailing punctuation off a www URL", () => {
+    expect(splitUrlSegments("at www.example.com.")).toEqual([
+      { text: "at ", url: null },
+      { text: "www.example.com", url: "https://www.example.com" },
+      { text: ".", url: null },
+    ]);
+  });
+
+  it("does not link a bare www. that the trim leaves empty", () => {
+    expect(
+      splitUrlSegments("www.: not a link").every((s) => s.url === null),
+    ).toBe(true);
+  });
+});
+
+describe("hrefFor", () => {
+  it("prefixes https onto a scheme-less www match", () => {
+    expect(hrefFor("www.example.com")).toBe("https://www.example.com");
+  });
+
+  it("leaves scheme'd URLs untouched", () => {
+    expect(hrefFor("https://example.com")).toBe("https://example.com");
+    expect(hrefFor("http://www.example.com")).toBe("http://www.example.com");
+  });
 });
 
 describe("LinkifiedText", () => {
@@ -49,6 +103,18 @@ describe("LinkifiedText", () => {
     const text = lastFrame() ?? "";
     expect(text).toContain(
       "\u001b]8;;https://cursor.com\u001b\\https://cursor.com\u001b]8;;\u001b\\",
+    );
+  });
+
+  it("points a www link's OSC 8 target at https while showing the bare text", () => {
+    const { lastFrame } = render(
+      <Text>
+        <LinkifiedText text="go www.example.com" />
+      </Text>,
+    );
+    const text = lastFrame() ?? "";
+    expect(text).toContain(
+      "\u001b]8;;https://www.example.com\u001b\\www.example.com\u001b]8;;\u001b\\",
     );
   });
 

--- a/src/tui/render/linkify-text.tsx
+++ b/src/tui/render/linkify-text.tsx
@@ -5,29 +5,60 @@ import { wrapOsc8 } from "./osc8-link.js";
 
 /**
  * One slice of a plain-text string: either inert text (`url: null`) or a
- * detected `http(s)://` URL that should render as a clickable hyperlink.
+ * detected URL that should render as a clickable hyperlink.
  */
 export interface UrlSegment {
-  /** Visible text of the segment. */
+  /** Visible text of the segment — exactly as the author typed it. */
   text: string;
-  /** Non-null when the segment is a clickable URL. */
+  /**
+   * Non-null when the segment is a clickable URL: the normalised
+   * `http(s)://` target (see {@link hrefFor}). Differs from `text` for
+   * scheme-less `www.` matches, where the visible label keeps the bare
+   * form but everything that *opens* the URL needs a real scheme.
+   */
   url: string | null;
 }
 
-const URL_PATTERN = /https?:\/\/[^\s]+/g;
+// `https?://` anywhere, plus scheme-less `www.` hosts — people type
+// `www.example.com` far more often than they type the scheme. The
+// lookbehind keeps mid-word runs from firing (`awww.cute` is not a
+// link, and the `www.` inside `api.www.host` belongs to the larger
+// hostname); it also stops a glued `xhttps://` from matching.
+const URL_PATTERN = /(?<![\w.])(?:https?:\/\/|www\.)[^\s]+/g;
 // Punctuation that commonly trails a URL in prose ("see https://x.io.")
 // but is not part of the link itself. Trimmed back into a plain segment so
 // the terminal's own URL detector (Terminal.app) and the OSC 8 target both
 // stay clean.
 const TRAILING_PUNCTUATION = /[.,;:!?)\]}>"'»]+$/;
+// What must survive the punctuation trim to still count as a URL: the
+// prefix plus at least one character of target. A trailing-punctuation
+// run can eat a match down to a bare `www` or `https://`, and those are
+// prose, not links.
+const MINIMAL_URL = /^(?:https?:\/\/|www\.)[^\s]/;
 
 /**
- * Splits a plain-text string into ordered segments, isolating `http(s)://`
- * URLs from surrounding prose. Pure function — no React, no Ink — so it is
- * trivially unit-testable. The URL text is preserved verbatim as the visible
- * label (label === url), which keeps links clickable even in terminals that
- * do not support OSC 8 (Terminal.app), since those rely on detecting the raw
- * URL text on screen.
+ * Normalises a detected URL into an openable target: a match without a
+ * scheme (`www.example.com`) gets `https://` prefixed, a scheme'd match
+ * passes through untouched. The visible text always stays as typed —
+ * only OSC 8 hrefs and anything that hands the URL to a browser go
+ * through here. Every consumer of the shared detector must use this
+ * rather than the raw match, or a bare `www.` target opens nothing.
+ */
+export function hrefFor(urlText: string): string {
+  // The pattern above admits exactly two shapes, so a missing scheme
+  // is precisely the `www.` one.
+  return urlText.startsWith("www.") ? `https://${urlText}` : urlText;
+}
+
+/**
+ * Splits a plain-text string into ordered segments, isolating URLs
+ * (`http(s)://` and bare `www.` hosts) from surrounding prose. Pure
+ * function — no React, no Ink — so it is trivially unit-testable. The
+ * URL text is preserved verbatim as the visible label, which keeps links
+ * clickable even in terminals that do not support OSC 8 (Terminal.app),
+ * since those rely on detecting the raw URL text on screen; the `url`
+ * field carries the normalised target for OSC 8 and the open-in-browser
+ * chips.
  */
 export function splitUrlSegments(text: string): UrlSegment[] {
   if (text.length === 0) return [];
@@ -48,7 +79,10 @@ export function splitUrlSegments(text: string): UrlSegment[] {
       segments.push({ text: text.slice(lastIndex, start), url: null });
     }
     if (url.length > 0) {
-      segments.push({ text: url, url });
+      segments.push({
+        text: url,
+        url: MINIMAL_URL.test(url) ? hrefFor(url) : null,
+      });
     }
     if (trailing.length > 0) {
       segments.push({ text: trailing, url: null });
@@ -62,9 +96,10 @@ export function splitUrlSegments(text: string): UrlSegment[] {
 }
 
 /**
- * Renders a single line of plain text with any `http(s)://` URL wrapped as a
- * clickable OSC 8 hyperlink. Designed to be used as inline children of an
- * outer `<Text>` (so the caller controls the base colour); the URL slices
+ * Renders a single line of plain text with any detected URL (scheme'd or
+ * bare `www.`) wrapped as a clickable OSC 8 hyperlink whose target is the
+ * normalised href. Designed to be used as inline children of an outer
+ * `<Text>` (so the caller controls the base colour); the URL slices
  * override the colour with `info` + underline to read as links.
  */
 export function LinkifiedText({ text }: { text: string }): ReactElement {

--- a/src/tui/render/markdown-inline.tsx
+++ b/src/tui/render/markdown-inline.tsx
@@ -2,6 +2,7 @@ import { Text } from "ink";
 import type { Token, Tokens } from "marked";
 import type { ReactElement } from "react";
 import { theme } from "../theme/theme.js";
+import { LinkifiedText } from "./linkify-text.js";
 import { wrapOsc8 } from "./osc8-link.js";
 
 /**
@@ -63,7 +64,16 @@ export function InlineToken({ token }: { token: Token }): ReactElement {
       if (textTok.tokens && textTok.tokens.length > 0) {
         return <Text>{renderInline(textTok.tokens)}</Text>;
       }
-      return <Text>{textTok.text}</Text>;
+      // Leaf text runs through the same bare-URL detector as the
+      // user/system bubbles: marked's GFM autolinker misses some URLs
+      // (non-ASCII hosts, for one), and those land here as plain text
+      // instead of a `link` token. Code stays verbatim — `codespan`
+      // and fenced blocks never reach this case.
+      return (
+        <Text>
+          <LinkifiedText text={textTok.text} />
+        </Text>
+      );
     }
     default:
       return (

--- a/src/tui/render/markdown-renderer.test.tsx
+++ b/src/tui/render/markdown-renderer.test.tsx
@@ -67,6 +67,37 @@ describe("MarkdownRenderer", () => {
     );
   });
 
+  it("linkifies a bare URL the GFM autolinker misses (non-ASCII host)", () => {
+    // marked leaves `https://пример.рф` as a plain `text` token — the
+    // GFM url rule only matches ASCII hosts — so this pins the
+    // splitUrlSegments fallback on the inline `text` path.
+    const { lastFrame } = render(
+      <MarkdownRenderer text="откройте https://пример.рф сейчас" />,
+    );
+    const text = lastFrame() ?? "";
+    expect(text).toContain(
+      "\u001b]8;;https://пример.рф\u001b\\https://пример.рф\u001b]8;;\u001b\\",
+    );
+  });
+
+  it("does not linkify a URL inside a codespan", () => {
+    const { lastFrame } = render(
+      <MarkdownRenderer text="run `https://cursor.com` verbatim" />,
+    );
+    const text = lastFrame() ?? "";
+    expect(strip(text)).toContain("https://cursor.com");
+    expect(text).not.toContain("\u001b]8;;");
+  });
+
+  it("does not linkify a URL inside a fenced code block", () => {
+    const { lastFrame } = render(
+      <MarkdownRenderer text={"```\ncurl https://cursor.com\n```"} />,
+    );
+    const text = lastFrame() ?? "";
+    expect(strip(text)).toContain("https://cursor.com");
+    expect(text).not.toContain("\u001b]8;;");
+  });
+
   it("renders bulleted lists with a bullet glyph", () => {
     const { lastFrame } = render(
       <MarkdownRenderer text={"- first\n- second"} />,

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -544,6 +544,14 @@ export interface TuiAppCallbacks {
    * `atomic-agent tui` in the same working directory.
    */
   onNewWindowRequested?(): void;
+  /**
+   * An `[open <host>]` chip under a chat message: open `url` — always a
+   * normalised http(s) URL by the time it gets here — in the OS default
+   * browser. A callback rather than an in-component spawn so the chip
+   * stays presentational and the failure report can travel the bus as a
+   * system message.
+   */
+  onOpenUrlRequested?(url: string): void;
 }
 
 export interface TuiAppProps {

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -45,6 +45,7 @@ import {
   currentTerminalLaunchInput,
   openAgentTerminalWindow,
 } from "./open-terminal-window.js";
+import { openUrlInBrowser } from "./open-url.js";
 import { detectKittyKeyboard } from "./detect-kitty-keyboard.js";
 import { setShiftEnterNewline } from "./shift-enter-support.js";
 import { makeTuiEventBus, TuiApp } from "./tui-app.js";
@@ -387,6 +388,7 @@ export async function tuiCommand(args: string[]): Promise<number> {
           orchestrator.quit();
         },
         onNewWindowRequested: () => openNewAgentWindow(parsed.workingDir, bus),
+        onOpenUrlRequested: (url) => openUrlFromChat(url, bus),
         onMemoryDumpRequested: () => orchestrator.dumpProfile(),
         onSkillCatalogRequested: () => orchestrator.dumpSkillCatalog(),
         onPersistLlamaUrl: (nextUrl) => persistLlamaUrl(nextUrl, bus, orchestrator, runtime),
@@ -746,6 +748,28 @@ function openNewAgentWindow(
       type: "system_message",
       variant: "warn",
       text: `could not open a new terminal window: ${result.reason}`,
+    });
+  })();
+}
+
+/**
+ * `[open <host>]` chip: hand `url` to the OS default browser. Success
+ * stays silent — the browser fronting itself *is* the feedback, and a
+ * chat-log line per opened link would be noise — but a failure is
+ * reported, because a chip that silently does nothing reads as a dead
+ * button (the same reasoning as `openNewAgentWindow` above).
+ */
+function openUrlFromChat(
+  url: string,
+  bus: ReturnType<typeof makeTuiEventBus>,
+): void {
+  void (async () => {
+    const result = await openUrlInBrowser(url);
+    if (result.ok) return;
+    bus.emit({
+      type: "system_message",
+      variant: "warn",
+      text: `could not open ${url}: ${result.reason}`,
     });
   })();
 }


### PR DESCRIPTION
URLs in chat are clickable in every terminal now, through two layers:

**In-text OSC 8 links** (terminals that support them: iTerm2, Kitty, WezTerm, VS Code, Windows Terminal — usually Cmd/Ctrl+click):
- **Streaming assistant replies** — the plain-text streaming branch of `AssistantBubble` routes through `LinkifiedText`, so a URL is clickable the moment it streams in instead of only after the turn finalises. The markdown-while-streaming gate is unchanged.
- **Finalized markdown, plain-text slices** — leaf `text` inline tokens run through the shared `splitUrlSegments` detector, catching URLs marked's autolinker misses.
- **Scheme-less `www.` URLs** are now detected everywhere bare URLs are (user bubbles, streaming assistant text, markdown leaf text) — styled as typed, targeted at `https://` when opened. A lookbehind keeps mid-word runs (`awww.cute`) from matching.

**`[open <host>]` chips** — the layer that works in *any* terminal, including ones that ignore OSC 8 (stock macOS Terminal.app): every finalized user and assistant message with URLs grows chips beside `[copy]`, routed through the TUI's own mouse layer. One click opens the OS default browser (`open` / `xdg-open` / `cmd start`), with an `[opening…]` badge as a double-click guard. Deduped, capped at 3 with a `+N more` note. Only http(s) URLs are ever handed to the OS (`file:`/`javascript:` are refused before any spawn); failures come back as a chat system message.

Tests: widened pattern (www match, no mid-word false positives, punctuation trim, https normalization), chip rendering/dedupe/cap/click-callback, per-platform opener argv (incl. the cmd.exe quoting), scheme guard, plus the original streaming/finalized/codespan linkification suite. `npm run lint` clean.

**Untouched:** the markdown `link` token path, `codespan`, and fenced code blocks — code stays verbatim, pinned by tests.
