### PR TITLE
fix(skills): honor skills.catalogTokenBudget when building the skill catalog

### DIFF
--- a/src/cli/trace-command.test.ts
+++ b/src/cli/trace-command.test.ts
@@ -106,6 +106,7 @@ describe("traceCommand", () => {
   afterEach(() => {
     rmSync(stateDir, { recursive: true, force: true });
     delete process.env.ATOMIC_AGENT_STATE_DIR;
+    delete process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET;
     resetConfigCache();
     vi.restoreAllMocks();
   });
@@ -179,6 +180,61 @@ describe("traceCommand", () => {
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed[0].type).toBe("session_started");
     expect(parsed[parsed.length - 1].type).toBe("turn_finished");
+  });
+
+  it("replay rebuilds the skill catalog with the configured token budget", async () => {
+    // Regression guard for the replay call-site wiring: `handleReplay`
+    // must pass `config.skills.catalogTokenBudget` to
+    // `buildSkillCatalog`. The skill catalog feeds the stable prefix, so
+    // an honored budget changes the recomputed hash; if replay silently
+    // fell back to the legacy 4096-char cap, both runs below would build
+    // the same two-entry catalog and print identical currentHash values.
+    const globalSkillsDir = join(stateDir, "skills");
+    for (const name of ["replay-budget-a", "replay-budget-b"]) {
+      mkdirSync(join(globalSkillsDir, name), { recursive: true });
+      writeFileSync(
+        join(globalSkillsDir, name, "SKILL.md"),
+        [
+          "---",
+          `name: ${name}`,
+          `description: "${"d".repeat(100)}"`,
+          "version: 0.1.0",
+          "---",
+          "",
+          `# ${name}`,
+        ].join("\n"),
+        "utf8",
+      );
+    }
+
+    const currentHashFromReplay = async (): Promise<string> => {
+      (process.stdout.write as ReturnType<typeof vi.fn>).mockClear();
+      const code = await traceCommand(["replay", "s-fixture"]);
+      // The fixture's recorded hash can never match a live prefix, so
+      // replay always reports drift (exit code 2).
+      expect(code).toBe(2);
+      const output = (process.stdout.write as ReturnType<typeof vi.fn>).mock
+        .calls.map((c) => c[0])
+        .join("");
+      const row = output
+        .split("\n")
+        .find((line) => line.includes("DRIFT"));
+      expect(row).toBeDefined();
+      const columns = (row as string).trim().split(/\s+/);
+      const currentHash = columns[columns.length - 1] as string;
+      expect(currentHash).toMatch(/^[0-9a-f]{16}$/);
+      return currentHash;
+    };
+
+    // Default budget: both catalog entries fit under the 4096-char cap.
+    const wideHash = await currentHashFromReplay();
+
+    // 4 tokens x 8 chars/token = 32 chars: the catalog is cut down to
+    // the single always-kept first entry, which must shift the prefix.
+    process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET = "4";
+    resetConfigCache();
+    const narrowHash = await currentHashFromReplay();
+    expect(narrowHash).not.toBe(wideHash);
   });
 
   it("fails gracefully for missing session", async () => {

--- a/src/cli/trace-command.ts
+++ b/src/cli/trace-command.ts
@@ -137,7 +137,9 @@ async function handleReplay(args: string[]): Promise<number> {
     projectDir: joinPath(workingDir, config.paths.projectSkillsDirName),
   });
   await skillRegistry.refresh();
-  const skillCatalog = buildSkillCatalog(skillRegistry.list());
+  const skillCatalog = buildSkillCatalog(skillRegistry.list(), {
+    tokenBudget: config.skills.catalogTokenBudget,
+  });
   const capabilities = await buildCapabilities({
     workingDir,
     browserChannel: config.browser.channel,

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -333,6 +333,15 @@ export interface AtomicAgentConfig {
     launchTimeoutMs: number;
   };
   skills: {
+    /**
+     * Soft budget for the `### skills` catalog in the stable prefix,
+     * in tokens. `buildSkillCatalog` converts it to a char cap at
+     * `SKILL_CATALOG_CHARS_PER_TOKEN` (8) chars/token and drops
+     * catalog entries past the cap so the prompt stays bounded. Env
+     * `ATOMIC_AGENT_SKILLS_CATALOG_BUDGET`, default `512` — which
+     * maps to the historical hardcoded 4096-char cap, so an unset
+     * key keeps pre-existing behavior byte-for-byte.
+     */
     catalogTokenBudget: number;
     /**
      * Names of installed skills that should be hidden from the

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -340,7 +340,9 @@ export interface AtomicAgentConfig {
      * catalog entries past the cap so the prompt stays bounded. Env
      * `ATOMIC_AGENT_SKILLS_CATALOG_BUDGET`, default `512` — which
      * maps to the historical hardcoded 4096-char cap, so an unset
-     * key keeps pre-existing behavior byte-for-byte.
+     * key keeps pre-existing behavior byte-for-byte. Env values are
+     * clamped to `[1, 100_000]` tokens, so a zero or negative value
+     * cannot drive `maxChars` to 0 and silently collapse the catalog.
      */
     catalogTokenBudget: number;
     /**

--- a/src/config/load-config.test.ts
+++ b/src/config/load-config.test.ts
@@ -13,7 +13,11 @@ import { join } from "node:path";
 import { loadConfig } from "./load-config.js";
 import { resetConfigCache } from "./config-cache.js";
 import { getUserConfigPath, writeUserConfigFileSync } from "./config-file.js";
-import { USER_CONFIG_DEFAULTS, USER_CONFIG_VERSION } from "./config-schema.js";
+import {
+  ENV_DEFAULTS,
+  USER_CONFIG_DEFAULTS,
+  USER_CONFIG_VERSION,
+} from "./config-schema.js";
 
 describe("loadConfig", () => {
   let stateDir: string;
@@ -32,6 +36,7 @@ describe("loadConfig", () => {
     delete process.env.ATOMIC_AGENT_LLAMA_MAX_TOKENS;
     delete process.env.ATOMIC_AGENT_BROWSER_CHANNEL;
     delete process.env.ATOMIC_AGENT_GRAMMARS_DIR;
+    delete process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET;
     delete process.env.ATOMIC_LOADCONFIG_TEST_KEY;
     resetConfigCache();
     vi.restoreAllMocks();
@@ -59,6 +64,26 @@ describe("loadConfig", () => {
     process.env.ATOMIC_AGENT_LLAMA_MAX_TOKENS = "999999999";
     resetConfigCache();
     expect(loadConfig().localModels.completionMaxTokens).toBe(131_072);
+  });
+
+  it("clamps ATOMIC_AGENT_SKILLS_CATALOG_BUDGET to a positive range", () => {
+    // The budget multiplies into the skill catalog's char cap; 0 or a
+    // negative value would collapse the catalog, so the loader clamps.
+    expect(loadConfig().skills.catalogTokenBudget).toBe(
+      ENV_DEFAULTS.SKILLS_CATALOG_BUDGET,
+    );
+    process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET = "0";
+    resetConfigCache();
+    expect(loadConfig().skills.catalogTokenBudget).toBe(1);
+    process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET = "-64";
+    resetConfigCache();
+    expect(loadConfig().skills.catalogTokenBudget).toBe(1);
+    process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET = "999999999";
+    resetConfigCache();
+    expect(loadConfig().skills.catalogTokenBudget).toBe(100_000);
+    process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET = "2048";
+    resetConfigCache();
+    expect(loadConfig().skills.catalogTokenBudget).toBe(2048);
   });
 
   it("reads localModels.completionMaxTokens from the user config file", () => {

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -292,9 +292,11 @@ export function loadConfig(): AtomicAgentConfig {
       ),
     },
     skills: {
-      catalogTokenBudget: readInt(
+      catalogTokenBudget: readBoundedPositiveInt(
         "ATOMIC_AGENT_SKILLS_CATALOG_BUDGET",
         ENV_DEFAULTS.SKILLS_CATALOG_BUDGET,
+        1,
+        100_000,
       ),
       disabled: user.skills.disabled,
       taps: user.skills.taps,

--- a/src/runtime/bootstrap.test.ts
+++ b/src/runtime/bootstrap.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -33,6 +40,7 @@ import type {
   TabsInput,
   TypeInput,
 } from "../tools/browser/browser-backend.js";
+import { buildSkillCatalog } from "../skills/index.js";
 import type { LogRecord } from "../tracing/structured-logger.js";
 import type { AgentLoopEvent } from "../agent/agent-loop.js";
 import type { CompletionResult } from "../llm/llama-server-client.js";
@@ -96,6 +104,7 @@ describe("createAgentRuntime", () => {
     rmSync(workingDir, { recursive: true, force: true });
     delete process.env.ATOMIC_AGENT_STATE_DIR;
     delete process.env.ATOMIC_AGENT_GRAMMARS_DIR;
+    delete process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET;
     resetConfigCache();
   });
 
@@ -124,6 +133,70 @@ describe("createAgentRuntime", () => {
       expect(names).toContain("skill.run_script");
     } finally {
       await runtime.shutdown();
+    }
+  });
+
+  it("wires skills.catalogTokenBudget into the runtime skill catalog, at boot and on refresh", async () => {
+    // Regression guard for the call-site wiring itself: the original bug
+    // was `buildSkillCatalog` being called WITHOUT options in bootstrap,
+    // which silently pinned the catalog to the legacy 4096-char cap. The
+    // unit tests on `buildSkillCatalog` cannot catch that, so this test
+    // sets the env knob and asserts the built runtime honors it.
+    const writeProjectSkill = (name: string): void => {
+      const dir = join(workingDir, ".atomic-agent", "skills", name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "SKILL.md"),
+        [
+          "---",
+          `name: ${name}`,
+          `description: "${"d".repeat(120)}"`,
+          "version: 0.1.0",
+          "---",
+          "",
+          `# ${name}`,
+        ].join("\n"),
+        "utf8",
+      );
+    };
+    writeProjectSkill("budget-a");
+    writeProjectSkill("budget-b");
+
+    // 4 tokens x 8 chars/token = 32 chars: far below one rendered entry,
+    // so an honored budget collapses the catalog to the single
+    // always-kept first entry, while the legacy 4096-char default would
+    // keep every skill written above.
+    process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET = "4";
+    resetConfigCache();
+    const runtime = await createAgentRuntime({
+      workingDir,
+      approvalLevel: 5,
+      overrides: { browserBackend: backend, skipLlamaHealthCheck: true },
+    });
+    try {
+      expect(runtime.config.skills.catalogTokenBudget).toBe(4);
+      const records = runtime.skillRegistry.list();
+      expect(records.length).toBeGreaterThan(1);
+      // Sanity: with the default cap this registry yields a bigger catalog,
+      // so the assertion below genuinely discriminates wired vs unwired.
+      expect(buildSkillCatalog(records).length).toBeGreaterThan(1);
+      expect([...runtime.skillCatalog]).toEqual(
+        buildSkillCatalog(records, { tokenBudget: 4 }),
+      );
+      expect(runtime.skillCatalog).toHaveLength(1);
+
+      // Second call site: the refresh path must rebuild with the same
+      // configured budget, not fall back to the legacy cap.
+      writeProjectSkill("budget-c");
+      await runtime.refreshSkills();
+      expect(runtime.skillRegistry.list().length).toBeGreaterThan(
+        records.length,
+      );
+      expect(runtime.skillCatalog).toHaveLength(1);
+    } finally {
+      await runtime.shutdown();
+      delete process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET;
+      resetConfigCache();
     }
   });
 
@@ -939,6 +1012,7 @@ describe("createAgentRuntime steering", () => {
     rmSync(workingDir, { recursive: true, force: true });
     delete process.env.ATOMIC_AGENT_STATE_DIR;
     delete process.env.ATOMIC_AGENT_GRAMMARS_DIR;
+    delete process.env.ATOMIC_AGENT_SKILLS_CATALOG_BUDGET;
     resetConfigCache();
   });
 

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -1245,6 +1245,7 @@ export async function createAgentRuntime(
 
   let skillCatalog: readonly SkillCatalogEntry[] = buildSkillCatalog(
     skillRegistry.list(),
+    { tokenBudget: config.skills.catalogTokenBudget },
   );
 
   let grammar = await buildGrammar(profile, config.paths.grammarsDir, {
@@ -2181,7 +2182,9 @@ export async function createAgentRuntime(
         error: e.error,
       });
     }
-    skillCatalog = buildSkillCatalog(skillRegistry.list());
+    skillCatalog = buildSkillCatalog(skillRegistry.list(), {
+      tokenBudget: config.skills.catalogTokenBudget,
+    });
     options.handlers?.onSkillRegistryChange?.([...skillCatalog]);
   };
 

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -23,6 +23,8 @@ export type { SkillChangeListener } from "./skill-registry.js";
 export {
   buildSkillCatalog,
   formatSkillCatalogLine,
+  SKILL_CATALOG_CHARS_PER_TOKEN,
+  DEFAULT_CATALOG_MAX_CHARS,
 } from "./skill-catalog.js";
 export type { BuildCatalogOptions } from "./skill-catalog.js";
 

--- a/src/skills/skill-catalog.test.ts
+++ b/src/skills/skill-catalog.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { buildSkillCatalog, formatSkillCatalogLine } from "./skill-catalog.js";
+import {
+  buildSkillCatalog,
+  formatSkillCatalogLine,
+  DEFAULT_CATALOG_MAX_CHARS,
+  SKILL_CATALOG_CHARS_PER_TOKEN,
+} from "./skill-catalog.js";
 import type { SkillRecord } from "./skill-loader.js";
 
 function record(
@@ -69,5 +74,50 @@ describe("buildSkillCatalog", () => {
     });
     expect(tight).toHaveLength(1);
     expect(tight[0]?.name).toBe("first");
+  });
+
+  it("honors tokenBudget: a raised budget keeps entries the default cap drops", () => {
+    // Ten records of ~600 rendered chars each (~6000 chars total):
+    // overflowing the default 4096-char cap but fitting in 1024 tokens
+    // (8192 chars).
+    const records = Array.from({ length: 10 }, (_, i) =>
+      record(`skill-${i}`, "d".repeat(580)),
+    );
+    const byDefault = buildSkillCatalog(records);
+    expect(byDefault.length).toBeLessThan(records.length);
+
+    const raised = buildSkillCatalog(records, { tokenBudget: 1024 });
+    expect(raised.length).toBeGreaterThan(byDefault.length);
+    expect(raised.length).toBe(records.length);
+  });
+
+  it("shipped default budget of 512 tokens maps to the historical 4096-char cap", () => {
+    expect(512 * SKILL_CATALOG_CHARS_PER_TOKEN).toBe(DEFAULT_CATALOG_MAX_CHARS);
+
+    // A record set sized to straddle the 4096-char boundary must be cut
+    // at the same entry whether the caller passes nothing (legacy
+    // hardcoded cap) or the shipped config default of 512 tokens.
+    const records = Array.from({ length: 12 }, (_, i) =>
+      record(`skill-${i}`, "d".repeat(390)),
+    );
+    const legacy = buildSkillCatalog(records);
+    const configured = buildSkillCatalog(records, { tokenBudget: 512 });
+    expect(configured).toEqual(legacy);
+    expect(legacy.length).toBeLessThan(records.length);
+  });
+
+  it("explicit maxChars wins over tokenBudget", () => {
+    const records = [record("first", "one"), record("second", "two")];
+    const firstLine = formatSkillCatalogLine({
+      name: "first",
+      description: "one",
+      source: "global",
+    });
+    const catalog = buildSkillCatalog(records, {
+      maxChars: firstLine.length + 1,
+      tokenBudget: 1024,
+    });
+    expect(catalog).toHaveLength(1);
+    expect(catalog[0]?.name).toBe("first");
   });
 });

--- a/src/skills/skill-catalog.test.ts
+++ b/src/skills/skill-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CATALOG_MAX_CHARS,
   SKILL_CATALOG_CHARS_PER_TOKEN,
 } from "./skill-catalog.js";
+import { ENV_DEFAULTS } from "../config/config-schema.js";
 import type { SkillRecord } from "./skill-loader.js";
 
 function record(
@@ -91,17 +92,23 @@ describe("buildSkillCatalog", () => {
     expect(raised.length).toBe(records.length);
   });
 
-  it("shipped default budget of 512 tokens maps to the historical 4096-char cap", () => {
-    expect(512 * SKILL_CATALOG_CHARS_PER_TOKEN).toBe(DEFAULT_CATALOG_MAX_CHARS);
+  it("shipped default budget maps to the historical 4096-char cap", () => {
+    // Import the real shipped default so a drive-by change to either the
+    // default or the chars/token factor trips this guard.
+    expect(
+      ENV_DEFAULTS.SKILLS_CATALOG_BUDGET * SKILL_CATALOG_CHARS_PER_TOKEN,
+    ).toBe(DEFAULT_CATALOG_MAX_CHARS);
 
     // A record set sized to straddle the 4096-char boundary must be cut
     // at the same entry whether the caller passes nothing (legacy
-    // hardcoded cap) or the shipped config default of 512 tokens.
+    // hardcoded cap) or the shipped config default.
     const records = Array.from({ length: 12 }, (_, i) =>
       record(`skill-${i}`, "d".repeat(390)),
     );
     const legacy = buildSkillCatalog(records);
-    const configured = buildSkillCatalog(records, { tokenBudget: 512 });
+    const configured = buildSkillCatalog(records, {
+      tokenBudget: ENV_DEFAULTS.SKILLS_CATALOG_BUDGET,
+    });
     expect(configured).toEqual(legacy);
     expect(legacy.length).toBeLessThan(records.length);
   });

--- a/src/skills/skill-catalog.ts
+++ b/src/skills/skill-catalog.ts
@@ -10,9 +10,35 @@ export function formatSkillCatalogLine(entry: SkillCatalogEntry): string {
   return `- ${tag} ${entry.name}: ${entry.description}`;
 }
 
+/**
+ * Chars of rendered catalog text budgeted per `skills.catalogTokenBudget`
+ * token. Deliberately NOT `estimateTokens`'s ~3.6 chars/token: the knob
+ * shipped with a default of 512 while the catalog was hard-capped at
+ * 4096 chars, so 8 chars/token is the one factor that makes the default
+ * config reproduce the historical cap byte-for-byte. Change it and every
+ * user who never touched the key gets a different `### skills` section
+ * (and a KV-cache invalidation) on upgrade.
+ */
+export const SKILL_CATALOG_CHARS_PER_TOKEN = 8;
+
+/**
+ * Historical hard cap, kept as the fallback when a caller passes neither
+ * `maxChars` nor `tokenBudget`. Equals the default `tokenBudget` of 512
+ * times {@link SKILL_CATALOG_CHARS_PER_TOKEN}.
+ */
+export const DEFAULT_CATALOG_MAX_CHARS = 4096;
+
 export interface BuildCatalogOptions {
   /** Soft cap for total `### skills` chars (join with `\n`). Defaults to 4096. */
   maxChars?: number;
+  /**
+   * `skills.catalogTokenBudget` from config (env
+   * `ATOMIC_AGENT_SKILLS_CATALOG_BUDGET`). Converted to a char cap at
+   * {@link SKILL_CATALOG_CHARS_PER_TOKEN} chars/token; ignored when
+   * `maxChars` is given explicitly. The shipped default of 512 maps to
+   * the historical 4096-char cap.
+   */
+  tokenBudget?: number;
 }
 
 /**
@@ -25,7 +51,11 @@ export function buildSkillCatalog(
   records: ReadonlyArray<SkillRecord>,
   options: BuildCatalogOptions = {},
 ): SkillCatalogEntry[] {
-  const maxChars = options.maxChars ?? 4096;
+  const maxChars =
+    options.maxChars ??
+    (options.tokenBudget !== undefined
+      ? options.tokenBudget * SKILL_CATALOG_CHARS_PER_TOKEN
+      : DEFAULT_CATALOG_MAX_CHARS);
   const entries: SkillCatalogEntry[] = [];
   let used = 0;
   for (const record of records) {


### PR DESCRIPTION
## What

Makes the config key `skills.catalogTokenBudget` (env `ATOMIC_AGENT_SKILLS_CATALOG_BUDGET`, default 512) actually control how much of the `### skills` catalog survives into the stable prefix. Until now the key was parsed (`src/config/load-config.ts`) and typed (`src/config/config-schema.ts`) but never read anywhere: all three `buildSkillCatalog` call sites — the runtime bootstrap's initial build, the `refreshSkills` rebuild, and trace replay — called it without options, so skill descriptions were truncated/dropped at a hardcoded 4096-char cap no matter what the config said.

## How

- `buildSkillCatalog` gains a `tokenBudget` option next to the existing `maxChars` (which still wins when passed explicitly).
- All three call sites now pass `{ tokenBudget: config.skills.catalogTokenBudget }`.
- The key speaks **tokens** while the builder caps **characters**. The conversion is a named constant `SKILL_CATALOG_CHARS_PER_TOKEN = 8`, chosen so that the shipped default maps exactly onto today's behavior: **512 tokens x 8 chars/token = 4096 chars — the historical hardcoded cap**. Users who never set the key get a byte-identical `### skills` section (and keep their KV cache) across the upgrade; the factor is deliberately not `estimateTokens`'s ~3.6 chars/token, and the doc comment on the constant says why.
- Doc comment added on `catalogTokenBudget` in the runtime config schema; constants exported from `src/skills/index.ts`.

No config key rename, no default change, no user-config-file migration.

## Test evidence

New coverage in `src/skills/skill-catalog.test.ts`:
- a raised budget (1024 tokens) keeps entries the default cap drops — **fails on main** (option ignored, entries still cut at 4096 chars);
- the shipped 512-token default cuts a boundary-straddling record set at exactly the same entry as the legacy no-options call — locks in back-compat;
- explicit `maxChars` still wins over `tokenBudget`.

Ran locally:
- `npm run lint` (tsc --noEmit): clean
- `npx vitest run src/skills/ src/config/ src/cli/trace-command.test.ts src/prompt/build-prompt.test.ts`: 31 files, 428 tests, all passed
- `npx vitest run src/runtime/bootstrap.test.ts src/runtime/bootstrap-queued-turn.test.ts`: 27 tests, all passed
- Reverting `skill-catalog.ts` only: the two new behavioral tests fail, confirming they guard the fix.

Reported on Discord: https://discord.com/channels/1515649306781155428/1515650562430079048/1543756491776069892
