### PR TITLE
tui: spell the newline hint chip as alt/option+enter

### DIFF
--- a/src/tui/components/hotkey-chips.ts
+++ b/src/tui/components/hotkey-chips.ts
@@ -30,7 +30,7 @@ export interface HotkeyChip {
 
   /**
    * What a click on this chip does. Only chips with one unambiguous
-   * meaning get one — "alt+enter newline" or "↑↓ select" describe a
+   * meaning get one — "alt/option+enter newline" or "↑↓ select" describe a
    * gesture, not a command, so they stay plain text rather than
    * pretending to be buttons.
    */
@@ -231,7 +231,7 @@ export function resolveChips(
     // to Enter and would submit. Alt+Enter works in both worlds, so it
     // is what the strip promises when the protocol is absent.
     {
-      key: hasShiftEnterNewline() ? "shift+enter" : "alt+enter",
+      key: hasShiftEnterNewline() ? "shift+enter" : "alt/option+enter",
       label: "newline",
       shed: 6,
     },

--- a/src/tui/components/hotkey-hint-modes.test.tsx
+++ b/src/tui/components/hotkey-hint-modes.test.tsx
@@ -44,10 +44,10 @@ afterEach(() => {
 });
 
 describe("newline chip vs terminal protocol", () => {
-  it("promises alt+enter when the terminal has no kitty protocol", () => {
+  it("promises alt/option+enter when the terminal has no kitty protocol", () => {
     setShiftEnterNewline(false);
     const out = renderHint(chatState());
-    expect(out).toContain("[alt+enter] newline");
+    expect(out).toContain("[alt/option+enter] newline");
     expect(out).not.toContain("shift+enter");
   });
 
@@ -55,7 +55,7 @@ describe("newline chip vs terminal protocol", () => {
     setShiftEnterNewline(true);
     const out = renderHint(chatState());
     expect(out).toContain("[shift+enter] newline");
-    expect(out).not.toContain("alt+enter");
+    expect(out).not.toContain("alt/option+enter");
   });
 });
 


### PR DESCRIPTION
The bottom hint strip advertised `[alt+enter] newline`. Mac keyboards label that key **option**, so Mac users scanning the strip had to translate. The chip now reads `[alt/option+enter] newline` and covers both spellings.

- `src/tui/components/hotkey-chips.ts`: the newline chip's non-kitty spelling becomes `alt/option+enter`; the kitty-protocol branch still advertises `shift+enter` unchanged. Doc-comment example updated to match.
- `src/tui/components/hotkey-hint-modes.test.tsx`: assertions and test names track the new spelling.

Tests: `hotkey-hint-modes.test.tsx` 6/6 green.