### PR TITLE
feat(tui): free/paid price facet on the cloud model pickers

### DIFF
--- a/src/llm/provider/model-pricing-filter.test.ts
+++ b/src/llm/provider/model-pricing-filter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterIdsByPricing,
+  isFreeModelEntry,
+  matchesModelPricingFilter,
+  nextModelPricingFilter,
+} from "./model-pricing-filter.js";
+import type { ModelCatalogEntry } from "./model-resolver.js";
+
+function chatEntry(
+  id: string,
+  pricing?: { input: number; output: number },
+): ModelCatalogEntry {
+  return {
+    id,
+    kind: "chat",
+    contextWindow: 128_000,
+    supportsVision: false,
+    supportsTools: "parallel",
+    supportsPromptCache: false,
+    reasoningFormat: "none",
+    ...(pricing ? { pricing } : {}),
+  };
+}
+
+describe("nextModelPricingFilter", () => {
+  it("cycles all → free → paid → all", () => {
+    expect(nextModelPricingFilter("all")).toBe("free");
+    expect(nextModelPricingFilter("free")).toBe("paid");
+    expect(nextModelPricingFilter("paid")).toBe("all");
+  });
+});
+
+describe("isFreeModelEntry", () => {
+  it("is true only when the catalog proves both prices are zero", () => {
+    expect(isFreeModelEntry("v/free", chatEntry("v/free", { input: 0, output: 0 }))).toBe(true);
+    expect(isFreeModelEntry("v/paid", chatEntry("v/paid", { input: 0.3, output: 2.5 }))).toBe(false);
+    // Output-only pricing is still a price.
+    expect(isFreeModelEntry("v/out", chatEntry("v/out", { input: 0, output: 1 }))).toBe(false);
+  });
+
+  it("treats missing pricing as not-free (aimlapi rows, live /v1/models ids)", () => {
+    expect(isFreeModelEntry("v/unknown", chatEntry("v/unknown"))).toBe(false);
+    expect(isFreeModelEntry("v/unknown", undefined)).toBe(false);
+  });
+
+  it("keeps openrouter/auto out of free: its tag reads 'routed', and it bills the routed model", () => {
+    const auto = chatEntry("openrouter/auto", { input: 0, output: 0 });
+    expect(isFreeModelEntry("openrouter/auto", auto)).toBe(false);
+  });
+});
+
+describe("matchesModelPricingFilter", () => {
+  const free = chatEntry("v/free", { input: 0, output: 0 });
+  const paid = chatEntry("v/paid", { input: 0.3, output: 2.5 });
+
+  it("'all' keeps every row", () => {
+    expect(matchesModelPricingFilter("all", "v/free", free)).toBe(true);
+    expect(matchesModelPricingFilter("all", "v/paid", paid)).toBe(true);
+    expect(matchesModelPricingFilter("all", "v/unknown", undefined)).toBe(true);
+  });
+
+  it("free and paid partition the catalog, so no row vanishes from both", () => {
+    expect(matchesModelPricingFilter("free", "v/free", free)).toBe(true);
+    expect(matchesModelPricingFilter("paid", "v/free", free)).toBe(false);
+    expect(matchesModelPricingFilter("free", "v/paid", paid)).toBe(false);
+    expect(matchesModelPricingFilter("paid", "v/paid", paid)).toBe(true);
+    // A row with no metadata cannot be promised free; it stays in paid.
+    expect(matchesModelPricingFilter("free", "v/unknown", undefined)).toBe(false);
+    expect(matchesModelPricingFilter("paid", "v/unknown", undefined)).toBe(true);
+  });
+});
+
+describe("filterIdsByPricing", () => {
+  const entries = new Map<string, ModelCatalogEntry>([
+    ["v/free", chatEntry("v/free", { input: 0, output: 0 })],
+    ["v/paid", chatEntry("v/paid", { input: 0.3, output: 2.5 })],
+  ]);
+  const lookup = (id: string): ModelCatalogEntry | undefined => entries.get(id);
+  const ids = ["v/free", "v/paid", "v/unknown"] as const;
+
+  it("returns the input array itself for 'all'", () => {
+    expect(filterIdsByPricing(ids, "all", lookup)).toBe(ids);
+  });
+
+  it("narrows to the facet through the lookup", () => {
+    expect(filterIdsByPricing(ids, "free", lookup)).toEqual(["v/free"]);
+    expect(filterIdsByPricing(ids, "paid", lookup)).toEqual(["v/paid", "v/unknown"]);
+  });
+
+  it("without a lookup nothing is provably free", () => {
+    expect(filterIdsByPricing(ids, "free", undefined)).toEqual([]);
+    expect(filterIdsByPricing(ids, "paid", undefined)).toEqual([...ids]);
+  });
+});

--- a/src/llm/provider/model-pricing-filter.ts
+++ b/src/llm/provider/model-pricing-filter.ts
@@ -1,0 +1,62 @@
+import { formatTokenPrice } from "./format-model-details.js";
+import type { ModelCatalogEntry } from "./model-resolver.js";
+import type { ModelEntryLookup } from "./model-search.js";
+
+/**
+ * The price facet of the cloud model pickers: `all` shows the whole
+ * catalog, `free` only the rows whose price tag reads "free", `paid`
+ * the rest.
+ *
+ * `free` is deliberately strict — a row stays only when the catalog
+ * proves both prices are zero, by the same `formatTokenPrice` rule that
+ * paints the "free" tag on the row, so the facet can never contradict
+ * what a row says about itself. Everything else is `paid`: rows with
+ * real prices, `openrouter/auto` (renders "routed" — it bills whatever
+ * model it picks), and rows with no pricing metadata at all (aimlapi,
+ * live `/v1/models` ids), which cannot be promised to cost nothing.
+ * The two facets partition the catalog, so no row ever vanishes from
+ * both views.
+ */
+export type ModelPricingFilter = "all" | "free" | "paid";
+
+/** Cycle order for the one-key toggle; `all` first because it is the default. */
+const PRICING_CYCLE: readonly ModelPricingFilter[] = ["all", "free", "paid"];
+
+export function nextModelPricingFilter(
+  current: ModelPricingFilter,
+): ModelPricingFilter {
+  const at = PRICING_CYCLE.indexOf(current);
+  return PRICING_CYCLE[(at + 1) % PRICING_CYCLE.length] ?? "all";
+}
+
+/** `true` when the row's rendered price tag reads "free" — see the type note. */
+export function isFreeModelEntry(
+  modelId: string,
+  entry: ModelCatalogEntry | undefined,
+): boolean {
+  if (!entry?.pricing) return false;
+  return formatTokenPrice(modelId, entry.pricing) === "free";
+}
+
+export function matchesModelPricingFilter(
+  filter: ModelPricingFilter,
+  modelId: string,
+  entry: ModelCatalogEntry | undefined,
+): boolean {
+  if (filter === "all") return true;
+  return isFreeModelEntry(modelId, entry) === (filter === "free");
+}
+
+/**
+ * `ids` narrowed to the facet. `all` returns the input array itself so
+ * the no-facet path costs nothing on a 350-row catalog rebuilt per
+ * keystroke (same discipline as `filterWizardRows`).
+ */
+export function filterIdsByPricing(
+  ids: readonly string[],
+  filter: ModelPricingFilter,
+  lookup: ModelEntryLookup | undefined,
+): readonly string[] {
+  if (filter === "all") return ids;
+  return ids.filter((id) => matchesModelPricingFilter(filter, id, lookup?.(id)));
+}

--- a/src/tui/components/llm-mode-rows-cloud.test.tsx
+++ b/src/tui/components/llm-mode-rows-cloud.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "ink-testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
+import { refreshOpenRouterChatCatalogFromApi } from "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js";
 import { selectLlmPanelRows } from "../llm-panel/llm-panel-selectors.js";
 import type { ProviderRow } from "../providers/providers-panel-state.js";
 import { fakeSession } from "../test-fixtures.js";
@@ -158,6 +159,78 @@ describe("CloudRows inline model section", () => {
     expect(frame).toContain("ENOTFOUND");
     expect(frame).toContain("showing current model only");
     expect(frame).toContain("nous/m-000 [text]");
+  });
+});
+
+describe("CloudRows price facet", () => {
+  /**
+   * Seed the module-scoped live OpenRouter cache with two free and two
+   * paid rows. Only this describe reads the openrouter catalog; every
+   * other test in the file drives openai-compatible providers off their
+   * own `/v1/models` cache, so the leftover cache cannot reach them.
+   */
+  async function seedOpenRouterCatalog(): Promise<void> {
+    const data = [
+      { id: "vendor/free-000", price: "0" },
+      { id: "vendor/paid-001", price: "0.000001" },
+      { id: "vendor/free-002", price: "0" },
+      { id: "vendor/paid-003", price: "0.000001" },
+    ].map((row, i) => ({
+      id: row.id,
+      name: `Model ${i}`,
+      context_length: 128_000,
+      pricing: { prompt: row.price, completion: row.price },
+      supported_parameters: ["tools"],
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ data }) })),
+    );
+    await refreshOpenRouterChatCatalogFromApi();
+    vi.unstubAllGlobals();
+  }
+
+  function openRouterProvider(): ProviderRow {
+    return compatProvider({
+      id: "or",
+      kind: "openrouter",
+      baseUrl: null,
+      chatModel: "vendor/free-000",
+      chatModelOptions: [],
+    });
+  }
+
+  it("renders the price line with its key hint in the default state", async () => {
+    await seedCompatCache("https://render.nous.example", ["m-000"]);
+    const frame = renderRows(cloudState([compatProvider()]), 30);
+    expect(frame).toContain("price: all · p cycles free/paid/all");
+  });
+
+  it("narrows the list to catalog-proven free rows and reports filtered of total", async () => {
+    await seedOpenRouterCatalog();
+    const state = cloudState([openRouterProvider()], {
+      cloudModelPricing: "free",
+    });
+    const frame = renderRows(state, 30);
+    expect(frame).toContain("price: free");
+    expect(frame).toContain("or/vendor/free-000 [text]");
+    expect(frame).toContain("or/vendor/free-002 [text]");
+    expect(frame).not.toContain("paid-001");
+    expect(frame).not.toContain("paid-003");
+    expect(frame).toContain("(1/2 of 4)");
+  });
+
+  it("keeps rows without a free price under the paid facet", async () => {
+    await seedOpenRouterCatalog();
+    const state = cloudState([openRouterProvider()], {
+      cloudModelPricing: "paid",
+    });
+    const frame = renderRows(state, 30);
+    expect(frame).toContain("price: paid");
+    expect(frame).toContain("or/vendor/paid-001 [text]");
+    expect(frame).toContain("or/vendor/paid-003 [text]");
+    expect(frame).not.toContain("free-000 [text]");
+    expect(frame).not.toContain("free-002 [text]");
   });
 });
 

--- a/src/tui/components/llm-mode-rows.tsx
+++ b/src/tui/components/llm-mode-rows.tsx
@@ -176,12 +176,13 @@ function CloudRows({
   const section = selectCloudModelSection(state);
   const filter = state.llmPanel.cloudModelFilter;
   const filterFocused = state.llmPanel.cloudModelFilterFocused;
+  const pricing = state.llmPanel.cloudModelPricing;
   const statusLine = section.status !== "ready";
   // Everything around the model window costs lines: section headers (3),
-  // their bottom margins (3), provider:/filter: (2), the counter (1),
-  // provider/embedding rows, plus a loading/error line when shown.
+  // their bottom margins (3), provider:/filter:/price: (3), the counter
+  // (1), provider/embedding rows, plus a loading/error line when shown.
   const overhead =
-    9 +
+    10 +
     Math.max(1, providerRows.length) +
     Math.max(1, embeddingRows.length) +
     (statusLine ? 1 : 0);
@@ -239,6 +240,19 @@ function CloudRows({
             ) : null}
           </Text>
         </PasteFieldTarget>
+        {/* The price facet stays visible even while narrowed to nothing:
+            "no match" under `price: free` explains itself, where a bare
+            empty list would read as a broken catalog. */}
+        <Text color={theme.colors.muted}>
+          {"price: "}
+          <Text
+            bold={pricing !== "all"}
+            color={pricing !== "all" ? theme.colors.accent : theme.colors.muted}
+          >
+            {pricing}
+          </Text>
+          {" · p cycles free/paid/all"}
+        </Text>
         {section.status === "loading" ? (
           <Text color={theme.colors.muted}>  fetching model list…</Text>
         ) : null}

--- a/src/tui/components/providers-wizard.tsx
+++ b/src/tui/components/providers-wizard.tsx
@@ -294,15 +294,23 @@ function CatalogChatModelStep(props: {
 
   const service =
     kind === "openrouter" ? "Chat model (OpenRouter)" : "Chat model (AI/ML API)";
+  // The active price facet rides on the title so it stays visible even
+  // while the search box owns the hint line: a list narrowed to free
+  // rows must say so wherever the operator happens to be looking.
+  const facet = w.pricingFilter === "all" ? "" : ` · ${w.pricingFilter} only`;
   // The refresh notice rides on the title rather than the hint line: it
   // describes the list, not a key, and the hint already runs to the edge
   // of a 100-column terminal once the search box has had its say.
   const title = loading
-    ? `${service} · updating model list from API…`
-    : service;
+    ? `${service}${facet} · updating model list from API…`
+    : `${service}${facet}`;
+  // `p` is advertised only while the search box is closed; open, the
+  // letter types into the query instead of cycling the facet.
   const hints = pickListHints(
     w.search,
-    "PgUp/PgDn jump · Enter select",
+    w.search === null
+      ? `PgUp/PgDn jump · Enter select · p price: ${w.pricingFilter}`
+      : "PgUp/PgDn jump · Enter select",
     "Esc back",
     "Esc clears search, again backs out",
   );

--- a/src/tui/llm-panel/llm-panel-actions.ts
+++ b/src/tui/llm-panel/llm-panel-actions.ts
@@ -13,7 +13,9 @@ export type LlmPanelAction =
   /** Focus/unfocus the Cloud pane's inline `filter:` row. */
   | { type: "llm_cloud_filter_focus_set"; focused: boolean }
   /** Replace the inline filter text (cursor snaps to the top of the result set). */
-  | { type: "llm_cloud_filter_set"; value: string };
+  | { type: "llm_cloud_filter_set"; value: string }
+  /** Cycle the inline list's price facet: all → free → paid → all. */
+  | { type: "llm_cloud_pricing_cycled" };
 
 export function isLlmPanelAction(
   action: { type: string },
@@ -28,6 +30,7 @@ export function isLlmPanelAction(
     action.type === "llm_stop_local_daemons_prompt_closed" ||
     action.type === "llm_external_url_draft_set" ||
     action.type === "llm_cloud_filter_focus_set" ||
-    action.type === "llm_cloud_filter_set"
+    action.type === "llm_cloud_filter_set" ||
+    action.type === "llm_cloud_pricing_cycled"
   );
 }

--- a/src/tui/llm-panel/llm-panel-key-bindings.test.ts
+++ b/src/tui/llm-panel/llm-panel-key-bindings.test.ts
@@ -161,6 +161,45 @@ describe("handleLlmPanelKey", () => {
     expect(typed).toEqual([{ type: "llm_cloud_filter_set", value: "c" }]);
   });
 
+  it("p cycles the price facet on the Cloud pane only, and is text in a focused filter", () => {
+    const base = seededState();
+    // On the Local pane the letter stays unclaimed.
+    const dispatchedLocal: TuiAction[] = [];
+    const handledLocal = handleLlmPanelKey("p", emptyKey(), {
+      state: base,
+      dispatch: (action) => dispatchedLocal.push(action),
+      callbacks: callbacks(),
+    });
+    expect(handledLocal).toBe(false);
+    expect(dispatchedLocal).toEqual([]);
+
+    const cloud = {
+      ...base,
+      llmPanel: { ...base.llmPanel, mode: "cloud" as const },
+    };
+    const dispatched: TuiAction[] = [];
+    const handled = handleLlmPanelKey("p", emptyKey(), {
+      state: cloud,
+      dispatch: (action) => dispatched.push(action),
+      callbacks: callbacks(),
+    });
+    expect(handled).toBe(true);
+    expect(dispatched).toEqual([{ type: "llm_cloud_pricing_cycled" }]);
+
+    // Focused filter: "p" is query text, never the facet key.
+    const focused = {
+      ...cloud,
+      llmPanel: { ...cloud.llmPanel, cloudModelFilterFocused: true },
+    };
+    const typed: TuiAction[] = [];
+    handleLlmPanelKey("p", emptyKey(), {
+      state: focused,
+      dispatch: (action) => typed.push(action),
+      callbacks: callbacks(),
+    });
+    expect(typed).toEqual([{ type: "llm_cloud_filter_set", value: "p" }]);
+  });
+
   it("selects an exact cloud embedding model", () => {
     const base = seededState();
     const state = {

--- a/src/tui/llm-panel/llm-panel-key-bindings.ts
+++ b/src/tui/llm-panel/llm-panel-key-bindings.ts
@@ -67,6 +67,15 @@ export function handleLlmPanelKey(
     return true;
   }
 
+  // `p` cycles the price facet of the inline model list: all → free →
+  // paid → all. Cloud pane only — the other panes have no priced rows to
+  // narrow. While the `filter:` row is focused the letter is query text
+  // instead (the focused branch above already consumed it).
+  if (input === "p" && state.llmPanel.mode === "cloud") {
+    dispatch({ type: "llm_cloud_pricing_cycled" });
+    return true;
+  }
+
   // `/` bootstraps the global slash-command palette. The LLM tab keeps
   // the editor unfocused so single letters act as panel hotkeys, which
   // means typing `/` never reaches the editor's onChange. Seed the input

--- a/src/tui/llm-panel/llm-panel-reducer.test.ts
+++ b/src/tui/llm-panel/llm-panel-reducer.test.ts
@@ -59,6 +59,28 @@ describe("llm-panel reducer", () => {
     expect(refreshed.llmPanel.mode).toBe("cloud");
     expect(refreshed.llmPanel.syncModeToActiveRoute).toBe(false);
   });
+
+  it("cycles the cloud price facet and snaps the cursor to the top of the model section", () => {
+    const base = createInitialTuiState(fakeSession());
+    const state = {
+      ...base,
+      llmPanel: { ...base.llmPanel, mode: "cloud" as const, cloudCursor: 5 },
+      providersPanel: {
+        ...base.providersPanel,
+        rows: [providerRow("openrouter", "openrouter", true)],
+      },
+    };
+
+    const free = reduceTuiState(state, { type: "llm_cloud_pricing_cycled" });
+    expect(free.llmPanel.cloudModelPricing).toBe("free");
+    // One provider row above the model section, so its top is index 1.
+    expect(free.llmPanel.cloudCursor).toBe(1);
+
+    const paid = reduceTuiState(free, { type: "llm_cloud_pricing_cycled" });
+    expect(paid.llmPanel.cloudModelPricing).toBe("paid");
+    const all = reduceTuiState(paid, { type: "llm_cloud_pricing_cycled" });
+    expect(all.llmPanel.cloudModelPricing).toBe("all");
+  });
 });
 
 function providerRow(id: string, kind: string, isActiveText: boolean) {

--- a/src/tui/llm-panel/llm-panel-reducer.ts
+++ b/src/tui/llm-panel/llm-panel-reducer.ts
@@ -1,3 +1,4 @@
+import { nextModelPricingFilter } from "../../llm/provider/model-pricing-filter.js";
 import type { TuiAction } from "../tui-action.js";
 import type { TuiState } from "../tui-state.js";
 import { isLlmPanelAction } from "./llm-panel-actions.js";
@@ -107,6 +108,25 @@ export function reduceLlmPanelAction(
       const next: TuiState = {
         ...state,
         llmPanel: { ...panel, cloudModelFilter: action.value },
+      };
+      const section = selectCloudModelSection(next);
+      return {
+        ...next,
+        llmPanel: {
+          ...next.llmPanel,
+          cloudCursor: section.sectionStart,
+        },
+      };
+    }
+    case "llm_cloud_pricing_cycled": {
+      // A facet change replaces the list wholesale, so the cursor snaps
+      // to the top of the new result set exactly like a filter edit.
+      const next: TuiState = {
+        ...state,
+        llmPanel: {
+          ...panel,
+          cloudModelPricing: nextModelPricingFilter(panel.cloudModelPricing),
+        },
       };
       const section = selectCloudModelSection(next);
       return {

--- a/src/tui/llm-panel/llm-panel-row-builders.ts
+++ b/src/tui/llm-panel/llm-panel-row-builders.ts
@@ -5,6 +5,7 @@ import type {
 import { getCachedOpenAiCompatModelsForBaseUrl } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { getCachedGeminiModelsForPanel } from "../../llm/provider/gemini/fetch-gemini-models.js";
 import { GEMINI_DEFAULT_CHAT_MODEL } from "../../llm/provider/gemini/gemini-provider.js";
+import { filterIdsByPricing } from "../../llm/provider/model-pricing-filter.js";
 import { filterModelIds, type ProviderRow } from "../providers/providers-panel-state.js";
 import {
   catalogEntryLookupForKind,
@@ -101,10 +102,14 @@ export function selectCloudModelSection(state: TuiState): CloudModelSection {
     };
   }
   const catalog = inlineModelsForProvider(state, provider);
+  const lookup = catalogEntryLookupForKind(provider.kind);
+  // The price facet narrows first, the typed filter second — same result
+  // either way, but this keeps the facet from paying the ranked-search
+  // cost on the rows it is about to drop.
   const filtered = filterModelIds(
-    catalog.models,
+    filterIdsByPricing(catalog.models, state.llmPanel.cloudModelPricing, lookup),
     state.llmPanel.cloudModelFilter,
-    catalogEntryLookupForKind(provider.kind),
+    lookup,
   );
   return { provider, ...catalog, filtered, sectionStart };
 }

--- a/src/tui/llm-panel/llm-panel-state.ts
+++ b/src/tui/llm-panel/llm-panel-state.ts
@@ -1,3 +1,5 @@
+import type { ModelPricingFilter } from "../../llm/provider/model-pricing-filter.js";
+
 /**
  * Panes of the LLM tab. `local` browses the managed llama.cpp catalog,
  * `cloud` the API providers, `external` the single base URL of a
@@ -46,6 +48,13 @@ export interface LlmPanelState {
    * `f` or `/model`.
    */
   cloudModelFilterFocused: boolean;
+  /**
+   * Price facet of the Cloud pane's inline model list, cycled with `p`.
+   * Own field rather than a term in `cloudModelFilter` so the two narrow
+   * independently, and separate from the providers wizard's facet so
+   * neither screen leaks its state into the other.
+   */
+  cloudModelPricing: ModelPricingFilter;
 }
 
 export function createInitialLlmPanelState(): LlmPanelState {
@@ -60,6 +69,7 @@ export function createInitialLlmPanelState(): LlmPanelState {
     externalUrlDraft: null,
     cloudModelFilter: "",
     cloudModelFilterFocused: false,
+    cloudModelPricing: "all",
   };
 }
 

--- a/src/tui/providers/providers-wizard-key-bindings.test.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.test.ts
@@ -868,3 +868,107 @@ function next(
   }
   return result.wizard;
 }
+
+describe("cloud pick list price facet (p)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Two free rows and two paid ones, identical scores so the payload
+   * order survives ranking (same trick as the navigation suite above).
+   * Fresh module graph per test: the live catalog cache is module-scoped
+   * and one test's refresh must not leak into the rest of this file.
+   */
+  async function freshMixedPickPhase() {
+    vi.resetModules();
+    const catalog = await import(
+      "../../llm/provider/openrouter/fetch-openrouter-chat-catalog.js"
+    );
+    const bindings = await import("./providers-wizard-key-bindings.js");
+    const phases = await import("./providers-wizard-phases.js");
+    const data = [
+      { id: "vendor/free-000", price: "0" },
+      { id: "vendor/paid-001", price: "0.000001" },
+      { id: "vendor/free-002", price: "0" },
+      { id: "vendor/paid-003", price: "0.000001" },
+    ].map((row, i) => ({
+      id: row.id,
+      name: `Model ${i}`,
+      context_length: 128_000,
+      pricing: { prompt: row.price, completion: row.price },
+      supported_parameters: ["tools"],
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ data }) })),
+    );
+    await catalog.refreshOpenRouterChatCatalogFromApi();
+    const wizard: ProvidersWizardState = {
+      ...createProvidersWizardState("add", { kind: "openrouter" }),
+      phase: "pick_chat_model",
+    };
+    const step = (
+      w: ProvidersWizardState,
+      input: string,
+      key: Key,
+    ): ProvidersWizardState => {
+      const result = bindings.handleProvidersWizardKey(input, key, w);
+      if (!result.handled || !("wizard" in result)) {
+        throw new Error("wizard key was not handled");
+      }
+      return result.wizard;
+    };
+    const visibleIds = (w: ProvidersWizardState): readonly string[] =>
+      phases.visibleRowsForPhase(w).map((row) => row.id);
+    return { bindings, wizard, step, visibleIds };
+  }
+
+  it("p narrows the list to the catalog-proven free rows", async () => {
+    const { wizard, step, visibleIds } = await freshMixedPickPhase();
+    expect(visibleIds(wizard)).toHaveLength(4);
+
+    const filtered = step(wizard, "p", emptyKey());
+    expect(filtered.pricingFilter).toBe("free");
+    expect(visibleIds(filtered)).toEqual(["vendor/free-000", "vendor/free-002"]);
+  });
+
+  it("cycles free → paid → all and back to the full list", async () => {
+    const { wizard, step, visibleIds } = await freshMixedPickPhase();
+
+    const paidView = step(step(wizard, "p", emptyKey()), "p", emptyKey());
+    expect(paidView.pricingFilter).toBe("paid");
+    expect(visibleIds(paidView)).toEqual(["vendor/paid-001", "vendor/paid-003"]);
+
+    const allView = step(paidView, "p", emptyKey());
+    expect(allView.pricingFilter).toBe("all");
+    expect(visibleIds(allView)).toHaveLength(4);
+  });
+
+  it("snaps the cursor to the top when the facet flips", async () => {
+    const { wizard, step } = await freshMixedPickPhase();
+    const deep = { ...wizard, cursor: 3 };
+    expect(step(deep, "p", emptyKey()).cursor).toBe(0);
+  });
+
+  it("Enter selects from the narrowed list, and the facet does not leak into the embedding screen", async () => {
+    const { wizard, step } = await freshMixedPickPhase();
+    const filtered = step(wizard, "p", emptyKey());
+    const moved = step(filtered, "", emptyKey({ downArrow: true }));
+
+    const submitted = step(moved, "", emptyKey({ return: true }));
+    // Row 1 of the free view is the second free model, not vendor/paid-001.
+    expect(submitted.selectedChatModelId).toBe("vendor/free-002");
+    expect(submitted.phase).toBe("pick_embedding");
+    expect(submitted.pricingFilter).toBe("all");
+  });
+
+  it("with the search box open, p is query text, not the facet key", async () => {
+    const { wizard, step } = await freshMixedPickPhase();
+    const searching = step(wizard, "/", emptyKey());
+
+    const typed = step(searching, "p", emptyKey());
+    expect(typed.search).toBe("p");
+    expect(typed.pricingFilter).toBe("all");
+  });
+});

--- a/src/tui/providers/providers-wizard-key-bindings.ts
+++ b/src/tui/providers/providers-wizard-key-bindings.ts
@@ -1,6 +1,7 @@
 import type { Key } from "ink";
 import { getCachedOpenAiCompatModels } from "../../llm/provider/openai/fetch-openai-compat-models.js";
 import { getCachedGeminiModels } from "../../llm/provider/gemini/fetch-gemini-models.js";
+import { nextModelPricingFilter } from "../../llm/provider/model-pricing-filter.js";
 import { findProviderPreset } from "./provider-presets.js";
 import {
   handleWizardSearchKey,
@@ -199,6 +200,22 @@ export function handleProvidersWizardKey(
 
   if (!isListPhase(wizard.phase)) {
     return { handled: false };
+  }
+
+  // `p` cycles the price facet of the curated chat-model list: all →
+  // free → paid → all. Only reachable while the search box is closed —
+  // open, `handleWizardSearchKey` above consumed every printable key as
+  // query text, `p` included. Handled before the empty-list bailout so
+  // a facet that matched nothing can still be cycled away from.
+  if (wizard.phase === "pick_chat_model" && input === "p" && !key.ctrl && !key.meta) {
+    return {
+      handled: true,
+      wizard: {
+        ...wizard,
+        pricingFilter: nextModelPricingFilter(wizard.pricingFilter),
+        cursor: 0,
+      },
+    };
   }
 
   // One list for the whole screen: the render highlights row `cursor` of

--- a/src/tui/providers/providers-wizard-phases.ts
+++ b/src/tui/providers/providers-wizard-phases.ts
@@ -1,3 +1,7 @@
+import {
+  matchesModelPricingFilter,
+  type ModelPricingFilter,
+} from "../../llm/provider/model-pricing-filter.js";
 import { findProviderPreset, PROVIDER_PRESETS } from "./provider-presets.js";
 import {
   filterWizardRows,
@@ -5,6 +9,7 @@ import {
 } from "./providers-wizard-filter.js";
 import { kindRowId, labelForKindRow } from "./providers-wizard-kind-labels.js";
 import {
+  catalogEntryLookupForKind,
   listAimlapiChatModels,
   listAimlapiEmbeddingModels,
   listOpenRouterChatModels,
@@ -187,7 +192,10 @@ export function visibleRowsForPhase(
   const { phase, kind, search } = wizard;
   if (phase === "pick_kind") return visibleKindRows(search);
   if (phase === "pick_chat_model" && kind && isCuratedCatalogKind(kind)) {
-    return filterWizardRows(listChatModelsForKind(kind), search);
+    return filterWizardRows(
+      chatRowsForPricing(kind, wizard.pricingFilter),
+      search,
+    );
   }
   if (phase === "pick_embedding" && kind && isCuratedCatalogKind(kind)) {
     return filterWizardRows(listEmbeddingModelsForKind(kind), search);
@@ -196,11 +204,36 @@ export function visibleRowsForPhase(
 }
 
 /**
+ * The chat-model rows left after the price facet (`p`). Runs before the
+ * search box so both narrow one list, and reads only row ids against the
+ * catalog map — never the lazy labels, which keeps a facet flip linear
+ * on a 340-row catalog (see `providers-model-options`).
+ */
+function chatRowsForPricing(
+  kind: NonNullable<ProvidersWizardState["kind"]>,
+  filter: ModelPricingFilter,
+): ReturnType<typeof listChatModelsForKind> {
+  const rows = listChatModelsForKind(kind);
+  if (filter === "all") return rows;
+  const lookup = catalogEntryLookupForKind(kind);
+  return rows.filter((row) =>
+    matchesModelPricingFilter(filter, row.id, lookup?.(row.id)),
+  );
+}
+
+/**
  * State every phase change resets. A query typed to find one row must
  * not still be narrowing the next screen's list, where the operator has
- * no reason to expect it and nothing they typed is on show.
+ * no reason to expect it and nothing they typed is on show. The price
+ * facet resets for the same reason: it belongs to the screen it was
+ * cycled on, never to the next one.
  */
-const PHASE_ENTRY = { cursor: 0, search: null, error: null } as const;
+const PHASE_ENTRY = {
+  cursor: 0,
+  search: null,
+  pricingFilter: "all",
+  error: null,
+} as const;
 
 export function advanceWizardPhase(
   wizard: ProvidersWizardState,

--- a/src/tui/providers/providers-wizard-state.ts
+++ b/src/tui/providers/providers-wizard-state.ts
@@ -1,4 +1,5 @@
 import type { SubscriptionCliName } from "../../config/llm-config.js";
+import type { ModelPricingFilter } from "../../llm/provider/model-pricing-filter.js";
 import { presetForEntryId } from "./provider-presets.js";
 
 export type ProvidersWizardKind =
@@ -74,6 +75,13 @@ export interface ProvidersWizardState {
    * screen, and `advanceWizardPhase` clears it on the way out.
    */
   search: string | null;
+  /**
+   * Price facet of the curated chat-model screen, cycled with `p` while
+   * the search box is closed. Reset by `advanceWizardPhase` alongside
+   * `search`, so a facet picked to find one row cannot silently narrow
+   * the next screen's list.
+   */
+  pricingFilter: ModelPricingFilter;
   apiKeyBuffer: string;
   baseUrlLine: string;
   chatModelLine: string;
@@ -133,6 +141,7 @@ export function createProvidersWizardState(
     presetId,
     cursor: 0,
     search: null,
+    pricingFilter: "all",
     apiKeyBuffer: "",
     baseUrlLine: opts?.baseUrl ?? "",
     chatModelLine: cliBacked ? (opts?.chatModel ?? "") : "",


### PR DESCRIPTION
## What

Adds a **free / paid / all price facet** next to the existing search on both cloud model list surfaces, cycled with the `p` key:

- **LLM pane → Cloud text models** (the live surface): a new `price:` line renders under `filter:` with the current facet and the key hint (`price: all · p cycles free/paid/all`). `p` cycles the facet; while the `filter:` row is focused, `p` stays query text (Esc out first, as the hint line already teaches). A facet flip snaps the cursor to the top of the result set, same rule as a filter edit, and the counter reports `n/filtered of total`.
- **Providers wizard → curated chat-model screen** (OpenRouter / AI/ML API): `p` cycles while the search box is closed (open, every printable key belongs to the query). The active facet rides on the title (`Chat model (OpenRouter) · free only`) so it stays visible even while the search box owns the hint line, and the closed-state hint names the key (`p price: all`).

## Why

The catalogs run past 300 rows and the only way to shop by price was typing `free` into the ranked search — which also subsequence-matches unrelated ids, and cannot express "hide the free ones".

## Semantics

One shared predicate (`src/llm/provider/model-pricing-filter.ts`), derived from the same `formatTokenPrice` rule that paints the price tag on the row, so the facet can never contradict what a row displays:

- **free** — the catalog proves both prices are zero (the row's tag reads "free"). `openrouter/auto` stays out: its tag reads "routed" and it bills whatever model it routes to.
- **paid** — everything else, including rows with no pricing metadata (aimlapi rows, live `/v1/models` ids), which cannot be promised to cost nothing. The two facets partition the catalog, so no row ever vanishes from both views.
- **all** — the default, everywhere.

## State does not leak between screens

- The wizard facet resets in `PHASE_ENTRY` alongside the search, so a facet cycled on the chat-model screen never narrows the embedding screen.
- The pane and the wizard keep separate facet fields, so neither surface leaks into the other.

## Test evidence

- `src/llm/provider/model-pricing-filter.test.ts` — predicate: free/paid/all classification, routed exception, unknown-pricing rows, partition property, cycle order (9 tests).
- `src/tui/providers/providers-wizard-key-bindings.test.ts` — against a live-seeded mixed catalog (fresh module graph, same harness as the navigation suite): `p` narrows to catalog-proven free rows, cycles through paid back to all, snaps the cursor, Enter selects from the narrowed list, the facet resets on advance to `pick_embedding`, and `p` is query text while the search box is open (5 tests).
- `src/tui/components/llm-mode-rows-cloud.test.tsx` — component: price line + hint in the default state, free facet narrows with the `(1/2 of 4)` counter, paid facet keeps unknown-priced rows (3 tests).
- `src/tui/llm-panel/llm-panel-key-bindings.test.ts` / `llm-panel-reducer.test.ts` — `p` is cloud-pane-only and filter-focus-safe; the reducer cycles and snaps the cursor (2 tests).

All 10 behavioral tests **fail with the implementation stashed** (verified). `npm run lint` (tsc) passes; targeted suites all green: `src/tui/providers` + `src/tui/llm-panel` + `src/llm/provider` (612 tests), wizard/onboarding/pick-list component suites (46), app-level layout suites incl. `manage-panel-fit` which guards the extra `price:` line against small-terminal overflow (59).

No Windows-specific code paths touched (pure TUI state/render); no Windows QA needed.

Reported on Discord: https://discord.com/channels/1515649306781155428/1515650562430079048/1536840031329853652
