### PR TITLE
fix(llm): stop cutting the live reasoning stream at a brace in the chain-of-thought

### DIFF
--- a/src/llm/grammar/stream-parser.test.ts
+++ b/src/llm/grammar/stream-parser.test.ts
@@ -186,6 +186,71 @@ describe("createStreamParser", () => {
     expect(concatReply(events)).toBe("Привет!");
   });
 
+  it("keeps streaming reasoning past a brace inside the chain-of-thought", () => {
+    // The brace lands in the buffer while the close tag has not arrived
+    // yet — the old parser treated it as the tool-call start, closed the
+    // reasoning stream and froze the live display for the rest of the step.
+    const events = feedAll([
+      'the config is {"a": 1} so I should',
+      " change it</think>",
+      '{"tool":"reply","args":{"text":"ok"}}',
+    ], { preOpenedThink: true });
+    expect(concatReasoning(events)).toBe(
+      'the config is {"a": 1} so I should change it',
+    );
+    expect(events.filter((e) => e.kind === "reasoning_close")).toHaveLength(1);
+    expect(concatReply(events)).toBe("ok");
+  });
+
+  it("keeps streaming reasoning past an array bracket inside the chain-of-thought", () => {
+    const events = feedAll([
+      "<think>steps [1, 2] look",
+      " fine</think>",
+      '{"tool":"reply","args":{"text":"ok"}}',
+    ]);
+    expect(concatReasoning(events)).toBe("steps [1, 2] look fine");
+    expect(concatReply(events)).toBe("ok");
+  });
+
+  it("still hands off to a close-sentinel-less tool call after a decoy brace", () => {
+    const events = feedAll([
+      '<think>set {"a": 1} hmm ',
+      '{"tool":"reply","args":{"text":"hi"}}',
+    ]);
+    expect(concatReasoning(events)).toBe('set {"a": 1} hmm ');
+    expect(events.filter((e) => e.kind === "reasoning_close")).toHaveLength(1);
+    expect(concatReply(events)).toBe("hi");
+  });
+
+  it("holds back a possible tool-call start split by the chunk boundary", () => {
+    // `{"to` alone could still become `{"tool": …` — it must be neither
+    // emitted as reasoning nor treated as a payload until resolved.
+    const events = feedAll([
+      "<think>go ",
+      '{"to',
+      'ol":"os.exec","args":{"command":"ls"}}',
+    ]);
+    expect(concatReasoning(events)).toBe("go ");
+    expect(events.filter((e) => e.kind === "reasoning_close")).toHaveLength(1);
+    expect(events.filter((e) => e.kind === "reply_text_delta")).toHaveLength(0);
+  });
+
+  it("gives up on a brace followed by a long whitespace run and streams it as reasoning", () => {
+    const events = feedAll([
+      "<think>a {" + " ".repeat(80),
+      "b</think>",
+      '{"tool":"reply","args":{"text":"y"}}',
+    ]);
+    expect(concatReasoning(events)).toBe("a {" + " ".repeat(80) + "b");
+    expect(concatReply(events)).toBe("y");
+  });
+
+  it("treats an unresolved trailing brace at stream end as reasoning", () => {
+    const events = feedAll(["<think>ends with {\"a\": 1}"]);
+    expect(concatReasoning(events)).toBe('ends with {"a": 1}');
+    expect(events.at(-1)).toEqual({ kind: "reasoning_close" });
+  });
+
   it("splits reply.args.text across chunks preserving backslash escapes", () => {
     const raw =
       '{"tool":"reply","args":{"text":"a\\\\b\\nc"}}';

--- a/src/llm/grammar/stream-parser.ts
+++ b/src/llm/grammar/stream-parser.ts
@@ -113,19 +113,30 @@ export function createStreamParser(options: StreamParserOptions = {}): StreamPar
           keepGoing = true;
           continue;
         }
-        const jsonIdx = findJsonToolStart(buffer);
-        if (jsonIdx !== -1) {
-          const before = buffer.slice(0, jsonIdx);
+        // A close-sentinel-less handoff to the tool call is only assumed
+        // when the buffer really starts a `{"tool": "` payload. A bare
+        // `{` / `[` inside genuine chain-of-thought (JSON snippets, array
+        // notation — routine when the model reasons about code) must NOT
+        // end the reasoning stream: doing so froze the live reasoning
+        // display for the rest of the step.
+        const start = findToolCallStart(buffer);
+        if (start !== null && start.resolved) {
+          const before = buffer.slice(0, start.index);
           if (before.length > 0) {
             out.push({ kind: "reasoning_delta", text: before });
           }
           out.push({ kind: "reasoning_close" });
-          buffer = buffer.slice(jsonIdx);
+          buffer = buffer.slice(start.index);
           state = "json_tool";
           keepGoing = true;
           continue;
         }
-        const cutAt = findSafeReasoningEmitIndex(buffer, reasoningCloseTag, closeHoldbackLen);
+        // Hold back an unresolved candidate (`{"to…` split by the chunk
+        // boundary) alongside the possible close-tag prefix; everything
+        // before either stays live reasoning.
+        const holdFrom = start === null ? buffer.length : start.index;
+        const safeIdx = findSafeReasoningEmitIndex(buffer, reasoningCloseTag, closeHoldbackLen);
+        const cutAt = Math.min(holdFrom, safeIdx);
         const emit = buffer.slice(0, cutAt);
         if (emit.length > 0) {
           out.push({ kind: "reasoning_delta", text: emit });
@@ -189,14 +200,14 @@ export function createStreamParser(options: StreamParserOptions = {}): StreamPar
     end(): StreamParseEvent[] {
       const out = advance();
       if (state === "inside_think") {
-        const jsonIdx = findJsonToolStart(buffer);
-        if (jsonIdx !== -1) {
-          const before = buffer.slice(0, jsonIdx);
+        const start = findToolCallStart(buffer);
+        if (start !== null && start.resolved) {
+          const before = buffer.slice(0, start.index);
           if (before.length > 0) {
             out.push({ kind: "reasoning_delta", text: before });
           }
           out.push({ kind: "reasoning_close" });
-          buffer = buffer.slice(jsonIdx);
+          buffer = buffer.slice(start.index);
           state = "json_tool";
           out.push(...advance());
         } else {
@@ -330,12 +341,91 @@ function escapeRegex(text: string): string {
 }
 
 /** Index of the first `[` or `{` that may start a grammar tool-call payload. */
-function findJsonToolStart(buffer: string): number {
-  const bracket = buffer.indexOf("[");
-  const brace = buffer.indexOf("{");
+function findJsonToolStart(buffer: string, from = 0): number {
+  const bracket = buffer.indexOf("[", from);
+  const brace = buffer.indexOf("{", from);
   if (bracket === -1) return brace;
   if (brace === -1) return bracket;
   return Math.min(bracket, brace);
+}
+
+/**
+ * Longest prefix a candidate may reach while still undecided:
+ * `[` + whitespace + `{` + whitespace + `"tool"` + whitespace + `:` +
+ * whitespace + `"`. Grammar output has next to no whitespace, so a
+ * candidate still unresolved past this budget is chain-of-thought, not
+ * a payload — the cap keeps the mid-think holdback (and thus the
+ * buffered memory) bounded.
+ */
+const TOOL_START_PROBE_CAP = 64;
+
+type ToolStartClass = "start" | "pending" | "no";
+
+interface ToolCallStartMatch {
+  index: number;
+  /** True when the `{"tool": "` shape is fully present at `index`. */
+  resolved: boolean;
+}
+
+/**
+ * Decide whether the text at `buffer[index]` (a `[` or `{`) begins a
+ * grammar tool-call payload — optional array opener, then `{`, then the
+ * `"tool"` key up to its opening value quote. "pending" means the
+ * buffer ended while still matching that shape, so the caller must
+ * wait for more stream before emitting the candidate as reasoning.
+ */
+function classifyToolCallStart(buffer: string, index: number): ToolStartClass {
+  let i = index;
+  const pending = (): ToolStartClass =>
+    i - index > TOOL_START_PROBE_CAP ? "no" : "pending";
+  if (buffer[i] === "[") {
+    i += 1;
+    i = skipJsonWhitespace(buffer, i);
+    if (i >= buffer.length) return pending();
+  }
+  if (buffer[i] !== "{") return "no";
+  i += 1;
+  i = skipJsonWhitespace(buffer, i);
+  const key = '"tool"';
+  for (let k = 0; k < key.length; k += 1, i += 1) {
+    if (i >= buffer.length) return pending();
+    if (buffer[i] !== key[k]) return "no";
+  }
+  i = skipJsonWhitespace(buffer, i);
+  if (i >= buffer.length) return pending();
+  if (buffer[i] !== ":") return "no";
+  i += 1;
+  i = skipJsonWhitespace(buffer, i);
+  if (i >= buffer.length) return pending();
+  return buffer[i] === '"' ? "start" : "no";
+}
+
+function skipJsonWhitespace(buffer: string, from: number): number {
+  let i = from;
+  while (i < buffer.length) {
+    const c = buffer[i]!;
+    if (c !== " " && c !== "\n" && c !== "\r" && c !== "\t") break;
+    i += 1;
+  }
+  return i;
+}
+
+/**
+ * First position in `buffer` that starts (resolved) or may still start
+ * (pending, cut off by the chunk boundary) a tool-call payload.
+ * Braces/brackets that provably do not are skipped — they are ordinary
+ * reasoning text.
+ */
+function findToolCallStart(buffer: string): ToolCallStartMatch | null {
+  let from = 0;
+  while (true) {
+    const idx = findJsonToolStart(buffer, from);
+    if (idx === -1) return null;
+    const cls = classifyToolCallStart(buffer, idx);
+    if (cls === "start") return { index: idx, resolved: true };
+    if (cls === "pending") return { index: idx, resolved: false };
+    from = idx + 1;
+  }
 }
 
 function holdPossibleTagStart(buffer: string, tag: string): string {


### PR DESCRIPTION
## What

The TUI stops showing reasoning tokens partway through long turns. The cutoff is in `src/llm/grammar/stream-parser.ts`, not in the TUI state: while `inside_think`, the first bare `{` or `[` in the buffer was treated as the start of the tool-call payload — the parser emitted `reasoning_close`, switched to `json_tool`, and every later reasoning delta of that step was silenced. Chain-of-thought that mentions JSON, code, or array notation (`{"a": 1}`, `[1, 2]`) hits this almost immediately, so on long thinking steps the live reasoning display freezes mid-stream and only recovers when the step's final canonical `reasoning` event replaces the block wholesale.

## Why this way

The early exit exists for a real case: with a pre-opened think block whose close sentinel the model never emits, the payload follows the reasoning directly and the parser must still catch it (pinned by the existing "streams array-only reply when think is pre-opened but close sentinel is missing" test). So the exit is kept but made precise: a brace ends the reasoning stream only when it actually begins a `{"tool": "` payload (optional array opener allowed). A candidate cut off by a chunk boundary (`{"to`) is held back until it resolves; a 64-char probe cap bounds the holdback (and the buffered memory — no new unbounded growth, mindful of the #121/#255 OOM history). Anything that provably is not a payload streams on as reasoning, and stream end treats an unresolved candidate as reasoning too.

Triage suspected the `pushRing`/`ringBufferSize` eviction of `state.reasoning` during the live turn; that mechanism does not hold up: reasoning entries are one per step (deltas merge by `stepIndex` in `appendReasoningDelta`/`upsertReasoning`), the TUI ring cap is 500, and `agent.maxSteps` defaults to 25 — eviction cannot fire mid-turn under any realistic configuration. The streaming-tail collapse (reasoning folds to a one-line summary once the final reply starts streaming) is deliberate UX and untouched.

## Test evidence

- 6 new tests in `src/llm/grammar/stream-parser.test.ts`; 5 fail without the fix (verified by stashing the source change), the 6th pins the new chunk-boundary holdback.
- `npx vitest run src/llm/ src/agent/ src/tui/agent-event-reducer.test.ts` — 69 files, 807 tests, all passing.
- `npm run lint` (tsc --noEmit) clean.

Reported on Discord: https://discord.com/channels/1515649306781155428/1515650562430079048/1540106636780376214

No platform-specific code touched; no Windows QA needed.
