### PR TITLE
feat(models-catalog): add uncensored Qwen3.8 27B, pinned last and never auto-recommended

### DIFF
--- a/src/cli/models-command.test.ts
+++ b/src/cli/models-command.test.ts
@@ -88,7 +88,7 @@ describe("modelsCommand", () => {
             l.includes("nemotron-") ||
             l.includes("muse-"),
         ),
-    ).toHaveLength(12);
+    ).toHaveLength(13);
   });
 
   describe("models the operator added from Hugging Face", () => {

--- a/src/local-llm/models-catalog.test.ts
+++ b/src/local-llm/models-catalog.test.ts
@@ -16,10 +16,10 @@ import {
 } from "./models-catalog.js";
 
 describe("models-catalog", () => {
-  it("has exactly 12 Qwen+Gemma+Nemotron+Muse models with unique ids", () => {
-    expect(LOCAL_MODELS_CATALOG.length).toBe(12);
+  it("has exactly 13 Qwen+Gemma+Nemotron+Muse models with unique ids", () => {
+    expect(LOCAL_MODELS_CATALOG.length).toBe(13);
     const ids = new Set(LOCAL_MODELS_CATALOG.map((m) => m.id));
-    expect(ids.size).toBe(12);
+    expect(ids.size).toBe(13);
   });
 
   it("defaults to qwen-3.5-4b", () => {
@@ -83,6 +83,34 @@ describe("models-catalog", () => {
     expect(muse.supportsVision).toBe(true);
     expect(muse.description).not.toMatch(/atem|harmony/i);
     expect(muse.description).toMatch(/generic tool calling/i);
+  });
+
+  // The reduced-refusal entry is deliberately last: the Manage panel
+  // draws the catalog in array order and the onboarding picker pins
+  // uncensored entries to the bottom, so the safe defaults always come
+  // first. The tag is what both surfaces show next to it.
+  it("keeps the uncensored entry last, tagged, and marked uncensored", () => {
+    const last = LOCAL_MODELS_CATALOG.at(-1);
+    expect(last?.id).toBe("qwen-3.8-27b-uncensored");
+    expect(last?.uncensored).toBe(true);
+    expect(last?.tag).toBe("Use at your own risk");
+    // noMTP on purpose: the fused quants carry an inline MTP head the
+    // daemon has no --model-draft wiring for; noMTP is plain GGUF.
+    expect(last?.filename).toBe("Qwen3.8-27B-Uncensored-noMTP-Q4_K_M.gguf");
+    // The projector is not named "mmproj" in this repo — the installer
+    // keys on these fields, not on filename patterns, so that is fine.
+    expect(last?.supportsVision).toBe(true);
+    expect(last?.mmprojFilename).toBe("Qwen3.8-27B-Uncensored-vision-f16.gguf");
+  });
+
+  // Every uncensored entry must carry a warning tag — the onboarding row
+  // surfaces exactly that string, and a tagless uncensored entry would
+  // reach the first-run screen with no caution at all.
+  it("ships a warning tag on every uncensored entry", () => {
+    for (const def of LOCAL_MODELS_CATALOG) {
+      if (def.uncensored !== true) continue;
+      expect(def.tag, `${def.id} must warn the operator`).toBeTruthy();
+    }
   });
 
   it("ensures mmproj URL points at the same HF repo as the GGUF weights", () => {

--- a/src/local-llm/models-catalog.ts
+++ b/src/local-llm/models-catalog.ts
@@ -11,6 +11,7 @@ export type CuratedLocalModelId =
   | "qwen-3.6-27b"
   | "qwen-3.6-35b-a3b"
   | "qwen-3.8-27b"
+  | "qwen-3.8-27b-uncensored"
   | "gemma-4-e4b"
   | "gemma-4-12b"
   | "gemma-4-26b-a4b"
@@ -72,6 +73,14 @@ export interface LocalModelDef {
    */
   chatTemplateAsset?: string;
   tag?: string;
+  /**
+   * Reduced-refusal ("abliterated" / uncensored) weights. Such entries
+   * are opt-in only: the first-run picker pins them to the bottom of the
+   * model list, renders their `tag` as a warning, and never picks one as
+   * the auto-recommendation (`recommendLocalModel`) — downloading one
+   * must always be a deliberate act, not the path of least resistance.
+   */
+  uncensored?: boolean;
   /**
    * Vision capability flag. When `true`, the model has an associated
    * mmproj projector file that llama-server needs (via `--mmproj <path>`)
@@ -337,6 +346,44 @@ export const LOCAL_MODELS_CATALOG: readonly LocalModelDef[] = [
       "https://huggingface.co/unsloth/Muse-Glimmer-30B-GGUF/resolve/main/mmproj-Muse-Glimmer-30B-Q8_0.gguf",
     mmprojFilename: "mmproj-Muse-Glimmer-30B-Q8_0.gguf",
     mmprojFileSizeGb: 2.05,
+  },
+  {
+    // Kept LAST on purpose: the Manage panel draws the catalog in array
+    // order and the onboarding picker pins uncensored entries to the
+    // bottom — an entry inserted above would put reduced-refusal weights
+    // ahead of the safe defaults.
+    //
+    // The `noMTP` file is deliberate: the repo's fused quants carry an
+    // inline MTP (speculative-decoding) head, while noMTP is a standard
+    // GGUF that any llama-server loads — and the daemon has no
+    // `--model-draft` wiring to use an MTP head anyway.
+    id: "qwen-3.8-27b-uncensored",
+    name: "Qwen3.8 27B Uncensored GGUF",
+    filename: "Qwen3.8-27B-Uncensored-noMTP-Q4_K_M.gguf",
+    huggingFaceUrl:
+      "https://huggingface.co/JonathanColetti/Qwen3.8-27B-Uncensored-GGUF/resolve/main/Qwen3.8-27B-Uncensored-noMTP-Q4_K_M.gguf",
+    fileSizeGb: 16.5,
+    sizeLabel: "16.5 GB",
+    description: "Reduced-refusal Qwen3.8 27B (abliterated)",
+    maxContextLength: 262_144,
+    contextLabel: "256K",
+    minRamGb: 20,
+    recommendedRamGb: 32,
+    family: "qwen",
+    tag: "Use at your own risk",
+    uncensored: true,
+    supportsVision: true,
+    // The vision file IS the projector — the model card states both
+    // vision files carry the same 334-tensor projector; it is simply not
+    // named "mmproj". Safe here: the installer and daemon key on the
+    // mmprojUrl/mmprojFilename *fields* (see `model-installer.ts`,
+    // `backend-paths.resolveMmprojFilePath`), never on filename patterns
+    // — `judgeGgufFile`'s "projector"/f16 rejections only run in the
+    // Hugging Face custom-add flow when picking MAIN weights.
+    mmprojUrl:
+      "https://huggingface.co/JonathanColetti/Qwen3.8-27B-Uncensored-GGUF/resolve/main/Qwen3.8-27B-Uncensored-vision-f16.gguf",
+    mmprojFilename: "Qwen3.8-27B-Uncensored-vision-f16.gguf",
+    mmprojFileSizeGb: 0.9,
   },
 ];
 

--- a/src/tui/components/onboarding-local-pick-step.test.tsx
+++ b/src/tui/components/onboarding-local-pick-step.test.tsx
@@ -1,0 +1,68 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { LOCAL_MODELS_CATALOG } from "../../local-llm/models-catalog.js";
+import {
+  buildLocalModelPicks,
+  orderLocalModelPicks,
+} from "../onboarding/local-model-picks.js";
+import { computeOnboardingFit } from "../onboarding/onboarding-fit.js";
+import {
+  LOCAL_PICK_WINDOW,
+  OnboardingLocalPickStep,
+  windowLocalPicks,
+} from "./onboarding-local-pick-step.js";
+
+const FULL = computeOnboardingFit({ columns: 100, rows: 30 });
+const MINIMAL = computeOnboardingFit({ columns: 60, rows: 14 });
+
+const UNCENSORED_ID = "qwen-3.8-27b-uncensored";
+
+function frameAt(cursor: number, ramGb: number, fit = FULL): string {
+  const picks = orderLocalModelPicks(buildLocalModelPicks(ramGb, LOCAL_MODELS_CATALOG));
+  const view = render(
+    <OnboardingLocalPickStep picks={picks} cursor={cursor} ramGb={ramGb} fit={fit} />,
+  );
+  const frame = (view.lastFrame() ?? "").replace(/\[[0-9;]*m/g, "");
+  view.unmount();
+  return frame;
+}
+
+describe("the uncensored row on the first-run pick screen", () => {
+  // The catalog outgrew the window, so the pinned-last uncensored row
+  // starts below the fold — the trailing counter is what says so, and
+  // the window follows the cursor until the row is on screen.
+  it("is reachable by scrolling even though it starts below the fold", () => {
+    const picks = orderLocalModelPicks(buildLocalModelPicks(16, LOCAL_MODELS_CATALOG));
+    expect(picks.length).toBeGreaterThan(LOCAL_PICK_WINDOW);
+    const atTop = windowLocalPicks(picks, 0);
+    expect(atTop.visible.some((p) => p.id === UNCENSORED_ID)).toBe(false);
+    expect(atTop.below).toBeGreaterThan(0);
+    const atBottom = windowLocalPicks(picks, picks.length - 1);
+    expect(atBottom.visible.at(-1)?.id).toBe(UNCENSORED_ID);
+    expect(atBottom.below).toBe(0);
+  });
+
+  it("draws the warning tag once scrolled to, above the Hugging Face row", () => {
+    const picks = orderLocalModelPicks(buildLocalModelPicks(16, LOCAL_MODELS_CATALOG));
+    const frame = frameAt(picks.length - 1, 16);
+    const lines = frame.split("\n").filter((l) => l.trim().length > 0);
+    const uncensoredLine = lines.findIndex((l) => l.includes(UNCENSORED_ID));
+    const hfLine = lines.findIndex((l) => l.includes("Add a model from Hugging Face"));
+    expect(uncensoredLine).toBeGreaterThan(-1);
+    expect(lines[uncensoredLine]).toContain("Use at your own risk");
+    // The last model row, with only the escape hatch below it.
+    expect(hfLine).toBe(uncensoredLine + 1);
+  });
+
+  // The minimal tier drops descriptions but must never drop the warning.
+  it("keeps the warning when the tier drops the row details", () => {
+    const picks = orderLocalModelPicks(buildLocalModelPicks(8, LOCAL_MODELS_CATALOG));
+    const frame = frameAt(picks.length - 1, 8, MINIMAL);
+    expect(frame).toContain("Use at your own risk");
+    // And the fit stays honest on a small host: 8 GB is under the 20 GB
+    // minimum, so the row asks for the RAM it actually needs.
+    expect(frame).toContain("needs 32 GB RAM");
+  });
+});

--- a/src/tui/components/onboarding-local-pick-step.tsx
+++ b/src/tui/components/onboarding-local-pick-step.tsx
@@ -16,7 +16,7 @@ import { theme } from "../theme/theme.js";
 export const LOCAL_PICK_WINDOW = 6;
 
 /** Model-name column, wide enough for the catalog's longest id plus a gap. */
-const LABEL_COLUMNS = 18;
+const LABEL_COLUMNS = 24;
 /** Size column, right-aligned so the numbers compare down the column. */
 const SIZE_COLUMNS = 8;
 /** Gap between the size and the note that follows it. */
@@ -168,6 +168,9 @@ function note(pick: LocalModelPick, fit: OnboardingFit): string {
   const parts: string[] = [];
   if (pick.recommended) parts.push("★ recommended");
   parts.push(pick.fit === "over" ? `needs ${pick.ramLabel}` : pick.ramLabel);
+  // The warning tag outranks the description — it stays on even in the
+  // minimal tier, and truncation eats the sales pitch before it.
+  if (pick.tag) parts.push(pick.tag);
   if (fit.rowDetails) parts.push(pick.description);
   return parts.join(" · ");
 }
@@ -180,6 +183,8 @@ function note(pick: LocalModelPick, fit: OnboardingFit): string {
  */
 function noteColour(pick: LocalModelPick): string {
   if (pick.fit === "over") return theme.colors.warn;
+  // An uncensored row reads as a caution even on a machine it fits.
+  if (pick.uncensored) return theme.colors.warn;
   if (pick.recommended) return theme.colors.success;
   return theme.colors.muted;
 }

--- a/src/tui/onboarding/local-model-picks.test.ts
+++ b/src/tui/onboarding/local-model-picks.test.ts
@@ -7,7 +7,7 @@ import {
   recommendLocalModel,
   FIRST_RUN_MAX_DOWNLOAD_GB,
 } from "./local-model-picks.js";
-import { setCustomLocalModels } from "../../local-llm/index.js";
+import { LOCAL_MODELS_CATALOG, setCustomLocalModels } from "../../local-llm/index.js";
 import type { LocalModelDef, LocalModelId } from "../../local-llm/index.js";
 
 function def(
@@ -15,6 +15,7 @@ function def(
   fileSizeGb: number,
   minRamGb: number,
   recommendedRamGb: number,
+  extra?: Partial<LocalModelDef>,
 ): LocalModelDef {
   return {
     id: id as LocalModelId,
@@ -29,6 +30,7 @@ function def(
     minRamGb,
     recommendedRamGb,
     family: "qwen",
+    ...extra,
   } as LocalModelDef;
 }
 
@@ -38,6 +40,8 @@ const CATALOG = [
   def("medium", 7, 8, 12),
   def("large", 18, 24, 32),
 ];
+
+const UNCENSORED_ID = "qwen-3.8-27b-uncensored";
 
 describe("recommendLocalModel", () => {
   it("picks the largest quick download the machine runs comfortably", () => {
@@ -59,6 +63,30 @@ describe("recommendLocalModel", () => {
   it("has nothing to say about an empty catalog", () => {
     expect(recommendLocalModel(16, [])).toBeNull();
   });
+
+  // The 16.5 GB uncensored file could never win the quick-download branch
+  // anyway (the ceiling is 8 GB) — but the fallbacks pick by size, so the
+  // guarantee is pinned across the whole RAM range, tiny hosts included.
+  it("never auto-recommends the uncensored model on any host", () => {
+    for (const ramGb of [1, 2, 4, 8, 16, 20, 24, 32, 48, 64, 128, 512]) {
+      expect(recommendLocalModel(ramGb, LOCAL_MODELS_CATALOG)).not.toBe(
+        UNCENSORED_ID,
+      );
+    }
+  });
+
+  // Structural, not accidental: even an uncensored model that would win
+  // on every usual criterion (comfortable, under the ceiling, largest)
+  // is excluded from the recommendation entirely.
+  it("excludes uncensored entries from recommendation even when they would win", () => {
+    const catalog = [
+      def("tame", 2, 4, 6),
+      def("edgy", 6, 4, 6, { uncensored: true, tag: "Use at your own risk" }),
+    ];
+    expect(recommendLocalModel(64, catalog)).toBe("tame");
+    // And a catalog of only uncensored entries recommends nothing at all.
+    expect(recommendLocalModel(64, [catalog[1]!])).toBeNull();
+  });
 });
 
 describe("buildLocalModelPicks", () => {
@@ -79,6 +107,44 @@ describe("orderLocalModelPicks", () => {
     expect(ordered[0]?.recommended).toBe(true);
     expect(ordered.at(-1)?.fit).toBe("over");
   });
+
+  // Pinned last even when the usual rule would rank it first: here the
+  // uncensored model is the only one that fits the host at all.
+  it("sinks an uncensored pick below every other model whatever its fit", () => {
+    const catalog = [
+      def("huge-a", 20, 24, 32),
+      def("huge-b", 22, 24, 32),
+      def("edgy", 3, 4, 6, { uncensored: true, tag: "Use at your own risk" }),
+    ];
+    const ordered = orderLocalModelPicks(buildLocalModelPicks(8, catalog));
+    expect(ordered.map((p) => p.id)).toEqual(["huge-a", "huge-b", "edgy"]);
+    expect(ordered.at(-1)?.fit).toBe("fits");
+  });
+
+  it("keeps the real catalog's uncensored entry as the last model row", () => {
+    // 16 GB would otherwise slot the 16.5 GB file mid-pack among the
+    // other "over" models; the pin overrides that size ordering.
+    for (const ramGb of [4, 16, 64]) {
+      const ordered = orderLocalModelPicks(
+        buildLocalModelPicks(ramGb, LOCAL_MODELS_CATALOG),
+      );
+      expect(ordered.at(-1)?.id).toBe(UNCENSORED_ID);
+      expect(ordered).toHaveLength(LOCAL_MODELS_CATALOG.length);
+    }
+  });
+
+  // Small machines still see it — with an honest fit label, not a faked
+  // one: 4 GB of RAM is under the 20 GB minimum, so the row says "over".
+  it("keeps the uncensored row present and honest on a small host", () => {
+    const ordered = orderLocalModelPicks(
+      buildLocalModelPicks(4, LOCAL_MODELS_CATALOG),
+    );
+    const last = ordered.at(-1);
+    expect(last?.id).toBe(UNCENSORED_ID);
+    expect(last?.fit).toBe("over");
+    expect(last?.tag).toBe("Use at your own risk");
+    expect(last?.recommended).toBe(false);
+  });
 });
 
 describe("buildLocalPickRows", () => {
@@ -93,6 +159,21 @@ describe("buildLocalPickRows", () => {
   // catalog still has to leave somewhere to go.
   it("offers the Hugging Face row even with no curated models", () => {
     expect(buildLocalPickRows([])).toEqual([{ kind: "hugging_face" }]);
+  });
+
+  // The full bottom of the first-run list, in order: every safe model,
+  // then the uncensored one, then the Hugging Face escape hatch.
+  it("puts the uncensored model directly above the Hugging Face row", () => {
+    const rows = buildLocalPickRows(
+      orderLocalModelPicks(buildLocalModelPicks(16, LOCAL_MODELS_CATALOG)),
+    );
+    expect(rows.at(-1)?.kind).toBe("hugging_face");
+    const lastModel = rows.at(-2);
+    expect(lastModel?.kind).toBe("model");
+    if (lastModel?.kind === "model") {
+      expect(lastModel.pick.id).toBe(UNCENSORED_ID);
+      expect(lastModel.pick.tag).toBe("Use at your own risk");
+    }
   });
 });
 

--- a/src/tui/onboarding/local-model-picks.ts
+++ b/src/tui/onboarding/local-model-picks.ts
@@ -21,6 +21,14 @@ export interface LocalModelPick {
   ramLabel: string;
   description: string;
   recommended: boolean;
+  /**
+   * Reduced-refusal weights. `orderLocalModelPicks` pins these below
+   * every other model, `recommendLocalModel` never proposes one, and the
+   * row renders `tag` in the warn tone.
+   */
+  uncensored: boolean;
+  /** The catalog's warning label for the row, e.g. "Use at your own risk". */
+  tag?: string;
 }
 
 /**
@@ -48,6 +56,11 @@ export function buildLocalModelPicks(
     ramLabel: `${def.recommendedRamGb} GB RAM`,
     description: def.description,
     recommended: def.id === recommendedId,
+    uncensored: def.uncensored === true,
+    // Only an uncensored entry's tag is a warning the first run must
+    // show; the marketing tags ("New", "Recommended") stay off this
+    // screen — the picker computes its own recommendation from RAM.
+    tag: def.uncensored === true ? def.tag : undefined,
   }));
 }
 
@@ -61,8 +74,13 @@ export function recommendLocalModel(
   ramGb: number,
   catalog: readonly LocalModelDef[] = LOCAL_MODELS_CATALOG,
 ): LocalModelId | null {
-  if (catalog.length === 0) return null;
-  const comfortable = catalog.filter((def) => def.recommendedRamGb <= ramGb);
+  // Reduced-refusal ("uncensored") entries are never candidates — not
+  // for the comfortable pick and not for any fallback. They stay in the
+  // list, tagged and pinned last, but choosing one has to be the
+  // operator's own act; the recommendation star must never point at one.
+  const candidates = catalog.filter((def) => def.uncensored !== true);
+  if (candidates.length === 0) return null;
+  const comfortable = candidates.filter((def) => def.recommendedRamGb <= ramGb);
   const quick = comfortable.filter(
     (def) => def.fileSizeGb <= FIRST_RUN_MAX_DOWNLOAD_GB,
   );
@@ -74,7 +92,7 @@ export function recommendLocalModel(
       def.fileSizeGb < best.fileSizeGb ? def : best,
     ).id;
   }
-  return catalog.reduce((best, def) =>
+  return candidates.reduce((best, def) =>
     def.fileSizeGb < best.fileSizeGb ? def : best,
   ).id;
 }
@@ -128,10 +146,18 @@ export function describeDownloadingModel(id: string | null): string {
 
 /** Rows ordered for the first run: the recommendation first, then by size. */
 export function orderLocalModelPicks(picks: readonly LocalModelPick[]): LocalModelPick[] {
-  return [...picks].sort((a, b) => {
+  const ordered = [...picks].sort((a, b) => {
     if (a.recommended !== b.recommended) return a.recommended ? -1 : 1;
     const fitRank = { fits: 0, tight: 1, over: 2 } as const;
     if (fitRank[a.fit] !== fitRank[b.fit]) return fitRank[a.fit] - fitRank[b.fit];
     return a.sizeLabel.localeCompare(b.sizeLabel, "en", { numeric: true });
   });
+  // Explicit pinning rule, applied AFTER the usual ordering: uncensored
+  // entries always sink below every other model, whatever their fit or
+  // size says — reaching one means scrolling past the safe defaults.
+  // (The Hugging Face row still comes after them; see buildLocalPickRows.)
+  return [
+    ...ordered.filter((pick) => !pick.uncensored),
+    ...ordered.filter((pick) => pick.uncensored),
+  ];
 }


### PR DESCRIPTION
Adds `qwen-3.8-27b-uncensored` to the curated local-models catalog and the first-run onboarding picker.

**Selection.** Most-downloaded uncensored model uploaded to Hugging Face in the last 4 weeks: `JonathanColetti/Qwen3.8-27B-Uncensored-GGUF` — 792 likes, 1.67M downloads, uploaded 2026-08-14, Apache 2.0.

**Why the noMTP Q4_K_M file.** The repo's fused quants carry an inline MTP (speculative-decoding) head; the noMTP variant is a standard GGUF any llama-server loads, and the daemon has no `--model-draft` wiring to use an MTP head anyway. The vision file is the projector (the model card states both vision files carry the same 334-tensor projector); it is not named `mmproj`, which is safe because the installer and daemon key on the catalog's mmproj fields, never on filename patterns.

**Safety rules, all pinned by tests:**
- Pinned last: last catalog entry (the Manage panel draws array order), and the onboarding picker sinks uncensored entries below every other model — above only the "Add a model from Hugging Face" row.
- Tagged: the row shows "Use at your own risk" in the warn tone, in every fit tier, ahead of the description in truncation order.
- Never auto-recommended: `recommendLocalModel` excludes uncensored entries from the recommendation and all fallbacks; a RAM sweep test (1–512 GB) asserts it can never become the first-run pick.
- Honest fit: on small machines the row reports `needs 32 GB RAM` like any other oversized model — nothing is faked.

With 13 models and a 6-row window the entry starts below the fold; the "↓ N more" counter advertises it and the window follows the cursor.

`npm run lint` clean; local-llm + onboarding + local-models + components suites green (851 tests).
