### PR TITLE
fix(agent): never leak raw reasoning as a reply; transport-aware prompt

### DIFF
--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -273,21 +273,129 @@ describe("executeStep batch handling", () => {
     ]);
   });
 
-  it("native_tools: reasoning-only completion (empty content, no tool_calls) is salvaged as a reply", async () => {
-    // Reasoning models served over OpenAI-compatible APIs (Qwen3.8 with
-    // `preserve_thinking` on, DeepSeek-R1) routinely end hard turns with
-    // the entire answer in `reasoning_content`, `content` empty and no
-    // `tool_calls`. Failing fast here (the pre-Qwen3.8 contract) killed
-    // whole sessions on healthy completions. The parser now salvages the
-    // reasoning body — GBNF batch if one is embedded, otherwise a
-    // length-1 `reply` — without burning a retry: no prompt is replayed,
-    // so the original fail-fast concern (replaying the same prompt into
-    // the same wall) does not apply.
+  it("native_tools: unparseable reasoning-only completion routes through parse_retry, never leaks CoT as a reply", async () => {
+    // `reasoning_content` is internal scratch space by OpenAI-compatible
+    // convention. An earlier salvage path wrapped an unparseable
+    // reasoning body verbatim into `reply { text }` — raw chain-of-
+    // thought delivered as deliberate agent speech (issue #285). The
+    // executor must instead treat it like any other unparseable body:
+    // one `parse_retry` through the repair prompt, and the repaired
+    // completion's answer — never the reasoning text — reaches the user.
     const registry = makeRegistry();
     const session = createEmptySessionState({
       id: "s-native-reasoning-only",
       workingDir: "/w",
     });
+    const events: Array<{ type: string }> = [];
+    const cot =
+      "The user asked whether reasoning tokens leak. I should inspect the binary...";
+    let llmCalls = 0;
+
+    const outcome = await executeStep(
+      {
+        session,
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "привет",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        async llmComplete() {
+          llmCalls += 1;
+          if (llmCalls === 1) {
+            return {
+              content: "",
+              reasoningContent: cot,
+              stop: true,
+              truncated: false,
+              timing: {
+                promptMs: 1,
+                predictedMs: 1,
+                promptTokens: 20,
+                predictedTokens: 5,
+              },
+              cacheHitTokens: 0,
+              slotId: -1,
+              modelId: "openai/gpt-5.5",
+            };
+          }
+          return {
+            content: "",
+            reasoningContent: "",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: 5,
+            },
+            cacheHitTokens: 0,
+            slotId: -1,
+            modelId: "openai/gpt-5.5",
+            toolCalls: [
+              {
+                id: "call-repair",
+                type: "function",
+                function: {
+                  name: "reply",
+                  arguments: JSON.stringify({ text: "Привет!" }),
+                },
+              },
+            ],
+          };
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+        onEvent(event) {
+          events.push({ type: event.type });
+        },
+      },
+    );
+
+    expect(llmCalls).toBe(2);
+    expect(events.some((event) => event.type === "parse_retry")).toBe(true);
+    expect(outcome.toolResults).toHaveLength(1);
+    expect(outcome.toolResults[0]?.status).toBe("ok");
+    expect(outcome.nextSession.turns.at(-1)).toMatchObject({
+      kind: "assistant_reply",
+      text: "Привет!",
+    });
+    // The leak itself: no reply anywhere in the transcript may carry the
+    // raw reasoning body.
+    for (const turn of outcome.nextSession.turns) {
+      if (turn.kind === "assistant_reply") {
+        expect(turn.text).not.toContain(cot);
+      }
+    }
+    expect(
+      outcome.toolCalls.some(
+        (call) =>
+          call.tool === "reply" &&
+          typeof call.args?.text === "string" &&
+          call.args.text.includes(cot),
+      ),
+    ).toBe(false);
+  });
+
+  it("native_tools: recovers a GBNF-shaped batch embedded in `reasoning_content` without a retry", async () => {
+    // Reasoning models sometimes emit the persona's `[{tool, args}]`
+    // array inside the think channel and end the turn with `content`
+    // empty. That is a real tool-call emission, not scratch space — the
+    // parser must recover it in place (no repair round-trip).
+    const registry = makeRegistry();
+    const session = createEmptySessionState({
+      id: "s-native-gbnf-in-reasoning",
+      workingDir: "/w",
+    });
+    const events: Array<{ type: string }> = [];
     let llmCalls = 0;
 
     const outcome = await executeStep(
@@ -307,18 +415,19 @@ describe("executeStep batch handling", () => {
           llmCalls += 1;
           return {
             content: "",
-            reasoningContent: "I should call reply.",
+            reasoningContent:
+              '[{"tool":"reply","args":{"text":"Привет, инициат!"}}]',
             stop: true,
             truncated: false,
             timing: {
               promptMs: 1,
               predictedMs: 1,
               promptTokens: 20,
-              predictedTokens: 5,
+              predictedTokens: 12,
             },
             cacheHitTokens: 0,
             slotId: -1,
-            modelId: "openai/gpt-5.5",
+            modelId: "z-ai/glm-5.3-flash",
           };
         },
         grammar: "",
@@ -326,16 +435,83 @@ describe("executeStep batch handling", () => {
         toolTransport: "native_tools",
         toolCallAdapter: null,
         supportsSlotAffinity: false,
+        onEvent(event) {
+          events.push({ type: event.type });
+        },
       },
     );
 
     expect(llmCalls).toBe(1);
-    expect(outcome.toolResults).toHaveLength(1);
-    expect(outcome.toolResults[0]?.status).toBe("ok");
+    expect(events.some((event) => event.type === "parse_retry")).toBe(false);
+    expect(outcome.toolCalls).toHaveLength(1);
+    expect(outcome.toolCalls[0]).toMatchObject({
+      tool: "reply",
+      args: { text: "Привет, инициат!" },
+    });
     expect(outcome.nextSession.turns.at(-1)).toMatchObject({
       kind: "assistant_reply",
-      text: "I should call reply.",
+      text: "Привет, инициат!",
     });
+  });
+
+  it("native_tools: reasoning-only on both attempts surfaces a parse error, not the CoT", async () => {
+    // Twice-unparseable reasoning ends the step as a GrammarError. Before
+    // issue #285 the first attempt already "succeeded" by leaking the
+    // reasoning body as the reply, so this path was unreachable.
+    const registry = makeRegistry();
+    const session = createEmptySessionState({
+      id: "s-native-reasoning-twice",
+      workingDir: "/w",
+    });
+    const events: Array<{ type: string }> = [];
+    let llmCalls = 0;
+
+    await expect(
+      executeStep(
+        {
+          session,
+          toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+          capabilities: CAPS,
+          skillCatalog: SKILLS,
+          stepIndex: 0,
+          signal: new AbortController().signal,
+          userMessage: "привет",
+        },
+        {
+          registry,
+          slotManager: new SlotManager(2),
+          async llmComplete() {
+            llmCalls += 1;
+            return {
+              content: "",
+              reasoningContent: "Hmm, let me think about the binary layout...",
+              stop: true,
+              truncated: false,
+              timing: {
+                promptMs: 1,
+                predictedMs: 1,
+                promptTokens: 20,
+                predictedTokens: 5,
+              },
+              cacheHitTokens: 0,
+              slotId: -1,
+              modelId: "z-ai/glm-5.3-flash",
+            };
+          },
+          grammar: "",
+          profile: PLAIN_INSTRUCT_PROFILE,
+          toolTransport: "native_tools",
+          toolCallAdapter: null,
+          supportsSlotAffinity: false,
+          onEvent(event) {
+            events.push({ type: event.type });
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ name: "GrammarError" });
+
+    expect(llmCalls).toBe(2);
+    expect(events.some((event) => event.type === "parse_retry")).toBe(true);
   });
 
   it("repairs a native-tools reply call with empty args before execution", async () => {

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -514,6 +514,107 @@ describe("executeStep batch handling", () => {
     expect(events.some((event) => event.type === "parse_retry")).toBe(true);
   });
 
+  it("native_tools: the repair prompt mandates native function-calling, never a corrected JSON array", async () => {
+    // The repair replays with the SAME llmParams as the failed attempt —
+    // under `native_tools` that request carries the OpenAI `tools`
+    // payload and a stable prefix that forbids text-JSON emission.
+    // Appending the grammar repair mandate ("Emit a corrected JSON array
+    // only", "Use a length-1 array") onto that prefix re-creates the
+    // issue #285 dual mandate at the one retry a failing model gets
+    // before GrammarError kills the step.
+    const registry = makeRegistry();
+    const session = createEmptySessionState({
+      id: "s-native-repair-prompt",
+      workingDir: "/w",
+    });
+    const prompts: string[] = [];
+    let llmCalls = 0;
+
+    const outcome = await executeStep(
+      {
+        session,
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "привет",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        async llmComplete({ prompt }) {
+          prompts.push(prompt);
+          llmCalls += 1;
+          if (llmCalls === 1) {
+            // Reasoning-only completion: unparseable, routes through the
+            // one-shot repair (the exact path issue #285 redirected).
+            return {
+              content: "",
+              reasoningContent: "Let me think about what to do here...",
+              stop: true,
+              truncated: false,
+              timing: {
+                promptMs: 1,
+                predictedMs: 1,
+                promptTokens: 20,
+                predictedTokens: 5,
+              },
+              cacheHitTokens: 0,
+              slotId: -1,
+              modelId: "openai/gpt-5.5",
+            };
+          }
+          return {
+            content: "",
+            reasoningContent: "",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: 5,
+            },
+            cacheHitTokens: 0,
+            slotId: -1,
+            modelId: "openai/gpt-5.5",
+            toolCalls: [
+              {
+                id: "call-repaired",
+                type: "function",
+                function: {
+                  name: "reply",
+                  arguments: JSON.stringify({ text: "готово" }),
+                },
+              },
+            ],
+          };
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      },
+    );
+
+    expect(outcome.terminal).toBe("turn");
+    expect(prompts).toHaveLength(2);
+    const repairPrompt = prompts[1]!;
+    expect(repairPrompt).toContain("### tool-call-repair");
+    // Native corrective mandate present...
+    expect(repairPrompt).toContain("native function-calling interface");
+    expect(repairPrompt).toContain("do NOT write tool-call JSON as text");
+    // ...and no trace of the text-array mandate anywhere in the repair
+    // prompt (stable prefix included).
+    expect(repairPrompt).not.toContain("Emit a corrected JSON array");
+    expect(repairPrompt).not.toContain("Use a length-1 array");
+    expect(repairPrompt).not.toContain("Emit a JSON ARRAY of tool calls now");
+    expect(repairPrompt).not.toContain("length-1 array");
+    expect(repairPrompt).not.toContain("One tool-call array per step");
+  });
+
   it("repairs a native-tools reply call with empty args before execution", async () => {
     const registry = makeRegistry();
     const session = createEmptySessionState({

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -336,6 +336,13 @@ async function executeStepInner(
     skillCatalog: ctx.skillCatalog,
     currentDate: formatCurrentDate(new Date()),
     profile: deps.profile,
+    // The prefix must match the request shape: a native-tools link gets
+    // native function-calling guidance instead of the text-JSON array
+    // mandate (issue #285). Configured transport, not `servedTransport`:
+    // the prompt is built before any fallback link serves the request.
+    ...(deps.toolTransport !== undefined
+      ? { toolTransport: deps.toolTransport }
+      : {}),
     ...(deps.contextWindow !== undefined
       ? { contextWindow: deps.contextWindow }
       : {}),
@@ -1054,9 +1061,11 @@ function isNativeToolsEmptyCompletionHandledByParser(
   // Reasoning-only completions (Qwen3.8 with preserve_thinking,
   // DeepSeek-R1 over OpenAI-compatible APIs): the model ends its turn
   // with all text in `reasoning_content`, `content` empty and no
-  // tool_calls. The parser salvages these — a GBNF-shaped batch inside
-  // the reasoning, or the reasoning itself as a `reply`. Only a
-  // completion with NOTHING in any channel routes through ModelError.
+  // tool_calls. The parser gets a crack at these: a GBNF-shaped batch
+  // inside the reasoning is recovered as real tool calls; anything else
+  // fails the parse and routes through the one-shot repair (never as a
+  // raw-CoT `reply` — issue #285). Only a completion with NOTHING in
+  // any channel routes through ModelError.
   const reasoning =
     typeof completion.reasoningContent === "string"
       ? completion.reasoningContent.trim()
@@ -1206,11 +1215,15 @@ function tryParseToolCalls(
         };
       }
       // Reasoning-only completion: no tool_calls, empty content, but the
-      // think channel carries text. Same two recovery paths as for plain
-      // content, applied to the reasoning body: models occasionally emit
-      // the GBNF-style call array inside the think block, and a model
-      // that reasoned its way to a final answer without ever leaving the
-      // think channel still has an answer worth delivering as `reply`.
+      // think channel carries text. Models occasionally emit the
+      // GBNF-style call array inside the think block — recover those
+      // calls (they are the model's real intent). Anything else is NOT
+      // salvaged: `reasoning_content` is internal scratch space by
+      // OpenAI-compatible convention, and wrapping it as a `reply` leaks
+      // raw chain-of-thought verbatim as deliberate agent speech (issue
+      // #285). Returning `ok: false` routes the completion through the
+      // same one-shot repair as every other unparseable body; a repair
+      // that fails too ends the step as a parse error, not a CoT leak.
       const reasoningText =
         typeof completion.reasoningContent === "string"
           ? completion.reasoningContent.trim()
@@ -1230,21 +1243,13 @@ function tryParseToolCalls(
             return { ok: true, batch: { ...grammarBatch, calls } };
           }
         } catch {
-          // Not GBNF-shaped — fall through to the reply wrap.
+          // Not GBNF-shaped — fall through to the parse failure below.
         }
         return {
-          ok: true,
-          batch: {
-            kind: "batch",
-            calls: [
-              {
-                tool: "reply",
-                args: { text: reasoningText },
-                reasoning: reasoningText,
-              },
-            ],
-            reasoning: reasoningText,
-          },
+          ok: false,
+          error: new Error(
+            "reasoning-only completion: no tool_calls, empty content, and the reasoning body is not a tool-call array",
+          ),
         };
       }
       return {

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -656,7 +656,12 @@ async function executeStepInner(
     const retryStartedAt = Date.now();
     completion = await deps.llmComplete({
       ...llmParams,
-      prompt: buildToolCallRepairPrompt(prompt.text, parsed.error, deps.profile),
+      prompt: buildToolCallRepairPrompt(
+        prompt.text,
+        parsed.error,
+        deps.profile,
+        deps.toolTransport,
+      ),
       // Bounded cap on the repair completion. Without it, reasoning
       // models (qwen-3.5-9b in particular) routinely fall into a
       // self-deliberation loop after a `BatchValidationError` and burn
@@ -1604,6 +1609,7 @@ function buildToolCallRepairPrompt(
   promptText: string,
   error: Error,
   profile?: ModelProfile,
+  toolTransport?: ToolCallTransport,
 ): string {
   // Strip the trailing reasoning open-tag prefill (e.g. `<think>` for
   // qwen-think, `<|channel>thought\n` for gemma4-think) before
@@ -1639,14 +1645,32 @@ function buildToolCallRepairPrompt(
       lines.push("per-call errors:", ...perCall);
     }
   }
-  lines.push(
-    "Emit a corrected JSON array only. No prose, no commentary after the array.",
-    "Use a length-1 array for `reply`, `finish`, approval-gated tools, or any call that depends on a previous result.",
-    "Do not repeat the invalid batch shape.",
-    "",
-    "### respond",
-    "Respond now.",
-  );
+  // The corrective mandate must match the request's transport. This
+  // repair replays with the SAME params as the failed attempt — under
+  // `native_tools` that request carries the OpenAI `tools` payload and a
+  // stable prefix that forbids text-JSON emission, so ordering a
+  // "corrected JSON array" here would re-create the exact dual mandate
+  // issue #285 removed, on the one retry a failing model gets before
+  // GrammarError ends the step.
+  if (toolTransport === "native_tools") {
+    lines.push(
+      "Call the tools again now, through the native function-calling interface (the `tools` payload on this API request) — do NOT write tool-call JSON as text, and do not leave the answer in the reasoning channel.",
+      "Make it a single tool call for `reply`, `finish`, approval-gated tools, or any call that depends on a previous result.",
+      "Do not repeat the invalid shape.",
+      "",
+      "### respond",
+      "Respond now.",
+    );
+  } else {
+    lines.push(
+      "Emit a corrected JSON array only. No prose, no commentary after the array.",
+      "Use a length-1 array for `reply`, `finish`, approval-gated tools, or any call that depends on a previous result.",
+      "Do not repeat the invalid batch shape.",
+      "",
+      "### respond",
+      "Respond now.",
+    );
+  }
   const openReasoning = renderOpenReasoningBlock(profile);
   if (openReasoning.length > 0) {
     lines.push(openReasoning);

--- a/src/prompt/build-prompt-types.ts
+++ b/src/prompt/build-prompt-types.ts
@@ -1,4 +1,5 @@
 import type { ModelProfile } from "../llm/model-profile.js";
+import type { ToolCallTransport } from "../llm/provider/completion-types.js";
 import type { ProfileFact } from "../memory/profile-store.js";
 import type { SessionState } from "../session/session-state.js";
 import type {
@@ -14,6 +15,14 @@ export interface BuildPromptInput {
   capabilities: CapabilitiesSummary;
   skillCatalog: readonly SkillCatalogEntry[];
   systemPersona?: string;
+  /**
+   * Transport the serving link uses for tool calls. Forwarded into
+   * `buildStablePrefix`, where `"native_tools"` swaps the text-JSON
+   * emission mandate for native function-calling guidance (issue #285).
+   * Omitted or `"grammar"` keeps the stable prefix byte-identical to
+   * the legacy output.
+   */
+  toolTransport?: ToolCallTransport;
   /**
    * Pre-formatted current date (see `formatCurrentDate`) rendered as a
    * `CURRENT DATE:` line in the variable tail just before `### respond`.

--- a/src/prompt/build-prompt.test.ts
+++ b/src/prompt/build-prompt.test.ts
@@ -1286,6 +1286,17 @@ describe("buildPrompt tool transport (issue #285)", () => {
     expect(native.stablePrefix).not.toContain(
       "Each step emits exactly one JSON array matching the tool grammar",
     );
+    // ...including the `### rules` opener — every text-array mandate
+    // must go, not just the persona and `### instructions` ones.
+    expect(native.stablePrefix).not.toContain("One tool-call array per step");
+    expect(native.stablePrefix).not.toContain(
+      "a solo action is a length-1 array",
+    );
+    // ...and the persona's reply-discipline line ("emit that tool JSON").
+    expect(native.stablePrefix).not.toContain("emit that tool JSON");
+    expect(native.stablePrefix).toContain("call that tool, not `reply`");
+    expect(native.stablePrefix).toContain("### rules");
+    expect(native.stablePrefix).toContain("One batch of tool calls per step");
     expect(native.stablePrefix).toContain("native function-calling interface");
     // The catalog stays: a fallback chain can hand this session to a
     // grammar-only link, and the catalog carries tier/tool.view docs.
@@ -1303,6 +1314,9 @@ describe("buildPrompt tool transport (issue #285)", () => {
     expect(explicit.stablePrefix).toContain("Emit a JSON ARRAY of tool calls now");
     expect(explicit.stablePrefix).toContain(
       "Each step emits exactly one JSON array matching the tool grammar",
+    );
+    expect(explicit.stablePrefix).toContain(
+      "One tool-call array per step (including `skill.view`); a solo action is a length-1 array. Destructive or privileged tools may require user approval.",
     );
   });
 

--- a/src/prompt/build-prompt.test.ts
+++ b/src/prompt/build-prompt.test.ts
@@ -1269,3 +1269,68 @@ describe("token-budget helpers", () => {
     expect(truncateToTokens("abc", 0)).toBe("");
   });
 });
+
+describe("buildPrompt tool transport (issue #285)", () => {
+  const base = () => ({
+    session: mkSession(),
+    toolDescriptors: TOOLS,
+    capabilities: CAPS,
+    skillCatalog: SKILLS,
+  });
+
+  it("native_tools prefix drops the text-JSON emission mandate but keeps the ### tools catalog", () => {
+    const native = buildPrompt({ ...base(), toolTransport: "native_tools" });
+    // The dual mandate: with an OpenAI `tools` payload on the request,
+    // the prompt must not also order text-JSON emission.
+    expect(native.stablePrefix).not.toContain("Emit a JSON ARRAY of tool calls now");
+    expect(native.stablePrefix).not.toContain(
+      "Each step emits exactly one JSON array matching the tool grammar",
+    );
+    expect(native.stablePrefix).toContain("native function-calling interface");
+    // The catalog stays: a fallback chain can hand this session to a
+    // grammar-only link, and the catalog carries tier/tool.view docs.
+    expect(native.stablePrefix).toContain("### tools");
+    expect(native.stablePrefix).toContain("# common (full)");
+    expect(native.stablePrefix).toContain("browser.navigate");
+    expect(native.stablePrefix).toContain("### instructions");
+  });
+
+  it("grammar prefix is byte-identical whether the transport is omitted or explicit", () => {
+    const implicit = buildPrompt(base());
+    const explicit = buildPrompt({ ...base(), toolTransport: "grammar" });
+    expect(explicit.stablePrefix).toBe(implicit.stablePrefix);
+    // And it still carries the legacy text-JSON mandate untouched.
+    expect(explicit.stablePrefix).toContain("Emit a JSON ARRAY of tool calls now");
+    expect(explicit.stablePrefix).toContain(
+      "Each step emits exactly one JSON array matching the tool grammar",
+    );
+  });
+
+  it("stable prefix stays byte-stable across turns for a fixed transport", () => {
+    const turn1 = buildPrompt({ ...base(), toolTransport: "native_tools" });
+    const turn2 = buildPrompt({
+      ...base(),
+      session: mkSession({
+        turns: [
+          { kind: "user", text: "Check inbox", at: 1 },
+          { kind: "assistant_reply", text: "Done", at: 2 },
+          { kind: "user", text: "Now archive it", at: 3 },
+        ],
+      }),
+      toolTransport: "native_tools",
+    });
+    expect(turn2.stablePrefix).toBe(turn1.stablePrefix);
+  });
+
+  it("an explicit systemPersona override wins on both transports", () => {
+    const persona = "You are a test persona.";
+    const native = buildPrompt({
+      ...base(),
+      systemPersona: persona,
+      toolTransport: "native_tools",
+    });
+    const grammar = buildPrompt({ ...base(), systemPersona: persona });
+    expect(native.stablePrefix).toContain(persona);
+    expect(grammar.stablePrefix).toContain(persona);
+  });
+});

--- a/src/prompt/build-prompt.ts
+++ b/src/prompt/build-prompt.ts
@@ -130,6 +130,9 @@ export function buildPrompt(input: BuildPromptInput): BuiltPrompt {
     ...(input.systemPersona !== undefined
       ? { systemPersona: input.systemPersona }
       : {}),
+    ...(input.toolTransport !== undefined
+      ? { toolTransport: input.toolTransport }
+      : {}),
   });
 
   const sessionParts = buildSessionSectionParts(

--- a/src/prompt/index.ts
+++ b/src/prompt/index.ts
@@ -3,6 +3,7 @@ export type { BuildPromptInput, BuiltPrompt } from "./build-prompt.js";
 export {
   buildStablePrefix,
   DEFAULT_SYSTEM_PERSONA,
+  NATIVE_TOOLS_SYSTEM_PERSONA,
   formatToolForLoadedTail,
 } from "./stable-prefix.js";
 export type {

--- a/src/prompt/stable-prefix.ts
+++ b/src/prompt/stable-prefix.ts
@@ -1,3 +1,4 @@
+import type { ToolCallTransport } from "../llm/provider/completion-types.js";
 import { formatSkillCatalogLine } from "../skills/skill-catalog.js";
 
 /**
@@ -75,16 +76,28 @@ export interface StablePrefixInput {
    */
   turnSystemOpen?: string;
   maxParallelToolCalls?: number;
+  /**
+   * Transport the serving link uses for tool calls. Under
+   * `"native_tools"` the persona's emission mandate and the
+   * `### instructions` block switch to native function-calling guidance:
+   * the text-JSON "Emit a JSON ARRAY" mandate contradicts the
+   * request-level `tools` payload and drives cloud models back to text
+   * emission (issue #285). The `### tools` catalog is rendered in both
+   * modes — the provider fallback chain can hand a native-shaped request
+   * to a grammar-only llama-server link, and the catalog carries the
+   * tier / `tool.view` semantics. Omitted or `"grammar"` keeps the
+   * prefix byte-identical to the legacy output (KV-cache safe).
+   */
+  toolTransport?: ToolCallTransport;
 }
 
 /**
- * The stable prefix is the part of the prompt that must stay byte-stable
- * within a session so llama.cpp can reuse its KV-cache. Order and spacing
- * are intentional — changing any byte invalidates the slot.
+ * Persona lines shared verbatim between the grammar and native-tools
+ * variants. Only the emission mandate (line 1) and the bias-toward-action
+ * phrasing (line 2) differ per transport; everything below is
+ * transport-neutral. Extracted so the two personas cannot drift apart.
  */
-export const DEFAULT_SYSTEM_PERSONA = [
-  "You are atomic-agent, a local operator. Each step emits exactly one JSON array matching the tool grammar — no other prose.",
-  "Bias toward action: keep planning minimal; unless the user explicitly asked for analysis or explanation only, choose the next tool-call array quickly instead of long deliberation. If the template forces a separate reasoning or thinking block before JSON, keep that block to a few words (or effectively empty), then emit the array.",
+const SYSTEM_PERSONA_SHARED_LINES = [
   "Terminals: `reply` returns the final answer to the user and ends the current macro-turn (session stays open). `finish` ends the entire session; only with explicit user intent.",
   "`reply` is ONLY for the final user-facing text after all needed tools ran. The user does not see intermediate text — if another tool is next, emit that tool JSON, not `reply`.",
   "Output discipline: when the request specifies an exact answer format, marker, length, or units, the `reply` text MUST be ONLY that — the bare value or the exact required line and nothing else (correct units, no preamble, no restating the question, no extra commentary or markdown before or after). If a specific final-answer line or marker is required, emit exactly that line as the entire reply. When no format is specified, answer as fully and helpfully as the task warrants.",
@@ -94,6 +107,33 @@ export const DEFAULT_SYSTEM_PERSONA = [
   "Large directories: `os.fs.list` only shows up to maxEntries matches—use extensions, pattern, sort, or `os.fs.glob` to narrow before assuming a file type is absent. For many PDFs or resumes prefer filename `os.fs.glob` patterns plus `os.fs.read_document` on a short candidate list; avoid sweeping `os.fs.grep` with `glob` over huge `*.pdf` trees.",
   "Deleting files or directories: when the user asks to delete, remove, erase, or trash paths, call `os.fs.trash` with concrete absolute paths in `paths` (use `os.fs.list` / `os.fs.glob` first if you need to discover names). Do not use `os.shell.run` with `rm`, `unlink`, or `rmdir` for that unless the user explicitly demands permanent irreversible shell deletion.",
   "Memory: persist with `memory.profile.*` and `memory.notes.*` as needed. Use `### lessons` (pointer view of distilled rules from past episodes — call `memory.lessons.recall { id }` to read the full principle), `### procedures` (pointer view of advisory how-to templates — call `memory.procedures.recall { id }` to read the `steps[]`; templates are guidance, not law — follow them or consciously deviate), `### recalled` / `### memory-index` and `memory.notes.recall` for past context. Store distilled facts, not full dumps. `### notice` in the tail is a hard nudge to change strategy.",
+];
+
+/**
+ * The stable prefix is the part of the prompt that must stay byte-stable
+ * within a session so llama.cpp can reuse its KV-cache. Order and spacing
+ * are intentional — changing any byte invalidates the slot.
+ */
+export const DEFAULT_SYSTEM_PERSONA = [
+  "You are atomic-agent, a local operator. Each step emits exactly one JSON array matching the tool grammar — no other prose.",
+  "Bias toward action: keep planning minimal; unless the user explicitly asked for analysis or explanation only, choose the next tool-call array quickly instead of long deliberation. If the template forces a separate reasoning or thinking block before JSON, keep that block to a few words (or effectively empty), then emit the array.",
+  ...SYSTEM_PERSONA_SHARED_LINES,
+].join("\n");
+
+/**
+ * Persona for the `native_tools` transport. The request already carries
+ * an OpenAI `tools` array with `tool_choice: "auto"`, so the persona must
+ * mandate the function-calling interface — repeating the grammar
+ * persona's "exactly one JSON array" line alongside a native `tools`
+ * payload is a dual mandate that measurably drives models back to
+ * text-JSON emission (issue #285: 0/6 native `tool_calls` under
+ * `native_tools`). Lines past the first two are shared with
+ * `DEFAULT_SYSTEM_PERSONA`.
+ */
+export const NATIVE_TOOLS_SYSTEM_PERSONA = [
+  "You are atomic-agent, a local operator. Each step calls tools through the native function-calling interface — never write tool-call JSON into the text of your answer, and never put your answer in the reasoning channel.",
+  "Bias toward action: keep planning minimal; unless the user explicitly asked for analysis or explanation only, choose the next tool call quickly instead of long deliberation. Keep any reasoning or thinking to a few words (or effectively empty), then make the call.",
+  ...SYSTEM_PERSONA_SHARED_LINES,
 ].join("\n");
 
 /**
@@ -110,7 +150,10 @@ export const WINDOWS_PLATFORM_HINT = [
 ].join("\n");
 
 export function buildStablePrefix(input: StablePrefixInput): string {
-  const persona = input.systemPersona ?? DEFAULT_SYSTEM_PERSONA;
+  const nativeTools = input.toolTransport === "native_tools";
+  const persona =
+    input.systemPersona ??
+    (nativeTools ? NATIVE_TOOLS_SYSTEM_PERSONA : DEFAULT_SYSTEM_PERSONA);
   const maxParallelToolCalls = input.maxParallelToolCalls ?? 8;
   const frequent: ToolDescriptor[] = [];
   const rare: ToolDescriptor[] = [];
@@ -167,12 +210,27 @@ export function buildStablePrefix(input: StablePrefixInput): string {
     caps,
     ``,
     `### instructions`,
-    `Emit a JSON ARRAY of tool calls now. Always start with \`[\` and end with \`]\`, even for a single call. Use \`reply\` for natural-language answers to the user.`,
-    `PARALLEL: when you need multiple INDEPENDENT actions (e.g. read 3 different files, run 2 globs, look up 4 git logs), put up to ${maxParallelToolCalls} calls in the SAME array — they run in parallel and cut wall time by ~Nx. Examples:`,
-    `  - one call: [{"tool":"os.fs.read","args":{"path":"a.ts"}}]`,
-    `  - parallel batch: [{"tool":"os.fs.read","args":{"path":"a.csv"}},{"tool":"os.fs.read","args":{"path":"b.csv"}},{"tool":"os.fs.read","args":{"path":"c.csv"}}]`,
-    `  - reply: [{"tool":"reply","args":{"text":"..."}}]`,
-    `Keep a call solo (length-1 array) when: it is \`reply\`/\`finish\`, may need approval (\`os.shell.run\`, \`os.fs.write\`, \`os.fs.edit\`, \`os.fs.trash\`, \`os.fs.patch\`, \`os.fs.archive.extract\`, \`os.proc.kill\`, \`os.http.request\`, \`skill.run_script\`), or its args depend on a previous call's result.`,
+    // The emission instructions are the one transport-dependent block.
+    // Grammar links parse text-JSON (GBNF-constrained locally), so they
+    // mandate the array literal; native links carry an OpenAI `tools`
+    // payload, and repeating the text-JSON mandate there is a dual
+    // mandate that drives models back to text emission (issue #285).
+    // The `### tools` catalog above stays in both modes — see
+    // `StablePrefixInput.toolTransport`.
+    ...(nativeTools
+      ? [
+          `Call tools now, through the native function-calling interface (the \`tools\` your API request carries) — do NOT write tool-call JSON as text. The \`### tools\` catalog above is reference documentation for those same tools (tiers, examples, \`tool.view\`). For the final user-facing answer call \`reply\`, or answer in plain text.`,
+          `PARALLEL: when you need multiple INDEPENDENT actions (e.g. read 3 different files, run 2 globs, look up 4 git logs), emit up to ${maxParallelToolCalls} tool calls in the SAME response — they run in parallel and cut wall time by ~Nx.`,
+          `Emit a single tool call (no others alongside) when: it is \`reply\`/\`finish\`, may need approval (\`os.shell.run\`, \`os.fs.write\`, \`os.fs.edit\`, \`os.fs.trash\`, \`os.fs.patch\`, \`os.fs.archive.extract\`, \`os.proc.kill\`, \`os.http.request\`, \`skill.run_script\`), or its args depend on a previous call's result.`,
+        ]
+      : [
+          `Emit a JSON ARRAY of tool calls now. Always start with \`[\` and end with \`]\`, even for a single call. Use \`reply\` for natural-language answers to the user.`,
+          `PARALLEL: when you need multiple INDEPENDENT actions (e.g. read 3 different files, run 2 globs, look up 4 git logs), put up to ${maxParallelToolCalls} calls in the SAME array — they run in parallel and cut wall time by ~Nx. Examples:`,
+          `  - one call: [{"tool":"os.fs.read","args":{"path":"a.ts"}}]`,
+          `  - parallel batch: [{"tool":"os.fs.read","args":{"path":"a.csv"}},{"tool":"os.fs.read","args":{"path":"b.csv"}},{"tool":"os.fs.read","args":{"path":"c.csv"}}]`,
+          `  - reply: [{"tool":"reply","args":{"text":"..."}}]`,
+          `Keep a call solo (length-1 array) when: it is \`reply\`/\`finish\`, may need approval (\`os.shell.run\`, \`os.fs.write\`, \`os.fs.edit\`, \`os.fs.trash\`, \`os.fs.patch\`, \`os.fs.archive.extract\`, \`os.proc.kill\`, \`os.http.request\`, \`skill.run_script\`), or its args depend on a previous call's result.`,
+        ]),
     ``,
   ].join("\n");
 }

--- a/src/prompt/stable-prefix.ts
+++ b/src/prompt/stable-prefix.ts
@@ -93,13 +93,27 @@ export interface StablePrefixInput {
 
 /**
  * Persona lines shared verbatim between the grammar and native-tools
- * variants. Only the emission mandate (line 1) and the bias-toward-action
- * phrasing (line 2) differ per transport; everything below is
+ * variants. Only the emission mandate (line 1), the bias-toward-action
+ * phrasing (line 2), and the reply-discipline line (line 4, see
+ * `REPLY_DISCIPLINE_LINE_*`) differ per transport; everything else is
  * transport-neutral. Extracted so the two personas cannot drift apart.
  */
+const SYSTEM_PERSONA_TERMINALS_LINE =
+  "Terminals: `reply` returns the final answer to the user and ends the current macro-turn (session stays open). `finish` ends the entire session; only with explicit user intent.";
+
+/** Byte-identical to the pre-#285 line (KV-cache safe). */
+const REPLY_DISCIPLINE_LINE_GRAMMAR =
+  "`reply` is ONLY for the final user-facing text after all needed tools ran. The user does not see intermediate text — if another tool is next, emit that tool JSON, not `reply`.";
+
+/**
+ * Native variant of the reply-discipline line: "emit that tool JSON" is
+ * yet another text-JSON emission mandate, so under `native_tools` it
+ * becomes "call that tool" (issue #285).
+ */
+const REPLY_DISCIPLINE_LINE_NATIVE =
+  "`reply` is ONLY for the final user-facing text after all needed tools ran. The user does not see intermediate text — if another tool is next, call that tool, not `reply`.";
+
 const SYSTEM_PERSONA_SHARED_LINES = [
-  "Terminals: `reply` returns the final answer to the user and ends the current macro-turn (session stays open). `finish` ends the entire session; only with explicit user intent.",
-  "`reply` is ONLY for the final user-facing text after all needed tools ran. The user does not see intermediate text — if another tool is next, emit that tool JSON, not `reply`.",
   "Output discipline: when the request specifies an exact answer format, marker, length, or units, the `reply` text MUST be ONLY that — the bare value or the exact required line and nothing else (correct units, no preamble, no restating the question, no extra commentary or markdown before or after). If a specific final-answer line or marker is required, emit exactly that line as the entire reply. When no format is specified, answer as fully and helpfully as the task warrants.",
   "Finishing the job: when the user asks you to build, run, compute, or verify something, the deliverable is a real result backed by actual tool output — not a description of one. Do not stop after a stub, a plan, or a single command; keep calling tools until you have actually produced the requested result, then `reply` with what real execution returned. If a tool, install, or network call fails and blocks the real path, say so directly and try an alternative (a different approach, or `reply` to ask the user). NEVER substitute plausible-looking fabricated output (made-up data, invented file contents, synthesised API responses) for results you could not actually produce — reporting a blocker honestly is always better than inventing a result.",
   "When a line in `### skills` matches the user's request, emit `skill.view` first — the catalog line is a stub, the body has the actual procedure — unless that skill is already under `### loaded-skills`. This applies to every skill, including text-only workflows; do not guess the answer from the catalog summary. Rare tool? `tool.view` first. Loop: tools, read `### world` / `### conversation`, then more tools or `reply`. `browser.navigate` / `browser.search` refresh the world; avoid redundant `read_aria`. Do not invent facts — use `reply` to ask if stuck.",
@@ -117,6 +131,8 @@ const SYSTEM_PERSONA_SHARED_LINES = [
 export const DEFAULT_SYSTEM_PERSONA = [
   "You are atomic-agent, a local operator. Each step emits exactly one JSON array matching the tool grammar — no other prose.",
   "Bias toward action: keep planning minimal; unless the user explicitly asked for analysis or explanation only, choose the next tool-call array quickly instead of long deliberation. If the template forces a separate reasoning or thinking block before JSON, keep that block to a few words (or effectively empty), then emit the array.",
+  SYSTEM_PERSONA_TERMINALS_LINE,
+  REPLY_DISCIPLINE_LINE_GRAMMAR,
   ...SYSTEM_PERSONA_SHARED_LINES,
 ].join("\n");
 
@@ -133,8 +149,25 @@ export const DEFAULT_SYSTEM_PERSONA = [
 export const NATIVE_TOOLS_SYSTEM_PERSONA = [
   "You are atomic-agent, a local operator. Each step calls tools through the native function-calling interface — never write tool-call JSON into the text of your answer, and never put your answer in the reasoning channel.",
   "Bias toward action: keep planning minimal; unless the user explicitly asked for analysis or explanation only, choose the next tool call quickly instead of long deliberation. Keep any reasoning or thinking to a few words (or effectively empty), then make the call.",
+  SYSTEM_PERSONA_TERMINALS_LINE,
+  REPLY_DISCIPLINE_LINE_NATIVE,
   ...SYSTEM_PERSONA_SHARED_LINES,
 ].join("\n");
+
+/**
+ * `### rules` body shared verbatim between the transports. Only the
+ * emission-shape opener differs: grammar mandates the length-1 text
+ * array, native mandates the function-calling interface — leaving the
+ * grammar opener in place under `native_tools` re-creates the dual
+ * mandate the transport split exists to remove (issue #285).
+ */
+const RULES_SHARED_TAIL =
+  "Destructive or privileged tools may require user approval. If `### skills` lists a playbook that fits the user goal, call `skill.view` first unless that skill is already under `### loaded-skills`; do not act on a catalog stub — the body has the procedure. This holds for every skill (text replies included), not just browser/shell shortcuts. Summaries in `# extras` list rare tools; call `tool.view` to load the full `args` schema into `### loaded-tools` before use. Large trees: narrow with `os.fs.list` filters or `os.fs.glob` before reading content; do not use `os.fs.grep` with broad binary globs (e.g. every `*.pdf`) across huge folders—use tight globs then `os.fs.read_document` on candidates.";
+
+/** Byte-identical to the pre-#285 `### rules` line (KV-cache safe). */
+const GRAMMAR_RULES_LINE = `One tool-call array per step (including \`skill.view\`); a solo action is a length-1 array. ${RULES_SHARED_TAIL}`;
+
+const NATIVE_TOOLS_RULES_LINE = `One batch of tool calls per step (including \`skill.view\`), all through the native function-calling interface — never written out as JSON text; a solo action is a single call. ${RULES_SHARED_TAIL}`;
 
 /**
  * Windows-only nudge appended after the persona. The default persona and
@@ -194,7 +227,7 @@ export function buildStablePrefix(input: StablePrefixInput): string {
       : []),
     ``,
     `### rules`,
-    `One tool-call array per step (including \`skill.view\`); a solo action is a length-1 array. Destructive or privileged tools may require user approval. If \`### skills\` lists a playbook that fits the user goal, call \`skill.view\` first unless that skill is already under \`### loaded-skills\`; do not act on a catalog stub — the body has the procedure. This holds for every skill (text replies included), not just browser/shell shortcuts. Summaries in \`# extras\` list rare tools; call \`tool.view\` to load the full \`args\` schema into \`### loaded-tools\` before use. Large trees: narrow with \`os.fs.list\` filters or \`os.fs.glob\` before reading content; do not use \`os.fs.grep\` with broad binary globs (e.g. every \`*.pdf\`) across huge folders—use tight globs then \`os.fs.read_document\` on candidates.`,
+    nativeTools ? NATIVE_TOOLS_RULES_LINE : GRAMMAR_RULES_LINE,
     ``,
     `### skills`,
     skills,

--- a/src/replay/replay-session.test.ts
+++ b/src/replay/replay-session.test.ts
@@ -138,6 +138,71 @@ describe("replaySession", () => {
         report.steps.every((s) => s.recordedHash === "deadbeef".repeat(8)),
       ).toBe(true);
       expect(report.steps[0]!.currentHash).not.toBe("deadbeef".repeat(8));
+      expect(report.steps.every((s) => s.matchedTransport === null)).toBe(true);
+    } finally {
+      rmSync(fx.tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("reports no drift for a native_tools-recorded trace when no transport is pinned", async () => {
+    // Since issue #285 the stable prefix differs by construction between
+    // the transports, and traces do not record which one served the
+    // session. An unpinned replay must therefore accept a match against
+    // either variant — otherwise every native-transport session (the
+    // default on openai / subscription-cli providers) reports 100% false
+    // drift.
+    const context = buildCurrentContext();
+    const nativeHash = hashPrefix(
+      buildStablePrefix({
+        toolDescriptors: context.toolDescriptors,
+        capabilities: context.capabilities,
+        skillCatalog: context.skillCatalog,
+        reasoningSystemToken: context.profile.reasoningSystemToken,
+        toolTransport: "native_tools",
+      }),
+    );
+    const fx = writeTrace({ recordedHash: nativeHash });
+    try {
+      const report = await replaySession({ path: fx.path, context });
+      expect(report.driftCount).toBe(0);
+      expect(
+        report.steps.every((s) => s.matchedTransport === "native_tools"),
+      ).toBe(true);
+      expect(report.steps.every((s) => s.currentHash === nativeHash)).toBe(
+        true,
+      );
+    } finally {
+      rmSync(fx.tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("a pinned transport restricts matching to that variant", async () => {
+    const context = buildCurrentContext();
+    const nativeHash = hashPrefix(
+      buildStablePrefix({
+        toolDescriptors: context.toolDescriptors,
+        capabilities: context.capabilities,
+        skillCatalog: context.skillCatalog,
+        reasoningSystemToken: context.profile.reasoningSystemToken,
+        toolTransport: "native_tools",
+      }),
+    );
+    const fx = writeTrace({ recordedHash: nativeHash });
+    try {
+      const pinnedNative = await replaySession({
+        path: fx.path,
+        context: { ...context, toolTransport: "native_tools" },
+      });
+      expect(pinnedNative.driftCount).toBe(0);
+
+      const pinnedGrammar = await replaySession({
+        path: fx.path,
+        context: { ...context, toolTransport: "grammar" },
+      });
+      expect(pinnedGrammar.driftCount).toBe(2);
+      expect(
+        pinnedGrammar.steps.every((s) => s.matchedTransport === null),
+      ).toBe(true);
     } finally {
       rmSync(fx.tmp, { recursive: true, force: true });
     }

--- a/src/replay/replay-session.ts
+++ b/src/replay/replay-session.ts
@@ -5,6 +5,7 @@ import type {
 } from "../prompt/stable-prefix.js";
 import { buildStablePrefix } from "../prompt/stable-prefix.js";
 import type { ModelProfile } from "../llm/model-profile.js";
+import type { ToolCallTransport } from "../llm/provider/completion-types.js";
 import { hashPrefix } from "../llm/slot-manager.js";
 
 import type { TraceEvent } from "../tracing/index.js";
@@ -21,13 +22,32 @@ export interface ReplayContext {
    * version that used a custom persona.
    */
   systemPersona?: string;
+  /**
+   * Transport the traced session used for tool calls. Since issue #285
+   * the stable prefix differs by construction between `"grammar"` and
+   * `"native_tools"`, so drift detection must compare against the right
+   * variant. Traces do not record the transport, so when this is omitted
+   * the replay builds BOTH variants and a recorded hash counts as clean
+   * when it matches EITHER — otherwise every native-transport trace
+   * (the default on openai / subscription-cli providers) would report
+   * 100% false drift. Supply the transport to pin the comparison to one
+   * variant when it is known.
+   */
+  toolTransport?: ToolCallTransport;
 }
 
 export interface ReplayStepReport {
   turnIndex: number;
   stepIndex: number;
   recordedHash: string;
+  /**
+   * Hash of the matched prefix variant; when nothing matched (drift),
+   * the hash of the pinned transport's variant, or of the `"grammar"`
+   * variant when no transport was pinned.
+   */
   currentHash: string;
+  /** Transport whose current prefix matched `recordedHash`; `null` on drift. */
+  matchedTransport: ToolCallTransport | null;
   drift: boolean;
   tokens: {
     recordedStablePrefix: number;
@@ -59,16 +79,27 @@ export async function replaySession(options: {
   context: ReplayContext;
 }): Promise<ReplayReport> {
   const { path, context } = options;
-  const currentStablePrefix = buildStablePrefix({
-    toolDescriptors: context.toolDescriptors,
-    capabilities: context.capabilities,
-    skillCatalog: context.skillCatalog,
-    reasoningSystemToken: context.profile.reasoningSystemToken,
-    ...(context.systemPersona !== undefined
-      ? { systemPersona: context.systemPersona }
-      : {}),
-  });
-  const currentHash = hashPrefix(currentStablePrefix);
+  const prefixFor = (transport: ToolCallTransport): string =>
+    buildStablePrefix({
+      toolDescriptors: context.toolDescriptors,
+      capabilities: context.capabilities,
+      skillCatalog: context.skillCatalog,
+      reasoningSystemToken: context.profile.reasoningSystemToken,
+      toolTransport: transport,
+      ...(context.systemPersona !== undefined
+        ? { systemPersona: context.systemPersona }
+        : {}),
+    });
+  // Candidate order matters only for the no-match `currentHash` fallback:
+  // the first entry (pinned transport, else `"grammar"`) supplies it.
+  const transports: readonly ToolCallTransport[] =
+    context.toolTransport !== undefined
+      ? [context.toolTransport]
+      : ["grammar", "native_tools"];
+  const candidates = transports.map((transport) => ({
+    transport,
+    hash: hashPrefix(prefixFor(transport)),
+  }));
 
   let sessionId = "";
   let workingDir: string | null = null;
@@ -82,12 +113,15 @@ export async function replaySession(options: {
     }
     if (event.type !== "prompt_captured") continue;
     const recorded = event as Extract<TraceEvent, { type: "prompt_captured" }>;
+    const matched =
+      candidates.find((c) => c.hash === recorded.stablePrefixHash) ?? null;
     steps.push({
       turnIndex: recorded.turnIndex,
       stepIndex: recorded.stepIndex,
       recordedHash: recorded.stablePrefixHash,
-      currentHash,
-      drift: recorded.stablePrefixHash !== currentHash,
+      currentHash: matched !== null ? matched.hash : candidates[0]!.hash,
+      matchedTransport: matched !== null ? matched.transport : null,
+      drift: matched === null,
       tokens: {
         recordedStablePrefix: recorded.tokens.stablePrefix,
         recordedTotal: recorded.tokens.total,


### PR DESCRIPTION
## What

Two-part fix for the reasoning-channel leak and the `native_tools` prompt contradiction reported in #285.

**1. Guardrail — stop salvaging raw CoT as a reply (`src/agent/step-executor.ts`)**

`tryParseToolCalls`'s `native_tools` branch handled a reasoning-only completion (empty `content`, no `tool_calls`, non-empty `reasoning_content`) by wrapping the raw reasoning text into a `reply { text }` call — delivering the model's internal chain-of-thought verbatim as deliberate agent speech, exactly as the reporter's transcript shows.

Now:
- a GBNF-shaped `[{tool, args}, ...]` batch embedded in the think channel is still recovered as real tool calls (that path recovers genuine intent and is kept);
- anything else returns `{ ok: false }`, routing the completion through the **existing** one-shot repair path (`parse_retry` event + `buildToolCallRepairPrompt` + `REPAIR_MAX_TOKENS` cap) that already handles every other unparseable body;
- a repair that fails too ends the step as a `GrammarError` — a normal parse error, never a CoT leak.

**2. Root cause — transport-aware stable prefix (`src/prompt/stable-prefix.ts` + threading)**

Under `llm.toolTransport: "native_tools"` the request carries an OpenAI `tools` array with `tool_choice: "auto"`, while the prompt simultaneously ordered *"Emit a JSON ARRAY of tool calls now"* and the persona mandated *"exactly one JSON array"*. The reporter measured 0/6 completions using native `tool_calls` under this dual mandate.

`buildStablePrefix` now takes `toolTransport` (threaded `StepDependencies` → `BuildPromptInput` → `buildStablePrefix`): under `native_tools` the persona's emission mandate and the `### instructions` block switch to native function-calling guidance ("call tools through the function-calling interface; `reply` / plain text for the final answer").

The `### tools` text catalog is deliberately kept in **both** modes: the provider fallback chain can hand a native-shaped request to a grammar-only llama-server link (see the `buildLlmStreamParams` comment about keeping `grammar` populated), and the catalog carries the tier / `tool.view` semantics. The JSON-array **emission mandate** was the contradiction, not the catalog.

## Byte-stability

The grammar-path prefix is byte-identical to `origin/main`'s output — verified by sha256-comparing `buildStablePrefix` from both revisions across variants (plain, `reasoningSystemToken`, Gemma-4 `turnSystemOpen`, `maxParallelToolCalls`, win32, custom `systemPersona`): all identical (`fde2b2b9…`). KV-cache reuse is unaffected for local models; within a session the transport is fixed, so the native prefix is byte-stable across turns too (pinned by a test).

## Known caveat

On a native-to-grammar mid-session fallover the prompt lacks the JSON-array mandate while the grammar link parses GBNF. Acceptable: llama-server's GBNF grammar constrains decoding to the array shape regardless of the prompt mandate.

## Test evidence

- Rewrote the pinned salvage test: `native_tools: unparseable reasoning-only completion routes through parse_retry, never leaks CoT as a reply` — asserts the repair round-trip and that no reply anywhere in the transcript carries the reasoning body.
- New: `native_tools: recovers a GBNF-shaped batch embedded in reasoning_content without a retry` (salvage of real tool calls is preserved).
- New: `native_tools: reasoning-only on both attempts surfaces a parse error, not the CoT` (rejects with `GrammarError`).
- New `buildPrompt tool transport (issue #285)` block: native prefix omits both text-JSON mandates but keeps `### tools`; grammar prefix byte-identical whether the field is omitted or explicit; native prefix byte-stable across turns; explicit `systemPersona` override wins on both transports.
- Without the fix, the two leak tests and the native-prefix test fail (verified by stashing the src changes); with it, all pass.
- `npm run lint` clean. Full suite: 610/611 files, 6436 passed / 1 failed — the one failure (`src/sidecar/send-message-concurrency.test.ts`) fails identically on pristine `origin/main` @ 4caff55 and is unrelated to this diff.

Fixes #285
