### PR TITLE
feat(tui): steer an Ollama-shaped External URL into the provider wizard

### DIFF
--- a/src/llm/describe-llama-health-failure.test.ts
+++ b/src/llm/describe-llama-health-failure.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { describeLlamaHealthFailure } from "./describe-llama-health-failure.js";
+import {
+  describeLlamaHealthFailure,
+  looksLikeOllamaUrl,
+} from "./describe-llama-health-failure.js";
 import type { HealthResult } from "./llama-server-health.js";
 
 function result(partial: Partial<HealthResult>): HealthResult {
@@ -21,6 +24,18 @@ describe("describeLlamaHealthFailure", () => {
     );
     expect(line).toContain("OpenAI-compatible");
     expect(line).toContain("openai-compatible, base URL http://127.0.0.1:1234");
+  });
+
+  it("names Ollama outright when the openai-compat server sits on :11434", () => {
+    // The most common shape of this verdict by far: the External URL
+    // pointed at `ollama serve`. "openai-compatible" alone did not tell
+    // an Ollama user the message was about them.
+    const line = describeLlamaHealthFailure(
+      result({ kind: "openai-compat", status: 404, error: "http 404" }),
+      "http://127.0.0.1:11434",
+    );
+    expect(line).toContain("Ollama");
+    expect(line).toContain("base URL http://127.0.0.1:11434");
   });
 
   it("says wait, not reconfigure, while the model is loading", () => {
@@ -50,5 +65,18 @@ describe("describeLlamaHealthFailure", () => {
       "http://10.0.0.7:8080",
     );
     expect(line).toBe("local-llm /health failed at http://10.0.0.7:8080: fetch failed");
+  });
+});
+
+describe("looksLikeOllamaUrl", () => {
+  it("recognizes Ollama's default port on any host", () => {
+    expect(looksLikeOllamaUrl("http://127.0.0.1:11434")).toBe(true);
+    expect(looksLikeOllamaUrl("http://192.168.1.50:11434")).toBe(true);
+  });
+
+  it("rejects other ports and unparseable URLs", () => {
+    expect(looksLikeOllamaUrl("http://127.0.0.1:1234")).toBe(false);
+    expect(looksLikeOllamaUrl("http://127.0.0.1:8080")).toBe(false);
+    expect(looksLikeOllamaUrl("not a url")).toBe(false);
   });
 });

--- a/src/llm/describe-llama-health-failure.test.ts
+++ b/src/llm/describe-llama-health-failure.test.ts
@@ -34,8 +34,24 @@ describe("describeLlamaHealthFailure", () => {
       result({ kind: "openai-compat", status: 404, error: "http 404" }),
       "http://127.0.0.1:11434",
     );
-    expect(line).toContain("Ollama");
-    expect(line).toContain("base URL http://127.0.0.1:11434");
+    expect(line).toContain("answers like Ollama");
+    expect(line).toContain("Ollama (local), base URL http://127.0.0.1:11434");
+  });
+
+  it("routes a remote Ollama through the manual compat row, keeping its host", () => {
+    // The "Ollama (local)" preset row never shows a base-URL screen —
+    // followed by hand it saves the preset's own localhost:11434 — so
+    // for a remote host the instruction must go through the manual
+    // openai-compatible row, which asks for the URL.
+    const line = describeLlamaHealthFailure(
+      result({ kind: "openai-compat", status: 404, error: "http 404" }),
+      "http://192.168.1.50:11434",
+    );
+    expect(line).toContain("answers like Ollama");
+    expect(line).toContain(
+      "openai-compatible, base URL http://192.168.1.50:11434",
+    );
+    expect(line).not.toContain("Ollama (local)");
   });
 
   it("says wait, not reconfigure, while the model is loading", () => {

--- a/src/llm/describe-llama-health-failure.ts
+++ b/src/llm/describe-llama-health-failure.ts
@@ -1,6 +1,21 @@
 import type { HealthResult } from "./llama-server-health.js";
 
 /**
+ * True when `url` points at Ollama's default port. Ollama is the server
+ * operators point the External llama.cpp URL at most often (verified:
+ * `ollama serve` answers 404 on `/health` and OpenAI-shape on
+ * `/v1/models`, so the probe reports `openai-compat`), and the port is
+ * the one signal the probe already has without another round trip.
+ */
+export function looksLikeOllamaUrl(url: string): boolean {
+  try {
+    return new URL(url).port === "11434";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * One operator-actionable line per probe verdict, shared by every
  * surface that saves an external llama.cpp URL (LLM tab External pane,
  * first-run wizard). Stub-verified failure shapes each map to what the
@@ -14,12 +29,17 @@ export function describeLlamaHealthFailure(
   switch (health.kind) {
     case "openai-compat":
       // A real server, wrong route: KoboldCpp / LM Studio / Ollama /
-      // vLLM speak /v1/* but not llama.cpp's native endpoints.
-      return (
-        `${url} answers like an OpenAI-compatible server, not llama.cpp. ` +
-        `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
-        `openai-compatible, base URL ${url}.`
-      );
+      // vLLM speak /v1/* but not llama.cpp's native endpoints. Port
+      // 11434 is named as Ollama outright — that is the server this
+      // verdict almost always is, and "openai-compatible" alone did not
+      // tell an Ollama user the message was about them.
+      return looksLikeOllamaUrl(url)
+        ? `${url} answers like Ollama (its default port), not llama.cpp. ` +
+            `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
+            `Ollama (local), base URL ${url}.`
+        : `${url} answers like an OpenAI-compatible server, not llama.cpp. ` +
+            `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
+            `openai-compatible, base URL ${url}.`;
     case "llama-loading":
       return (
         `${url} is a llama.cpp server still loading its model. ` +

--- a/src/llm/describe-llama-health-failure.ts
+++ b/src/llm/describe-llama-health-failure.ts
@@ -1,4 +1,8 @@
 import type { HealthResult } from "./llama-server-health.js";
+// A leaf predicate with no imports of its own — the one home of the
+// loopback host spellings, shared here so the steer text and the
+// provider wizard agree on what "local" means.
+import { isLocalProviderUrl } from "../tui/providers/is-local-provider-url.js";
 
 /**
  * True when `url` points at Ollama's default port. Ollama is the server
@@ -33,13 +37,26 @@ export function describeLlamaHealthFailure(
       // 11434 is named as Ollama outright — that is the server this
       // verdict almost always is, and "openai-compatible" alone did not
       // tell an Ollama user the message was about them.
-      return looksLikeOllamaUrl(url)
-        ? `${url} answers like Ollama (its default port), not llama.cpp. ` +
-            `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
-            `Ollama (local), base URL ${url}.`
-        : `${url} answers like an OpenAI-compatible server, not llama.cpp. ` +
-            `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
-            `openai-compatible, base URL ${url}.`;
+      if (looksLikeOllamaUrl(url)) {
+        // The "Ollama (local)" preset row shows no base-URL screen — it
+        // saves its own localhost:11434 — so pointing at it is only
+        // followable when that is the server probed here. A remote
+        // Ollama goes through the manual compat row instead, which asks
+        // for the URL and so keeps the host.
+        return isLocalProviderUrl(url)
+          ? `${url} answers like Ollama (its default port), not llama.cpp. ` +
+              `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
+              `Ollama (local), base URL ${url}.`
+          : `${url} answers like Ollama (its default port), not llama.cpp. ` +
+              `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
+              `openai-compatible, base URL ${url} (any API key value ` +
+              `passes — a stock Ollama has no auth).`;
+      }
+      return (
+        `${url} answers like an OpenAI-compatible server, not llama.cpp. ` +
+        `Add it as a cloud provider instead: LLM tab › Cloud › n › ` +
+        `openai-compatible, base URL ${url}.`
+      );
     case "llama-loading":
       return (
         `${url} is a llama.cpp server still loading its model. ` +

--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -220,6 +220,7 @@ export function isPanelModalOpen(state: TuiState): boolean {
       state.localModelsPanel.embeddingOnboardingPrompt !== null ||
       state.providersPanel.chatModelPicker !== null ||
       state.llmPanel.externalUrlDraft !== null ||
+      state.llmPanel.externalCompatSteerUrl !== null ||
       state.llmPanel.stopLocalDaemonsPrompt !== null ||
       // Focused inline model filter is a text-entry surface: Tab/Ctrl+B
       // must not cycle the nav away mid-typing.

--- a/src/tui/components/llm-panel-modals.tsx
+++ b/src/tui/components/llm-panel-modals.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import type { ReactElement, ReactNode } from "react";
+import { looksLikeOllamaUrl } from "../../llm/describe-llama-health-failure.js";
 import { PasteFieldTarget } from "../context-menu/paste-field-target.js";
 import { pasteIntoLlmModalField } from "../llm-panel/llm-panel-paste.js";
 import { theme } from "../theme/theme.js";
@@ -58,6 +59,7 @@ export function hasLlmModal(state: TuiState): boolean {
     state.localModelsPanel.embeddingRemoveConfirmId !== null ||
     state.providersPanel.chatModelPicker !== null ||
     state.llmPanel.externalUrlDraft !== null ||
+    state.llmPanel.externalCompatSteerUrl !== null ||
     state.llmPanel.stopLocalDaemonsPrompt !== null
   );
 }
@@ -221,6 +223,28 @@ export function LlmPanelModals({
         {valid ? null : <Text color={theme.colors.error}>invalid URL</Text>}
         <Text color={theme.colors.muted}>
           Saved after a /health probe succeeds. Enter save · Esc cancel
+        </Text>
+      </PromptBox>
+    );
+  }
+  if (state.llmPanel.externalCompatSteerUrl !== null) {
+    const url = state.llmPanel.externalCompatSteerUrl;
+    const ollama = looksLikeOllamaUrl(url);
+    return (
+      <PromptBox
+        tone="accent"
+        title={
+          ollama
+            ? "Ollama detected — add it as a cloud provider?"
+            : "OpenAI-compatible server — add it as a cloud provider?"
+        }
+      >
+        <Text wrap="truncate-end">
+          {url} answers like {ollama ? "Ollama" : "an OpenAI-compatible server"},
+          which the External llama.cpp route cannot drive.
+        </Text>
+        <Text color={theme.colors.muted}>
+          y open the provider wizard with this URL · n/Esc dismiss
         </Text>
       </PromptBox>
     );

--- a/src/tui/llm-panel/llm-panel-actions.ts
+++ b/src/tui/llm-panel/llm-panel-actions.ts
@@ -10,6 +10,9 @@ export type LlmPanelAction =
   | { type: "llm_stop_local_daemons_prompt_closed" }
   /** Opens (string), edits (string) or closes (`null`) the external URL editor. */
   | { type: "llm_external_url_draft_set"; value: string | null }
+  /** A refused External save probed `openai-compat` at `url`: open the steer prompt. */
+  | { type: "llm_external_compat_steer_opened"; url: string }
+  | { type: "llm_external_compat_steer_closed" }
   /** Focus/unfocus the Cloud pane's inline `filter:` row. */
   | { type: "llm_cloud_filter_focus_set"; focused: boolean }
   /** Replace the inline filter text (cursor snaps to the top of the result set). */
@@ -27,6 +30,8 @@ export function isLlmPanelAction(
     action.type === "llm_stop_local_daemons_prompt_opened" ||
     action.type === "llm_stop_local_daemons_prompt_closed" ||
     action.type === "llm_external_url_draft_set" ||
+    action.type === "llm_external_compat_steer_opened" ||
+    action.type === "llm_external_compat_steer_closed" ||
     action.type === "llm_cloud_filter_focus_set" ||
     action.type === "llm_cloud_filter_set"
   );

--- a/src/tui/llm-panel/llm-panel-external.test.ts
+++ b/src/tui/llm-panel/llm-panel-external.test.ts
@@ -271,15 +271,47 @@ describe("openai-compat steer prompt", () => {
   });
 
   it("swallows panel hotkeys while the prompt is open", () => {
-    // `s` is the daemon start/stop hotkey outside the modal.
-    const onStop = vi.fn();
-    const dispatched = press(
-      "s",
-      emptyKey(),
-      steerState(),
-      callbacks({ onLocalModelsDaemonStopRequested: onStop }),
-    );
-    expect(dispatched).toEqual([]);
-    expect(onStop).not.toHaveBeenCalled();
+    // Baseline first: without the prompt, `]` cycles the pane. The
+    // empty dispatch below then proves the steer swallowed the key —
+    // not that the fixture never wired it.
+    expect(press("]", emptyKey(), externalState())).toEqual([
+      { type: "llm_mode_set", mode: "fallback" },
+    ]);
+    expect(press("]", emptyKey(), steerState())).toEqual([]);
+  });
+
+  it("refuses to open while the URL editor is open", () => {
+    // The steer arrives asynchronously (the refused save's probe); by
+    // then Enter on the External row may have reopened the editor. The
+    // reducer skips the steer rather than stacking two modals — the
+    // editor's next save re-probes and re-offers it.
+    const editing = externalState();
+    editing.llmPanel = {
+      ...editing.llmPanel,
+      externalUrlDraft: "http://127.0.0.1:11434",
+    };
+    const next = reduceLlmPanelAction(editing, {
+      type: "llm_external_compat_steer_opened",
+      url: "http://127.0.0.1:11434",
+    });
+    expect(next?.llmPanel.externalCompatSteerUrl).toBeNull();
+  });
+
+  it("keeps the keyboard on the URL editor if both are somehow open", () => {
+    // Built directly (the reducer refuses to create this state) to pin
+    // the handler's precedence to the render order: the editor is the
+    // modal on screen, so it must be the one receiving keys — `y` types
+    // into the URL instead of invisibly accepting the hidden steer.
+    const state = steerState();
+    state.llmPanel = {
+      ...state.llmPanel,
+      externalUrlDraft: "http://127.0.0.1:808",
+    };
+    expect(press("8", emptyKey(), state)).toEqual([
+      { type: "llm_external_url_draft_set", value: "http://127.0.0.1:8088" },
+    ]);
+    expect(press("y", emptyKey(), state)).toEqual([
+      { type: "llm_external_url_draft_set", value: "http://127.0.0.1:808y" },
+    ]);
   });
 });

--- a/src/tui/llm-panel/llm-panel-external.test.ts
+++ b/src/tui/llm-panel/llm-panel-external.test.ts
@@ -205,3 +205,81 @@ describe("external llama.cpp pane", () => {
     expect(next?.llmPanel.localCursor).toBe(state.llmPanel.localCursor);
   });
 });
+
+describe("openai-compat steer prompt", () => {
+  function steerState(url = "http://127.0.0.1:11434"): TuiState {
+    const state = externalState();
+    state.llmPanel = { ...state.llmPanel, externalCompatSteerUrl: url };
+    return state;
+  }
+
+  it("opens on the openai-compat verdict action and closes again", () => {
+    const opened = reduceLlmPanelAction(externalState(), {
+      type: "llm_external_compat_steer_opened",
+      url: "http://127.0.0.1:11434",
+    });
+    expect(opened?.llmPanel.externalCompatSteerUrl).toBe(
+      "http://127.0.0.1:11434",
+    );
+    const closed = reduceLlmPanelAction(opened!, {
+      type: "llm_external_compat_steer_closed",
+    });
+    expect(closed?.llmPanel.externalCompatSteerUrl).toBeNull();
+  });
+
+  it("y opens the provider wizard on the Ollama preset with the probed URL", () => {
+    const dispatched = press("y", emptyKey(), steerState());
+    expect(dispatched[0]).toEqual({ type: "llm_external_compat_steer_closed" });
+    expect(dispatched[1]).toEqual({ type: "llm_mode_set", mode: "cloud" });
+    expect(dispatched[2]).toMatchObject({
+      type: "providers_wizard_opened",
+      wizard: {
+        mode: "add",
+        kind: "openai-compatible",
+        presetId: "ollama",
+        baseUrlLine: "http://127.0.0.1:11434",
+        phase: "chat_model_line",
+      },
+    });
+  });
+
+  it("prefills the manual compat route for a non-Ollama server", () => {
+    const dispatched = press(
+      "",
+      emptyKey({ return: true }),
+      steerState("http://127.0.0.1:5001"),
+    );
+    expect(dispatched[2]).toMatchObject({
+      type: "providers_wizard_opened",
+      wizard: {
+        kind: "openai-compatible",
+        presetId: null,
+        baseUrlLine: "http://127.0.0.1:5001",
+        phase: "base_url",
+      },
+    });
+  });
+
+  it("n and Esc dismiss without opening the wizard", () => {
+    for (const [input, key] of [
+      ["n", emptyKey()],
+      ["", emptyKey({ escape: true })],
+    ] as const) {
+      const dispatched = press(input, key, steerState());
+      expect(dispatched).toEqual([{ type: "llm_external_compat_steer_closed" }]);
+    }
+  });
+
+  it("swallows panel hotkeys while the prompt is open", () => {
+    // `s` is the daemon start/stop hotkey outside the modal.
+    const onStop = vi.fn();
+    const dispatched = press(
+      "s",
+      emptyKey(),
+      steerState(),
+      callbacks({ onLocalModelsDaemonStopRequested: onStop }),
+    );
+    expect(dispatched).toEqual([]);
+    expect(onStop).not.toHaveBeenCalled();
+  });
+});

--- a/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
@@ -3,6 +3,7 @@ import type { TuiAction } from "../tui-action.js";
 import type { TuiAppCallbacks } from "../tui-app.js";
 import type { TuiState } from "../tui-state.js";
 import { handleProvidersWizardKey } from "../providers/providers-wizard-key-bindings.js";
+import { wizardForOpenAiCompatUrl } from "../providers/openai-compat-steer.js";
 import { normalizeLocalLlmBaseUrl } from "../persist-user-local-models-config.js";
 import { filteredPickerModels } from "../providers/providers-panel-state.js";
 import { stopLocalDaemonsForCloudSelection } from "./llm-panel-primary-actions.js";
@@ -168,6 +169,28 @@ export function handleLlmModalKey(
       return true;
     }
     // Loading (or any other key): the modal owns the keyboard.
+    return true;
+  }
+
+  const steerUrl = state.llmPanel.externalCompatSteerUrl;
+  if (steerUrl !== null) {
+    // `y`/Enter accepts the steer: same two dispatches as the `n`
+    // hotkey (flip to the Cloud pane, open the add wizard), except the
+    // wizard opens on the OpenAI-compatible route with the refused URL
+    // already filled in — Ollama URLs land on the Ollama preset.
+    if (input.toLowerCase() === "y" || key.return) {
+      dispatch({ type: "llm_external_compat_steer_closed" });
+      dispatch({ type: "llm_mode_set", mode: "cloud" });
+      dispatch({
+        type: "providers_wizard_opened",
+        wizard: wizardForOpenAiCompatUrl(steerUrl),
+      });
+      return true;
+    }
+    if (input.toLowerCase() === "n" || key.escape) {
+      dispatch({ type: "llm_external_compat_steer_closed" });
+      return true;
+    }
     return true;
   }
 

--- a/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-modal-key-bindings.ts
@@ -172,28 +172,6 @@ export function handleLlmModalKey(
     return true;
   }
 
-  const steerUrl = state.llmPanel.externalCompatSteerUrl;
-  if (steerUrl !== null) {
-    // `y`/Enter accepts the steer: same two dispatches as the `n`
-    // hotkey (flip to the Cloud pane, open the add wizard), except the
-    // wizard opens on the OpenAI-compatible route with the refused URL
-    // already filled in — Ollama URLs land on the Ollama preset.
-    if (input.toLowerCase() === "y" || key.return) {
-      dispatch({ type: "llm_external_compat_steer_closed" });
-      dispatch({ type: "llm_mode_set", mode: "cloud" });
-      dispatch({
-        type: "providers_wizard_opened",
-        wizard: wizardForOpenAiCompatUrl(steerUrl),
-      });
-      return true;
-    }
-    if (input.toLowerCase() === "n" || key.escape) {
-      dispatch({ type: "llm_external_compat_steer_closed" });
-      return true;
-    }
-    return true;
-  }
-
   const urlDraft = state.llmPanel.externalUrlDraft;
   if (urlDraft !== null) {
     if (key.escape) {
@@ -218,6 +196,33 @@ export function handleLlmModalKey(
     }
     if (input && input.length > 0 && !key.ctrl && !key.meta) {
       dispatch({ type: "llm_external_url_draft_set", value: urlDraft + input });
+      return true;
+    }
+    return true;
+  }
+
+  // Checked after the URL draft, matching `LlmPanelModals` render order:
+  // whichever modal is on screen must be the one holding the keyboard.
+  // (The reducer refuses to open the steer under an open draft, so both
+  // being non-null is unreachable today — this order keeps the handler
+  // correct even if a future path recreates that state.)
+  const steerUrl = state.llmPanel.externalCompatSteerUrl;
+  if (steerUrl !== null) {
+    // `y`/Enter accepts the steer: same two dispatches as the `n`
+    // hotkey (flip to the Cloud pane, open the add wizard), except the
+    // wizard opens on the OpenAI-compatible route with the refused URL
+    // already filled in — Ollama URLs land on the Ollama preset.
+    if (input.toLowerCase() === "y" || key.return) {
+      dispatch({ type: "llm_external_compat_steer_closed" });
+      dispatch({ type: "llm_mode_set", mode: "cloud" });
+      dispatch({
+        type: "providers_wizard_opened",
+        wizard: wizardForOpenAiCompatUrl(steerUrl),
+      });
+      return true;
+    }
+    if (input.toLowerCase() === "n" || key.escape) {
+      dispatch({ type: "llm_external_compat_steer_closed" });
       return true;
     }
     return true;

--- a/src/tui/llm-panel/llm-panel-reducer.ts
+++ b/src/tui/llm-panel/llm-panel-reducer.ts
@@ -72,6 +72,13 @@ export function reduceLlmPanelAction(
         llmPanel: { ...panel, externalUrlDraft: action.value },
       };
     case "llm_external_compat_steer_opened":
+      // The steer arrives asynchronously — the refused save's /health
+      // probe can take seconds — and the operator may have reopened the
+      // URL editor meanwhile. Opening underneath it would split the
+      // modals (the draft renders, a hidden steer would contest the
+      // keys), so the steer yields: the editor's next save re-probes
+      // and re-offers it.
+      if (panel.externalUrlDraft !== null) return state;
       return {
         ...state,
         llmPanel: { ...panel, externalCompatSteerUrl: action.url },

--- a/src/tui/llm-panel/llm-panel-reducer.ts
+++ b/src/tui/llm-panel/llm-panel-reducer.ts
@@ -71,6 +71,16 @@ export function reduceLlmPanelAction(
         ...state,
         llmPanel: { ...panel, externalUrlDraft: action.value },
       };
+    case "llm_external_compat_steer_opened":
+      return {
+        ...state,
+        llmPanel: { ...panel, externalCompatSteerUrl: action.url },
+      };
+    case "llm_external_compat_steer_closed":
+      return {
+        ...state,
+        llmPanel: { ...panel, externalCompatSteerUrl: null },
+      };
     case "llm_cloud_filter_focus_set": {
       if (!action.focused) {
         return {

--- a/src/tui/llm-panel/llm-panel-state.ts
+++ b/src/tui/llm-panel/llm-panel-state.ts
@@ -36,6 +36,13 @@ export interface LlmPanelState {
    */
   externalUrlDraft: string | null;
   /**
+   * URL of a refused External save whose probe answered `openai-compat`
+   * (Ollama, LM Studio, vLLM…). Non-null opens the steer prompt: `y`
+   * deep-links into the provider wizard prefilled with this URL instead
+   * of leaving the operator at a dead-end verdict line.
+   */
+  externalCompatSteerUrl: string | null;
+  /**
    * Typed filter of the Cloud pane's inline model list. Persists when
    * the filter row loses focus (Esc keeps the text, like the modal did).
    */
@@ -58,6 +65,7 @@ export function createInitialLlmPanelState(): LlmPanelState {
     syncModeToActiveRoute: false,
     stopLocalDaemonsPrompt: null,
     externalUrlDraft: null,
+    externalCompatSteerUrl: null,
     cloudModelFilter: "",
     cloudModelFilterFocused: false,
   };

--- a/src/tui/providers/openai-compat-steer.test.ts
+++ b/src/tui/providers/openai-compat-steer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { wizardForOpenAiCompatUrl } from "./openai-compat-steer.js";
+
+describe("wizardForOpenAiCompatUrl", () => {
+  it("lands an Ollama URL on the Ollama preset, skipping the key screen", () => {
+    // `ollama serve` answers 404 on /health and OpenAI-shape on
+    // /v1/models, so the External probe reports `openai-compat`; the
+    // steer must open the same state Enter on the "Ollama (local)"
+    // pick_kind row builds — no key screen, straight to the model list.
+    const wizard = wizardForOpenAiCompatUrl("http://127.0.0.1:11434");
+    expect(wizard).toMatchObject({
+      mode: "add",
+      kind: "openai-compatible",
+      presetId: "ollama",
+      baseUrlLine: "http://127.0.0.1:11434",
+      phase: "chat_model_line",
+    });
+  });
+
+  it("keeps a remote Ollama host instead of the preset's localhost", () => {
+    const wizard = wizardForOpenAiCompatUrl("http://192.168.1.50:11434");
+    expect(wizard.presetId).toBe("ollama");
+    expect(wizard.baseUrlLine).toBe("http://192.168.1.50:11434");
+  });
+
+  it("opens the manual compat row prefilled for a non-Ollama server", () => {
+    // LM Studio / vLLM / KoboldCpp: same verdict, no preset identity to
+    // assume, so the add flow starts on the URL screen with the probed
+    // URL already typed — Enter confirms it and walks URL → key → model.
+    const wizard = wizardForOpenAiCompatUrl("http://127.0.0.1:5001");
+    expect(wizard).toMatchObject({
+      mode: "add",
+      kind: "openai-compatible",
+      presetId: null,
+      baseUrlLine: "http://127.0.0.1:5001",
+      phase: "base_url",
+    });
+  });
+});

--- a/src/tui/providers/openai-compat-steer.ts
+++ b/src/tui/providers/openai-compat-steer.ts
@@ -1,0 +1,41 @@
+import { looksLikeOllamaUrl } from "../../llm/describe-llama-health-failure.js";
+import { presetNeedsKeyScreen } from "./providers-wizard-phases.js";
+import {
+  createProvidersWizardState,
+  type ProvidersWizardState,
+} from "./providers-wizard-state.js";
+
+/**
+ * The provider wizard, opened where a refused External llama.cpp save
+ * points: at the OpenAI-compatible route for the URL that answered the
+ * probe. Users keep aiming the External pane at Ollama (:11434); since
+ * the `openai-compat` verdict became visible the refusal at least said
+ * why, but acting on it still meant retyping the URL into a wizard four
+ * screens away. This builds the exact state picking the row by hand
+ * would have built — Ollama's URL lands on its preset (entry id, env
+ * var, no key screen: `ollama serve` has no key), any other compat
+ * server on the manual row — with the probed URL prefilled.
+ */
+export function wizardForOpenAiCompatUrl(url: string): ProvidersWizardState {
+  if (looksLikeOllamaUrl(url)) {
+    // Mirrors Enter on the "Ollama (local)" pick_kind row, except the
+    // base URL is the one the operator actually probed — a remote
+    // Ollama on 192.168.x.x:11434 keeps its host.
+    return {
+      ...createProvidersWizardState("add"),
+      kind: "openai-compatible",
+      presetId: "ollama",
+      baseUrlLine: url,
+      phase: presetNeedsKeyScreen("ollama") ? "api_key" : "chat_model_line",
+    };
+  }
+  // Manual compat row with the URL already filled in: Enter confirms it
+  // and walks the normal URL → key → model flow (a loopback URL makes
+  // the key optional, same as typing it by hand).
+  return {
+    ...createProvidersWizardState("add"),
+    kind: "openai-compatible",
+    baseUrlLine: url,
+    phase: "base_url",
+  };
+}

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -849,6 +849,14 @@ function persistLlamaUrl(
       });
       if (!health.reachable) {
         report(describeLlamaHealthFailure(health, nextUrl));
+        // An openai-compat verdict has a real path forward — the same
+        // server saved as a cloud provider — so beyond naming it, open
+        // the steer prompt: `y` there deep-links into the provider
+        // wizard prefilled with this URL (Ollama URLs land on the
+        // Ollama preset) instead of leaving a dead-end refusal.
+        if (health.kind === "openai-compat") {
+          bus.emit({ type: "llm_external_compat_steer_opened", url: nextUrl });
+        }
         return;
       }
       persistUserLocalLlmUrl(nextUrl);


### PR DESCRIPTION
## What / why

Users keep pointing the **External llama.cpp** URL at Ollama (`:11434`). The `/health` probe classifies it `openai-compat` and refuses the save — since 26102be the verdict is at least visible on the panel's status line, but there was no path forward: acting on it meant retyping the same URL into the provider wizard four screens away.

Re-verified against a live `ollama serve` before coding: `/health` answers **404** and `/v1/models` answers the OpenAI list shape, so `checkLlamaServer`'s verdict for Ollama is exactly `openai-compat` (status 404, via the secondary `/v1/models` probe).

### The steer

- On an `openai-compat` refusal the External pane now opens a prompt naming the server ("Ollama detected — add it as a cloud provider?"). `y`/Enter deep-links into the provider wizard on the OpenAI-compatible route with the probed URL prefilled; `n`/Esc dismisses. The verdict line still lands on the feed + status line as before.
- A URL on Ollama's default port lands on the **"Ollama (local)" preset** — the exact state Enter on that `pick_kind` row builds (entry id, `OLLAMA_API_KEY` env var, no key screen since `ollama serve` is keyless, straight to the live `/v1/models` pick list) — but keeping the operator's own host, so a remote Ollama on `192.168.x.x:11434` survives.
- Any other compat server (LM Studio, vLLM, KoboldCpp) lands on the manual `openai-compatible` row's URL screen with the URL prefilled; Enter confirms and walks the normal URL → key → model flow (loopback keeps the key optional).
- `describeLlamaHealthFailure` now names Ollama outright for `:11434` URLs and points at the preset row, so the onboarding custom-URL branch (which shares the describer) stops calling an Ollama user's server merely "OpenAI-compatible".

Wizard Esc behavior comes for free: stepping back from the steered screen lands on the provider list with the cursor on the row the steer chose.

## Test evidence

New/extended vitest coverage, all of which **fails without the change** (verified by stashing the implementation: 7 failures, 0 with it):

- `src/tui/providers/openai-compat-steer.test.ts` — verdict-to-steer mapping: Ollama URL → `presetId: "ollama"`, `phase: "chat_model_line"`, host kept; non-Ollama → manual row at `base_url`, URL prefilled.
- `src/llm/describe-llama-health-failure.test.ts` — the Ollama-named line for `:11434`, `looksLikeOllamaUrl` accept/reject cases; the existing non-Ollama steer line still asserted.
- `src/tui/llm-panel/llm-panel-external.test.ts` — reducer open/close round-trip; `y` dispatches close + Cloud-pane flip + `providers_wizard_opened` with the prefilled wizard; `n`/Esc dismiss; panel hotkeys swallowed while the prompt owns the keyboard.

`npm run lint` clean; targeted suites green: `src/tui/llm-panel`, `src/tui/providers`, `llm-panel.test.tsx`, `providers-wizard.test.tsx`, `llm-mode-rows-cloud.test.tsx`, `llama-server-health.test.ts`, `slash-command-handler.test.ts`, `app-key-bindings.test.ts` — 33 files, 486 tests, 0 failures.

Reported on Discord: https://discord.com/channels/1515649306781155428/1515650562430079048/1542269245050589287
