### PR TITLE
fix(tui): uninstall from the menu never ran — confirm didn't unmount Ink

### DIFF
--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -1074,7 +1074,10 @@ function handleUninstallKey(
   if (key.return) {
     if (!isUninstallConfirmed(flow.typed)) return true;
     dispatch({ type: "uninstall_started" });
+    // The callback only flags the post-exit uninstall handoff;
+    // `quit_requested` is what unmounts Ink so the handoff is reached.
     callbacks.onUninstallConfirmed?.();
+    dispatch({ type: "quit_requested" });
     return true;
   }
   if (key.backspace || key.delete) {

--- a/src/tui/uninstall/uninstall-keys.test.ts
+++ b/src/tui/uninstall/uninstall-keys.test.ts
@@ -156,6 +156,9 @@ describe("uninstall ladder keys", () => {
     );
     expect(dispatch).toHaveBeenCalledWith({ type: "uninstall_started" });
     expect(onUninstallConfirmed).toHaveBeenCalledOnce();
+    // Without this the app never unmounts and the post-exit removal
+    // in tui-command never runs — the ladder froze on "closing".
+    expect(dispatch).toHaveBeenCalledWith({ type: "quit_requested" });
   });
 
   it("backspace clears what was typed", () => {


### PR DESCRIPTION
## Symptom

Menu → Danger zone → **Uninstall atomic-agent…** (or `/uninstall`): you walk the whole confirmation ladder, type `uninstall`, press Enter — and nothing happens. The modal freezes on "shutting the agent down first…", the app keeps running, nothing is removed, no message is printed. Since the closing step swallows every key (deliberately, to protect a half-finished removal), the TUI is stuck until the terminal is killed.

## Root cause

The confirm branch in `handleUninstallKey` (`src/tui/app-key-bindings.ts`) did:

```ts
dispatch({ type: "uninstall_started" });   // modal → "closing"
callbacks.onUninstallConfirmed?.();        // uninstallRequested = true; orchestrator.quit()
```

`ChatOrchestrator.quit()` only sets a private flag and aborts turns — it never unmounts Ink. The app exits only when `state.status === "quitting"` (the exit effect in `tui-app.tsx` calls `app.exit()`), and that status is set solely by the `quit_requested` action, which this path never dispatched. So `ink.waitUntilExit()` in `tui-command.ts` never resolved and the post-exit handoff — `performUninstall()`, which prints `uninstalling atomic-agent…` / `atomic-agent is uninstalled.` and does the actual removal — was never reached.

The self-update restart path documents the intended contract (callback arranges the post-exit work; the key binding *additionally* dispatches `quit_requested` so Ink unmounts). The uninstall branch simply omitted that second dispatch. The CLI `atomic-agent uninstall` path was unaffected.

## Fix

One line: after `onUninstallConfirmed`, dispatch `quit_requested`, mirroring the update-restart pattern. Ink unmounts, `tui-command.ts` reaches the uninstall handoff, the removal runs and its result is printed to the restored terminal.

## Tests

- Extended `uninstall-keys.test.ts` "enter fires once the word is complete" to also assert `quit_requested` is dispatched — exactly the missing assertion the bug slipped through. Verified it fails without the fix.
- `npx vitest run src/tui/uninstall src/tui/uninstall-modal-focus.test.tsx src/tui/components/uninstall-modal.test.tsx`: 4 files, 32 tests, all pass.
- `npm run lint` (tsc --noEmit): clean.