### PR TITLE
feat(tui): + new on the Tasks header, with the running counter centered — and counted correctly

### DIFF
--- a/src/tui/components/sidebar.test.tsx
+++ b/src/tui/components/sidebar.test.tsx
@@ -1,6 +1,10 @@
 import { render } from "ink-testing-library";
 import { describe, expect, it } from "vitest";
 import { Sidebar } from "./sidebar.js";
+import {
+  countRunningTasks,
+  selectSidebarTasks,
+} from "../sidebar-tasks-selector.js";
 import type { TaskSummaryRow } from "../tasks/tasks-panel-state.js";
 import type { SessionPickerEntry } from "../tui-state.js";
 
@@ -79,6 +83,60 @@ describe("Sidebar", () => {
     expect(text).toContain("TASKS");
     expect(text).not.toContain("Workspace");
     expect(text).not.toContain("LLM");
+  });
+
+  it("puts a + new chip on the Tasks header with the counter mid-gap", () => {
+    const { lastFrame } = render(
+      <Sidebar
+        width={32}
+        sessions={SESSIONS}
+        sessionsCursor={0}
+        currentSessionId="abcdef1234"
+        tasks={TASKS}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={false}
+      />,
+    );
+    const line = strip(lastFrame() ?? "")
+      .split("\n")
+      .find((candidate) => candidate.includes("TASKS"));
+    // Both headers carry the control, so minting a task is exactly as
+    // discoverable as minting a session. The trailing literal space
+    // pins the chip's own padding cell, leaving the groups with the
+    // spacers alone.
+    const match = /TASKS(\s+)1 running(\s+) \+ new/.exec(line ?? "");
+    expect(match).not.toBeNull();
+    // The counter sits in the MIDDLE of the gap: real air on both
+    // sides, split evenly give or take the cell Yoga cannot halve.
+    const [, before, after] = match!;
+    expect(before!.length).toBeGreaterThanOrEqual(2);
+    expect(after!.length).toBeGreaterThanOrEqual(2);
+    expect(Math.abs(before!.length - after!.length)).toBeLessThanOrEqual(1);
+  });
+
+  it("counts running tasks over the full snapshot, not the visible slice", () => {
+    // Seven running, five rows on the rail: the header must still say
+    // seven. The count travels as its own prop because the `tasks`
+    // prop is the projected slice — counting it is how "5 running"
+    // got printed under seven live tasks.
+    const rows = Array.from({ length: 7 }, (_, idx) =>
+      taskRow({ id: `run-${idx}`, status: "running", userMessage: `run ${idx}` }),
+    );
+    const { lastFrame } = render(
+      <Sidebar
+        width={32}
+        sessions={SESSIONS}
+        sessionsCursor={0}
+        currentSessionId={null}
+        tasks={selectSidebarTasks(rows)}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={false}
+        runningTaskCount={countRunningTasks(rows)}
+      />,
+    );
+    expect(strip(lastFrame() ?? "")).toContain("7 running");
   });
 
   it("shows the empty state when there are no sessions", () => {

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -37,6 +37,14 @@ export interface SidebarProps {
    */
   maxSessionRows?: number;
   maxTaskRows?: number;
+  /**
+   * Tasks counted as running in the header, measured over the FULL
+   * snapshot by the caller. The `tasks` prop is already the projected
+   * slice — filtered and capped by `selectSidebarTasks` — so counting
+   * it here read "5 running" while a sixth and seventh ran below the
+   * fold. Callers that do not measure fall back to the visible rows.
+   */
+  runningTaskCount?: number;
 }
 
 const DEFAULT_MAX_SESSION_ROWS = 10;
@@ -93,6 +101,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
     sessionId = null,
     maxSessionRows = DEFAULT_MAX_SESSION_ROWS,
     maxTaskRows = DEFAULT_MAX_TASK_ROWS,
+    runningTaskCount,
   } = props;
   const sessionsActive = focused && activeSection === "sessions";
   const tasksActive = focused && activeSection === "tasks";
@@ -155,7 +164,8 @@ export function Sidebar(props: SidebarProps): ReactElement {
         title="Tasks"
         active={tasksActive}
         inner={inner}
-        counter={`${runningCount(tasks)} running`}
+        counter={`${runningTaskCount ?? runningCount(tasks)} running`}
+        trailing={<NewTaskButton />}
       />
       <TasksList
         tasks={tasks}
@@ -310,6 +320,30 @@ function NewSessionButton(): ReactElement {
 }
 
 /**
+ * Starts a scheduled task. It sits on the Tasks header for the same
+ * reason the session `+ new` sits on Sessions: the control lives on the
+ * list the new thing joins. Clicking it lands on the Tasks tab with the
+ * create form already open — the same place the in-panel `n` key
+ * reaches, without having to know the panel or the key exists.
+ */
+function NewTaskButton(): ReactElement {
+  const mouse = useMouseCommands();
+  const label = <Chip label="+ new" />;
+  if (!mouse) return label;
+  return (
+    <MouseTarget
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        mouse.callbacks.onTaskNewRequested?.();
+        return true;
+      }}
+    >
+      {label}
+    </MouseTarget>
+  );
+}
+
+/**
  * The one control on the rail. `ctrl+p` opens the same menu; this is
  * what makes it reachable without knowing that, which was the whole
  * complaint about the old top bar — nothing on screen said the menu
@@ -349,7 +383,10 @@ interface SectionHeaderProps {
   title: string;
   active: boolean;
   inner: number;
-  /** Right-aligned status, e.g. `0 running`. */
+  /**
+   * Status, e.g. `0 running`. Alone it rides the right edge; next to a
+   * `trailing` control it sits mid-gap between the title and the chip.
+   */
   counter?: string;
   /** Right-aligned control, e.g. the `+ new` chip. */
   trailing?: ReactNode;
@@ -362,9 +399,12 @@ function SectionHeader({
   counter,
   trailing,
 }: SectionHeaderProps): ReactElement {
-  // The header is a row, not a line: the counter and the `+ new` control
-  // are pushed to the right edge of the rail the way the design sets
-  // them, which a single clipped string cannot express.
+  // The header is a row, not a line: its cells are placed by spacers,
+  // which a single clipped string cannot express. With one of counter /
+  // trailing present it is pushed to the right edge the way the design
+  // sets it; with both, a second spacer seats the counter in the middle
+  // of the gap — status reads as its own cell rather than as a label
+  // glued to the chip.
   return (
     <Box width={inner} flexShrink={0}>
       <Text
@@ -380,12 +420,17 @@ function SectionHeader({
           {counter}
         </Text>
       ) : null}
+      {counter && trailing ? <Box flexGrow={1} /> : null}
       {trailing ?? null}
     </Box>
   );
 }
 
-/** Tasks the design counts in the header: the ones actually running. */
+/**
+ * Fallback for callers that pass no `runningTaskCount`: count what is
+ * visible. The rows here are the projected slice, so this undercounts
+ * once running tasks fall off the rail — the measured prop is the fix.
+ */
 function runningCount(tasks: readonly TaskSummaryRow[]): number {
   return tasks.filter((row) => row.status === "running").length;
 }

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -151,12 +151,15 @@ function mountApp(): {
   seedSessions: () => void;
   /** Session ids the app asked the host to delete. */
   deleted: string[];
+  /** Clicks the Tasks header's `+ new` chip delivered to the host. */
+  taskNews: number[];
   unmount: () => void;
 } {
   const bus = makeTuiEventBus();
   const mouse = makeMouseSource();
   const deleted: string[] = [];
   const copied: string[] = [];
+  const taskNews: number[] = [];
   const clipboard = {
     copy: async (text: string) => {
       copied.push(text);
@@ -171,6 +174,7 @@ function mountApp(): {
       callbacks={{
         ...noopCallbacks(),
         onSessionDeleteConfirmed: (sessionId) => deleted.push(sessionId),
+        onTaskNewRequested: () => taskNews.push(taskNews.length),
       }}
       mouse={mouse}
     />
@@ -181,6 +185,7 @@ function mountApp(): {
     mouse,
     stdin,
     deleted,
+    taskNews,
     copied,
     seedSessions: () => {
       bus.emit({
@@ -500,6 +505,30 @@ describe("TuiApp mouse", () => {
       expect(app.deleted).toEqual([]);
       app.unmount();
     });
+  });
+
+  it("requests a new task from the Tasks header's + new chip", async () => {
+    const app = mountApp();
+    await waitUntil(() => app.frame().includes("TASKS"), "the rail on screen");
+    // Two `+ new` chips are on screen — the Sessions header owns the
+    // first, so the one under test is the chip sharing a line with the
+    // TASKS label.
+    await clickUntil(
+      app.mouse,
+      () => {
+        const lines = app.frame().split("\n");
+        for (const [y, line] of lines.entries()) {
+          if (!line.includes("TASKS")) continue;
+          const x = line.indexOf("+ new");
+          if (x !== -1) return { x: x + 1, y };
+        }
+        throw new Error(`no "+ new" on the TASKS line:\n${app.frame()}`);
+      },
+      () => app.taskNews.length > 0,
+      "click the Tasks + new chip",
+    );
+    expect(app.taskNews.length).toBeGreaterThan(0);
+    app.unmount();
   });
 
   it("puts a start-page tip in the composer when it is clicked", async () => {

--- a/src/tui/sidebar-tasks-selector.test.ts
+++ b/src/tui/sidebar-tasks-selector.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { selectSidebarTasks, SIDEBAR_TASKS_LIMIT } from "./sidebar-tasks-selector.js";
+import {
+  countRunningTasks,
+  selectSidebarTasks,
+  SIDEBAR_TASKS_LIMIT,
+} from "./sidebar-tasks-selector.js";
 import type { TaskSummaryRow } from "./tasks/tasks-panel-state.js";
 
 function row(overrides: Partial<TaskSummaryRow>): TaskSummaryRow {
@@ -71,5 +75,26 @@ describe("selectSidebarTasks", () => {
     );
     const result = selectSidebarTasks(many);
     expect(result).toHaveLength(SIDEBAR_TASKS_LIMIT);
+  });
+});
+
+describe("countRunningTasks", () => {
+  it("counts every running row, including the ones the rail truncates", () => {
+    const rows = Array.from({ length: SIDEBAR_TASKS_LIMIT + 2 }, (_, i) =>
+      row({ id: `r-${i}`, status: "running", updatedAt: i }),
+    );
+    // The projection tops out at the cap; the counter must not.
+    expect(selectSidebarTasks(rows)).toHaveLength(SIDEBAR_TASKS_LIMIT);
+    expect(countRunningTasks(rows)).toBe(SIDEBAR_TASKS_LIMIT + 2);
+  });
+
+  it("ignores rows in every other status", () => {
+    expect(
+      countRunningTasks([
+        row({ id: "a", status: "pending" }),
+        row({ id: "b", status: "completed", recurring: true }),
+        row({ id: "c", status: "failed" }),
+      ]),
+    ).toBe(0);
   });
 });

--- a/src/tui/sidebar-tasks-selector.ts
+++ b/src/tui/sidebar-tasks-selector.ts
@@ -45,3 +45,13 @@ export function selectSidebarTasks(
   });
   return sorted.slice(0, limit);
 }
+
+/**
+ * Running tasks in the FULL snapshot, for the rail's header counter.
+ * Counting the projected slice undercounts: {@link selectSidebarTasks}
+ * caps it at {@link SIDEBAR_TASKS_LIMIT}, so seven running tasks read
+ * as "5 running" the moment the sixth falls off the rail.
+ */
+export function countRunningTasks(rows: readonly TaskSummaryRow[]): number {
+  return rows.filter((row) => row.status === "running").length;
+}

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -74,7 +74,10 @@ import {
   THEMES,
 } from "./theme/theme.js";
 import { Sidebar } from "./components/sidebar.js";
-import { selectSidebarTasks } from "./sidebar-tasks-selector.js";
+import {
+  countRunningTasks,
+  selectSidebarTasks,
+} from "./sidebar-tasks-selector.js";
 import { SlashPalette } from "./components/slash-palette.js";
 import { StatusBar } from "./components/status-bar.js";
 import { TasksCancelModal } from "./components/tasks-cancel-modal.js";
@@ -257,6 +260,12 @@ export interface TuiAppCallbacks {
    * detail view, mirroring what the operator would do manually.
    */
   onSidebarTaskActivated?(taskId: string): void;
+  /**
+   * Sidebar Tasks header: `+ new` clicked. The handler is expected to
+   * surface the Tasks debug tab with its create form open, mirroring
+   * the in-panel `n` key.
+   */
+  onTaskNewRequested?(): void;
   /** Switch the chat transcript to the task's session. */
   onTaskOpenSessionRequested?(taskId: string): void;
   /** Proceed with a task cancellation — the caller owns any confirm modal. */
@@ -1698,6 +1707,7 @@ export function TuiApp({
             sessionsCursor={state.sidebarCursor}
             currentSessionId={state.session.sessionId}
             tasks={selectSidebarTasks(state.tasksPanel.rows)}
+            runningTaskCount={countRunningTasks(state.tasksPanel.rows)}
             tasksCursor={state.sidebarTasksCursor}
             activeSection={state.sidebarSection}
             focused={sidebarFocused}

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -404,6 +404,16 @@ export async function tuiCommand(args: string[]): Promise<number> {
           bus.emit({ type: "tab_changed", tab: "tasks" });
           orchestrator.tasks.openDetail(taskId);
         },
+        onTaskNewRequested: () => {
+          // Sidebar `+ new` on the Tasks header: land on the Tasks debug
+          // tab with the create form already open — the destination the
+          // in-panel `n` key reaches, minus the walk. The form-open
+          // action is the same one `n` dispatches, emitted on the bus
+          // for the reason the sibling above spells out.
+          bus.emit({ type: "ui_mode_set", mode: "debug" });
+          bus.emit({ type: "tab_changed", tab: "tasks" });
+          bus.emit({ type: "tasks_create_form_opened" });
+        },
         onTaskOpenSessionRequested: (taskId) =>
           orchestrator.tasks.openSession(taskId),
         onTaskCancelConfirmed: (taskId) => orchestrator.tasks.cancelTask(taskId),


### PR DESCRIPTION
The rail's Sessions header has a `+ new` chip; Tasks had nothing, so the create form was only reachable by knowing the panel's `n` key. This adds the same chip to the Tasks header — clicking it lands on the Tasks tab with the create form already open, dispatching the exact action `n` uses.

With both a counter and a control on one header, right-aligning both glued "N running" to the chip. A second spacer now seats the counter mid-gap between the title and the chip; headers with only one of the two keep today's right-aligned layout.

**Bug fixed in passing:** the header counted running tasks on the sidebar's projected slice, which `selectSidebarTasks` filters and caps at 5 rows — seven running tasks displayed as "5 running". The count now arrives as a prop measured over the full `state.tasksPanel.rows` snapshot (`countRunningTasks`).

Tests: chip renders on the Tasks header; a mouse-layer click fires the new-task callback; the counter shows the full count past the 5-row cap; the mid-gap geometry is asserted on the rendered line. `SIDEBAR_CHROME_ROWS` unchanged (no new rows); `sidebar-fit` stays green. `npm run lint` clean; 106 targeted tests pass.
