### PR TITLE
feat(local-llm): CPU llama.cpp backend fallback for Windows boxes whose GPU build cannot serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Managed mode downloads the backend, pulls GGUF models, selects the active model,
 
 The managed chat daemon stops when the last session exits, freeing the RAM and VRAM the model was holding; set `localModels.managed.stopOnExit: false` in `config.json` to keep the model warm between sessions. Daemons started standalone with `models start` are never touched.
 
+On Windows the backend zip is picked per machine (CUDA when a capable NVIDIA driver is present, Vulkan otherwise). If the GPU build cannot serve a model on your hardware — typical for iGPU-only boxes — the start falls back to the CPU build automatically and records `localModels.managed.backendVariant: "cpu"` in `config.json`; set it to `"auto"`, `"vulkan"`, `"cuda-12.4"` or `"cuda-13.3"` to pick a build yourself (e.g. after a driver update).
+
 Cloud models are searchable from the same command — by id, vendor, or capability, across every configured cloud provider:
 
 ```bash

--- a/src/cli/models-handlers.test.ts
+++ b/src/cli/models-handlers.test.ts
@@ -1,0 +1,167 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../local-llm/index.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../local-llm/index.js")>(
+      "../local-llm/index.js",
+    );
+  return {
+    ...actual,
+    maybeAutoUpdateBackend: vi.fn(),
+    resolveManagedDevice: vi.fn(),
+    startChatAndEmbeddingDaemons: vi.fn(),
+    fallBackToCpuBackend: vi.fn(),
+  };
+});
+
+import { getUserConfigPath, writeUserConfigFileSync } from "../config/config-file.js";
+import { USER_CONFIG_DEFAULTS } from "../config/config-schema.js";
+import { getConfig, resetConfigCache } from "../config/index.js";
+import * as localLlm from "../local-llm/index.js";
+import { resolveBackendDir } from "../local-llm/index.js";
+import { writeBackendVersion } from "../local-llm/backend-version.js";
+import { DaemonHealthError } from "../local-llm/daemon-lifecycle.js";
+import {
+  WINDOWS_BACKEND_ASSETS,
+  setConfiguredBackendVariant,
+} from "../local-llm/windows-backend-variant.js";
+import { runLocalModelsStart } from "./models-handlers.js";
+
+const healthError = () =>
+  new DaemonHealthError(
+    "llama-server did not become healthy within 30000ms. Log tail:\n(no log)",
+  );
+
+/**
+ * Integration tests for the CPU-backend fallback retry block inside
+ * `runLocalModelsStart` — the CLI twin of the orchestrator wiring
+ * covered in `local-models-orchestrator-cpu-fallback.test.ts`. The pure
+ * pieces have their own tests; these prove the handler actually
+ * consults them, retries on the CPU device, and persists the variant.
+ */
+describe("runLocalModelsStart CPU-backend fallback", () => {
+  let stateDir: string;
+  let stderrChunks: string[];
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "atomic-models-cpufb-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    // The fallback is Windows-only; the real eligibility gate must see
+    // win32 or these tests would silently assert nothing.
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.spyOn(process, "arch", "get").mockReturnValue("x64");
+    resetConfigCache();
+    setConfiguredBackendVariant("auto");
+    stderrChunks = [];
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+    vi.mocked(localLlm.maybeAutoUpdateBackend)
+      .mockReset()
+      .mockResolvedValue({ action: "current", tag: "turboquant-win" });
+    vi.mocked(localLlm.resolveManagedDevice).mockReset().mockResolvedValue("Vulkan0");
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockReset();
+    vi.mocked(localLlm.fallBackToCpuBackend)
+      .mockReset()
+      .mockResolvedValue({ tag: "turboquant-win" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setConfiguredBackendVariant("auto");
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("retries once on the CPU device and persists the variant", async () => {
+    const dataDir = prepareManagedWindowsInstall();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons)
+      .mockRejectedValueOnce(healthError())
+      .mockResolvedValueOnce({ chat: { pid: 777 }, embedding: { skipped: true } });
+
+    await expect(runLocalModelsStart()).resolves.toBe(0);
+
+    // The download must carry a deadline and progress — the exact
+    // stalled-open-connection hazard the auto-update path guards.
+    expect(localLlm.fallBackToCpuBackend).toHaveBeenCalledTimes(1);
+    const [calledDataDir, dlOpts] = vi.mocked(localLlm.fallBackToCpuBackend).mock
+      .calls[0]! as [string, { signal?: AbortSignal; onProgress?: unknown }];
+    expect(calledDataDir).toBe(dataDir);
+    expect(dlOpts.signal).toBeInstanceOf(AbortSignal);
+    expect(dlOpts.onProgress).toBeTypeOf("function");
+
+    // The GPU device picked against the old binary must not leak into
+    // the retry — the CPU build would reject `--device Vulkan0`.
+    const starts = vi.mocked(localLlm.startChatAndEmbeddingDaemons).mock.calls;
+    expect(starts).toHaveLength(2);
+    expect(starts[0]![0].chat.device).toBe("Vulkan0");
+    expect(starts[1]![0].chat.device).toBe("cpu");
+
+    // Loop-guard against auto-update reinstalling the broken GPU build.
+    expect(getConfig().localModels.managed.backendVariant).toBe("cpu");
+    const stderr = stderrChunks.join("");
+    expect(stderr).toContain("falling back to the CPU build");
+    expect(stderr).toContain('recorded backendVariant "cpu"');
+  });
+
+  it("does not fall back on a pre-spawn failure", async () => {
+    prepareManagedWindowsInstall();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockRejectedValue(
+      new Error("model qwen not downloaded"),
+    );
+
+    await expect(runLocalModelsStart()).resolves.toBe(1);
+
+    expect(localLlm.fallBackToCpuBackend).not.toHaveBeenCalled();
+    expect(localLlm.startChatAndEmbeddingDaemons).toHaveBeenCalledTimes(1);
+    expect(getConfig().localModels.managed.backendVariant).toBe("auto");
+    expect(stderrChunks.join("")).toContain("model qwen not downloaded");
+  });
+
+  it("surfaces a failed CPU download and exits non-zero", async () => {
+    prepareManagedWindowsInstall();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockRejectedValue(healthError());
+    vi.mocked(localLlm.fallBackToCpuBackend).mockRejectedValue(new Error("HTTP 503"));
+
+    await expect(runLocalModelsStart()).resolves.toBe(1);
+
+    expect(localLlm.startChatAndEmbeddingDaemons).toHaveBeenCalledTimes(1);
+    expect(stderrChunks.join("")).toContain("HTTP 503");
+  });
+
+  /**
+   * Managed mode over a stub Windows GPU install, so the real
+   * `shouldFallBackToCpuBackend` sees an eligible machine: win32,
+   * variant `auto`, a GPU asset recorded in backend-version.json.
+   */
+  function prepareManagedWindowsInstall(): string {
+    writeUserConfigFileSync(getUserConfigPath(stateDir), {
+      ...USER_CONFIG_DEFAULTS,
+      localModels: {
+        ...USER_CONFIG_DEFAULTS.localModels,
+        mode: "managed",
+        managed: {
+          ...USER_CONFIG_DEFAULTS.localModels.managed,
+          modelId: "qwen-3.5-4b",
+        },
+      },
+    });
+    resetConfigCache();
+    const dataDir = getConfig().paths.localModelsDataDir;
+    mkdirSync(resolveBackendDir(dataDir), { recursive: true });
+    writeBackendVersion(dataDir, {
+      tag: "turboquant-win",
+      downloadedAt: "2026-06-02T00:00:00.000Z",
+      asset: WINDOWS_BACKEND_ASSETS.vulkan,
+      releasedAt: "2026-06-01T00:00:00Z",
+    });
+    return dataDir;
+  }
+});

--- a/src/cli/models-handlers.ts
+++ b/src/cli/models-handlers.ts
@@ -9,6 +9,8 @@ import {
   downloadEmbeddingModel,
   downloadModel,
   EMBEDDING_MODELS_CATALOG,
+  fallBackToCpuBackend,
+  getConfiguredBackendVariant,
   getDaemonStatus,
   getEmbeddingDaemonStatus,
   getEmbeddingModelDef,
@@ -30,6 +32,7 @@ import {
   resolveMmprojFilePath,
   resolvePlatformAsset,
   resolveServerBinPath,
+  shouldFallBackToCpuBackend,
   startChatAndEmbeddingDaemons,
   stopChatAndEmbeddingDaemons,
 } from "../local-llm/index.js";
@@ -308,8 +311,8 @@ export async function runLocalModelsStart(): Promise<number> {
     `device:         ${describeDeviceChoice(cfg.localModels.managed.device, device)}\n`,
   );
 
-  try {
-    const result = await startChatAndEmbeddingDaemons({
+  const startWithDevice = (dev: string | undefined) =>
+    startChatAndEmbeddingDaemons({
       chat: {
         dataDir,
         modelId: mid,
@@ -317,7 +320,7 @@ export async function runLocalModelsStart(): Promise<number> {
         contextSize: cfg.localModels.managed.contextSize,
         ...(tpl ? { chatTemplateFile: tpl } : {}),
         ...(mmprojFile ? { mmprojFile } : {}),
-        ...(device ? { device } : {}),
+        ...(dev ? { device: dev } : {}),
       },
       ...(embRequested && embReady
         ? {
@@ -325,11 +328,48 @@ export async function runLocalModelsStart(): Promise<number> {
               dataDir,
               modelId: embCfg.modelId as never,
               port: embCfg.port,
-              ...(device ? { device } : {}),
+              ...(dev ? { device: dev } : {}),
             },
           }
         : {}),
     });
+
+  try {
+    let result: Awaited<ReturnType<typeof startWithDevice>>;
+    try {
+      result = await startWithDevice(device);
+    } catch (e) {
+      // Windows iGPU-only rescue: the installed GPU build spawned but
+      // never became healthy (its compute backend cannot load a model
+      // on this machine — e.g. Vulkan on an AMD APU), so swap in the
+      // CPU build the nightly also publishes and retry once.
+      if (
+        !shouldFallBackToCpuBackend({
+          installedAsset: readBackendVersion(dataDir)?.asset,
+          configuredVariant: getConfiguredBackendVariant(),
+          error: e,
+        })
+      ) {
+        throw e;
+      }
+      process.stderr.write(
+        "the GPU llama.cpp build failed to serve on this machine — falling back to the CPU build…\n",
+      );
+      persistBackendVariantCpu(cfg.paths.userConfigFile);
+      await fallBackToCpuBackend(dataDir, {
+        signal: AbortSignal.timeout(BACKEND_DOWNLOAD_TIMEOUT_MS),
+        onProgress: (p: number, t: number, tot: number) => {
+          const line = renderPullProgress("cpu backend zip", p, t, tot);
+          if (process.stderr.isTTY) process.stderr.write(`\r${line.padEnd(79)}`);
+          else if (p % 5 === 0 || p === 100) process.stderr.write(`${line}\n`);
+        },
+      });
+      if (process.stderr.isTTY) process.stderr.write("\n");
+      // The GPU device picked against the old binary is meaningless to
+      // the CPU build (it would reject `--device Vulkan0`).
+      process.stderr.write("retrying start on the CPU build…\n");
+      result = await startWithDevice("cpu");
+    }
     const visionLine = mmprojFile
       ? `, vision enabled (${m.mmprojFilename})`
       : m.supportsVision
@@ -358,6 +398,36 @@ export async function runLocalModelsStart(): Promise<number> {
   } catch (e) {
     process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
     return 1;
+  }
+}
+
+/**
+ * Record the CPU fallback as `localModels.managed.backendVariant = "cpu"`.
+ * Without this the next auto-update's variant-staleness check would
+ * resolve the GPU zip again and reinstall the build that just failed.
+ * Best-effort: a config write failure downgrades to a session-only
+ * fallback (`fallBackToCpuBackend` flips the in-process preference
+ * regardless) with a note.
+ */
+function persistBackendVariantCpu(path: string): void {
+  try {
+    const user = ensureUserConfigFileSync(path);
+    const next: UserConfigFile = {
+      ...user,
+      localModels: {
+        ...user.localModels,
+        managed: { ...user.localModels.managed, backendVariant: "cpu" },
+      },
+    };
+    writeUserConfigFileSync(path, next);
+    resetConfigCache();
+    process.stderr.write(
+      'recorded backendVariant "cpu" in config.json — set it to "auto" or "vulkan" to try the GPU build again (e.g. after a driver update)\n',
+    );
+  } catch (e) {
+    process.stderr.write(
+      `note: could not persist backendVariant — ${e instanceof Error ? e.message : String(e)}; the CPU build is used for this session only\n`,
+    );
   }
 }
 

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -734,6 +734,35 @@ describe("parseUserConfigFile", () => {
     expect(parsed.localModels.managed.device).toBe("auto");
   });
 
+  it("defaults localModels.managed.backendVariant to 'auto', v45 files included", () => {
+    expect(
+      parseUserConfigFile({ version: USER_CONFIG_VERSION }).localModels.managed
+        .backendVariant,
+    ).toBe("auto");
+    // A pre-v46 file has no such key — it transparently inherits the
+    // detection behaviour it already had.
+    expect(
+      parseUserConfigFile({ version: 45 }).localModels.managed.backendVariant,
+    ).toBe("auto");
+  });
+
+  it("preserves an explicit localModels.managed.backendVariant", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      localModels: { managed: { backendVariant: "cpu" } },
+    });
+    expect(parsed.localModels.managed.backendVariant).toBe("cpu");
+  });
+
+  it("rejects an unknown localModels.managed.backendVariant", () => {
+    expect(() =>
+      parseUserConfigFile({
+        version: USER_CONFIG_VERSION,
+        localModels: { managed: { backendVariant: "opencl" } },
+      }),
+    ).toThrow(/localModels.managed.backendVariant/);
+  });
+
   it("defaults localModels.managed.stopOnExit to true", () => {
     const parsed = parseUserConfigFile({ version: USER_CONFIG_VERSION });
     expect(parsed.localModels.managed.stopOnExit).toBe(true);

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -11,6 +11,11 @@ import {
   isKnownLocalModelId,
   type LocalModelDef,
 } from "../local-llm/models-catalog.js";
+import {
+  BACKEND_VARIANT_PREFERENCES,
+  isBackendVariantPreference,
+  type BackendVariantPreference,
+} from "../local-llm/windows-backend-variant.js";
 import { parseCustomLocalModels } from "./custom-models-schema.js";
 import {
   MCP_SERVER_NAME_MAX_LENGTH,
@@ -946,6 +951,22 @@ export interface UserManagedLocalLlmConfig {
    */
   device: string;
   /**
+   * Which llama.cpp build (release zip) the managed backend installs.
+   * Windows-only — every other platform publishes a single asset.
+   *   - `"auto"` (default) — probe `nvidia-smi` and pick the newest CUDA
+   *     build the driver can run, else Vulkan.
+   *   - `"cpu"` — the CPU-only build. For machines whose Vulkan stack
+   *     cannot load a model at all (iGPU-only boxes); also written back
+   *     automatically when a GPU build fails to serve (see
+   *     `cpu-backend-fallback.ts`). Distinct from `device: "cpu"`, which
+   *     only disables offload — the broken compute backend would still
+   *     be baked into the binary.
+   *   - `"vulkan"` / `"cuda-12.4"` / `"cuda-13.3"` — pin that build
+   *     (and undo an automatic CPU fallback after a driver fix).
+   * Added in config v46; older files transparently get `"auto"`.
+   */
+  backendVariant: BackendVariantPreference;
+  /**
    * llama-server context window (`--ctx-size`) for the managed chat
    * daemon.
    *   - `0` (default) — auto: fit the context to the target device's
@@ -1599,7 +1620,14 @@ export interface UserConfigFile {
 // implied. (It was drafted as a second v44, but v44 was already spent on
 // `customModels` in the same release — the stamp ships as v45 so the two
 // additive changes keep distinct numbers.)
-export const USER_CONFIG_VERSION = 45;
+// v46: localModels.managed gains `backendVariant` — which llama.cpp
+// release zip the managed backend installs on Windows (`auto` | `cpu` |
+// `vulkan` | `cuda-12.4` | `cuda-13.3`). Exists for iGPU-only boxes whose
+// Vulkan build cannot load a model; the start-failure fallback persists
+// `"cpu"` here so auto-update stops reinstalling the broken GPU build.
+// Additive: older files transparently inherit `"auto"`, the exact
+// detection behaviour they already had.
+export const USER_CONFIG_VERSION = 46;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1733,6 +1761,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   42,
   43,
   44,
+  45,
   USER_CONFIG_VERSION,
 ];
 
@@ -1749,6 +1778,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       autoUpdate: true,
       stopOnExit: true,
       device: "auto",
+      backendVariant: "auto",
       contextSize: 0,
     },
     embeddings: {
@@ -2083,6 +2113,17 @@ export function parseLocalLlmMode(raw: unknown, field: string): LocalLlmMode {
   throw new ConfigValidationError(
     field,
     `expected external|managed, got ${JSON.stringify(raw)}`,
+  );
+}
+
+export function parseBackendVariant(
+  raw: unknown,
+  field: string,
+): BackendVariantPreference {
+  if (isBackendVariantPreference(raw)) return raw;
+  throw new ConfigValidationError(
+    field,
+    `expected ${BACKEND_VARIANT_PREFERENCES.join("|")}, got ${JSON.stringify(raw)}`,
   );
 }
 
@@ -3097,6 +3138,11 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
     device: parseNonEmptyString(
       rawManaged.device ?? USER_CONFIG_DEFAULTS.localModels.managed.device,
       "localModels.managed.device",
+    ),
+    backendVariant: parseBackendVariant(
+      rawManaged.backendVariant ??
+        USER_CONFIG_DEFAULTS.localModels.managed.backendVariant,
+      "localModels.managed.backendVariant",
     ),
     contextSize: parseNonNegativeInt(
       rawManaged.contextSize ??

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -14,6 +14,7 @@ import {
   getUserConfigPath,
 } from "./config-file.js";
 import { setCustomLocalModels } from "../local-llm/models-catalog.js";
+import { setConfiguredBackendVariant } from "../local-llm/windows-backend-variant.js";
 import { loadDotenvFromStateDir } from "./load-dotenv.js";
 import { resolveLlmProviderApiKey } from "./resolve-llm-api-key.js";
 import type { UserLlmFileConfig } from "./llm-config.js";
@@ -118,6 +119,10 @@ export function loadConfig(): AtomicAgentConfig {
   // `getLocalModelDef` and `isKnownLocalModelId` resolve them everywhere
   // a curated id already works.
   setCustomLocalModels(user.localModels.customModels);
+  // Same push-in pattern: the backend-zip variant preference has to be
+  // visible to `resolveDownloadAsset`, which runs deep inside the
+  // config-free local-llm layer.
+  setConfiguredBackendVariant(user.localModels.managed.backendVariant);
   const grammarsDir = resolveAssetDir("ATOMIC_AGENT_GRAMMARS_DIR", "grammars");
 
   const browserChannel: BrowserChannel = readBrowserChannel(

--- a/src/local-llm/backend-installer.test.ts
+++ b/src/local-llm/backend-installer.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./backend-installer.js";
 import { resolveServerBinPath } from "./backend-paths.js";
 import { readBackendVersion, writeBackendVersion } from "./backend-version.js";
+import { setConfiguredBackendVariant } from "./windows-backend-variant.js";
 
 /** Minimal GitHub releases-list payload for the macOS arm64 asset. */
 function releasesResponse(
@@ -479,6 +480,40 @@ describe("backend-installer", () => {
       const check = await checkForBackendUpdate(dir);
       expect(check.updateAvailable).toBe(true);
     } finally {
+      platformSpy.mockRestore();
+      archSpy.mockRestore();
+    }
+  });
+
+  it("offers the CPU zip as an update when backendVariant 'cpu' is configured over a Vulkan install", async () => {
+    // The CPU-fallback persistence loop-guard: after the fallback wrote
+    // backendVariant "cpu", the staleness check must resolve the CPU
+    // asset — not re-detect Vulkan and reinstall the build that just
+    // failed on this machine.
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const archSpy = vi.spyOn(process, "arch", "get").mockReturnValue("x64");
+    setConfiguredBackendVariant("cpu");
+    writeBackendVersion(dir, {
+      tag: "turboquant-win",
+      downloadedAt: "2026-06-02T00:00:00.000Z",
+      asset: "llama-turboquant-windows-x64-vulkan.zip",
+      releasedAt: "2026-06-01T00:00:00Z",
+    });
+    globalThis.fetch = vi.fn(async () =>
+      releasesResponse([
+        {
+          tag: "turboquant-win",
+          publishedAt: "2026-06-01T00:00:00Z",
+          assetName: "llama-turboquant-windows-x64-cpu.zip",
+        },
+      ]),
+    ) as typeof fetch;
+
+    try {
+      const check = await checkForBackendUpdate(dir);
+      expect(check.updateAvailable).toBe(true);
+    } finally {
+      setConfiguredBackendVariant("auto");
       platformSpy.mockRestore();
       archSpy.mockRestore();
     }

--- a/src/local-llm/cpu-backend-fallback.test.ts
+++ b/src/local-llm/cpu-backend-fallback.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const downloadBackendMock = vi.hoisted(() => vi.fn());
+const stopBothMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./backend-installer.js", () => ({
+  downloadBackend: downloadBackendMock,
+}));
+vi.mock("./daemon-lifecycle.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./daemon-lifecycle.js")>()),
+  stopChatAndEmbeddingDaemons: stopBothMock,
+}));
+
+import {
+  fallBackToCpuBackend,
+  shouldFallBackToCpuBackend,
+} from "./cpu-backend-fallback.js";
+import { DaemonHealthError } from "./daemon-lifecycle.js";
+import {
+  WINDOWS_BACKEND_ASSETS,
+  getConfiguredBackendVariant,
+  setConfiguredBackendVariant,
+} from "./windows-backend-variant.js";
+
+const healthError = new DaemonHealthError(
+  "llama-server did not become healthy within 30000ms. Log tail:\n(no log)",
+);
+
+describe("shouldFallBackToCpuBackend", () => {
+  const eligible = {
+    installedAsset: WINDOWS_BACKEND_ASSETS.vulkan,
+    configuredVariant: "auto" as const,
+    error: healthError,
+    platform: "win32" as const,
+  };
+
+  it("falls back for a Vulkan install that never became healthy", () => {
+    expect(shouldFallBackToCpuBackend(eligible)).toBe(true);
+  });
+
+  it("falls back for either CUDA install too", () => {
+    expect(
+      shouldFallBackToCpuBackend({
+        ...eligible,
+        installedAsset: WINDOWS_BACKEND_ASSETS.cuda124,
+      }),
+    ).toBe(true);
+    expect(
+      shouldFallBackToCpuBackend({
+        ...eligible,
+        installedAsset: WINDOWS_BACKEND_ASSETS.cuda133,
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back for a pre-`asset`-field install (undefined asset)", () => {
+    expect(
+      shouldFallBackToCpuBackend({ ...eligible, installedAsset: undefined }),
+    ).toBe(true);
+  });
+
+  it("never falls back off Windows", () => {
+    expect(shouldFallBackToCpuBackend({ ...eligible, platform: "darwin" })).toBe(
+      false,
+    );
+    expect(shouldFallBackToCpuBackend({ ...eligible, platform: "linux" })).toBe(
+      false,
+    );
+  });
+
+  it("honours an operator-pinned variant, including 'cpu' itself", () => {
+    expect(
+      shouldFallBackToCpuBackend({ ...eligible, configuredVariant: "vulkan" }),
+    ).toBe(false);
+    expect(
+      shouldFallBackToCpuBackend({ ...eligible, configuredVariant: "cpu" }),
+    ).toBe(false);
+  });
+
+  it("does not fall back when the CPU build is already installed", () => {
+    expect(
+      shouldFallBackToCpuBackend({
+        ...eligible,
+        installedAsset: WINDOWS_BACKEND_ASSETS.cpu,
+      }),
+    ).toBe(false);
+  });
+
+  it("only reacts to a health-wait failure, not pre-spawn errors", () => {
+    // A missing model, a bound port or an "already running" daemon would
+    // fail the CPU build identically — no swap can fix those.
+    expect(
+      shouldFallBackToCpuBackend({
+        ...eligible,
+        error: new Error("model qwen not downloaded"),
+      }),
+    ).toBe(false);
+    expect(
+      shouldFallBackToCpuBackend({ ...eligible, error: "not even an Error" }),
+    ).toBe(false);
+  });
+});
+
+describe("fallBackToCpuBackend", () => {
+  beforeEach(() => {
+    setConfiguredBackendVariant("auto");
+    downloadBackendMock.mockReset().mockResolvedValue({ ok: true, tag: "turboquant-x" });
+    stopBothMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    setConfiguredBackendVariant("auto");
+  });
+
+  it("flips the variant to cpu, stops the half-started daemon, re-downloads", async () => {
+    const result = await fallBackToCpuBackend("/data");
+    expect(result).toEqual({ tag: "turboquant-x" });
+    expect(getConfiguredBackendVariant()).toBe("cpu");
+    expect(stopBothMock).toHaveBeenCalledWith("/data");
+    expect(downloadBackendMock).toHaveBeenCalledWith("/data", {});
+    // The stop must land before the download, or the Windows file lock
+    // held by a hung loader would fail the backend swap.
+    expect(stopBothMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      downloadBackendMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("still downloads when stopping the old daemon fails", async () => {
+    stopBothMock.mockRejectedValue(new Error("foreign pid"));
+    await expect(fallBackToCpuBackend("/data")).resolves.toEqual({
+      tag: "turboquant-x",
+    });
+    expect(downloadBackendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a failed download, leaving the cpu preference set", async () => {
+    downloadBackendMock.mockRejectedValue(new Error("HTTP 503"));
+    await expect(fallBackToCpuBackend("/data")).rejects.toThrow("HTTP 503");
+    expect(getConfiguredBackendVariant()).toBe("cpu");
+  });
+
+  it("forwards progress callback and abort signal to the download", async () => {
+    const onProgress = vi.fn();
+    const signal = AbortSignal.timeout(60_000);
+    await fallBackToCpuBackend("/data", { onProgress, signal });
+    expect(downloadBackendMock).toHaveBeenCalledWith("/data", {
+      onProgress,
+      signal,
+    });
+  });
+});

--- a/src/local-llm/cpu-backend-fallback.ts
+++ b/src/local-llm/cpu-backend-fallback.ts
@@ -1,0 +1,73 @@
+import { downloadBackend } from "./backend-installer.js";
+import type { DownloadProgressFn } from "./download-file.js";
+import { DaemonHealthError, stopChatAndEmbeddingDaemons } from "./daemon-lifecycle.js";
+import {
+  isWindowsGpuBackendAsset,
+  setConfiguredBackendVariant,
+  type BackendVariantPreference,
+} from "./windows-backend-variant.js";
+
+/**
+ * Windows-only escape hatch for machines whose GPU stack cannot actually
+ * serve a model — most commonly an iGPU-only box (e.g. AMD 5600G) where
+ * the Vulkan build initializes but crashes or hangs on model load, so a
+ * `-ngl 0` device override cannot save it: the broken compute backend is
+ * baked into the binary. The only fix is swapping the installed zip for
+ * the CPU build the turboquant nightly also publishes.
+ *
+ * `shouldFallBackToCpuBackend` is the pure eligibility decision; the
+ * callers (TUI orchestrator, CLI `models start`) own the messaging, the
+ * `backendVariant: "cpu"` config persistence, and the single retry.
+ */
+export function shouldFallBackToCpuBackend(opts: {
+  /** `readBackendVersion(dataDir)?.asset` — undefined on old installs. */
+  installedAsset: string | undefined;
+  /** Configured `localModels.managed.backendVariant`. */
+  configuredVariant: BackendVariantPreference;
+  /** The error `startDaemon` / `startChatAndEmbeddingDaemons` rejected with. */
+  error: unknown;
+  platform?: NodeJS.Platform;
+}): boolean {
+  const platform = opts.platform ?? process.platform;
+  if (platform !== "win32") return false;
+  // An operator who pinned a variant made a call — honour it, even when
+  // that variant fails. `"cpu"` also lands here: falling back to what is
+  // already installed would loop.
+  if (opts.configuredVariant !== "auto") return false;
+  // Only a health-wait failure implicates the compute backend. A missing
+  // model file, a port already bound, or "already running" would fail the
+  // CPU build identically.
+  if (!(opts.error instanceof DaemonHealthError)) return false;
+  return isWindowsGpuBackendAsset(opts.installedAsset);
+}
+
+/**
+ * Swap the installed Windows backend for the CPU build: flip the
+ * in-process variant preference to `"cpu"` (so `resolveDownloadAsset`
+ * picks the CPU zip), stop whatever half-started daemon is holding the
+ * binary (a hung loader would otherwise wedge the Windows file-lock on
+ * the swap), and re-download. Persisting `backendVariant: "cpu"` into
+ * the user config is the caller's job — without it the next
+ * auto-update's variant-staleness check would reinstall the GPU build
+ * and re-break the machine.
+ */
+export async function fallBackToCpuBackend(
+  dataDir: string,
+  opts?: {
+    onProgress?: DownloadProgressFn;
+    signal?: AbortSignal;
+  },
+): Promise<{ tag: string }> {
+  setConfiguredBackendVariant("cpu");
+  try {
+    await stopChatAndEmbeddingDaemons(dataDir);
+  } catch {
+    // Best-effort: a foreign or already-dead pid must not block the
+    // swap attempt; downloadBackend will surface a real file lock.
+  }
+  const { tag } = await downloadBackend(dataDir, {
+    ...(opts?.onProgress ? { onProgress: opts.onProgress } : {}),
+    ...(opts?.signal ? { signal: opts.signal } : {}),
+  });
+  return { tag };
+}

--- a/src/local-llm/daemon-lifecycle.test.ts
+++ b/src/local-llm/daemon-lifecycle.test.ts
@@ -1,19 +1,37 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { resolveEmbeddingPidFilePath, resolvePidFilePath } from "./backend-paths.js";
+const spawnMock = vi.hoisted(() => vi.fn());
+const execSyncMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+  execSync: execSyncMock,
+  execFile: execFileMock,
+}));
+
+import {
+  resolveEmbeddingPidFilePath,
+  resolveModelFilePath,
+  resolvePidFilePath,
+  resolveServerBinPath,
+} from "./backend-paths.js";
 import {
   buildEmbeddingServerArgs,
   buildLlamaServerArgs,
+  DaemonHealthError,
   ForeignDaemonError,
   readRunningPid,
+  startDaemon,
   stopDaemon,
   stopEmbeddingDaemon,
   type DaemonStartOptions,
   type EmbeddingDaemonStartOptions,
 } from "./daemon-lifecycle.js";
+import { getLocalModelDef } from "./models-catalog.js";
 
 const baseOpts: DaemonStartOptions = {
   dataDir: "/tmp/data",
@@ -369,5 +387,54 @@ describe("stopDaemon / stopEmbeddingDaemon (cross-user ownership)", () => {
       await expect(stopEmbeddingDaemon(dataDir)).rejects.toBeInstanceOf(ForeignDaemonError);
       expect(existsSync(pidPath)).toBe(true);
     });
+  });
+});
+
+describe("startDaemon health-wait failure", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    spawnMock.mockReset();
+  });
+
+  it("throws DaemonHealthError when the spawned server never becomes healthy", async () => {
+    // The typed class is load-bearing: the Windows CPU-backend fallback
+    // keys on `instanceof DaemonHealthError` to distinguish "the compute
+    // backend cannot serve on this machine" from pre-spawn failures. A
+    // revert to a bare `Error` would silently disable the fallback.
+    const dataDir = mkdtempSync(`${tmpdir()}/atomic-daemon-health-`);
+    try {
+      const binPath = resolveServerBinPath(dataDir, "llama-server");
+      mkdirSync(dirname(binPath), { recursive: true });
+      writeFileSync(binPath, "#!/bin/sh\n", "utf-8");
+      const model = getLocalModelDef("qwen-3.5-4b");
+      const modelPath = resolveModelFilePath(dataDir, model.id, model.filename);
+      mkdirSync(dirname(modelPath), { recursive: true });
+      writeFileSync(modelPath, "gguf", "utf-8");
+
+      spawnMock.mockReturnValue({ pid: 4242, unref: () => {} });
+      // Every health probe fails — the "server" crashed right after spawn.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          throw new Error("ECONNREFUSED");
+        }),
+      );
+
+      vi.useFakeTimers();
+      const started = startDaemon({
+        dataDir,
+        modelId: "qwen-3.5-4b",
+        port: 19099,
+        // Pinned device skips the --list-devices / VRAM probes so the
+        // whole wait runs on the mocked clock.
+        device: "cpu",
+      });
+      const rejects = expect(started).rejects.toBeInstanceOf(DaemonHealthError);
+      await vi.advanceTimersByTimeAsync(31_000);
+      await rejects;
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/local-llm/daemon-lifecycle.ts
+++ b/src/local-llm/daemon-lifecycle.ts
@@ -260,6 +260,21 @@ export function readRunningPid(
   return pid;
 }
 
+/**
+ * Thrown when a spawned llama-server never reached a healthy `/health`
+ * within the deadline — the process crashed on startup or could not
+ * load the model. Typed (rather than a bare `Error`) so the Windows
+ * CPU-backend fallback can distinguish "the installed compute backend
+ * cannot serve on this machine" from pre-spawn failures like a missing
+ * model file, which no backend swap would fix.
+ */
+export class DaemonHealthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DaemonHealthError";
+  }
+}
+
 async function waitForHealthOkWithLog(dataDir: string, port: number, timeoutMs: number): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -275,7 +290,7 @@ async function waitForHealthOkWithLog(dataDir: string, port: number, timeoutMs: 
   } catch {
     tail = "(no log)";
   }
-  throw new Error(
+  throw new DaemonHealthError(
     `llama-server did not become healthy within ${timeoutMs}ms. Log tail:\n${tail}`,
   );
 }

--- a/src/local-llm/index.ts
+++ b/src/local-llm/index.ts
@@ -22,7 +22,19 @@ export {
   type PlatformAsset,
 } from "./platform-assets.js";
 
-export { resolveDownloadAsset } from "./windows-backend-variant.js";
+export {
+  resolveDownloadAsset,
+  BACKEND_VARIANT_PREFERENCES,
+  getConfiguredBackendVariant,
+  isBackendVariantPreference,
+  isWindowsGpuBackendAsset,
+  setConfiguredBackendVariant,
+  type BackendVariantPreference,
+} from "./windows-backend-variant.js";
+export {
+  fallBackToCpuBackend,
+  shouldFallBackToCpuBackend,
+} from "./cpu-backend-fallback.js";
 
 export {
   resolveBackendDir,
@@ -87,6 +99,7 @@ export {
   getDaemonStatus,
   readRunningPid,
   classifyPidLiveness,
+  DaemonHealthError,
   ForeignDaemonError,
   probeLlamaHealth,
   buildLlamaServerArgs,

--- a/src/local-llm/windows-backend-variant.test.ts
+++ b/src/local-llm/windows-backend-variant.test.ts
@@ -5,10 +5,12 @@ vi.mock("node:child_process", () => ({ execSync: execSyncMock }));
 
 import {
   WINDOWS_BACKEND_ASSETS,
+  isWindowsGpuBackendAsset,
   parseDriverCudaVersion,
   resetWindowsBackendAssetCache,
   resolveDownloadAsset,
   selectWindowsBackendAsset,
+  setConfiguredBackendVariant,
 } from "./windows-backend-variant.js";
 
 const NVIDIA_SMI_HEADER = `
@@ -91,14 +93,34 @@ describe("selectWindowsBackendAsset", () => {
   });
 });
 
+describe("isWindowsGpuBackendAsset", () => {
+  it("recognises the three GPU builds", () => {
+    expect(isWindowsGpuBackendAsset(WINDOWS_BACKEND_ASSETS.vulkan)).toBe(true);
+    expect(isWindowsGpuBackendAsset(WINDOWS_BACKEND_ASSETS.cuda124)).toBe(true);
+    expect(isWindowsGpuBackendAsset(WINDOWS_BACKEND_ASSETS.cuda133)).toBe(true);
+  });
+
+  it("rejects the CPU build", () => {
+    expect(isWindowsGpuBackendAsset(WINDOWS_BACKEND_ASSETS.cpu)).toBe(false);
+  });
+
+  it("treats a pre-`asset`-field install as a GPU build", () => {
+    // The CPU zip was not downloadable before the field existed, so an
+    // undefined asset on win32 can only be one of the GPU builds.
+    expect(isWindowsGpuBackendAsset(undefined)).toBe(true);
+  });
+});
+
 describe("resolveDownloadAsset", () => {
   beforeEach(() => {
     resetWindowsBackendAssetCache();
+    setConfiguredBackendVariant("auto");
     execSyncMock.mockReset();
   });
 
   afterEach(() => {
     resetWindowsBackendAssetCache();
+    setConfiguredBackendVariant("auto");
   });
 
   it("leaves macOS/Linux assets untouched (no nvidia-smi probe)", () => {
@@ -133,5 +155,57 @@ describe("resolveDownloadAsset", () => {
     resolveDownloadAsset("win32", "x64");
     resolveDownloadAsset("win32", "x64");
     expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a configured 'cpu' variant pins the CPU zip without probing nvidia-smi", () => {
+    setConfiguredBackendVariant("cpu");
+    expect(resolveDownloadAsset("win32", "x64").assetName).toBe(
+      WINDOWS_BACKEND_ASSETS.cpu,
+    );
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("a configured 'vulkan' variant beats a CUDA-capable driver", () => {
+    execSyncMock.mockReturnValue(Buffer.from(NVIDIA_SMI_HEADER));
+    setConfiguredBackendVariant("vulkan");
+    expect(resolveDownloadAsset("win32", "x64").assetName).toBe(
+      WINDOWS_BACKEND_ASSETS.vulkan,
+    );
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("a variant configured after detection is not shadowed by the cache", () => {
+    // The CPU fallback flips the preference mid-process, after the
+    // auto-update path already detected (and cached) a GPU asset.
+    execSyncMock.mockReturnValue(Buffer.from(NVIDIA_SMI_HEADER));
+    expect(resolveDownloadAsset("win32", "x64").assetName).toBe(
+      WINDOWS_BACKEND_ASSETS.cuda124,
+    );
+    setConfiguredBackendVariant("cpu");
+    expect(resolveDownloadAsset("win32", "x64").assetName).toBe(
+      WINDOWS_BACKEND_ASSETS.cpu,
+    );
+  });
+
+  it("returning to 'auto' restores detection", () => {
+    execSyncMock.mockReturnValue(Buffer.from(NVIDIA_SMI_HEADER));
+    setConfiguredBackendVariant("cpu");
+    expect(resolveDownloadAsset("win32", "x64").assetName).toBe(
+      WINDOWS_BACKEND_ASSETS.cpu,
+    );
+    setConfiguredBackendVariant("auto");
+    expect(resolveDownloadAsset("win32", "x64").assetName).toBe(
+      WINDOWS_BACKEND_ASSETS.cuda124,
+    );
+  });
+
+  it("ignores the variant preference off Windows (single-asset platforms)", () => {
+    setConfiguredBackendVariant("cpu");
+    expect(resolveDownloadAsset("darwin", "arm64").assetName).toBe(
+      "llama-turboquant-macos-arm64.zip",
+    );
+    expect(resolveDownloadAsset("linux", "x64").assetName).toBe(
+      "llama-turboquant-linux-x64-vulkan.zip",
+    );
   });
 });

--- a/src/local-llm/windows-backend-variant.ts
+++ b/src/local-llm/windows-backend-variant.ts
@@ -7,13 +7,83 @@ import { resolvePlatformAsset, type PlatformAsset } from "./platform-assets.js";
  * inside every zip is `llama-server.exe`; only the bundled compute
  * backend differs. We pick the fastest one the machine can actually run
  * and fall back to Vulkan (broadest GPU support, no CUDA driver
- * requirement) when no compatible NVIDIA driver is detected.
+ * requirement) when no compatible NVIDIA driver is detected. The CPU
+ * build is never picked by detection — it exists for boxes whose only
+ * "GPU" is an iGPU the Vulkan build cannot actually load a model on
+ * (e.g. AMD 5600G Vega), reached via `localModels.managed.backendVariant`
+ * or the automatic start-failure fallback in `cpu-backend-fallback.ts`.
  */
 export const WINDOWS_BACKEND_ASSETS = {
   vulkan: "llama-turboquant-windows-x64-vulkan.zip",
   cuda124: "llama-turboquant-windows-x64-cuda-12.4.zip",
   cuda133: "llama-turboquant-windows-x64-cuda-13.3.zip",
+  cpu: "llama-turboquant-windows-x64-cpu.zip",
 } as const;
+
+/**
+ * Operator-facing values for `localModels.managed.backendVariant`.
+ * `"auto"` keeps the nvidia-smi driven detection; the rest pin one of
+ * the Windows zips outright (no probe). Meaningful only on win32 —
+ * every other platform publishes a single asset, so the preference is
+ * ignored there.
+ */
+export const BACKEND_VARIANT_PREFERENCES = [
+  "auto",
+  "cpu",
+  "vulkan",
+  "cuda-12.4",
+  "cuda-13.3",
+] as const;
+
+export type BackendVariantPreference = (typeof BACKEND_VARIANT_PREFERENCES)[number];
+
+export function isBackendVariantPreference(
+  raw: unknown,
+): raw is BackendVariantPreference {
+  return BACKEND_VARIANT_PREFERENCES.includes(raw as BackendVariantPreference);
+}
+
+const ASSET_BY_VARIANT_PREFERENCE: Record<
+  Exclude<BackendVariantPreference, "auto">,
+  string
+> = {
+  cpu: WINDOWS_BACKEND_ASSETS.cpu,
+  vulkan: WINDOWS_BACKEND_ASSETS.vulkan,
+  "cuda-12.4": WINDOWS_BACKEND_ASSETS.cuda124,
+  "cuda-13.3": WINDOWS_BACKEND_ASSETS.cuda133,
+};
+
+/**
+ * Configured `localModels.managed.backendVariant`, pushed in by
+ * `loadConfig` the same way `setCustomLocalModels` publishes custom
+ * models — the local-llm layer stays config-free. Also flipped to
+ * `"cpu"` in-process by the start-failure fallback so the re-download
+ * that follows resolves the CPU zip without waiting for a config
+ * round-trip.
+ */
+let configuredBackendVariant: BackendVariantPreference = "auto";
+
+export function setConfiguredBackendVariant(v: BackendVariantPreference): void {
+  configuredBackendVariant = v;
+}
+
+export function getConfiguredBackendVariant(): BackendVariantPreference {
+  return configuredBackendVariant;
+}
+
+/**
+ * True when `assetName` is one of the Windows GPU builds (or an install
+ * old enough to predate `BackendVersionInfo.asset` — the CPU zip was not
+ * downloadable back then, so an undefined asset on win32 is a GPU build).
+ */
+export function isWindowsGpuBackendAsset(assetName: string | undefined): boolean {
+  if (assetName === undefined) return true;
+  return (
+    assetName === WINDOWS_BACKEND_ASSETS.vulkan ||
+    assetName === WINDOWS_BACKEND_ASSETS.cuda124 ||
+    assetName === WINDOWS_BACKEND_ASSETS.cuda133
+  );
+}
 
 export interface CudaVersion {
   major: number;
@@ -92,8 +162,14 @@ let cachedWindowsAsset: string | null = null;
  * result process-wide. Hardware does not change during a run, so we
  * probe `nvidia-smi` at most once; the hot path (`isBackendDownloaded`
  * poll) never triggers a probe because it only needs `binaryName`.
+ * A non-`auto` configured variant bypasses both the probe and the
+ * cache — the preference can change mid-process (config edit, CPU
+ * fallback), so it must never be shadowed by a stale detection result.
  */
 export function detectWindowsBackendAsset(): string {
+  if (configuredBackendVariant !== "auto") {
+    return ASSET_BY_VARIANT_PREFERENCE[configuredBackendVariant];
+  }
   if (cachedWindowsAsset !== null) return cachedWindowsAsset;
   cachedWindowsAsset = selectWindowsBackendAsset(detectDriverCudaVersion());
   return cachedWindowsAsset;

--- a/src/tui/local-models/local-models-orchestrator-cpu-fallback.test.ts
+++ b/src/tui/local-models/local-models-orchestrator-cpu-fallback.test.ts
@@ -1,0 +1,244 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../local-llm/index.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../local-llm/index.js")>(
+      "../../local-llm/index.js",
+    );
+  return {
+    ...actual,
+    getDaemonStatus: vi.fn(),
+    getEmbeddingDaemonStatus: vi.fn(),
+    startChatAndEmbeddingDaemons: vi.fn(),
+    fallBackToCpuBackend: vi.fn(),
+    resolveManagedDevice: vi.fn(),
+    listVulkanDevices: vi.fn(),
+    probeNvidiaVramMiB: vi.fn(),
+    maybeAutoUpdateBackend: vi.fn(),
+  };
+});
+
+import { getConfig, resetConfigCache } from "../../config/index.js";
+import * as localLlm from "../../local-llm/index.js";
+import {
+  resolveBackendDir,
+  resolveModelFilePath,
+  resolveServerBinPath,
+} from "../../local-llm/index.js";
+import { writeBackendVersion } from "../../local-llm/backend-version.js";
+import { DaemonHealthError } from "../../local-llm/daemon-lifecycle.js";
+import { resolvePlatformAsset } from "../../local-llm/platform-assets.js";
+import {
+  WINDOWS_BACKEND_ASSETS,
+  setConfiguredBackendVariant,
+} from "../../local-llm/windows-backend-variant.js";
+import { persistUserLocalModelsConfig } from "../persist-user-local-models-config.js";
+import { LocalModelsOrchestrator } from "./local-models-orchestrator.js";
+
+type Emitted = {
+  type: string;
+  line?: string;
+  message?: string;
+  kind?: string;
+  percent?: number;
+};
+
+const healthError = () =>
+  new DaemonHealthError(
+    "llama-server did not become healthy within 30000ms. Log tail:\n(no log)",
+  );
+
+/**
+ * Integration tests for the Windows CPU-backend fallback WIRING in
+ * `startDaemon` — the pure pieces (`shouldFallBackToCpuBackend`,
+ * `fallBackToCpuBackend`) are covered in `cpu-backend-fallback.test.ts`,
+ * but only these tests prove the orchestrator actually consults them:
+ * that an eligible health failure swaps the backend and retries exactly
+ * once, that the retry cannot recurse, and that the download runs with
+ * a deadline and live progress (a stalled-open connection must not pin
+ * the start on "starting" for the life of the process).
+ */
+describe("LocalModelsOrchestrator CPU-backend fallback", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "local-models-cpufb-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    // The fallback is Windows-only; the real eligibility gate must see
+    // win32 or these tests would silently assert nothing.
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.spyOn(process, "arch", "get").mockReturnValue("x64");
+    resetConfigCache();
+    setConfiguredBackendVariant("auto");
+    vi.mocked(localLlm.getDaemonStatus).mockReset();
+    vi.mocked(localLlm.getEmbeddingDaemonStatus).mockReset();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockReset();
+    vi.mocked(localLlm.fallBackToCpuBackend)
+      .mockReset()
+      .mockResolvedValue({ tag: "turboquant-x" });
+    vi.mocked(localLlm.resolveManagedDevice).mockReset().mockResolvedValue(undefined);
+    vi.mocked(localLlm.listVulkanDevices).mockReset().mockResolvedValue([]);
+    vi.mocked(localLlm.probeNvidiaVramMiB).mockReset().mockResolvedValue(null);
+    vi.mocked(localLlm.maybeAutoUpdateBackend).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setConfiguredBackendVariant("auto");
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("swaps in the CPU build, persists the variant and retries once", async () => {
+    const dataDir = prepareManagedWindowsInstall();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons)
+      .mockRejectedValueOnce(healthError())
+      .mockResolvedValueOnce({ chat: { pid: 4242 }, embedding: { skipped: true } });
+
+    const { orchestrator, actions } = makeOrchestrator();
+
+    await expect(orchestrator.startDaemon({ backendAlreadyChecked: true })).resolves.toBe(
+      true,
+    );
+
+    expect(localLlm.fallBackToCpuBackend).toHaveBeenCalledTimes(1);
+    expect(localLlm.startChatAndEmbeddingDaemons).toHaveBeenCalledTimes(2);
+    // The loop-guard against auto-update reinstalling the broken GPU
+    // build: the preference must land in the user config, not just in
+    // process memory.
+    expect(getConfig().localModels.managed.backendVariant).toBe("cpu");
+    const lines = actions.map((a) => a.line).filter(Boolean);
+    expect(lines.some((l) => l!.includes("falling back to the CPU build"))).toBe(true);
+    expect(lines.some((l) => l!.includes('recorded backendVariant "cpu"'))).toBe(true);
+    // Download surfaced as a regular backend pull so the panel shows it.
+    expect(actions.some((a) => a.type === "local_models_pull_started")).toBe(true);
+    expect(actions.some((a) => a.type === "local_models_pull_finished")).toBe(true);
+
+    // The download must carry a deadline and live progress — without
+    // them a stalled-open connection pins the start forever with zero
+    // feedback (the exact hazard the auto-update path guards against).
+    const [calledDataDir, dlOpts] = vi.mocked(localLlm.fallBackToCpuBackend).mock
+      .calls[0]! as [string, { signal?: AbortSignal; onProgress?: (p: number, t: number, tot: number) => void }];
+    expect(calledDataDir).toBe(dataDir);
+    expect(dlOpts.signal).toBeInstanceOf(AbortSignal);
+    expect(dlOpts.onProgress).toBeTypeOf("function");
+    dlOpts.onProgress!(50, 15_000_000, 30_000_000);
+    expect(
+      actions.some((a) => a.type === "local_models_pull_progress" && a.percent === 50),
+    ).toBe(true);
+  });
+
+  it("falls back at most once — a CPU build that also fails to serve stops", async () => {
+    prepareManagedWindowsInstall();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockRejectedValue(healthError());
+
+    const { orchestrator, actions } = makeOrchestrator();
+
+    await expect(orchestrator.startDaemon({ backendAlreadyChecked: true })).resolves.toBe(
+      false,
+    );
+
+    expect(localLlm.fallBackToCpuBackend).toHaveBeenCalledTimes(1);
+    expect(localLlm.startChatAndEmbeddingDaemons).toHaveBeenCalledTimes(2);
+    expect(actions.some((a) => a.type === "local_models_daemon_error_set")).toBe(true);
+  });
+
+  it("reports the failure and gives up when the CPU download itself fails", async () => {
+    prepareManagedWindowsInstall();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockRejectedValue(healthError());
+    vi.mocked(localLlm.fallBackToCpuBackend).mockRejectedValue(new Error("HTTP 503"));
+
+    const { orchestrator, actions } = makeOrchestrator();
+
+    await expect(orchestrator.startDaemon({ backendAlreadyChecked: true })).resolves.toBe(
+      false,
+    );
+
+    expect(localLlm.startChatAndEmbeddingDaemons).toHaveBeenCalledTimes(1);
+    expect(actions.some((a) => a.type === "local_models_pull_failed")).toBe(true);
+    const err = actions.find((a) => a.type === "local_models_daemon_error_set");
+    expect(err?.message).toContain("CPU backend fallback failed — HTTP 503");
+    expect(err?.message).toContain("original start failure");
+  });
+
+  it("leaves a non-health start failure alone", async () => {
+    prepareManagedWindowsInstall();
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockRejectedValue(
+      new Error("port 19091 already in use"),
+    );
+
+    const { orchestrator, actions } = makeOrchestrator();
+
+    await expect(orchestrator.startDaemon({ backendAlreadyChecked: true })).resolves.toBe(
+      false,
+    );
+
+    expect(localLlm.fallBackToCpuBackend).not.toHaveBeenCalled();
+    expect(getConfig().localModels.managed.backendVariant).toBe("auto");
+    const err = actions.find((a) => a.type === "local_models_daemon_error_set");
+    expect(err?.message).toContain("port 19091 already in use");
+  });
+
+  it("never falls back when the CPU build is already installed", async () => {
+    prepareManagedWindowsInstall(WINDOWS_BACKEND_ASSETS.cpu);
+    vi.mocked(localLlm.startChatAndEmbeddingDaemons).mockRejectedValue(healthError());
+
+    const { orchestrator } = makeOrchestrator();
+
+    await expect(orchestrator.startDaemon({ backendAlreadyChecked: true })).resolves.toBe(
+      false,
+    );
+
+    expect(localLlm.fallBackToCpuBackend).not.toHaveBeenCalled();
+  });
+
+  function makeOrchestrator(): {
+    orchestrator: LocalModelsOrchestrator;
+    actions: Emitted[];
+  } {
+    const actions: Emitted[] = [];
+    const orchestrator = new LocalModelsOrchestrator({
+      emit(a: unknown) {
+        actions.push(a as Emitted);
+      },
+      subscribe: () => () => {},
+    });
+    vi.spyOn(orchestrator, "refresh").mockResolvedValue();
+    return { orchestrator, actions };
+  }
+
+  /**
+   * Managed mode with a (stub) Windows GPU install + chat model on
+   * disk, so the real `shouldFallBackToCpuBackend` sees an eligible
+   * machine: win32, variant `auto`, a GPU asset recorded.
+   */
+  function prepareManagedWindowsInstall(
+    asset: string = WINDOWS_BACKEND_ASSETS.vulkan,
+  ): string {
+    const dataDir = getConfig().paths.localModelsDataDir;
+    const backendDir = resolveBackendDir(dataDir);
+    mkdirSync(backendDir, { recursive: true });
+    const { binaryName } = resolvePlatformAsset();
+    writeFileSync(resolveServerBinPath(dataDir, binaryName), "");
+    writeBackendVersion(dataDir, {
+      tag: "turboquant-win",
+      downloadedAt: "2026-06-02T00:00:00.000Z",
+      asset,
+      releasedAt: "2026-06-01T00:00:00Z",
+    });
+    const def = localLlm.getLocalModelDef("qwen-3.5-4b");
+    mkdirSync(join(dataDir, "models", def.id), { recursive: true });
+    writeFileSync(resolveModelFilePath(dataDir, def.id, def.filename), "stub");
+    persistUserLocalModelsConfig({
+      mode: "managed",
+      managed: { modelId: "qwen-3.5-4b" },
+    });
+    resetConfigCache();
+    return dataDir;
+  }
+});

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -1174,11 +1174,39 @@ export class LocalModelsOrchestrator {
         line: `local-llm: could not persist backendVariant — ${msg}; the CPU build is used for this session only`,
       });
     }
+    this.bus.emit({
+      type: "local_models_pull_started",
+      pull: {
+        kind: "backend",
+        modelId: "_backend",
+        label: "llama.cpp backend",
+        percent: 0,
+        transferredBytes: 0,
+        totalBytes: 0,
+        error: null,
+      },
+    });
     try {
-      await fallBackToCpuBackend(dataDir);
+      await fallBackToCpuBackend(dataDir, {
+        // Same hazard as the auto-update path above: without a deadline
+        // a stalled-open connection would pin the start on "starting"
+        // for the life of the process.
+        signal: AbortSignal.timeout(BACKEND_DOWNLOAD_TIMEOUT_MS),
+        onProgress: (percent: number, transferred: number, total: number) => {
+          this.bus.emit({
+            type: "local_models_pull_progress",
+            kind: "backend",
+            percent,
+            transferredBytes: transferred,
+            totalBytes: total,
+          });
+        },
+      });
+      this.bus.emit({ type: "local_models_pull_finished", kind: "backend" });
     } catch (dlErr) {
       const msg = dlErr instanceof Error ? dlErr.message : String(dlErr);
       const combined = `CPU backend fallback failed — ${msg} (original start failure: ${failureMsg})`;
+      this.bus.emit({ type: "local_models_pull_failed", kind: "backend", error: msg });
       this.bus.emit({ type: "local_models_daemon_error_set", message: combined });
       this.bus.emit({ type: "runtime_info", line: `local-llm: ${combined}` });
       return false;

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -12,6 +12,8 @@ import {
   downloadMmproj,
   downloadModel,
   EMBEDDING_MODELS_CATALOG,
+  fallBackToCpuBackend,
+  getConfiguredBackendVariant,
   getDaemonStatus,
   getEmbeddingDaemonStatus,
   getEmbeddingModelDef,
@@ -41,6 +43,7 @@ import {
   resolvePlatformAsset,
   resolveHuggingFaceGgufChoices,
   resolveServerBinPath,
+  shouldFallBackToCpuBackend,
   startChatAndEmbeddingDaemons,
   startEmbeddingDaemon,
   stopChatAndEmbeddingDaemons,
@@ -986,6 +989,11 @@ export class LocalModelsOrchestrator {
    */
   async startDaemon(opts?: {
     backendAlreadyChecked?: boolean;
+    /**
+     * Set by the retry the Windows CPU-backend fallback issues, so a
+     * start that fails even on the CPU build cannot recurse forever.
+     */
+    cpuFallbackAttempted?: boolean;
   }): Promise<boolean> {
     const cfg = getConfig();
     if (cfg.localModels.mode !== "managed") {
@@ -1112,6 +1120,16 @@ export class LocalModelsOrchestrator {
       return true;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
+      if (
+        !opts?.cpuFallbackAttempted &&
+        shouldFallBackToCpuBackend({
+          installedAsset: readBackendVersion(dataDir)?.asset,
+          configuredVariant: getConfiguredBackendVariant(),
+          error: e,
+        })
+      ) {
+        return await this.fallBackToCpuBackendAndRetry(dataDir, msg);
+      }
       this.bus.emit({ type: "local_models_daemon_error_set", message: msg });
       this.bus.emit({ type: "runtime_info", line: `local-llm: start failed — ${msg}` });
       return false;
@@ -1119,6 +1137,60 @@ export class LocalModelsOrchestrator {
       this.endActiveRefresh();
       await this.refresh();
     }
+  }
+
+  /**
+   * Windows iGPU-only rescue: the installed GPU llama.cpp build spawned
+   * but never became healthy (the compute backend cannot load a model on
+   * this machine — e.g. Vulkan on an AMD APU), so swap in the CPU build
+   * the nightly also publishes and retry the start once. The choice is
+   * persisted as `localModels.managed.backendVariant = "cpu"` — without
+   * that, the next auto-update's variant-staleness check would reinstall
+   * the GPU build and re-break the machine.
+   */
+  private async fallBackToCpuBackendAndRetry(
+    dataDir: string,
+    failureMsg: string,
+  ): Promise<boolean> {
+    this.bus.emit({
+      type: "runtime_info",
+      line:
+        "local-llm: the GPU llama.cpp build failed to serve on this machine — " +
+        "falling back to the CPU build…",
+    });
+    try {
+      persistUserLocalModelsConfig({ managed: { backendVariant: "cpu" } });
+      this.bus.emit({
+        type: "runtime_info",
+        line:
+          'local-llm: recorded backendVariant "cpu" in config.json — set it to ' +
+          '"auto" or "vulkan" to try the GPU build again (e.g. after a driver update)',
+      });
+    } catch (persistErr) {
+      const msg =
+        persistErr instanceof Error ? persistErr.message : String(persistErr);
+      this.bus.emit({
+        type: "runtime_info",
+        line: `local-llm: could not persist backendVariant — ${msg}; the CPU build is used for this session only`,
+      });
+    }
+    try {
+      await fallBackToCpuBackend(dataDir);
+    } catch (dlErr) {
+      const msg = dlErr instanceof Error ? dlErr.message : String(dlErr);
+      const combined = `CPU backend fallback failed — ${msg} (original start failure: ${failureMsg})`;
+      this.bus.emit({ type: "local_models_daemon_error_set", message: combined });
+      this.bus.emit({ type: "runtime_info", line: `local-llm: ${combined}` });
+      return false;
+    }
+    this.bus.emit({
+      type: "runtime_info",
+      line: "local-llm: CPU build installed — retrying start…",
+    });
+    return await this.startDaemon({
+      backendAlreadyChecked: true,
+      cpuFallbackAttempted: true,
+    });
   }
 
   /**


### PR DESCRIPTION
## What

Windows machines without a working GPU compute stack — typically iGPU-only boxes (AMD 5600G / Vega) — could not load local models at all: `windows-backend-variant.ts` only knew the Vulkan and two CUDA turboquant zips, so a box with no NVIDIA driver always got Vulkan, and when that build crashed or hung on model load there was **no CPU build to reach and no way to ask for one**. A `device: "cpu"` override does not help — that only sets `-ngl 0`, the broken compute backend is still baked into the binary.

This PR adds the full escape hatch:

- **CPU backend variant** — registers `llama-turboquant-windows-x64-cpu.zip`, which the `atomic-llama-cpp-turboquant-nightly` release already publishes (verified via the GitHub API against `turboquant-07b9908`, the only release; its asset list is macOS-arm64, linux-x64-vulkan, and win-x64 {vulkan, cuda-12.4, cuda-13.3, **cpu**}). Windows is the only platform with a CPU asset, so the fallback is Windows-only; if the nightly ever publishes a linux-x64-cpu zip the same machinery extends to it.
- **Selection logic unchanged for GPUs** — detection still prefers CUDA > Vulkan; the CPU build is never chosen by detection.
- **Automatic fallback on start failure** — when a GPU-variant install spawns but never becomes healthy (new typed `DaemonHealthError`, i.e. the server crashed or could not load the model — pre-spawn failures like a missing model file do not trigger it), both the TUI start path and CLI `models start`:
  1. surface a clear message,
  2. persist `localModels.managed.backendVariant: "cpu"` (config v46) — without this the next auto-update's variant-staleness check would resolve Vulkan again and reinstall the build that just failed,
  3. swap in the CPU zip (stopping the half-started daemon first, or the Windows file lock wedges the swap), and
  4. retry the start once (never recursing further).
- **User-selectable override** — `localModels.managed.backendVariant`: `"auto"` (default, previous behavior) | `"cpu"` | `"vulkan"` | `"cuda-12.4"` | `"cuda-13.3"`. Pinning a GPU variant is also how you undo the automatic fallback after a driver fix. Wired into the config-free local-llm layer via the same push-in pattern as `setCustomLocalModels`.

Why no "no capable GPU detected → CPU at selection time": there is no reliable pre-download Vulkan-capability probe on Windows (nvidia-smi covers NVIDIA only, and the reporter's box *has* a Vulkan device — it just cannot load a model on it), so eligibility is failure-driven plus the explicit override.

**On the linked upstream issue**: ggml-org/llama.cpp#22786 is a Gemma-4 tool-call-parsed-as-content bug, closed 2026-05-08 — unrelated to Vulkan model-load failures, and the nightly build (`turboquant-07b9908`, published 2026-08-14) postdates it anyway. There is also no pinned tag to bump in this repo: the installer always resolves the newest nightly release, so no version bump ships here. If the reporter's crash is an upstream ggml-vulkan bug, the durable fix is a fresh nightly build; this PR makes such boxes work either way.

## Test evidence

- `npm run lint` (tsc) clean.
- New/extended vitest coverage, each proven to fail without the change (verified by temporarily reverting the specific behavior):
  - `windows-backend-variant.test.ts` — CPU zip registration, override pins without probing nvidia-smi, override set *after* a cached detection still wins, `"auto"` restores detection, non-Windows platforms ignore the preference, `isWindowsGpuBackendAsset` matrix (4 failed with the override check disabled).
  - `daemon-lifecycle.test.ts` — `startDaemon` rejects with typed `DaemonHealthError` when the spawned server never becomes healthy (failed when reverted to a bare `Error`).
  - `cpu-backend-fallback.test.ts` — full eligibility matrix (platform / pinned variant / already-CPU / non-health errors) and the swap glue (stop-before-download ordering, stop failure tolerated, download failure propagated, progress/signal forwarded).
  - `backend-installer.test.ts` — configured `"cpu"` over an installed Vulkan build reports `updateAvailable` (the anti-flip-back loop guard).
  - `config-schema.test.ts` — v46 `backendVariant` default (incl. transparent v45 upgrade), explicit value preserved, unknown value rejected.
- Full `src/local-llm`, `src/config`, `src/tui/local-models`, `src/cli/models-command` suites pass (the pre-existing unhandled `spawn EACCES` warning in `local-models-orchestrator-auto-update.test.ts` reproduces on clean `main`).

## Windows QA needed

Runtime verification requires an iGPU-only Windows box (none available here). Manual steps are in the PR discussion below the fold: run `atomic-agent models start` on a box where Vulkan fails to load a model, expect the "falling back to the CPU build" flow, `backendVariant: "cpu"` written to config.json, and a healthy daemon on the CPU build; subsequent starts must stay on the CPU zip.

Reported on Discord: https://discord.com/channels/1515649306781155428/1515649308161085612/1540671929755631699 (+ follow-ups)


## Review fixes (5d0a242)

- **TUI fallback download now has a deadline and progress**: `fallBackToCpuBackendAndRetry` was calling `fallBackToCpuBackend(dataDir)` bare — a stalled-open connection could pin the start on "starting" forever with zero feedback. It now passes `AbortSignal.timeout(BACKEND_DOWNLOAD_TIMEOUT_MS)` and surfaces the download as a regular backend pull (`started`/`progress`/`finished`/`failed`) on the bus, matching the auto-update path and the CLI path.
- **Fallback wiring is now integration-tested** (previously only the extracted pure pieces were): `local-models-orchestrator-cpu-fallback.test.ts` (5 tests — swap+persist+single retry, recursion cap, failed download reported, non-health and already-CPU cases inert, deadline+progress forwarded) and `models-handlers.test.ts` (3 tests — CLI retry lands on `--device cpu`, variant persisted, signal/progress forwarded, pre-spawn failures and failed downloads exit non-zero). Both proven non-vacuous: deleting either caller's retry block fails 5 tests; making the TUI download call bare again fails 1.
- Manual QA comment corrected: `models start` takes no model argument — step 1 now selects the model via `models pull` + `models use`.
