### PR TITLE
fix(tui): clicking a slash-palette row runs that row's command

### DIFF
--- a/src/tui/components/slash-palette.tsx
+++ b/src/tui/components/slash-palette.tsx
@@ -5,7 +5,7 @@ import type { SlashCommandDef } from "../commands/slash-commands.js";
 import { theme } from "../theme/theme.js";
 import { MouseListRow } from "../mouse/mouse-list-row.js";
 import { MOUSE_LAYER_MODAL } from "../mouse/mouse-registry.js";
-import { handleEditorSubmit } from "../submit-handler.js";
+import { runSlashCommand } from "../submit-handler.js";
 
 interface SlashPaletteProps {
   query: string;
@@ -65,10 +65,14 @@ export function SlashPalette(props: SlashPaletteProps): ReactElement | null {
             })
           }
           onActivate={(mouse) => {
-            const state = mouse.getState();
-            handleEditorSubmit(
-              state.inputValue,
-              state,
+            // The clicked row IS the choice: run its completion, the same
+            // way the palette-highlight branch in `handleEditorSubmit`
+            // runs the highlighted row on Enter. Submitting the raw
+            // buffer here would run the typed prefix instead, and a
+            // partial like "/mod" errors as an unknown command.
+            runSlashCommand(
+              `/${cmd.name}`,
+              mouse.getState(),
               mouse.dispatch,
               mouse.callbacks,
             );

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -153,6 +153,8 @@ function mountApp(): {
   deleted: string[];
   /** Clicks the Tasks header's `+ new` chip delivered to the host. */
   taskNews: number[];
+  /** Provider ids `/model` asked the orchestrator to ensure a catalog for. */
+  modelEnsures: Array<string | null>;
   unmount: () => void;
 } {
   const bus = makeTuiEventBus();
@@ -160,6 +162,7 @@ function mountApp(): {
   const deleted: string[] = [];
   const copied: string[] = [];
   const taskNews: number[] = [];
+  const modelEnsures: Array<string | null> = [];
   const clipboard = {
     copy: async (text: string) => {
       copied.push(text);
@@ -175,6 +178,8 @@ function mountApp(): {
         ...noopCallbacks(),
         onSessionDeleteConfirmed: (sessionId) => deleted.push(sessionId),
         onTaskNewRequested: () => taskNews.push(taskNews.length),
+        onProvidersInlineModelsEnsureRequested: (providerId) =>
+          modelEnsures.push(providerId),
       }}
       mouse={mouse}
     />
@@ -186,6 +191,7 @@ function mountApp(): {
     stdin,
     deleted,
     taskNews,
+    modelEnsures,
     copied,
     seedSessions: () => {
       bus.emit({
@@ -572,6 +578,35 @@ describe("TuiApp mouse", () => {
     expect(app.frame()).toContain("❯ /sessions");
     // Seeded, not run: no palette over the buffer we just filled.
     expect(app.frame()).not.toContain("/dump");
+    app.unmount();
+  });
+
+  it("runs the clicked slash-palette completion, not the typed prefix", async () => {
+    // "/mod" lists /mode (highlighted) and /model. Clicking /model must
+    // run /model — not submit the raw buffer, which is no command at all
+    // ("unknown command: /mod").
+    const app = mountApp();
+    await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
+    app.stdin.write("/mod");
+    await waitUntil(
+      () => app.frame().includes("open chat model picker"),
+      "the /model row in the palette",
+    );
+    await delay(150);
+    // The /model row is not the highlighted one, so the first click only
+    // selects it; `clickUntil` keeps clicking until the second one
+    // activates and the command reaches the orchestrator callback.
+    await clickUntil(
+      app.mouse,
+      () => {
+        const at = locate(app.frame(), "open chat model picker");
+        return { x: at.x + 2, y: at.y };
+      },
+      () => app.modelEnsures.length > 0,
+      "click the /model completion",
+    );
+    expect(app.modelEnsures).toEqual([null]);
+    expect(app.frame()).not.toContain("unknown command");
     app.unmount();
   });
 


### PR DESCRIPTION
## What

Clicking a slash-command completion in the palette now runs the clicked row's command. Before, the second click on a row (the activate click) submitted the raw editor buffer via `handleEditorSubmit(state.inputValue, …)` — and since `resolveSlashCommand` is exact-match only, a partial buffer like `/mod` errored with `unknown command: /mod` instead of running the `/model` the operator clicked.

## Why

The clicked row IS the choice. The fix mirrors the keyboard palette-highlight branch in `handleEditorSubmit` (which runs the highlighted completion via `runSlashCommand`): `onActivate` in `src/tui/components/slash-palette.tsx` now calls `runSlashCommand(`/${cmd.name}`, …)` with the clicked row's own name. Buffer clearing and palette close keep working — `runSlashCommand` already dispatches both.

## Test evidence

New Ink test in `src/tui/mouse/mouse-app.test.tsx` ("runs the clicked slash-palette completion, not the typed prefix"): types `/mod`, clicks the `/model` row through the synthetic mouse source (first click selects, second activates), asserts the `/model` command reached the orchestrator callback (`onProvidersInlineModelsEnsureRequested(null)`) and no "unknown command" error was rendered.

- Fails on main without the fix (the activation ran the typed buffer, showed the unknown-command error, and closed the palette).
- Passes with the fix.
- `npx vitest run src/tui/mouse/ src/tui/submit-handler.test.ts src/tui/tui-command.mouse.test.ts src/tui/tui-app.test.tsx src/tui/commands/` — 203/203 passed.
- `npx vitest run src/tui/components/ src/tui/composer-ink.test.tsx src/tui/composer-visibility.test.tsx` — 547/547 passed.
- `npm run lint` clean.

Reported on Discord: https://discord.com/channels/1515649306781155428/1515649308161085612/1540446464440926248

No platform-specific code touched; no Windows QA needed beyond normal TUI smoke.
