### PR TITLE
feat(cli): `memory export` — one-way Obsidian vault export of agent memory

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { configCommand } from "./config-command.js";
 import { serveCommand } from "./serve-command.js";
 import { traceCommand } from "./trace-command.js";
 import { taskCommand } from "./task-command.js";
+import { memoryCommand } from "./memory-command.js";
 import { modelsCommand } from "./models-command.js";
 import { importCommand } from "./import-command.js";
 import { uninstallCommand } from "./uninstall-command.js";
@@ -28,9 +29,9 @@ interface CommandDescriptor {
    *   2  usage error — unknown command or subcommand, missing required
    *      argument, argument of the wrong kind. Nothing was attempted.
    *
-   * `run`, `skill` and the dispatcher below implement this split. The
-   * rest of the table does not, and a caller must not read their codes
-   * through it:
+   * `run`, `skill`, `memory` and the dispatcher below implement this
+   * split. The rest of the table does not, and a caller must not read
+   * their codes through it:
    *
    *   - `config`, `serve`, `trace`, `task`, `models`, `import` predate
    *     the split and return `1` for usage errors too, so their `1` does
@@ -95,6 +96,11 @@ const COMMANDS: CommandDescriptor[] = [
     name: "task",
     summary: "Manage durable tasks (list|show|create|cancel|run)",
     run: taskCommand,
+  },
+  {
+    name: "memory",
+    summary: "Inspect + export the cross-session memory store (export)",
+    run: memoryCommand,
   },
   {
     name: "models",

--- a/src/cli/memory-command.test.ts
+++ b/src/cli/memory-command.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resetConfigCache } from "../config/index.js";
+import { MemoryStore } from "../memory/memory-store.js";
+
+import { memoryCommand } from "./memory-command.js";
+
+describe("memoryCommand", () => {
+  let stateDir: string;
+  let vaultDir: string;
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  let savedVaultEnv: string | undefined;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "atomic-memory-cli-"));
+    vaultDir = join(stateDir, "vault");
+    mkdirSync(vaultDir);
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    savedVaultEnv = process.env.OBSIDIAN_VAULT_PATH;
+    delete process.env.OBSIDIAN_VAULT_PATH;
+    resetConfigCache();
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    if (savedVaultEnv === undefined) delete process.env.OBSIDIAN_VAULT_PATH;
+    else process.env.OBSIDIAN_VAULT_PATH = savedVaultEnv;
+    resetConfigCache();
+    vi.restoreAllMocks();
+  });
+
+  function stdout(): string {
+    return stdoutChunks.join("");
+  }
+
+  function stderr(): string {
+    return stderrChunks.join("");
+  }
+
+  function seedMemory(): void {
+    const store = new MemoryStore({
+      dbFile: join(stateDir, "memory.sqlite"),
+      maxEntries: 100,
+    });
+    try {
+      store.store({ content: "remember the milk", tags: ["errand"] });
+    } finally {
+      store.close();
+    }
+  }
+
+  it("prints help when no subcommand is passed", async () => {
+    const code = await memoryCommand([]);
+    expect(code).toBe(0);
+    expect(stdout()).toMatch(/atomic-agent memory/);
+    expect(stdout()).toMatch(/export \[--vault/);
+  });
+
+  it("rejects an unknown subcommand with a usage error", async () => {
+    const code = await memoryCommand(["nope"]);
+    expect(code).toBe(2);
+    expect(stderr()).toMatch(/unknown subcommand: nope/);
+  });
+
+  it("requires a vault path from --vault or OBSIDIAN_VAULT_PATH", async () => {
+    const code = await memoryCommand(["export"]);
+    expect(code).toBe(2);
+    expect(stderr()).toMatch(/--vault <path>/);
+  });
+
+  it("exports the state-dir corpus into the vault passed via --vault", async () => {
+    seedMemory();
+    const code = await memoryCommand(["export", "--vault", vaultDir]);
+    expect(code).toBe(0);
+    expect(stdout()).toMatch(/exported 1 notes, 0 lessons, 0 procedures -> /);
+    expect(
+      existsSync(join(vaultDir, "atomic-agent", "notes", "note-1.md")),
+    ).toBe(true);
+  });
+
+  it("falls back to OBSIDIAN_VAULT_PATH and honors --folder", async () => {
+    seedMemory();
+    process.env.OBSIDIAN_VAULT_PATH = vaultDir;
+    const code = await memoryCommand(["export", "--folder", "brain"]);
+    expect(code).toBe(0);
+    expect(existsSync(join(vaultDir, "brain", "notes", "note-1.md"))).toBe(true);
+  });
+
+  it("maps a folder escaping the vault to a usage error", async () => {
+    seedMemory();
+    const code = await memoryCommand([
+      "export",
+      "--vault",
+      vaultDir,
+      "--folder",
+      "..",
+    ]);
+    expect(code).toBe(2);
+    expect(stderr()).toMatch(/--folder must name a subfolder/);
+  });
+
+  it("reports a missing memory database as an operational failure", async () => {
+    const code = await memoryCommand(["export", "--vault", vaultDir]);
+    expect(code).toBe(1);
+    expect(stderr()).toMatch(/memory export failed: no memory database/);
+  });
+});

--- a/src/cli/memory-command.ts
+++ b/src/cli/memory-command.ts
@@ -1,0 +1,95 @@
+import { getConfig } from "../config/index.js";
+import {
+  DEFAULT_EXPORT_FOLDER,
+  ObsidianExportUsageError,
+  exportMemoryToObsidian,
+} from "../memory/index.js";
+
+const HELP =
+  [
+    "atomic-agent memory — inspect + export the cross-session memory store",
+    "",
+    "The corpus (notes / lessons / procedures) lives in <stateDir>/memory.sqlite.",
+    "",
+    "Subcommands:",
+    "  export [--vault <path>] [--folder <name>]",
+    "                            One-way export of the corpus into an Obsidian",
+    "                            vault as markdown files with YAML frontmatter",
+    "                            and [[wikilinks]] along the schema's own edges",
+    "                            (memory links, lesson/procedure parents).",
+    "                            --vault defaults to $OBSIDIAN_VAULT_PATH and",
+    "                            must point at an existing vault directory.",
+    `                            --folder is the vault subfolder the export`,
+    `                            owns (default '${DEFAULT_EXPORT_FOLDER}'). Idempotent:`,
+    "                            re-exports overwrite in place; stale note-<n>.md /",
+    "                            lesson-<n>.md / procedure-<n>.md files whose",
+    "                            record is gone are pruned; other files are",
+    "                            never touched. The database is opened",
+    "                            read-only — nothing syncs back.",
+    "",
+    "Examples:",
+    "  atomic-agent memory export --vault ~/Documents/MyVault",
+    "  OBSIDIAN_VAULT_PATH=~/Documents/MyVault atomic-agent memory export",
+  ].join("\n") + "\n";
+
+export async function memoryCommand(args: string[]): Promise<number> {
+  const sub = args[0];
+  if (!sub || sub === "-h" || sub === "--help") {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  switch (sub) {
+    case "export":
+      return handleExport(args.slice(1));
+    default:
+      process.stderr.write(`unknown subcommand: ${sub}\n`);
+      process.stderr.write(HELP);
+      return 2;
+  }
+}
+
+function handleExport(args: string[]): number {
+  if (args.includes("-h") || args.includes("--help")) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  // `getConfig()` first: it merges `<stateDir>/.env` into `process.env`,
+  // so an OBSIDIAN_VAULT_PATH kept there is visible below.
+  const config = getConfig();
+  const vaultDir = readOption(args, "--vault") ?? process.env.OBSIDIAN_VAULT_PATH;
+  if (!vaultDir) {
+    process.stderr.write(
+      "usage: atomic-agent memory export --vault <path> [--folder <name>] (or set OBSIDIAN_VAULT_PATH)\n",
+    );
+    return 2;
+  }
+  const folder = readOption(args, "--folder");
+  try {
+    const result = exportMemoryToObsidian({
+      dbFile: config.paths.memoryDbFile,
+      vaultDir,
+      ...(folder !== undefined ? { folder } : {}),
+    });
+    const pruned = result.pruned > 0 ? ` (pruned ${result.pruned} stale)` : "";
+    process.stdout.write(
+      `exported ${result.notes} notes, ${result.lessons} lessons, ${result.procedures} procedures -> ${result.root}${pruned}\n`,
+    );
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (err instanceof ObsidianExportUsageError) {
+      process.stderr.write(`${message}\n`);
+      return 2;
+    }
+    process.stderr.write(`memory export failed: ${message}\n`);
+    return 1;
+  }
+}
+
+function readOption(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx < 0) return undefined;
+  const value = args[idx + 1];
+  if (!value || value.startsWith("--")) return undefined;
+  return value;
+}

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -63,3 +63,12 @@ export type {
   HybridRecallOptions,
   LlamaEmbeddingClientOptions,
 } from "./embeddings/index.js";
+export {
+  DEFAULT_EXPORT_FOLDER,
+  ObsidianExportUsageError,
+  exportMemoryToObsidian,
+} from "./obsidian-export.js";
+export type {
+  ObsidianExportOptions,
+  ObsidianExportResult,
+} from "./obsidian-export.js";

--- a/src/memory/obsidian-export.test.ts
+++ b/src/memory/obsidian-export.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Database as DatabaseCtor } from "../native/load-better-sqlite3.js";
+import { MemoryStore } from "./memory-store.js";
+import { LessonStore } from "./lessons/lesson-store.js";
+import { ProcedureStore } from "./procedures/procedure-store.js";
+import { LinkStore } from "./links/link-store.js";
+import {
+  ObsidianExportUsageError,
+  exportMemoryToObsidian,
+} from "./obsidian-export.js";
+
+const T0 = Date.UTC(2026, 0, 2, 3, 4, 5); // 2026-01-02T03:04:05.000Z
+
+/**
+ * Build a small corpus exercising every exported edge kind: a
+ * note→note link, a lesson with parents (one evicted), an archived
+ * note, and a procedure sourced from both a lesson and a note.
+ *
+ * Returns the ids so assertions don't hardcode AUTOINCREMENT values.
+ */
+function buildCorpus(dbFile: string): {
+  noteA: number;
+  noteB: number;
+  noteC: number;
+  lesson: number;
+  procedure: number;
+} {
+  const notes = new MemoryStore({ dbFile, maxEntries: 100, now: () => T0 });
+  const lessons = new LessonStore({ dbFile, now: () => T0 });
+  const procedures = new ProcedureStore({ dbFile, now: () => T0 });
+  try {
+    const noteA = notes.store({
+      content: "Tap the simulator with a duration or taps get dropped.",
+      tags: ["ios", "simulator"],
+    }).id;
+    const noteB = notes.store({ content: "idb is the reliable input path." }).id;
+    const noteC = notes.store({ content: "A note that will be deleted." }).id;
+
+    const links = new LinkStore({
+      db: notes.getDatabaseHandleForEmbeddings(),
+      now: () => T0,
+    });
+    links.add({ fromId: noteA, toId: noteB, kind: "RELATES_TO" });
+
+    const lesson = lessons.create({
+      activation: "when driving the ios simulator",
+      principle: "Prefer idb, and always tap with an explicit duration.",
+      tags: ["ios"],
+      // 9999 is a soft pointer to an evicted episode — must not render.
+      parentIds: [noteA, noteB, 9999],
+    }).id;
+    notes.archiveInto([noteA], lesson);
+
+    const procedure = procedures.create({
+      activation: "installing an app on the simulator",
+      steps: [
+        { description: "Boot the target simulator", toolHint: "os.exec" },
+        { description: "Install and launch the app" },
+      ],
+      tags: ["ios"],
+      parentLessonIds: [lesson],
+      parentMemoryIds: [noteB, 9999],
+    }).id;
+
+    return { noteA, noteB, noteC, lesson, procedure };
+  } finally {
+    procedures.close();
+    lessons.close();
+    notes.close();
+  }
+}
+
+describe("exportMemoryToObsidian", () => {
+  let dir: string;
+  let dbFile: string;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "atomic-obsidian-export-"));
+    dbFile = join(dir, "memory.sqlite");
+    vaultDir = join(dir, "vault");
+    mkdirSync(vaultDir);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("exports notes, lessons and procedures as markdown with frontmatter", () => {
+    const ids = buildCorpus(dbFile);
+    const result = exportMemoryToObsidian({ dbFile, vaultDir });
+
+    expect(result).toMatchObject({
+      notes: 3,
+      lessons: 1,
+      procedures: 1,
+      pruned: 0,
+    });
+    expect(result.root).toBe(join(vaultDir, "atomic-agent"));
+
+    const noteA = readFileSync(
+      join(result.root, "notes", `note-${ids.noteA}.md`),
+      "utf8",
+    );
+    expect(noteA).toContain("type: memory-note");
+    expect(noteA).toContain(`id: ${ids.noteA}`);
+    expect(noteA).toContain("created: 2026-01-02T03:04:05.000Z");
+    expect(noteA).toContain('source: "agent"');
+    expect(noteA).toContain('  - "ios"');
+    expect(noteA).toContain('  - "simulator"');
+    expect(noteA).toContain(
+      "Tap the simulator with a duration or taps get dropped.",
+    );
+
+    const lesson = readFileSync(
+      join(result.root, "lessons", `lesson-${ids.lesson}.md`),
+      "utf8",
+    );
+    expect(lesson).toContain("type: memory-lesson");
+    expect(lesson).toContain('status: "active"');
+    expect(lesson).toContain("**When:** when driving the ios simulator");
+    expect(lesson).toContain(
+      "Prefer idb, and always tap with an explicit duration.",
+    );
+
+    const procedure = readFileSync(
+      join(result.root, "procedures", `procedure-${ids.procedure}.md`),
+      "utf8",
+    );
+    expect(procedure).toContain("type: memory-procedure");
+    expect(procedure).toContain('source: "consolidator"');
+    expect(procedure).toContain("1. Boot the target simulator (`os.exec`)");
+    expect(procedure).toContain("2. Install and launch the app");
+  });
+
+  it("renders wikilinks along schema edges and skips dangling soft pointers", () => {
+    const ids = buildCorpus(dbFile);
+    const result = exportMemoryToObsidian({ dbFile, vaultDir });
+
+    const noteA = readFileSync(
+      join(result.root, "notes", `note-${ids.noteA}.md`),
+      "utf8",
+    );
+    expect(noteA).toContain(`- relates to [[note-${ids.noteB}]]`);
+    expect(noteA).toContain(`- consolidated into [[lesson-${ids.lesson}]]`);
+
+    const lesson = readFileSync(
+      join(result.root, "lessons", `lesson-${ids.lesson}.md`),
+      "utf8",
+    );
+    expect(lesson).toContain(`- [[note-${ids.noteA}]]`);
+    expect(lesson).toContain(`- [[note-${ids.noteB}]]`);
+    expect(lesson).not.toContain("9999");
+
+    const procedure = readFileSync(
+      join(result.root, "procedures", `procedure-${ids.procedure}.md`),
+      "utf8",
+    );
+    expect(procedure).toContain(`- [[lesson-${ids.lesson}]]`);
+    expect(procedure).toContain(`- [[note-${ids.noteB}]]`);
+    expect(procedure).not.toContain("9999");
+
+    // noteB has no outgoing edges and is not archived — no Links section.
+    const noteB = readFileSync(
+      join(result.root, "notes", `note-${ids.noteB}.md`),
+      "utf8",
+    );
+    expect(noteB).not.toContain("## Links");
+  });
+
+  it("is idempotent: a re-export against an unchanged corpus is byte-identical", () => {
+    buildCorpus(dbFile);
+    const first = exportMemoryToObsidian({ dbFile, vaultDir });
+    const snapshot = new Map<string, string>();
+    for (const sub of ["notes", "lessons", "procedures"]) {
+      for (const name of readdirSync(join(first.root, sub))) {
+        snapshot.set(
+          `${sub}/${name}`,
+          readFileSync(join(first.root, sub, name), "utf8"),
+        );
+      }
+    }
+
+    const second = exportMemoryToObsidian({ dbFile, vaultDir });
+    expect(second).toEqual(first);
+    for (const [rel, content] of snapshot) {
+      expect(readFileSync(join(first.root, rel), "utf8")).toBe(content);
+    }
+  });
+
+  it("prunes machine-owned files of deleted records but never user files", () => {
+    const ids = buildCorpus(dbFile);
+    const first = exportMemoryToObsidian({ dbFile, vaultDir });
+    const stale = join(first.root, "notes", `note-${ids.noteC}.md`);
+    expect(existsSync(stale)).toBe(true);
+
+    // A user file inside the export folder and one in the vault root:
+    // both must survive every re-export.
+    const userFile = join(first.root, "notes", "my own thoughts.md");
+    writeFileSync(userFile, "hands off\n");
+    const rootFile = join(vaultDir, "daily.md");
+    writeFileSync(rootFile, "unrelated vault note\n");
+
+    const notes = new MemoryStore({ dbFile, maxEntries: 100, now: () => T0 });
+    try {
+      expect(notes.remove(ids.noteC)).toBe(true);
+    } finally {
+      notes.close();
+    }
+
+    const second = exportMemoryToObsidian({ dbFile, vaultDir });
+    expect(second.notes).toBe(2);
+    expect(second.pruned).toBe(1);
+    expect(existsSync(stale)).toBe(false);
+    expect(readFileSync(userFile, "utf8")).toBe("hands off\n");
+    expect(readFileSync(rootFile, "utf8")).toBe("unrelated vault note\n");
+  });
+
+  it("overwrites an exported file after the underlying record changed", () => {
+    const ids = buildCorpus(dbFile);
+    const first = exportMemoryToObsidian({ dbFile, vaultDir });
+    const path = join(first.root, "notes", `note-${ids.noteB}.md`);
+    expect(readFileSync(path, "utf8")).toContain("idb is the reliable input path.");
+
+    const db = new DatabaseCtor(dbFile);
+    try {
+      db.prepare(`UPDATE memories SET content = ? WHERE id = ?`).run(
+        "idb is the ONLY reliable input path.",
+        ids.noteB,
+      );
+    } finally {
+      db.close();
+    }
+
+    exportMemoryToObsidian({ dbFile, vaultDir });
+    expect(readFileSync(path, "utf8")).toContain(
+      "idb is the ONLY reliable input path.",
+    );
+  });
+
+  it("honors --folder and refuses folders escaping the vault", () => {
+    buildCorpus(dbFile);
+    const result = exportMemoryToObsidian({
+      dbFile,
+      vaultDir,
+      folder: "zettel/agent-memory",
+    });
+    expect(result.root).toBe(join(vaultDir, "zettel", "agent-memory"));
+    expect(existsSync(join(result.root, "notes"))).toBe(true);
+
+    for (const folder of ["", "  ", "..", ".", "../outside"]) {
+      expect(() =>
+        exportMemoryToObsidian({ dbFile, vaultDir, folder }),
+      ).toThrow(ObsidianExportUsageError);
+    }
+  });
+
+  it("fails on a missing database or a missing vault directory", () => {
+    expect(() => exportMemoryToObsidian({ dbFile, vaultDir })).toThrow(
+      /no memory database/,
+    );
+    buildCorpus(dbFile);
+    expect(() =>
+      exportMemoryToObsidian({ dbFile, vaultDir: join(dir, "nope") }),
+    ).toThrow(/vault directory does not exist/);
+  });
+
+  it("reads a pre-lessons legacy schema without migrating it", () => {
+    // Hand-rolled v2-era database: only `memories`, no lessons /
+    // procedures / links tables, no `consolidated_into` column.
+    const db = new DatabaseCtor(dbFile);
+    try {
+      db.exec(`
+        CREATE TABLE memories (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          content TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          source TEXT NOT NULL,
+          session_id TEXT,
+          working_dir TEXT,
+          tags TEXT
+        );
+      `);
+      db.prepare(
+        `INSERT INTO memories (content, created_at, updated_at, source, tags)
+         VALUES (?, ?, ?, 'agent', ?)`,
+      ).run("legacy note", T0, T0, JSON.stringify(["old"]));
+    } finally {
+      db.close();
+    }
+
+    const result = exportMemoryToObsidian({ dbFile, vaultDir });
+    expect(result).toMatchObject({ notes: 1, lessons: 0, procedures: 0 });
+    const note = readFileSync(
+      join(result.root, "notes", "note-1.md"),
+      "utf8",
+    );
+    expect(note).toContain("legacy note");
+    expect(note).toContain('  - "old"');
+
+    // Read-only guarantee: the export created none of the newer tables.
+    const check = new DatabaseCtor(dbFile, { readonly: true });
+    try {
+      const tables = check
+        .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
+        .all() as { name: string }[];
+      expect(tables.map((t) => t.name)).toEqual(["memories", "sqlite_sequence"]);
+    } finally {
+      check.close();
+    }
+  });
+});

--- a/src/memory/obsidian-export.ts
+++ b/src/memory/obsidian-export.ts
@@ -1,0 +1,435 @@
+/**
+ * One-way export of the cross-session memory corpus (`memory.sqlite`)
+ * into an Obsidian vault as plain markdown.
+ *
+ * Design decisions (v1, `memory export` CLI):
+ *
+ *  - **One-way, read-only.** The database is opened with
+ *    `{ readonly: true }` and migrations are *not* applied — an export
+ *    must never mutate agent state, not even a schema bump. Tables
+ *    that predate the current schema (`lessons`, `procedures`,
+ *    `memory_links`) are treated as empty when absent, and rows are
+ *    read via `SELECT *` so missing columns degrade to `undefined`
+ *    instead of a thrown error.
+ *
+ *  - **Stable, id-based filenames.** `notes/note-<id>.md`,
+ *    `lessons/lesson-<id>.md`, `procedures/procedure-<id>.md` under a
+ *    single export folder inside the vault. Ids are AUTOINCREMENT so a
+ *    record keeps its filename (and therefore its Obsidian identity,
+ *    backlinks included) across re-exports. Obsidian resolves
+ *    `[[note-17]]` by basename regardless of folder.
+ *
+ *  - **Idempotent + overwrite-safe.** File content is a pure function
+ *    of the database row (no export timestamps), files are rewritten
+ *    only when their bytes actually changed (stable mtimes for vault
+ *    sync tools), and pruning of stale files is restricted to names
+ *    matching the machine-owned `note-<n>.md` / `lesson-<n>.md` /
+ *    `procedure-<n>.md` patterns inside the three export subfolders.
+ *    Anything else the user keeps in those folders is never touched.
+ *
+ *  - **Wikilinks follow the schema's own edges.** `memory_links` rows
+ *    become a `## Links` section on the source note; `consolidated_into`
+ *    points a note at its lesson; `lessons.parent_ids` and
+ *    `procedures.parent_lesson_ids` / `parent_memory_ids` become
+ *    `## Sources` sections. Soft pointers whose target row no longer
+ *    exists (evicted episodes) are skipped rather than rendered as
+ *    dangling links.
+ *
+ * No watch mode, no sync-back, no conflict handling — a re-export
+ * overwrites the exported files, full stop.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve, sep } from "node:path";
+import type Database from "better-sqlite3";
+import { Database as DatabaseCtor } from "../native/load-better-sqlite3.js";
+
+export const DEFAULT_EXPORT_FOLDER = "atomic-agent";
+
+/**
+ * Invalid-argument errors (bad `folder`, …) — the CLI maps these to
+ * exit code 2 (usage) while every other throw stays an operational
+ * failure (exit code 1).
+ */
+export class ObsidianExportUsageError extends Error {}
+
+export interface ObsidianExportOptions {
+  /** Path to `memory.sqlite` (usually `getConfig().paths.memoryDbFile`). */
+  dbFile: string;
+  /** Existing Obsidian vault directory. Never created by the export. */
+  vaultDir: string;
+  /**
+   * Subfolder of the vault that the export owns. Default
+   * `atomic-agent`. Must stay inside the vault and must not be the
+   * vault root itself — the pruning pass only runs inside this
+   * folder's `notes/` / `lessons/` / `procedures/` subfolders.
+   */
+  folder?: string;
+}
+
+export interface ObsidianExportResult {
+  /** Absolute path of the export folder inside the vault. */
+  root: string;
+  notes: number;
+  lessons: number;
+  procedures: number;
+  /** Stale machine-owned files removed because their record is gone. */
+  pruned: number;
+}
+
+interface Row {
+  [column: string]: unknown;
+}
+
+const NOTE_FILE = /^note-(\d+)\.md$/;
+const LESSON_FILE = /^lesson-(\d+)\.md$/;
+const PROCEDURE_FILE = /^procedure-(\d+)\.md$/;
+
+export function exportMemoryToObsidian(
+  options: ObsidianExportOptions,
+): ObsidianExportResult {
+  const root = resolveExportRoot(options.vaultDir, options.folder);
+  if (!existsSync(options.dbFile)) {
+    throw new Error(
+      `no memory database at ${options.dbFile} — nothing to export`,
+    );
+  }
+  if (!existsSync(options.vaultDir)) {
+    throw new Error(
+      `vault directory does not exist: ${options.vaultDir} (pass an existing Obsidian vault — the export never creates one)`,
+    );
+  }
+
+  const db = new DatabaseCtor(options.dbFile, {
+    readonly: true,
+    fileMustExist: true,
+  }) as Database.Database;
+  let notes: Row[];
+  let lessons: Row[];
+  let procedures: Row[];
+  let links: Row[];
+  try {
+    notes = readAll(db, "memories", "id");
+    lessons = readAll(db, "lessons", "id");
+    procedures = readAll(db, "procedures", "id");
+    links = readAll(db, "memory_links", "from_id, to_id, kind");
+  } finally {
+    db.close();
+  }
+
+  const noteIds = new Set(notes.map((r) => asId(r.id)));
+  const lessonIds = new Set(lessons.map((r) => asId(r.id)));
+  const procedureIds = new Set(procedures.map((r) => asId(r.id)));
+
+  const linksByFrom = new Map<number, Row[]>();
+  for (const link of links) {
+    const from = asId(link.from_id);
+    const bucket = linksByFrom.get(from);
+    if (bucket) bucket.push(link);
+    else linksByFrom.set(from, [link]);
+  }
+
+  const notesDir = join(root, "notes");
+  const lessonsDir = join(root, "lessons");
+  const proceduresDir = join(root, "procedures");
+  mkdirSync(notesDir, { recursive: true });
+  mkdirSync(lessonsDir, { recursive: true });
+  mkdirSync(proceduresDir, { recursive: true });
+
+  for (const row of notes) {
+    const id = asId(row.id);
+    writeIfChanged(
+      join(notesDir, `note-${id}.md`),
+      renderNote(row, linksByFrom.get(id) ?? [], noteIds, lessonIds),
+    );
+  }
+  for (const row of lessons) {
+    const id = asId(row.id);
+    writeIfChanged(join(lessonsDir, `lesson-${id}.md`), renderLesson(row, noteIds));
+  }
+  for (const row of procedures) {
+    const id = asId(row.id);
+    writeIfChanged(
+      join(proceduresDir, `procedure-${id}.md`),
+      renderProcedure(row, noteIds, lessonIds),
+    );
+  }
+
+  const pruned =
+    pruneStale(notesDir, NOTE_FILE, noteIds) +
+    pruneStale(lessonsDir, LESSON_FILE, lessonIds) +
+    pruneStale(proceduresDir, PROCEDURE_FILE, procedureIds);
+
+  return {
+    root,
+    notes: notes.length,
+    lessons: lessons.length,
+    procedures: procedures.length,
+    pruned,
+  };
+}
+
+function resolveExportRoot(vaultDir: string, folder: string | undefined): string {
+  const name = folder ?? DEFAULT_EXPORT_FOLDER;
+  if (name.trim().length === 0) {
+    throw new ObsidianExportUsageError("--folder must not be empty");
+  }
+  const vault = resolve(vaultDir);
+  const root = resolve(vault, name);
+  if (root === vault || !root.startsWith(vault + sep)) {
+    throw new ObsidianExportUsageError(
+      `--folder must name a subfolder inside the vault, got: ${name}`,
+    );
+  }
+  return root;
+}
+
+function readAll(db: Database.Database, table: string, orderBy: string): Row[] {
+  const present = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
+    .get(table);
+  if (present === undefined) return [];
+  return db.prepare(`SELECT * FROM ${table} ORDER BY ${orderBy}`).all() as Row[];
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function renderNote(
+  row: Row,
+  outgoing: Row[],
+  noteIds: Set<number>,
+  lessonIds: Set<number>,
+): string {
+  const lines = [
+    "---",
+    "type: memory-note",
+    `id: ${asId(row.id)}`,
+    `created: ${isoDate(row.created_at)}`,
+    `updated: ${isoDate(row.updated_at)}`,
+    `source: ${yamlScalar(asOptionalString(row.source) ?? "agent")}`,
+    ...yamlTags(parseStringArray(row.tags)),
+    "---",
+    "",
+    asOptionalString(row.content) ?? "",
+  ];
+
+  const linkLines: string[] = [];
+  for (const link of outgoing) {
+    const to = asId(link.to_id);
+    if (!noteIds.has(to)) continue;
+    linkLines.push(`- ${linkKindLabel(link.kind)} [[note-${to}]]`);
+  }
+  const consolidatedInto = asOptionalId(row.consolidated_into);
+  if (consolidatedInto !== null && lessonIds.has(consolidatedInto)) {
+    linkLines.push(`- consolidated into [[lesson-${consolidatedInto}]]`);
+  }
+  if (linkLines.length > 0) {
+    lines.push("", "## Links", "", ...linkLines);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderLesson(row: Row, noteIds: Set<number>): string {
+  const lines = [
+    "---",
+    "type: memory-lesson",
+    `id: ${asId(row.id)}`,
+    `created: ${isoDate(row.created_at)}`,
+    `updated: ${isoDate(row.updated_at)}`,
+    `status: ${yamlScalar(asOptionalString(row.status) ?? "active")}`,
+    ...yamlTags(parseStringArray(row.tags)),
+    "---",
+    "",
+    `**When:** ${asOptionalString(row.activation) ?? ""}`,
+    "",
+    asOptionalString(row.principle) ?? "",
+  ];
+  const sources = parseNumberArray(row.parent_ids).filter((id) =>
+    noteIds.has(id),
+  );
+  if (sources.length > 0) {
+    lines.push("", "## Sources", "", ...sources.map((id) => `- [[note-${id}]]`));
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderProcedure(
+  row: Row,
+  noteIds: Set<number>,
+  lessonIds: Set<number>,
+): string {
+  const lines = [
+    "---",
+    "type: memory-procedure",
+    `id: ${asId(row.id)}`,
+    `created: ${isoDate(row.created_at)}`,
+    `updated: ${isoDate(row.updated_at)}`,
+    `status: ${yamlScalar(asOptionalString(row.status) ?? "active")}`,
+    `source: ${yamlScalar(asOptionalString(row.source) ?? "consolidator")}`,
+    ...yamlTags(parseStringArray(row.tags)),
+    "---",
+    "",
+    `**When:** ${asOptionalString(row.activation) ?? ""}`,
+  ];
+  const steps = parseSteps(row.steps);
+  if (steps.length > 0) {
+    lines.push("", "## Steps", "");
+    steps.forEach((step, index) => {
+      const hint = step.toolHint ? ` (\`${step.toolHint}\`)` : "";
+      lines.push(`${index + 1}. ${step.description}${hint}`);
+    });
+  }
+  const sourceLines = [
+    ...parseNumberArray(row.parent_lesson_ids)
+      .filter((id) => lessonIds.has(id))
+      .map((id) => `- [[lesson-${id}]]`),
+    ...parseNumberArray(row.parent_memory_ids)
+      .filter((id) => noteIds.has(id))
+      .map((id) => `- [[note-${id}]]`),
+  ];
+  if (sourceLines.length > 0) {
+    lines.push("", "## Sources", "", ...sourceLines);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** `RELATES_TO` → `relates to` — a human-readable edge label. */
+function linkKindLabel(kind: unknown): string {
+  const raw = asOptionalString(kind) ?? "relates to";
+  return raw.toLowerCase().replace(/_/g, " ");
+}
+
+// ---------------------------------------------------------------------------
+// YAML helpers — double-quoted JSON scalars are valid YAML, so the
+// escaping burden collapses onto JSON.stringify.
+// ---------------------------------------------------------------------------
+
+function yamlScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
+function yamlTags(tags: string[]): string[] {
+  if (tags.length === 0) return ["tags: []"];
+  return ["tags:", ...tags.map((tag) => `  - ${yamlScalar(tag)}`)];
+}
+
+// ---------------------------------------------------------------------------
+// Defensive row decoding — the export must survive rows written by any
+// past schema version, so every accessor tolerates missing / malformed
+// values instead of trusting the current column shapes.
+// ---------------------------------------------------------------------------
+
+function asId(value: unknown): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    throw new Error(`memory export: non-numeric row id: ${String(value)}`);
+  }
+  return n;
+}
+
+function asOptionalId(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function asOptionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function isoDate(value: unknown): string {
+  const n = Number(value);
+  const ms = Number.isFinite(n) ? n : 0;
+  return new Date(ms).toISOString();
+}
+
+function parseStringArray(raw: unknown): string[] {
+  if (typeof raw !== "string" || raw.length === 0) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((item): item is string => typeof item === "string");
+  } catch {
+    return [];
+  }
+}
+
+function parseNumberArray(raw: unknown): number[] {
+  if (typeof raw !== "string" || raw.length === 0) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item) => Number(item))
+      .filter((item) => Number.isFinite(item));
+  } catch {
+    return [];
+  }
+}
+
+function parseSteps(raw: unknown): { description: string; toolHint: string | null }[] {
+  if (typeof raw !== "string" || raw.length === 0) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const steps: { description: string; toolHint: string | null }[] = [];
+    for (const item of parsed) {
+      if (typeof item !== "object" || item === null) continue;
+      const description = (item as Row).description;
+      if (typeof description !== "string") continue;
+      const toolHint = (item as Row).toolHint;
+      steps.push({
+        description,
+        toolHint: typeof toolHint === "string" && toolHint.length > 0 ? toolHint : null,
+      });
+    }
+    return steps;
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem
+// ---------------------------------------------------------------------------
+
+/** Skip the write when bytes match so vault-sync tools see stable mtimes. */
+function writeIfChanged(path: string, content: string): void {
+  if (existsSync(path)) {
+    try {
+      if (readFileSync(path, "utf8") === content) return;
+    } catch {
+      // Unreadable existing file — fall through to the overwrite.
+    }
+  }
+  writeFileSync(path, content);
+}
+
+/**
+ * Remove machine-owned files whose record no longer exists. Only exact
+ * `<kind>-<n>.md` names are candidates — the user's own files in the
+ * export folders are never touched.
+ */
+function pruneStale(dir: string, pattern: RegExp, liveIds: Set<number>): number {
+  let pruned = 0;
+  for (const name of readdirSync(dir)) {
+    const match = pattern.exec(name);
+    if (!match) continue;
+    const id = Number(match[1]);
+    if (liveIds.has(id)) continue;
+    rmSync(join(dir, name));
+    pruned += 1;
+  }
+  return pruned;
+}


### PR DESCRIPTION
## What

A minimal v1 of the Discord-requested Obsidian integration: a new `atomic-agent memory` CLI command with an `export` subcommand that mirrors the cross-session memory corpus (`<stateDir>/memory.sqlite`) into an existing Obsidian vault.

```
atomic-agent memory export --vault ~/Documents/MyVault [--folder atomic-agent]
# or: OBSIDIAN_VAULT_PATH=~/Documents/MyVault atomic-agent memory export
```

Each record becomes one markdown file with YAML frontmatter (`type`, `created`, `updated`, `tags`, plus `status`/`source` where the row has them) under the export subfolder:

- `notes/note-<id>.md` — `memories` rows, body = content, `## Links` section from `memory_links` edges and the `consolidated_into` back-pointer
- `lessons/lesson-<id>.md` — activation + principle, `## Sources` wikilinks to parent notes
- `procedures/procedure-<id>.md` — activation + numbered steps (with tool hints), `## Sources` wikilinks to parent lessons/notes

## Design assumptions (the reporter never described a flow, so v1 commits to these)

- **One-way, read-only.** The DB is opened `readonly` and never migrated — an export cannot mutate agent state. Older schema files degrade gracefully (missing `lessons`/`procedures`/`memory_links` tables ⇒ empty sets). No watch mode, no sync-back, no conflict handling: a re-export overwrites the exported files.
- **Stable id-based filenames** so a record keeps its Obsidian identity (and backlinks) across re-exports; Obsidian resolves `[[note-17]]` by basename.
- **Idempotent + overwrite-safe.** File content is a pure function of the rows (no export timestamps — an unchanged corpus re-exports byte-identically, and unchanged files are not rewritten, keeping mtimes stable for sync tools). Stale-file pruning only touches machine-owned `note-<n>.md` / `lesson-<n>.md` / `procedure-<n>.md` names inside the export's three subfolders; anything else the user keeps there is never touched.
- **Soft pointers to evicted rows are skipped** rather than rendered as dangling wikilinks; profile facts and vote/embedding internals are out of scope for v1.
- The vault directory must already exist (the export never creates a vault at a typo'd path), and `--folder` must stay a subfolder of the vault (usage error otherwise). The new command implements the CLI's 0/1/2 exit-code split.

## Tests

- `src/memory/obsidian-export.test.ts` (8 tests): frontmatter + body rendering, every wikilink edge kind, dangling-soft-pointer skip, byte-identical idempotency, prune-vs-user-files safety, record-update overwrite, `--folder` traversal guards, missing DB/vault errors, and a hand-rolled pre-lessons legacy schema exported without migration (asserts no new tables were created).
- `src/cli/memory-command.test.ts` (7 tests): help, unknown subcommand ⇒ 2, missing vault ⇒ 2, `--vault` happy path against a seeded state dir, `$OBSIDIAN_VAULT_PATH` fallback + `--folder`, escaping folder ⇒ 2, missing DB ⇒ 1.
- Verified the prune test fails when pruning is disabled (mutation check).
- `npm run lint` clean; full `src/memory` + `src/cli` suites: 58 files / 696 tests passed.
- Manual end-to-end through `npx tsx src/cli/index.ts memory export --vault …` against a seeded corpus: files, wikilinks, and second-run idempotency verified.

Reported on Discord: https://discord.com/channels/1515649306781155428/1515649308161085612/1540448454373941361

Windows note: paths go through `node:path` (`join`/`resolve`/`sep`) throughout and tests use tmp dirs, but this was runtime-verified on macOS only.
