### PR TITLE
feat(onboarding): import your data from other agents as the last first-run step

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ atag
 > Need a second agent? Press **Ctrl+N** (or run `/window`) inside the TUI — it opens a new terminal window with a fresh atomic-agent in the same directory.
 
 > [!TIP]
-> Coming from Hermes or OpenClaw? Run `/import` in the TUI for a one-shot migration: sessions, cron jobs, and optionally your provider keys.
+> Coming from another agent? The first run offers to bring your data over from **Hermes, OpenClaw, Claude Code, or Codex** — skills, memory, MCP servers, sessions, cron jobs, and (opt-in) provider keys, with a dry-run preview before anything is written. Later, run `/import` in the TUI or `atomic-agent import <hermes|openclaw|claude-code|codex>` from the shell.
 
 ### Uninstall
 

--- a/src/cli/import-command.ts
+++ b/src/cli/import-command.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { getConfig } from "../config/index.js";
+import { MemoryStore } from "../memory/index.js";
 import { SessionStore } from "../session/index.js";
 import { TaskStore } from "../tasks/index.js";
 import {
@@ -15,7 +16,18 @@ import {
   OpenclawOptionError,
   OPENCLAW_DEFAULT_AGENT,
   resolveOpenclawOptions,
+  ClaudeCodeImporter,
+  ClaudeCodeSource,
+  ClaudeCodeOptionError,
+  resolveClaudeCodeOptions,
+  CodexImporter,
+  CodexSource,
+  CodexOptionError,
+  resolveCodexOptions,
+  importAgentDir,
   type ImportOptionId,
+  type ClaudeCodeOptionId,
+  type CodexOptionId,
   type OpenclawOptionId,
   type ImportReport,
 } from "../import/index.js";
@@ -27,6 +39,8 @@ const HELP =
     "Subcommands:",
     "  hermes [options]          Import conversation history + cron jobs from ~/.hermes",
     "  openclaw [options]        Import conversation history + cron jobs from ~/.openclaw",
+    "  claude-code [options]     Import skills, memory, MCP servers + sessions from ~/.claude",
+    "  codex [options]           Import skills, instructions + sessions from ~/.codex",
     "",
     "Options (import hermes):",
     "  --source <dir>            Hermes state dir (default ~/.hermes, env HERMES_STATE_DIR)",
@@ -49,12 +63,35 @@ const HELP =
     "  --dry-run                 Preview only; never write",
     "  --yes                     Skip the interactive confirmation",
     "",
+    "Options (import claude-code):",
+    "  --source <dir>            Claude Code state dir (default ~/.claude, env CLAUDE_CODE_STATE_DIR)",
+    "  --include a,b             Add options (skills,memory,mcp,sessions)",
+    "  --exclude a,b             Remove options",
+    "  --migrate-secrets         Also copy ANTHROPIC_API_KEY (settings.json env) into <stateDir>/.env",
+    "  --limit N                 Cap the number of sessions imported (newest first)",
+    "  --overwrite               Overwrite destinations that differ (default: flag as conflict)",
+    "  --dry-run                 Preview only; never write",
+    "  --yes                     Skip the interactive confirmation",
+    "",
+    "Options (import codex):",
+    "  --source <dir>            Codex state dir (default ~/.codex, env CODEX_STATE_DIR)",
+    "  --include a,b             Add options (skills,memory,sessions)",
+    "  --exclude a,b             Remove options",
+    "  --migrate-secrets         Also copy OPENAI_API_KEY (auth.json) into <stateDir>/.env",
+    "  --limit N                 Cap the number of sessions imported (newest first)",
+    "  --overwrite               Overwrite destinations that differ (default: flag as conflict)",
+    "  --dry-run                 Preview only; never write",
+    "  --yes                     Skip the interactive confirmation",
+    "",
     "Examples:",
     "  atomic-agent import hermes --dry-run",
     "  atomic-agent import hermes --yes",
     "  atomic-agent import hermes --migrate-secrets --overwrite",
     "  atomic-agent import openclaw --dry-run",
     "  atomic-agent import openclaw --agent main --yes",
+    "  atomic-agent import claude-code --dry-run",
+    "  atomic-agent import claude-code --exclude sessions --yes",
+    "  atomic-agent import codex --limit 50 --yes",
   ].join("\n") + "\n";
 
 export async function importCommand(args: string[]): Promise<number> {
@@ -68,6 +105,12 @@ export async function importCommand(args: string[]): Promise<number> {
   }
   if (sub === "openclaw") {
     return importOpenclaw(args.slice(1));
+  }
+  if (sub === "claude-code") {
+    return importClaudeCode(args.slice(1));
+  }
+  if (sub === "codex") {
+    return importCodex(args.slice(1));
   }
   process.stderr.write(`unknown import source: ${sub}\n`);
   process.stderr.write(HELP);
@@ -278,6 +321,231 @@ async function importOpenclaw(args: string[]): Promise<number> {
     source.close();
     sessionStore.close();
     taskStore.close();
+  }
+}
+
+async function importClaudeCode(args: string[]): Promise<number> {
+  const sourceDir =
+    readOption(args, "--source") ?? importAgentDir("claude-code");
+  const include = parseCsv(readOption(args, "--include"));
+  const exclude = parseCsv(readOption(args, "--exclude"));
+  const migrateSecrets = args.includes("--migrate-secrets");
+  const overwrite = args.includes("--overwrite");
+  const dryRun = args.includes("--dry-run");
+  const yes = args.includes("--yes");
+  const limitRaw = readOption(args, "--limit");
+
+  let limit: number | undefined;
+  if (limitRaw !== undefined) {
+    limit = Number.parseInt(limitRaw, 10);
+    if (!Number.isFinite(limit) || limit < 0) {
+      process.stderr.write("--limit must be a non-negative integer\n");
+      return 1;
+    }
+  }
+
+  let options: ClaudeCodeOptionId[];
+  try {
+    options = resolveClaudeCodeOptions({ include, exclude, migrateSecrets });
+  } catch (err) {
+    if (err instanceof ClaudeCodeOptionError) {
+      process.stderr.write(`${err.message}\n`);
+      return 1;
+    }
+    throw err;
+  }
+
+  if (options.length === 0) {
+    process.stderr.write("nothing selected to import\n");
+    return 1;
+  }
+
+  const config = getConfig();
+  const sessionStore = new SessionStore({
+    dbFile: config.paths.sessionsDbFile,
+  });
+  // Dedup and eviction stay off on this handle: the importer does its
+  // own exact-content skip, and a near-match merge during an import
+  // would silently rewrite what the operator asked to copy verbatim.
+  const memoryStore = new MemoryStore({
+    dbFile: config.paths.memoryDbFile,
+    maxEntries: config.memory.notes.maxEntries,
+  });
+  const source = new ClaudeCodeSource(sourceDir);
+
+  try {
+    const importer = new ClaudeCodeImporter({
+      source,
+      sessionStore,
+      memoryStore,
+      stateDir: config.paths.stateDir,
+      userConfigFile: config.paths.userConfigFile,
+      globalSkillsDir: config.paths.globalSkillsDir,
+      workingDirFallback: process.cwd(),
+    });
+
+    process.stdout.write(`Source: ${sourceDir}\n`);
+    process.stdout.write(`Selected: ${options.join(", ")}\n\n`);
+
+    // Phase 1: preview.
+    const preview = await importer.run({
+      options,
+      execute: false,
+      overwrite,
+      limit,
+    });
+    process.stdout.write("Preview:\n");
+    process.stdout.write(`${formatReport(preview)}\n`);
+
+    if (dryRun) {
+      process.stdout.write("\nDry-run: nothing was written.\n");
+      return 0;
+    }
+
+    const actionable =
+      preview.summary.migrated + preview.summary.conflict > 0;
+    if (!actionable) {
+      process.stdout.write("\nNothing to import.\n");
+      return 0;
+    }
+
+    if (!yes) {
+      if (!process.stdin.isTTY) {
+        process.stdout.write(
+          "\nNon-interactive: re-run with --yes to apply, or --dry-run to preview only.\n",
+        );
+        return 0;
+      }
+      const confirmed = await confirm("\nApply this import? [y/N] ");
+      if (!confirmed) {
+        process.stdout.write("Aborted.\n");
+        return 0;
+      }
+    }
+
+    // Phase 2: execute.
+    const final = await importer.run({
+      options,
+      execute: true,
+      overwrite,
+      limit,
+    });
+    process.stdout.write("\nResult:\n");
+    process.stdout.write(`${formatReport(final)}\n`);
+    return final.summary.error > 0 ? 1 : 0;
+  } finally {
+    sessionStore.close();
+    memoryStore.close();
+  }
+}
+
+async function importCodex(args: string[]): Promise<number> {
+  const sourceDir = readOption(args, "--source") ?? importAgentDir("codex");
+  const include = parseCsv(readOption(args, "--include"));
+  const exclude = parseCsv(readOption(args, "--exclude"));
+  const migrateSecrets = args.includes("--migrate-secrets");
+  const overwrite = args.includes("--overwrite");
+  const dryRun = args.includes("--dry-run");
+  const yes = args.includes("--yes");
+  const limitRaw = readOption(args, "--limit");
+
+  let limit: number | undefined;
+  if (limitRaw !== undefined) {
+    limit = Number.parseInt(limitRaw, 10);
+    if (!Number.isFinite(limit) || limit < 0) {
+      process.stderr.write("--limit must be a non-negative integer\n");
+      return 1;
+    }
+  }
+
+  let options: CodexOptionId[];
+  try {
+    options = resolveCodexOptions({ include, exclude, migrateSecrets });
+  } catch (err) {
+    if (err instanceof CodexOptionError) {
+      process.stderr.write(`${err.message}\n`);
+      return 1;
+    }
+    throw err;
+  }
+
+  if (options.length === 0) {
+    process.stderr.write("nothing selected to import\n");
+    return 1;
+  }
+
+  const config = getConfig();
+  const sessionStore = new SessionStore({
+    dbFile: config.paths.sessionsDbFile,
+  });
+  const memoryStore = new MemoryStore({
+    dbFile: config.paths.memoryDbFile,
+    maxEntries: config.memory.notes.maxEntries,
+  });
+  const source = new CodexSource(sourceDir);
+
+  try {
+    const importer = new CodexImporter({
+      source,
+      sessionStore,
+      memoryStore,
+      stateDir: config.paths.stateDir,
+      globalSkillsDir: config.paths.globalSkillsDir,
+      workingDirFallback: process.cwd(),
+    });
+
+    process.stdout.write(`Source: ${sourceDir}\n`);
+    process.stdout.write(`Selected: ${options.join(", ")}\n\n`);
+
+    // Phase 1: preview.
+    const preview = await importer.run({
+      options,
+      execute: false,
+      overwrite,
+      limit,
+    });
+    process.stdout.write("Preview:\n");
+    process.stdout.write(`${formatReport(preview)}\n`);
+
+    if (dryRun) {
+      process.stdout.write("\nDry-run: nothing was written.\n");
+      return 0;
+    }
+
+    const actionable =
+      preview.summary.migrated + preview.summary.conflict > 0;
+    if (!actionable) {
+      process.stdout.write("\nNothing to import.\n");
+      return 0;
+    }
+
+    if (!yes) {
+      if (!process.stdin.isTTY) {
+        process.stdout.write(
+          "\nNon-interactive: re-run with --yes to apply, or --dry-run to preview only.\n",
+        );
+        return 0;
+      }
+      const confirmed = await confirm("\nApply this import? [y/N] ");
+      if (!confirmed) {
+        process.stdout.write("Aborted.\n");
+        return 0;
+      }
+    }
+
+    // Phase 2: execute.
+    const final = await importer.run({
+      options,
+      execute: true,
+      overwrite,
+      limit,
+    });
+    process.stdout.write("\nResult:\n");
+    process.stdout.write(`${formatReport(final)}\n`);
+    return final.summary.error > 0 ? 1 : 0;
+  } finally {
+    sessionStore.close();
+    memoryStore.close();
   }
 }
 

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -16,6 +16,7 @@ describe("tui.onboarding (config v43, extended in v45)", () => {
       skippedAt: null,
       proposedSecondBackendAt: null,
       localSetupSeenAt: null,
+      importOfferedAt: null,
     });
     expect(parsed.tui.theme).toBe("nord");
   });

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -1675,7 +1675,14 @@ export interface UserConfigFile {
 // auto-pick, byte-identical launch args). Two or more ratios opt the managed
 // chat daemon into multi-GPU layer splitting (`--split-mode layer
 // --tensor-split <ratios>`). Older files transparently inherit `[]`.
-export const USER_CONFIG_VERSION = 48;
+// v49: a sixth stamp in `tui.onboarding` — `importOfferedAt`, written when
+// the first run offers the "bring your data over from another agent" step
+// (shown once, on the way out of setup, and only when a known agent's
+// state dir actually exists). Recorded when it is offered, not when it is
+// taken: a declined offer must not come back on a re-run after a reset.
+// Additive: an older file parses with it `null`, which reads as "never
+// offered", the same answer that file has always implied.
+export const USER_CONFIG_VERSION = 49;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1812,6 +1819,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   45,
   46,
   47,
+  48,
   USER_CONFIG_VERSION,
 ];
 
@@ -2066,6 +2074,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
     mouse: true,
     onboarding: {
       completedAt: null,
+      importOfferedAt: null,
       introSeenAt: null,
       localSetupSeenAt: null,
       proposedSecondBackendAt: null,
@@ -4049,6 +4058,7 @@ export interface OnboardingState {
   skippedAt: string | null;
   proposedSecondBackendAt: string | null;
   localSetupSeenAt: string | null;
+  importOfferedAt: string | null;
 }
 
 /**
@@ -4078,6 +4088,10 @@ export function parseOnboardingState(raw: unknown): OnboardingState {
     localSetupSeenAt: parseTimestampOrNull(
       obj.localSetupSeenAt,
       "tui.onboarding.localSetupSeenAt",
+    ),
+    importOfferedAt: parseTimestampOrNull(
+      obj.importOfferedAt,
+      "tui.onboarding.importOfferedAt",
     ),
   };
 }

--- a/src/import/claude-code/claude-code-importer.test.ts
+++ b/src/import/claude-code/claude-code-importer.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureUserConfigFileSync } from "../../config/index.js";
+import { SessionStore } from "../../session/index.js";
+import { ClaudeCodeImporter } from "./claude-code-importer.js";
+import { ClaudeCodeSource } from "./claude-code-source.js";
+import { resolveClaudeCodeOptions } from "./import-options.js";
+
+function line(obj: unknown): string {
+  return `${JSON.stringify(obj)}\n`;
+}
+
+const SKILL_MD = [
+  "---",
+  "name: triage",
+  "description: Sort the inbox",
+  "---",
+  "",
+  "# triage",
+  "",
+].join("\n");
+
+describe("ClaudeCodeImporter", () => {
+  let home: string;
+  let sourceDir: string;
+  let stateDir: string;
+  let sessionStore: SessionStore;
+  let memoryContents: string[];
+
+  function memoryStore() {
+    return {
+      list: () => memoryContents.map((content) => ({ content })),
+      store: (input: { content: string }) => {
+        memoryContents.push(input.content);
+      },
+    };
+  }
+
+  function buildImporter(): ClaudeCodeImporter {
+    return new ClaudeCodeImporter({
+      source: new ClaudeCodeSource(sourceDir),
+      sessionStore,
+      memoryStore: memoryStore(),
+      stateDir,
+      userConfigFile: join(stateDir, "config.json"),
+      globalSkillsDir: join(stateDir, "skills"),
+      workingDirFallback: "/fallback",
+    });
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "cc-imp-src-"));
+    sourceDir = join(home, ".claude");
+    mkdirSync(sourceDir, { recursive: true });
+    stateDir = mkdtempSync(join(tmpdir(), "cc-imp-dst-"));
+    sessionStore = new SessionStore({ dbFile: join(stateDir, "sessions.sqlite") });
+    memoryContents = [];
+  });
+
+  afterEach(() => {
+    sessionStore.close();
+    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmSync(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  function seedSkill(): void {
+    mkdirSync(join(sourceDir, "skills", "triage"), { recursive: true });
+    writeFileSync(join(sourceDir, "skills", "triage", "SKILL.md"), SKILL_MD);
+    writeFileSync(join(sourceDir, "skills", "triage", "notes.txt"), "extra file");
+  }
+
+  function seedSession(): void {
+    const projectDir = join(sourceDir, "projects", "-work");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, "s1.jsonl"),
+      [
+        line({
+          type: "user",
+          cwd: "/work",
+          timestamp: "2026-08-02T10:00:00Z",
+          message: { role: "user", content: "hi" },
+        }),
+        line({
+          type: "assistant",
+          timestamp: "2026-08-02T10:00:01Z",
+          message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+        }),
+      ].join(""),
+    );
+  }
+
+  it("imports skills, memory, mcp, sessions and (opt-in) the key", async () => {
+    seedSkill();
+    seedSession();
+    writeFileSync(join(sourceDir, "CLAUDE.md"), "be brief\n");
+    writeFileSync(
+      join(home, ".claude.json"),
+      JSON.stringify({
+        mcpServers: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+      }),
+    );
+    writeFileSync(
+      join(sourceDir, "settings.json"),
+      JSON.stringify({ env: { ANTHROPIC_API_KEY: "sk-ant-1" } }),
+    );
+
+    const report = await buildImporter().run({
+      options: resolveClaudeCodeOptions({ migrateSecrets: true }),
+      execute: true,
+      overwrite: false,
+    });
+
+    expect(report.executed).toBe(true);
+    expect(report.summary.error).toBe(0);
+    expect(report.summary.conflict).toBe(0);
+    expect(report.summary.migrated).toBe(5);
+
+    // Skill dir copied whole, under the manifest name.
+    expect(existsSync(join(stateDir, "skills", "triage", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(stateDir, "skills", "triage", "notes.txt"))).toBe(true);
+    // Memory note stored.
+    expect(memoryContents).toEqual(["be brief"]);
+    // MCP server appended to the user config.
+    const config = ensureUserConfigFileSync(join(stateDir, "config.json"));
+    expect(config.mcp.servers.map((s) => s.name)).toEqual(["linear"]);
+    // Session saved under the prefixed id.
+    expect(sessionStore.load("claude-code:s1")).not.toBeNull();
+    // Key written to .env.
+    expect(readFileSync(join(stateDir, ".env"), "utf8")).toContain(
+      "ANTHROPIC_API_KEY=",
+    );
+  });
+
+  it("previews without writing anything", async () => {
+    seedSkill();
+    seedSession();
+    const report = await buildImporter().run({
+      options: resolveClaudeCodeOptions(),
+      execute: false,
+      overwrite: false,
+    });
+    expect(report.executed).toBe(false);
+    expect(report.summary.migrated).toBe(2); // skill + session
+    expect(existsSync(join(stateDir, "skills", "triage"))).toBe(false);
+    expect(sessionStore.load("claude-code:s1")).toBeNull();
+  });
+
+  it("re-runs idempotently: matches skip, differing skills conflict", async () => {
+    seedSkill();
+    seedSession();
+    const importer = buildImporter();
+    const options = resolveClaudeCodeOptions();
+    await importer.run({ options, execute: true, overwrite: false });
+
+    const second = await buildImporter().run({
+      options,
+      execute: true,
+      overwrite: false,
+    });
+    expect(second.summary.migrated).toBe(0);
+    expect(second.items.every((i) => i.status === "skipped")).toBe(true);
+
+    // A drifted source manifest is a conflict until --overwrite.
+    writeFileSync(
+      join(sourceDir, "skills", "triage", "SKILL.md"),
+      SKILL_MD.replace("Sort the inbox", "Sort the inbox twice"),
+    );
+    const third = await buildImporter().run({
+      options: resolveClaudeCodeOptions({ exclude: ["memory", "mcp", "sessions"] }),
+      execute: true,
+      overwrite: false,
+    });
+    expect(third.items[0]).toMatchObject({ kind: "skills", status: "conflict" });
+
+    const forced = await buildImporter().run({
+      options: resolveClaudeCodeOptions({ exclude: ["memory", "mcp", "sessions"] }),
+      execute: true,
+      overwrite: true,
+    });
+    expect(forced.items[0]).toMatchObject({
+      kind: "skills",
+      status: "migrated",
+      reason: "overwritten",
+    });
+  });
+
+  it("skips an mcp server whose name is already configured", async () => {
+    writeFileSync(
+      join(home, ".claude.json"),
+      JSON.stringify({
+        mcpServers: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+      }),
+    );
+    const importer = buildImporter();
+    const options = resolveClaudeCodeOptions({
+      exclude: ["skills", "memory", "sessions"],
+    });
+    await importer.run({ options, execute: true, overwrite: false });
+    const second = await buildImporter().run({
+      options,
+      execute: true,
+      overwrite: false,
+    });
+    expect(second.items[0]).toMatchObject({
+      kind: "mcp",
+      status: "skipped",
+      reason: "server with this name already configured",
+    });
+  });
+
+  it("caps sessions at the limit, newest first", async () => {
+    const projectDir = join(sourceDir, "projects", "p");
+    mkdirSync(projectDir, { recursive: true });
+    for (const id of ["a", "b", "c"]) {
+      writeFileSync(
+        join(projectDir, `${id}.jsonl`),
+        line({
+          type: "user",
+          timestamp: "2026-08-02T10:00:00Z",
+          message: { role: "user", content: `msg ${id}` },
+        }),
+      );
+    }
+    const report = await buildImporter().run({
+      options: resolveClaudeCodeOptions({ exclude: ["skills", "memory", "mcp"] }),
+      execute: false,
+      overwrite: false,
+    });
+    expect(report.items.filter((i) => i.kind === "sessions")).toHaveLength(3);
+
+    const limited = await buildImporter().run({
+      options: resolveClaudeCodeOptions({ exclude: ["skills", "memory", "mcp"] }),
+      execute: false,
+      overwrite: false,
+      limit: 2,
+    });
+    expect(limited.items.filter((i) => i.kind === "sessions")).toHaveLength(2);
+  });
+
+  it("reports empty domains as skipped with a reason", async () => {
+    const report = await buildImporter().run({
+      options: resolveClaudeCodeOptions({ migrateSecrets: true }),
+      execute: true,
+      overwrite: false,
+    });
+    expect(report.summary.migrated).toBe(0);
+    expect(report.items.map((i) => [i.kind, i.status])).toEqual([
+      ["skills", "skipped"],
+      ["memory", "skipped"],
+      ["mcp", "skipped"],
+      ["sessions", "skipped"],
+      ["secrets", "skipped"],
+    ]);
+  });
+});

--- a/src/import/claude-code/claude-code-importer.ts
+++ b/src/import/claude-code/claude-code-importer.ts
@@ -1,0 +1,461 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  ensureUserConfigFileSync,
+  parseUserConfigFile,
+  resetConfigCache,
+  writeUserConfigFileSync,
+} from "../../config/index.js";
+import { ConfigValidationError } from "../../config/config-validation-error.js";
+import { setDotenvKey } from "../../config/dotenv-writer.js";
+import type { McpServerConfig } from "../../mcp/mcp-types.js";
+import type { SessionStore } from "../../session/index.js";
+import type { SessionState } from "../../session/session-state.js";
+import { installSkill } from "../../skills/skill-installer.js";
+import { parseSkillFile } from "../../skills/skill-manifest.js";
+import { MEMORY_CONTENT_MAX_LENGTH } from "../../memory/index.js";
+import { readDotenvValue } from "../dotenv-read.js";
+import {
+  buildReport,
+  type ImportItemResult,
+  type ImportReport,
+} from "../import-report.js";
+import { splitMemoryNote } from "../split-note.js";
+import type { ClaudeCodeSource } from "./claude-code-source.js";
+import type { ClaudeCodeOptionId } from "./import-options.js";
+import { mapClaudeCodeMcpServer } from "./map-mcp.js";
+import { mapClaudeCodeSession } from "./map-session.js";
+
+/** The only key ever read from Claude Code's settings or written to `.env`. */
+export const CLAUDE_CODE_SECRET_ALLOWLIST = ["ANTHROPIC_API_KEY"] as const;
+
+/** Tag stamped on every imported memory note, for later retrieval/cleanup. */
+export const CLAUDE_CODE_MEMORY_TAG = "imported:claude-code";
+
+/**
+ * The slice of `MemoryStore` the importer needs. Narrow on purpose: the
+ * runtime hands its live `notesStore`, the CLI opens its own handle, and
+ * tests stub two methods instead of building a real SQLite store.
+ */
+export interface ImportMemoryTarget {
+  list(opts: { scope: "all"; limit: number }): Array<{ content: string }>;
+  store(input: { content: string; tags?: string[]; source?: "user" }): unknown;
+}
+
+/**
+ * Why the sessions cap exists at all: `~/.claude/projects` grows to
+ * gigabytes, and the first-run flow must not spend minutes previewing
+ * transcripts nobody asked to keep. The CLI leaves `limit` unset
+ * (import everything) unless `--limit` says otherwise; the onboarding
+ * step imports this many newest sessions instead.
+ */
+export const ONBOARDING_SESSION_LIMIT = 100;
+
+export interface ClaudeCodeImporterDeps {
+  source: ClaudeCodeSource;
+  sessionStore: SessionStore;
+  memoryStore: ImportMemoryTarget;
+  /** State dir whose `.env` receives the migrated provider key. */
+  stateDir: string;
+  /** `<stateDir>/config.json`, where imported MCP servers are appended. */
+  userConfigFile: string;
+  /** Root the imported skills are installed under. */
+  globalSkillsDir: string;
+  /** Working dir applied to sessions whose transcript recorded no cwd. */
+  workingDirFallback: string;
+}
+
+export interface ClaudeCodeRunOptions {
+  /** Resolved option set (already gated by `resolveClaudeCodeOptions`). */
+  options: readonly ClaudeCodeOptionId[];
+  /** When false, compute the report without writing anything. */
+  execute: boolean;
+  /** Overwrite differing destinations instead of flagging a conflict. */
+  overwrite: boolean;
+  /** Cap on the number of sessions processed (newest first). */
+  limit?: number;
+}
+
+/**
+ * Orchestrates a one-shot Claude Code -> atomic-agent import. Each option
+ * is processed independently and contributes `ImportItemResult`s to a
+ * single `ImportReport`. Safe to re-run: unchanged destinations skip on
+ * match, differing ones require `overwrite`.
+ *
+ * Async where the Hermes importer is sync because skill installation
+ * copies directories through `installSkill`'s promise API.
+ */
+export class ClaudeCodeImporter {
+  constructor(private readonly deps: ClaudeCodeImporterDeps) {}
+
+  async run(options: ClaudeCodeRunOptions): Promise<ImportReport<ClaudeCodeOptionId>> {
+    const items: ImportItemResult<ClaudeCodeOptionId>[] = [];
+    const selected = new Set(options.options);
+
+    if (selected.has("skills")) {
+      await this.importSkills(items, options);
+    }
+    if (selected.has("memory")) {
+      this.importMemory(items, options);
+    }
+    if (selected.has("mcp")) {
+      this.importMcp(items, options);
+    }
+    if (selected.has("sessions")) {
+      this.importSessions(items, options);
+    }
+    if (selected.has("secrets")) {
+      this.importSecrets(items, options);
+    }
+
+    return buildReport(items, options.execute);
+  }
+
+  private async importSkills(
+    items: ImportItemResult<ClaudeCodeOptionId>[],
+    options: ClaudeCodeRunOptions,
+  ): Promise<void> {
+    const skills = this.deps.source.listSkills();
+    if (skills.length === 0) {
+      items.push({
+        kind: "skills",
+        status: "skipped",
+        reason: `no skills found in ${this.deps.source.skillsDir()}`,
+      });
+      return;
+    }
+    for (const skill of skills) {
+      const base: ImportItemResult<ClaudeCodeOptionId> = {
+        kind: "skills",
+        source: skill.name,
+        status: "migrated",
+      };
+      let manifestName: string;
+      try {
+        const manifestRaw = readFileSync(join(skill.dir, "SKILL.md"), "utf8");
+        manifestName = parseSkillFile(manifestRaw).manifest.name;
+      } catch (err) {
+        items.push({
+          ...base,
+          status: "error",
+          reason: `invalid SKILL.md: ${errorMessage(err)}`,
+        });
+        continue;
+      }
+      const destination = join(this.deps.globalSkillsDir, manifestName);
+      const exists = existsSync(destination);
+      if (exists) {
+        if (manifestsMatch(skill.dir, destination)) {
+          items.push({
+            ...base,
+            destination: manifestName,
+            status: "skipped",
+            reason: "already installed",
+          });
+          continue;
+        }
+        if (!options.overwrite) {
+          items.push({
+            ...base,
+            destination: manifestName,
+            status: "conflict",
+            reason: "skill exists with a different SKILL.md; use --overwrite",
+          });
+          continue;
+        }
+      }
+      if (options.execute) {
+        try {
+          await installSkill({
+            sourceDir: skill.dir,
+            targetRoot: this.deps.globalSkillsDir,
+            force: exists,
+          });
+        } catch (err) {
+          items.push({ ...base, status: "error", reason: errorMessage(err) });
+          continue;
+        }
+      }
+      items.push({
+        ...base,
+        destination: manifestName,
+        ...(exists ? { reason: "overwritten" } : {}),
+      });
+    }
+  }
+
+  private importMemory(
+    items: ImportItemResult<ClaudeCodeOptionId>[],
+    options: ClaudeCodeRunOptions,
+  ): void {
+    let files;
+    try {
+      files = this.deps.source.listMemoryFiles();
+    } catch (err) {
+      items.push({ kind: "memory", status: "error", reason: errorMessage(err) });
+      return;
+    }
+    if (files.length === 0) {
+      items.push({
+        kind: "memory",
+        status: "skipped",
+        reason: "no memory notes or CLAUDE.md found",
+      });
+      return;
+    }
+    // Exact-content dedup against what the store already holds, so a
+    // re-run skips instead of doubling every note.
+    const existing = new Set(
+      this.deps.memoryStore
+        .list({ scope: "all", limit: 100_000 })
+        .map((entry) => entry.content),
+    );
+    for (const file of files) {
+      const base: ImportItemResult<ClaudeCodeOptionId> = {
+        kind: "memory",
+        source: file.relPath,
+        status: "migrated",
+      };
+      // A note longer than the store's cap arrives as several notes
+      // rather than an error — losing the biggest notes would invert
+      // what an import is for.
+      const chunks = splitMemoryNote(file.content, MEMORY_CONTENT_MAX_LENGTH);
+      const missing = chunks.filter((chunk) => !existing.has(chunk));
+      if (missing.length === 0) {
+        items.push({ ...base, status: "skipped", reason: "already imported" });
+        continue;
+      }
+      if (options.execute) {
+        try {
+          for (const chunk of missing) {
+            this.deps.memoryStore.store({
+              content: chunk,
+              tags: [CLAUDE_CODE_MEMORY_TAG],
+              source: "user",
+            });
+          }
+        } catch (err) {
+          items.push({ ...base, status: "error", reason: errorMessage(err) });
+          continue;
+        }
+      }
+      items.push({
+        ...base,
+        ...(chunks.length > 1
+          ? { reason: `split into ${chunks.length} notes` }
+          : {}),
+      });
+    }
+  }
+
+  private importMcp(
+    items: ImportItemResult<ClaudeCodeOptionId>[],
+    options: ClaudeCodeRunOptions,
+  ): void {
+    let servers;
+    try {
+      servers = this.deps.source.readMcpServers();
+    } catch (err) {
+      items.push({ kind: "mcp", status: "error", reason: errorMessage(err) });
+      return;
+    }
+    if (servers.length === 0) {
+      items.push({
+        kind: "mcp",
+        status: "skipped",
+        reason: `no mcpServers found in ${this.deps.source.mcpConfigPath()}`,
+      });
+      return;
+    }
+    const path = this.deps.userConfigFile;
+    const prev = ensureUserConfigFileSync(path);
+    const existingNames = new Set(prev.mcp.servers.map((s) => s.name));
+    const toAppend: McpServerConfig[] = [];
+    for (const entry of servers) {
+      const base: ImportItemResult<ClaudeCodeOptionId> = {
+        kind: "mcp",
+        source: entry.name,
+        destination: entry.name,
+        status: "migrated",
+      };
+      const mapped = mapClaudeCodeMcpServer(entry);
+      if (mapped.kind === "skip") {
+        items.push({ ...base, status: "skipped", reason: mapped.reason });
+        continue;
+      }
+      if (existingNames.has(mapped.server.name)) {
+        // Name collisions never overwrite, even with the flag: the
+        // existing entry may carry the operator's own edits, and MCP
+        // servers are cheap to re-add by hand next to a renamed twin.
+        items.push({
+          ...base,
+          status: "skipped",
+          reason: "server with this name already configured",
+        });
+        continue;
+      }
+      toAppend.push(mapped.server);
+      items.push(base);
+    }
+    if (!options.execute || toAppend.length === 0) return;
+    try {
+      const nextMcp = {
+        ...prev.mcp,
+        servers: [...prev.mcp.servers, ...toAppend],
+      };
+      const validated = parseUserConfigFile({ ...prev, mcp: nextMcp });
+      writeUserConfigFileSync(path, validated);
+      resetConfigCache();
+    } catch (err) {
+      const reason =
+        err instanceof ConfigValidationError
+          ? `${err.field}: ${err.message}`
+          : errorMessage(err);
+      // The single write failed: every "migrated" mcp item above is a
+      // claim the file does not back. Downgrade them all to errors.
+      for (const item of items) {
+        if (item.kind === "mcp" && item.status === "migrated") {
+          item.status = "error";
+          item.reason = `config write failed: ${reason}`;
+        }
+      }
+    }
+  }
+
+  private importSessions(
+    items: ImportItemResult<ClaudeCodeOptionId>[],
+    options: ClaudeCodeRunOptions,
+  ): void {
+    if (!this.deps.source.hasProjects()) {
+      items.push({
+        kind: "sessions",
+        status: "skipped",
+        reason: `no projects dir at ${this.deps.source.projectsDir()}`,
+      });
+      return;
+    }
+    let metas = this.deps.source.listSessions();
+    if (options.limit !== undefined && options.limit >= 0) {
+      metas = metas.slice(0, options.limit);
+    }
+    for (const meta of metas) {
+      let mapped: SessionState;
+      try {
+        const session = this.deps.source.readSession(meta);
+        if (session.messages.length === 0) {
+          // Warm-up / title-only transcript files: nothing to keep.
+          continue;
+        }
+        mapped = mapClaudeCodeSession(session, this.deps.workingDirFallback);
+      } catch (err) {
+        items.push({
+          kind: "sessions",
+          source: meta.id,
+          status: "error",
+          reason: errorMessage(err),
+        });
+        continue;
+      }
+      items.push(this.reconcileSession(mapped, meta.id, options));
+    }
+  }
+
+  private reconcileSession(
+    mapped: SessionState,
+    sourceId: string,
+    options: ClaudeCodeRunOptions,
+  ): ImportItemResult<ClaudeCodeOptionId> {
+    const base: ImportItemResult<ClaudeCodeOptionId> = {
+      kind: "sessions",
+      source: sourceId,
+      destination: mapped.id,
+      status: "migrated",
+    };
+    const existing = this.deps.sessionStore.load(mapped.id);
+    if (!existing) {
+      if (options.execute) this.deps.sessionStore.save(mapped);
+      return base;
+    }
+    if (sessionsMatch(existing, mapped)) {
+      return { ...base, status: "skipped", reason: "already matches" };
+    }
+    if (!options.overwrite) {
+      return {
+        ...base,
+        status: "conflict",
+        reason: "destination differs; use --overwrite",
+      };
+    }
+    if (options.execute) this.deps.sessionStore.save(mapped);
+    return { ...base, status: "migrated", reason: "overwritten" };
+  }
+
+  private importSecrets(
+    items: ImportItemResult<ClaudeCodeOptionId>[],
+    options: ClaudeCodeRunOptions,
+  ): void {
+    const envMap = this.deps.source.readEnvKeys(CLAUDE_CODE_SECRET_ALLOWLIST);
+    if (envMap.size === 0) {
+      items.push({
+        kind: "secrets",
+        status: "skipped",
+        reason: "no migratable provider key found in Claude Code settings",
+      });
+      return;
+    }
+    const targetEnvPath = join(this.deps.stateDir, ".env");
+    for (const key of CLAUDE_CODE_SECRET_ALLOWLIST) {
+      const value = envMap.get(key);
+      if (value === undefined) continue;
+      const current = readDotenvValue(targetEnvPath, key);
+      const base: ImportItemResult<ClaudeCodeOptionId> = {
+        kind: "secrets",
+        source: key,
+        destination: key,
+        status: "migrated",
+      };
+      if (current === undefined) {
+        if (options.execute) setDotenvKey(this.deps.stateDir, key, value);
+        items.push(base);
+        continue;
+      }
+      if (current === value) {
+        items.push({ ...base, status: "skipped", reason: "already set" });
+        continue;
+      }
+      if (!options.overwrite) {
+        items.push({
+          ...base,
+          status: "conflict",
+          reason: "key exists with a different value; use --overwrite",
+        });
+        continue;
+      }
+      if (options.execute) setDotenvKey(this.deps.stateDir, key, value);
+      items.push({ ...base, reason: "overwritten" });
+    }
+  }
+}
+
+/** Whether two skill dirs carry byte-identical `SKILL.md` manifests. */
+function manifestsMatch(sourceDir: string, targetDir: string): boolean {
+  try {
+    return (
+      readFileSync(join(sourceDir, "SKILL.md"), "utf8") ===
+      readFileSync(join(targetDir, "SKILL.md"), "utf8")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Structural equality of two sessions' transcripts. */
+function sessionsMatch(a: SessionState, b: SessionState): boolean {
+  if (a.turns.length !== b.turns.length) return false;
+  return JSON.stringify(a.turns) === JSON.stringify(b.turns);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/import/claude-code/claude-code-source.test.ts
+++ b/src/import/claude-code/claude-code-source.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ClaudeCodeSource } from "./claude-code-source.js";
+
+function line(obj: unknown): string {
+  return `${JSON.stringify(obj)}\n`;
+}
+
+describe("ClaudeCodeSource", () => {
+  let home: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "claude-src-"));
+    stateDir = join(home, ".claude");
+    mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("lists only skill dirs holding a SKILL.md", () => {
+    mkdirSync(join(stateDir, "skills", "beta"), { recursive: true });
+    writeFileSync(join(stateDir, "skills", "beta", "SKILL.md"), "---\nname: beta\n---\n");
+    mkdirSync(join(stateDir, "skills", "alpha"), { recursive: true });
+    writeFileSync(join(stateDir, "skills", "alpha", "SKILL.md"), "---\nname: alpha\n---\n");
+    mkdirSync(join(stateDir, "skills", "not-a-skill"), { recursive: true });
+
+    const source = new ClaudeCodeSource(stateDir);
+    expect(source.listSkills().map((s) => s.name)).toEqual(["alpha", "beta"]);
+  });
+
+  it("collects memory notes and CLAUDE.md, skipping the MEMORY.md index", () => {
+    writeFileSync(join(stateDir, "CLAUDE.md"), "always be typing\n");
+    const memoryDir = join(stateDir, "projects", "-home-me-app", "memory");
+    mkdirSync(memoryDir, { recursive: true });
+    writeFileSync(join(memoryDir, "MEMORY.md"), "# index\n");
+    writeFileSync(join(memoryDir, "fact.md"), "the deploy takes ten minutes\n");
+    writeFileSync(join(memoryDir, "empty.md"), "   \n");
+
+    const source = new ClaudeCodeSource(stateDir);
+    const files = source.listMemoryFiles();
+    expect(files.map((f) => f.relPath)).toEqual([
+      "CLAUDE.md",
+      join("projects", "-home-me-app", "memory", "fact.md"),
+    ]);
+    expect(files[1]!.content).toBe("the deploy takes ten minutes");
+  });
+
+  it("reads mcpServers from the sibling ~/.claude.json", () => {
+    writeFileSync(
+      join(home, ".claude.json"),
+      JSON.stringify({
+        mcpServers: {
+          linear: { type: "http", url: "https://mcp.linear.app/mcp" },
+          gmail: { command: "npx", args: ["gmail-mcp"], env: { X: "1" } },
+        },
+        otherKey: true,
+      }),
+    );
+    const source = new ClaudeCodeSource(stateDir);
+    const servers = source.readMcpServers();
+    expect(servers.map((s) => s.name)).toEqual(["linear", "gmail"]);
+  });
+
+  it("reads only allowlisted env keys from settings.json", () => {
+    writeFileSync(
+      join(stateDir, "settings.json"),
+      JSON.stringify({
+        env: { ANTHROPIC_API_KEY: "sk-ant-x", PATH: "/evil", EMPTY: "" },
+      }),
+    );
+    const source = new ClaudeCodeSource(stateDir);
+    const keys = source.readEnvKeys(["ANTHROPIC_API_KEY", "EMPTY"]);
+    expect([...keys.entries()]).toEqual([["ANTHROPIC_API_KEY", "sk-ant-x"]]);
+  });
+
+  it("lists transcripts newest-first and projects their rows", () => {
+    const projectDir = join(stateDir, "projects", "-work-repo");
+    mkdirSync(projectDir, { recursive: true });
+    const older = join(projectDir, "aaa.jsonl");
+    const newer = join(projectDir, "bbb.jsonl");
+    writeFileSync(
+      older,
+      line({
+        type: "user",
+        cwd: "/work/repo",
+        timestamp: "2026-08-01T10:00:00Z",
+        message: { role: "user", content: "hello there" },
+      }),
+    );
+    writeFileSync(
+      newer,
+      [
+        line({ type: "queue-operation", operation: "x" }),
+        line({ type: "ai-title", aiTitle: "Fixing the build" }),
+        line({
+          type: "user",
+          cwd: "/work/repo",
+          timestamp: "2026-08-02T10:00:00Z",
+          message: { role: "user", content: "fix the build" },
+        }),
+        line({
+          type: "assistant",
+          timestamp: "2026-08-02T10:00:05Z",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "look at CI first" },
+              { type: "text", text: "on it" },
+              { type: "tool_use", id: "t1", name: "Bash", input: { command: "make" } },
+            ],
+          },
+        }),
+        line({
+          type: "user",
+          timestamp: "2026-08-02T10:00:09Z",
+          message: {
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "t1", content: "built", is_error: false },
+            ],
+          },
+        }),
+        line({
+          type: "user",
+          isSidechain: true,
+          timestamp: "2026-08-02T10:00:10Z",
+          message: { role: "user", content: "subagent chatter" },
+        }),
+        "not json at all\n",
+      ].join(""),
+    );
+    utimesSync(older, new Date("2026-08-01T10:00:00Z"), new Date("2026-08-01T10:00:00Z"));
+    utimesSync(newer, new Date("2026-08-02T10:00:00Z"), new Date("2026-08-02T10:00:00Z"));
+
+    const source = new ClaudeCodeSource(stateDir);
+    const metas = source.listSessions();
+    expect(metas.map((m) => m.id)).toEqual(["bbb", "aaa"]);
+
+    const session = source.readSession(metas[0]!);
+    expect(session.id).toBe("bbb");
+    expect(session.cwd).toBe("/work/repo");
+    expect(session.title).toBe("Fixing the build");
+    expect(session.messages).toHaveLength(3);
+    expect(session.messages[0]).toMatchObject({
+      role: "user",
+      blocks: [{ type: "text", text: "fix the build" }],
+    });
+    expect(session.messages[1]!.blocks).toEqual([
+      { type: "thinking", thinking: "look at CI first" },
+      { type: "text", text: "on it" },
+      { type: "toolUse", id: "t1", name: "Bash", args: { command: "make" } },
+    ]);
+    expect(session.messages[2]!.blocks).toEqual([
+      { type: "toolResult", toolUseId: "t1", text: "built", isError: false },
+    ]);
+  });
+
+  it("prefers a custom title over the ai title", () => {
+    const projectDir = join(stateDir, "projects", "p");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, "s.jsonl"),
+      [
+        line({ type: "ai-title", aiTitle: "generated" }),
+        line({ type: "custom-title", customTitle: "mine" }),
+        line({
+          type: "user",
+          timestamp: "2026-08-02T10:00:00Z",
+          message: { role: "user", content: "hi" },
+        }),
+      ].join(""),
+    );
+    const source = new ClaudeCodeSource(stateDir);
+    expect(source.readSession(source.listSessions()[0]!).title).toBe("mine");
+  });
+});

--- a/src/import/claude-code/claude-code-source.ts
+++ b/src/import/claude-code/claude-code-source.ts
@@ -1,0 +1,411 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Read-only access to a `~/.claude` state directory (Claude Code). This
+ * is the **only** file in the Claude Code import feature that touches
+ * its physical layout; everything downstream operates on the neutral
+ * types exported here.
+ *
+ * Layout:
+ *  - `skills/<name>/SKILL.md`                — agent skills (same manifest
+ *    family atomic-agent uses, so a skill imports as a directory copy).
+ *  - `projects/<slug>/<uuid>.jsonl`          — session transcripts, one
+ *    JSON event per line (`user` / `assistant` rows carry the messages).
+ *  - `projects/<slug>/memory/*.md`           — per-project auto-memory
+ *    notes; `MEMORY.md` is the index and is skipped.
+ *  - `CLAUDE.md`                             — global user instructions.
+ *  - `settings.json` `env` block             — provider keys (opt-in).
+ *  - sibling file `~/.claude.json` `mcpServers` — MCP server configs.
+ */
+export class ClaudeCodeSourceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClaudeCodeSourceError";
+  }
+}
+
+/** A skill directory holding a `SKILL.md` manifest. */
+export interface ClaudeCodeSkill {
+  /** Directory basename — the skill's install name. */
+  name: string;
+  /** Absolute path to the skill's root directory. */
+  dir: string;
+}
+
+/** One auto-memory note, or the global `CLAUDE.md` instructions file. */
+export interface ClaudeCodeMemoryFile {
+  /** Path relative to the state dir, used as the item's source id. */
+  relPath: string;
+  content: string;
+}
+
+/** A raw `mcpServers` entry, unvalidated — the mapper normalises it. */
+export interface ClaudeCodeMcpServer {
+  name: string;
+  raw: Record<string, unknown>;
+}
+
+/** Lightweight session header; the transcript is read separately. */
+export interface ClaudeCodeSessionMeta {
+  /** Transcript file basename without `.jsonl` (the session uuid). */
+  id: string;
+  /** Absolute path to the `<uuid>.jsonl` transcript. */
+  file: string;
+  /** File mtime in ms — the cheap recency key the listing sorts by. */
+  mtimeMs: number;
+}
+
+/** A content block inside a projected transcript message. */
+export type ClaudeCodeBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string }
+  | { type: "toolUse"; id: string | null; name: string; args: Record<string, unknown> }
+  | { type: "toolResult"; toolUseId: string | null; text: string; isError: boolean };
+
+/** A projected `user` / `assistant` transcript row. */
+export interface ClaudeCodeMessage {
+  role: "user" | "assistant";
+  blocks: ClaudeCodeBlock[];
+  atMs: number;
+}
+
+/** A fully-read session: header fields plus the projected messages. */
+export interface ClaudeCodeSessionData {
+  id: string;
+  cwd: string | null;
+  title: string | null;
+  messages: ClaudeCodeMessage[];
+}
+
+export class ClaudeCodeSource {
+  constructor(private readonly sourceDir: string) {}
+
+  skillsDir(): string {
+    return join(this.sourceDir, "skills");
+  }
+
+  projectsDir(): string {
+    return join(this.sourceDir, "projects");
+  }
+
+  settingsPath(): string {
+    return join(this.sourceDir, "settings.json");
+  }
+
+  globalClaudeMdPath(): string {
+    return join(this.sourceDir, "CLAUDE.md");
+  }
+
+  /**
+   * `~/.claude.json` — Claude Code keeps `mcpServers` in a sibling file
+   * next to the state dir, not inside it.
+   */
+  mcpConfigPath(): string {
+    return join(dirname(this.sourceDir), ".claude.json");
+  }
+
+  hasSkills(): boolean {
+    return existsSync(this.skillsDir());
+  }
+
+  hasProjects(): boolean {
+    return existsSync(this.projectsDir());
+  }
+
+  /** Skill dirs that hold a `SKILL.md`, sorted by name. */
+  listSkills(): ClaudeCodeSkill[] {
+    const root = this.skillsDir();
+    if (!existsSync(root)) return [];
+    const skills: ClaudeCodeSkill[] = [];
+    for (const entry of readdirSync(root)) {
+      const dir = join(root, entry);
+      if (!existsSync(join(dir, "SKILL.md"))) continue;
+      skills.push({ name: entry, dir });
+    }
+    skills.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return skills;
+  }
+
+  /**
+   * Auto-memory notes from every project's `memory/` dir plus the global
+   * `CLAUDE.md`. `MEMORY.md` (the index Claude Code regenerates from the
+   * notes) is skipped; empty files are skipped.
+   */
+  listMemoryFiles(): ClaudeCodeMemoryFile[] {
+    const files: ClaudeCodeMemoryFile[] = [];
+    const globalMd = this.globalClaudeMdPath();
+    if (existsSync(globalMd)) {
+      const content = readFileSync(globalMd, "utf8").trim();
+      if (content.length > 0) files.push({ relPath: "CLAUDE.md", content });
+    }
+    const projects = this.projectsDir();
+    if (!existsSync(projects)) return files;
+    for (const slug of sortedEntries(projects)) {
+      const memoryDir = join(projects, slug, "memory");
+      if (!existsSync(memoryDir)) continue;
+      for (const entry of sortedEntries(memoryDir)) {
+        if (!entry.endsWith(".md") || entry === "MEMORY.md") continue;
+        const path = join(memoryDir, entry);
+        let content: string;
+        try {
+          content = readFileSync(path, "utf8").trim();
+        } catch {
+          continue;
+        }
+        if (content.length === 0) continue;
+        files.push({
+          relPath: join("projects", slug, "memory", entry),
+          content,
+        });
+      }
+    }
+    return files;
+  }
+
+  /**
+   * Raw `mcpServers` entries from `~/.claude.json`. Returns an empty
+   * list when the file is missing or holds no such block; malformed JSON
+   * throws a `ClaudeCodeSourceError` (a broken config file is worth a
+   * loud error item, not a silent zero).
+   */
+  readMcpServers(): ClaudeCodeMcpServer[] {
+    const path = this.mcpConfigPath();
+    if (!existsSync(path)) return [];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(path, "utf8"));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new ClaudeCodeSourceError(`failed to parse ${path}: ${message}`);
+    }
+    if (!parsed || typeof parsed !== "object") return [];
+    const servers = (parsed as { mcpServers?: unknown }).mcpServers;
+    if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+      return [];
+    }
+    const result: ClaudeCodeMcpServer[] = [];
+    for (const [name, raw] of Object.entries(servers)) {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+      result.push({ name, raw: raw as Record<string, unknown> });
+    }
+    return result;
+  }
+
+  /**
+   * Read `settings.json`'s `env` block and return only the keys present
+   * in `allowlist` with non-empty string values.
+   */
+  readEnvKeys(allowlist: readonly string[]): Map<string, string> {
+    const result = new Map<string, string>();
+    const path = this.settingsPath();
+    if (!existsSync(path)) return result;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(path, "utf8"));
+    } catch {
+      return result;
+    }
+    if (!parsed || typeof parsed !== "object") return result;
+    const env = (parsed as { env?: unknown }).env;
+    if (!env || typeof env !== "object" || Array.isArray(env)) return result;
+    const allowed = new Set(allowlist);
+    for (const [key, value] of Object.entries(env)) {
+      if (!allowed.has(key)) continue;
+      if (typeof value !== "string" || value.length === 0) continue;
+      result.set(key, value);
+    }
+    return result;
+  }
+
+  /**
+   * List transcript headers across every project, newest-first by file
+   * mtime. Recency comes from the mtime rather than a parse because a
+   * listing that opened a gigabyte of JSONL to sort itself would make
+   * every preview pay for sessions a `limit` then discards.
+   */
+  listSessions(): ClaudeCodeSessionMeta[] {
+    const projects = this.projectsDir();
+    if (!existsSync(projects)) return [];
+    const metas: ClaudeCodeSessionMeta[] = [];
+    for (const slug of sortedEntries(projects)) {
+      const projectDir = join(projects, slug);
+      let entries: string[];
+      try {
+        entries = readdirSync(projectDir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (!entry.endsWith(".jsonl")) continue;
+        const file = join(projectDir, entry);
+        let mtimeMs: number;
+        try {
+          const stats = statSync(file);
+          if (!stats.isFile()) continue;
+          mtimeMs = stats.mtimeMs;
+        } catch {
+          continue;
+        }
+        metas.push({ id: entry.slice(0, -".jsonl".length), file, mtimeMs });
+      }
+    }
+    metas.sort(
+      (a, b) =>
+        b.mtimeMs - a.mtimeMs || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+    );
+    return metas;
+  }
+
+  /**
+   * Read one transcript into a neutral session. Meta rows (`system`,
+   * `queue-operation`, attachments, …) are skipped; sidechain rows
+   * (subagent transcripts interleaved into the same file) are skipped;
+   * `custom-title` wins over `ai-title` for the session title.
+   */
+  readSession(meta: ClaudeCodeSessionMeta): ClaudeCodeSessionData {
+    let text: string;
+    try {
+      text = readFileSync(meta.file, "utf8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new ClaudeCodeSourceError(`failed to read ${meta.file}: ${message}`);
+    }
+    let cwd: string | null = null;
+    let customTitle: string | null = null;
+    let aiTitle: string | null = null;
+    const messages: ClaudeCodeMessage[] = [];
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      let event: Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (!parsed || typeof parsed !== "object") continue;
+        event = parsed as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const type = event.type;
+      if (type === "custom-title" && typeof event.customTitle === "string") {
+        customTitle = event.customTitle;
+        continue;
+      }
+      if (type === "ai-title" && typeof event.aiTitle === "string") {
+        aiTitle = event.aiTitle;
+        continue;
+      }
+      if (type !== "user" && type !== "assistant") continue;
+      if (event.isSidechain === true) continue;
+      if (cwd === null && typeof event.cwd === "string") cwd = event.cwd;
+      const projected = projectMessage(type, event);
+      if (projected) messages.push(projected);
+    }
+    return {
+      id: meta.id,
+      cwd,
+      title: customTitle ?? aiTitle,
+      messages,
+    };
+  }
+}
+
+function sortedEntries(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries.sort();
+}
+
+function projectMessage(
+  role: "user" | "assistant",
+  event: Record<string, unknown>,
+): ClaudeCodeMessage | null {
+  const message = event.message;
+  if (!message || typeof message !== "object") return null;
+  const content = (message as { content?: unknown }).content;
+  const blocks = projectBlocks(content);
+  if (blocks.length === 0) return null;
+  const atMs =
+    typeof event.timestamp === "string" ? isoToMs(event.timestamp) ?? 0 : 0;
+  return { role, blocks, atMs };
+}
+
+function projectBlocks(content: unknown): ClaudeCodeBlock[] {
+  if (typeof content === "string") {
+    return content.length > 0 ? [{ type: "text", text: content }] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const blocks: ClaudeCodeBlock[] = [];
+  for (const raw of content) {
+    if (!raw || typeof raw !== "object") continue;
+    const block = raw as Record<string, unknown>;
+    switch (block.type) {
+      case "text":
+        if (typeof block.text === "string" && block.text.length > 0) {
+          blocks.push({ type: "text", text: block.text });
+        }
+        break;
+      case "thinking":
+        if (typeof block.thinking === "string" && block.thinking.length > 0) {
+          blocks.push({ type: "thinking", thinking: block.thinking });
+        }
+        break;
+      case "tool_use": {
+        const name = block.name;
+        if (typeof name !== "string" || name.length === 0) break;
+        blocks.push({
+          type: "toolUse",
+          id: typeof block.id === "string" ? block.id : null,
+          name,
+          args:
+            block.input && typeof block.input === "object" &&
+            !Array.isArray(block.input)
+              ? (block.input as Record<string, unknown>)
+              : {},
+        });
+        break;
+      }
+      case "tool_result":
+        blocks.push({
+          type: "toolResult",
+          toolUseId:
+            typeof block.tool_use_id === "string" ? block.tool_use_id : null,
+          text: flattenResultContent(block.content),
+          isError: block.is_error === true,
+        });
+        break;
+      default:
+        break;
+    }
+  }
+  return blocks;
+}
+
+/** Tool results carry a string or a list of text blocks; flatten both. */
+function flattenResultContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const raw of content) {
+    if (!raw || typeof raw !== "object") continue;
+    const block = raw as Record<string, unknown>;
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function isoToMs(value: string): number | null {
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : ms;
+}

--- a/src/import/claude-code/import-options.test.ts
+++ b/src/import/claude-code/import-options.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ClaudeCodeOptionError,
+  resolveClaudeCodeOptions,
+} from "./import-options.js";
+
+describe("resolveClaudeCodeOptions", () => {
+  it("defaults to every non-secret option", () => {
+    expect(resolveClaudeCodeOptions()).toEqual([
+      "skills",
+      "memory",
+      "mcp",
+      "sessions",
+    ]);
+  });
+
+  it("applies exclude and keeps registry order", () => {
+    expect(resolveClaudeCodeOptions({ exclude: ["sessions", "memory"] })).toEqual([
+      "skills",
+      "mcp",
+    ]);
+  });
+
+  it("adds secrets only through the explicit flag", () => {
+    expect(resolveClaudeCodeOptions({ migrateSecrets: true })).toContain("secrets");
+    expect(() => resolveClaudeCodeOptions({ include: ["secrets"] })).toThrow(
+      ClaudeCodeOptionError,
+    );
+  });
+
+  it("rejects unknown option ids", () => {
+    expect(() => resolveClaudeCodeOptions({ include: ["cron"] })).toThrow(
+      ClaudeCodeOptionError,
+    );
+    expect(() => resolveClaudeCodeOptions({ exclude: ["nope"] })).toThrow(
+      ClaudeCodeOptionError,
+    );
+  });
+});

--- a/src/import/claude-code/import-options.ts
+++ b/src/import/claude-code/import-options.ts
@@ -1,0 +1,119 @@
+/**
+ * Claude Code-specific import domains and their selection logic. Same
+ * contract as the Hermes module: the source declares its own importable
+ * domains, the shared report layer only aggregates results, and
+ * `secrets` never enters a preset — the explicit flag is the single
+ * gate for credentials.
+ */
+export type ClaudeCodeOptionId =
+  | "skills"
+  | "memory"
+  | "mcp"
+  | "sessions"
+  | "secrets";
+
+export interface ClaudeCodeOptionMeta {
+  id: ClaudeCodeOptionId;
+  label: string;
+  description: string;
+}
+
+/** Registry of every importable Claude Code option. */
+export const CLAUDE_CODE_IMPORT_OPTIONS: readonly ClaudeCodeOptionMeta[] = [
+  {
+    id: "skills",
+    label: "Skills",
+    description: "Skill directories (skills/*/SKILL.md) -> global skills dir",
+  },
+  {
+    id: "memory",
+    label: "Memory",
+    description: "Auto-memory notes + CLAUDE.md -> memory.sqlite",
+  },
+  {
+    id: "mcp",
+    label: "MCP servers",
+    description: "mcpServers (~/.claude.json) -> config.mcp.servers",
+  },
+  {
+    id: "sessions",
+    label: "Sessions",
+    description: "Transcripts (projects/*/*.jsonl) -> sessions.sqlite",
+  },
+  {
+    id: "secrets",
+    label: "Provider key",
+    description: "ANTHROPIC_API_KEY (settings.json env) -> <stateDir>/.env",
+  },
+];
+
+export class ClaudeCodeOptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClaudeCodeOptionError";
+  }
+}
+
+const KNOWN_OPTION_IDS: ReadonlySet<string> = new Set(
+  CLAUDE_CODE_IMPORT_OPTIONS.map((o) => o.id),
+);
+
+/** Everything except `secrets`, which only `migrateSecrets` can add. */
+const DEFAULT_OPTIONS: readonly ClaudeCodeOptionId[] = [
+  "skills",
+  "memory",
+  "mcp",
+  "sessions",
+];
+
+export interface ResolveClaudeCodeOptionsInput {
+  include?: readonly string[];
+  exclude?: readonly string[];
+  /** When true, `secrets` is added to the resolved set. */
+  migrateSecrets?: boolean;
+}
+
+/**
+ * Resolve the final option set: the non-secret default, `include` /
+ * `exclude` applied, every id validated against the registry, and
+ * `secrets` added only through the explicit flag.
+ */
+export function resolveClaudeCodeOptions(
+  input: ResolveClaudeCodeOptionsInput = {},
+): ClaudeCodeOptionId[] {
+  const selected = new Set<ClaudeCodeOptionId>(DEFAULT_OPTIONS);
+
+  for (const raw of input.include ?? []) {
+    const id = raw.trim();
+    if (id.length === 0) continue;
+    if (!KNOWN_OPTION_IDS.has(id)) {
+      throw new ClaudeCodeOptionError(`unknown option in --include: ${id}`);
+    }
+    if (id === "secrets") {
+      throw new ClaudeCodeOptionError(
+        "secrets cannot be selected via --include; use --migrate-secrets",
+      );
+    }
+    selected.add(id as ClaudeCodeOptionId);
+  }
+
+  for (const raw of input.exclude ?? []) {
+    const id = raw.trim();
+    if (id.length === 0) continue;
+    if (!KNOWN_OPTION_IDS.has(id)) {
+      throw new ClaudeCodeOptionError(`unknown option in --exclude: ${id}`);
+    }
+    selected.delete(id as ClaudeCodeOptionId);
+  }
+
+  if (input.migrateSecrets) {
+    selected.add("secrets");
+  } else {
+    selected.delete("secrets");
+  }
+
+  // Preserve registry order for deterministic output.
+  return CLAUDE_CODE_IMPORT_OPTIONS.map((o) => o.id).filter((id) =>
+    selected.has(id),
+  );
+}

--- a/src/import/claude-code/index.ts
+++ b/src/import/claude-code/index.ts
@@ -1,0 +1,40 @@
+export {
+  ClaudeCodeSource,
+  ClaudeCodeSourceError,
+} from "./claude-code-source.js";
+export type {
+  ClaudeCodeBlock,
+  ClaudeCodeMcpServer,
+  ClaudeCodeMemoryFile,
+  ClaudeCodeMessage,
+  ClaudeCodeSessionData,
+  ClaudeCodeSessionMeta,
+  ClaudeCodeSkill,
+} from "./claude-code-source.js";
+export {
+  CLAUDE_CODE_IMPORT_OPTIONS,
+  ClaudeCodeOptionError,
+  resolveClaudeCodeOptions,
+} from "./import-options.js";
+export type {
+  ClaudeCodeOptionId,
+  ClaudeCodeOptionMeta,
+  ResolveClaudeCodeOptionsInput,
+} from "./import-options.js";
+export {
+  CLAUDE_CODE_MEMORY_TAG,
+  CLAUDE_CODE_SECRET_ALLOWLIST,
+  ClaudeCodeImporter,
+  ONBOARDING_SESSION_LIMIT,
+} from "./claude-code-importer.js";
+export type {
+  ClaudeCodeImporterDeps,
+  ClaudeCodeRunOptions,
+  ImportMemoryTarget,
+} from "./claude-code-importer.js";
+export {
+  CLAUDE_CODE_SESSION_ID_PREFIX,
+  mapClaudeCodeSession,
+} from "./map-session.js";
+export { mapClaudeCodeMcpServer } from "./map-mcp.js";
+export type { MapMcpResult } from "./map-mcp.js";

--- a/src/import/claude-code/map-mcp.test.ts
+++ b/src/import/claude-code/map-mcp.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { mapClaudeCodeMcpServer } from "./map-mcp.js";
+
+describe("mapClaudeCodeMcpServer", () => {
+  it("maps a stdio entry, keeping args and env", () => {
+    const result = mapClaudeCodeMcpServer({
+      name: "gmail",
+      raw: {
+        type: "stdio",
+        command: "npx",
+        args: ["gmail-mcp", "--flag"],
+        env: { TOKEN_PATH: "/tmp/t" },
+      },
+    });
+    expect(result.kind).toBe("server");
+    if (result.kind !== "server") return;
+    expect(result.server.name).toBe("gmail");
+    expect(result.server.transport).toMatchObject({
+      kind: "stdio",
+      command: "npx",
+      args: ["gmail-mcp", "--flag"],
+    });
+    expect(result.server.env).toEqual({ TOKEN_PATH: "/tmp/t" });
+  });
+
+  it("maps http and sse url entries onto the matching transports", () => {
+    const http = mapClaudeCodeMcpServer({
+      name: "linear",
+      raw: { type: "http", url: "https://mcp.linear.app/mcp" },
+    });
+    expect(http.kind).toBe("server");
+    if (http.kind === "server") {
+      expect(http.server.transport).toMatchObject({
+        kind: "streamable_http",
+        url: "https://mcp.linear.app/mcp",
+      });
+    }
+
+    const sse = mapClaudeCodeMcpServer({
+      name: "old-school",
+      raw: { type: "sse", url: "https://example.com/sse", headers: { A: "b" } },
+    });
+    expect(sse.kind).toBe("server");
+    if (sse.kind === "server") {
+      expect(sse.server.transport).toMatchObject({
+        kind: "sse",
+        url: "https://example.com/sse",
+      });
+    }
+  });
+
+  it("skips entries with neither command nor url", () => {
+    const result = mapClaudeCodeMcpServer({ name: "weird", raw: { type: "ws" } });
+    expect(result.kind).toBe("skip");
+    if (result.kind === "skip") {
+      expect(result.reason).toContain("no command or url");
+    }
+  });
+
+  it("skips entries the canonical validator rejects", () => {
+    const result = mapClaudeCodeMcpServer({
+      name: "Bad Name With Spaces",
+      raw: { command: "npx" },
+    });
+    expect(result.kind).toBe("skip");
+  });
+});

--- a/src/import/claude-code/map-mcp.ts
+++ b/src/import/claude-code/map-mcp.ts
@@ -1,0 +1,65 @@
+import { parseMcpServers } from "../../config/config-schema.js";
+import { ConfigValidationError } from "../../config/config-validation-error.js";
+import type { McpServerConfig } from "../../mcp/mcp-types.js";
+import type { ClaudeCodeMcpServer } from "./claude-code-source.js";
+
+/**
+ * Normalise one Claude Code `mcpServers` entry into a validated
+ * `McpServerConfig`, or explain why it cannot be.
+ *
+ * Claude Code's dialect is the common client shortcut — `type` +
+ * `command`/`url` at the top level — where atomic-agent's canonical
+ * shape is a `transport: { kind, … }` envelope. The mapper builds a
+ * clean candidate from the keys it understands and runs it through the
+ * canonical validator, so nothing unvalidated can reach the config file.
+ */
+export type MapMcpResult =
+  | { kind: "server"; server: McpServerConfig }
+  | { kind: "skip"; reason: string };
+
+export function mapClaudeCodeMcpServer(entry: ClaudeCodeMcpServer): MapMcpResult {
+  const raw = entry.raw;
+  const type = typeof raw.type === "string" ? raw.type : null;
+
+  let transport: Record<string, unknown>;
+  if (typeof raw.command === "string" && (type === null || type === "stdio")) {
+    transport = { kind: "stdio", command: raw.command };
+    if (Array.isArray(raw.args)) transport.args = raw.args;
+  } else if (typeof raw.url === "string") {
+    transport = {
+      kind: type === "sse" ? "sse" : "streamable_http",
+      url: raw.url,
+    };
+    if (raw.headers && typeof raw.headers === "object") {
+      transport.headers = raw.headers;
+    }
+  } else {
+    return {
+      kind: "skip",
+      reason: `unsupported server shape${type !== null ? ` (type ${JSON.stringify(type)})` : ""} — no command or url`,
+    };
+  }
+
+  const candidate: Record<string, unknown> = {
+    name: entry.name,
+    transport,
+  };
+  if (raw.env && typeof raw.env === "object" && !Array.isArray(raw.env)) {
+    candidate.env = raw.env;
+  }
+
+  try {
+    const out = parseMcpServers([candidate], "mcp.servers");
+    const first = out[0];
+    if (!first) return { kind: "skip", reason: "validation produced no config" };
+    return { kind: "server", server: first };
+  } catch (err) {
+    if (err instanceof ConfigValidationError) {
+      return { kind: "skip", reason: `${err.field}: ${err.message}` };
+    }
+    return {
+      kind: "skip",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/import/claude-code/map-session.test.ts
+++ b/src/import/claude-code/map-session.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CLAUDE_CODE_SESSION_ID_PREFIX,
+  mapClaudeCodeSession,
+} from "./map-session.js";
+import type { ClaudeCodeSessionData } from "./claude-code-source.js";
+
+const T0 = Date.parse("2026-08-02T10:00:00Z");
+
+function session(partial: Partial<ClaudeCodeSessionData>): ClaudeCodeSessionData {
+  return {
+    id: "abc",
+    cwd: "/work",
+    title: null,
+    messages: [],
+    ...partial,
+  };
+}
+
+describe("mapClaudeCodeSession", () => {
+  it("maps text rows onto user and assistant turns", () => {
+    const mapped = mapClaudeCodeSession(
+      session({
+        title: "Build fix",
+        messages: [
+          { role: "user", blocks: [{ type: "text", text: "hi" }], atMs: T0 },
+          {
+            role: "assistant",
+            blocks: [
+              { type: "thinking", thinking: "ponder" },
+              { type: "text", text: "hello" },
+            ],
+            atMs: T0 + 1000,
+          },
+        ],
+      }),
+      "/fallback",
+    );
+
+    expect(mapped.id).toBe(`${CLAUDE_CODE_SESSION_ID_PREFIX}abc`);
+    expect(mapped.workingDir).toBe("/work");
+    expect(mapped.createdAt).toBe(T0);
+    expect(mapped.updatedAt).toBe(T0 + 1000);
+    expect(mapped.turnCount).toBe(1);
+    expect(mapped.metadata).toMatchObject({
+      importedFrom: "claude-code",
+      claudeCodeSessionId: "abc",
+      title: "Build fix",
+    });
+    expect(mapped.turns).toEqual([
+      { kind: "user", text: "hi", at: T0 },
+      {
+        kind: "assistant_reply",
+        text: "hello",
+        at: T0 + 1000,
+        reasoning: "ponder",
+      },
+    ]);
+  });
+
+  it("names tool results through the tool_use id seen earlier", () => {
+    const mapped = mapClaudeCodeSession(
+      session({
+        messages: [
+          {
+            role: "assistant",
+            blocks: [
+              { type: "toolUse", id: "t1", name: "Bash", args: { command: "ls" } },
+            ],
+            atMs: T0,
+          },
+          {
+            role: "user",
+            blocks: [
+              { type: "toolResult", toolUseId: "t1", text: "ok", isError: false },
+              { type: "toolResult", toolUseId: "t9", text: "?", isError: true },
+            ],
+            atMs: T0 + 1,
+          },
+        ],
+      }),
+      "/fallback",
+    );
+
+    expect(mapped.turns).toEqual([
+      { kind: "assistant_tool_call", tool: "Bash", args: { command: "ls" }, at: T0 },
+      { kind: "tool_result", tool: "Bash", status: "ok", summary: "ok", at: T0 + 1 },
+      { kind: "tool_result", tool: "unknown", status: "error", summary: "?", at: T0 + 1 },
+    ]);
+  });
+
+  it("emits the reply before the calls when a row carries both", () => {
+    const mapped = mapClaudeCodeSession(
+      session({
+        messages: [
+          {
+            role: "assistant",
+            blocks: [
+              { type: "text", text: "running it" },
+              { type: "toolUse", id: "t1", name: "Bash", args: {} },
+            ],
+            atMs: T0,
+          },
+        ],
+      }),
+      "/fallback",
+    );
+    expect(mapped.turns.map((t) => t.kind)).toEqual([
+      "assistant_reply",
+      "assistant_tool_call",
+    ]);
+  });
+
+  it("keeps a thinking-only row as an empty reply with reasoning", () => {
+    const mapped = mapClaudeCodeSession(
+      session({
+        messages: [
+          {
+            role: "assistant",
+            blocks: [{ type: "thinking", thinking: "interrupted" }],
+            atMs: T0,
+          },
+        ],
+      }),
+      "/fallback",
+    );
+    expect(mapped.turns).toEqual([
+      { kind: "assistant_reply", text: "", at: T0, reasoning: "interrupted" },
+    ]);
+  });
+
+  it("falls back to the provided working dir", () => {
+    const mapped = mapClaudeCodeSession(session({ cwd: null }), "/fallback");
+    expect(mapped.workingDir).toBe("/fallback");
+  });
+});

--- a/src/import/claude-code/map-session.ts
+++ b/src/import/claude-code/map-session.ts
@@ -1,0 +1,150 @@
+import {
+  assistantReplyTurn,
+  assistantToolCallTurn,
+  toolResultTurn,
+  userTurn,
+  type ConversationTurn,
+} from "../../session/conversation-turn.js";
+import type { SessionState } from "../../session/session-state.js";
+import type {
+  ClaudeCodeBlock,
+  ClaudeCodeMessage,
+  ClaudeCodeSessionData,
+} from "./claude-code-source.js";
+
+/** Prefix applied to imported session ids so they never collide with native ids. */
+export const CLAUDE_CODE_SESSION_ID_PREFIX = "claude-code:";
+
+/**
+ * Map one Claude Code transcript into a native `SessionState`. Pure — no
+ * I/O. The projected rows fold onto the four-kind `ConversationTurn`
+ * model:
+ *
+ *  - user `text` blocks        → `user` turn (joined).
+ *  - user `toolResult` blocks  → one `tool_result` turn each; the tool
+ *    name resolves through the `tool_use` id seen on an earlier
+ *    assistant row, since Claude Code's result rows carry only the id.
+ *  - assistant `text` blocks   → `assistant_reply` (reasoning from
+ *    `thinking` blocks rides along); `toolUse` blocks → one
+ *    `assistant_tool_call` each. A message with both emits the reply
+ *    first, matching the order the blocks were produced in.
+ */
+export function mapClaudeCodeSession(
+  session: ClaudeCodeSessionData,
+  fallbackWorkingDir: string,
+): SessionState {
+  const turns: ConversationTurn[] = [];
+  /** `tool_use` id → tool name, for naming the matching result rows. */
+  const toolNames = new Map<string, string>();
+  for (const message of session.messages) {
+    appendMessageTurns(turns, message, toolNames);
+  }
+
+  const createdAt =
+    session.messages.length > 0 ? session.messages[0]!.atMs : 0;
+  const lastMessageAt =
+    session.messages.length > 0
+      ? session.messages[session.messages.length - 1]!.atMs
+      : createdAt;
+  const turnCount = turns.filter((t) => t.kind === "assistant_reply").length;
+
+  return {
+    id: `${CLAUDE_CODE_SESSION_ID_PREFIX}${session.id}`,
+    workingDir: session.cwd ?? fallbackWorkingDir,
+    status: "completed",
+    knownFacts: [],
+    latestResult: null,
+    loadedSkills: [],
+    loadedTools: [],
+    worldSnapshot: null,
+    stepCount: 0,
+    turnCount,
+    turns,
+    createdAt,
+    updatedAt: lastMessageAt,
+    lastError: null,
+    metadata: {
+      importedFrom: "claude-code",
+      claudeCodeSessionId: session.id,
+      ...(session.title !== null ? { title: session.title } : {}),
+    },
+  };
+}
+
+function appendMessageTurns(
+  turns: ConversationTurn[],
+  message: ClaudeCodeMessage,
+  toolNames: Map<string, string>,
+): void {
+  const at = message.atMs;
+  if (message.role === "user") {
+    const text = joinText(message.blocks);
+    if (text.length > 0) turns.push(userTurn(text, at));
+    for (const block of message.blocks) {
+      if (block.type !== "toolResult") continue;
+      turns.push(
+        toolResultTurn({
+          tool:
+            (block.toolUseId !== null
+              ? toolNames.get(block.toolUseId)
+              : undefined) ?? "unknown",
+          status: block.isError ? "error" : "ok",
+          summary: block.text,
+          at,
+        }),
+      );
+    }
+    return;
+  }
+  const reasoning = joinThinking(message.blocks);
+  const text = joinText(message.blocks);
+  const calls = message.blocks.filter(
+    (b): b is Extract<ClaudeCodeBlock, { type: "toolUse" }> =>
+      b.type === "toolUse",
+  );
+  if (text.length > 0) {
+    turns.push(
+      assistantReplyTurn(text, {
+        at,
+        ...(reasoning.length > 0 ? { reasoning } : {}),
+      }),
+    );
+  }
+  calls.forEach((call, index) => {
+    if (call.id !== null) toolNames.set(call.id, call.name);
+    turns.push(
+      assistantToolCallTurn({
+        tool: call.name,
+        args: call.args,
+        at,
+        // One inference => one reasoning block. It rode the reply when
+        // there was one; otherwise it attaches to the first call.
+        ...(index === 0 && text.length === 0 && reasoning.length > 0
+          ? { reasoning }
+          : {}),
+      }),
+    );
+  });
+  if (text.length === 0 && calls.length === 0 && reasoning.length > 0) {
+    // A thinking-only row (interrupted turn): keep the reasoning rather
+    // than dropping the message whole.
+    turns.push(assistantReplyTurn("", { at, reasoning }));
+  }
+}
+
+function joinText(blocks: readonly ClaudeCodeBlock[]): string {
+  return blocks
+    .filter((b): b is Extract<ClaudeCodeBlock, { type: "text" }> => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+}
+
+function joinThinking(blocks: readonly ClaudeCodeBlock[]): string {
+  return blocks
+    .filter(
+      (b): b is Extract<ClaudeCodeBlock, { type: "thinking" }> =>
+        b.type === "thinking",
+    )
+    .map((b) => b.thinking)
+    .join("\n");
+}

--- a/src/import/codex/codex-importer.test.ts
+++ b/src/import/codex/codex-importer.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SessionStore } from "../../session/index.js";
+import { CodexImporter } from "./codex-importer.js";
+import { CodexSource } from "./codex-source.js";
+import { resolveCodexOptions } from "./import-options.js";
+
+function line(obj: unknown): string {
+  return `${JSON.stringify(obj)}\n`;
+}
+
+describe("CodexImporter", () => {
+  let sourceDir: string;
+  let stateDir: string;
+  let sessionStore: SessionStore;
+  let memoryContents: string[];
+
+  function buildImporter(): CodexImporter {
+    return new CodexImporter({
+      source: new CodexSource(sourceDir),
+      sessionStore,
+      memoryStore: {
+        list: () => memoryContents.map((content) => ({ content })),
+        store: (input: { content: string }) => {
+          memoryContents.push(input.content);
+        },
+      },
+      stateDir,
+      globalSkillsDir: join(stateDir, "skills"),
+      workingDirFallback: "/fallback",
+    });
+  }
+
+  beforeEach(() => {
+    sourceDir = mkdtempSync(join(tmpdir(), "codex-imp-src-"));
+    stateDir = mkdtempSync(join(tmpdir(), "codex-imp-dst-"));
+    sessionStore = new SessionStore({ dbFile: join(stateDir, "sessions.sqlite") });
+    memoryContents = [];
+  });
+
+  afterEach(() => {
+    sessionStore.close();
+    rmSync(sourceDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmSync(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  function seedAll(): void {
+    mkdirSync(join(sourceDir, "skills", "review"), { recursive: true });
+    writeFileSync(
+      join(sourceDir, "skills", "review", "SKILL.md"),
+      "---\nname: review\ndescription: Review code\n---\n",
+    );
+    writeFileSync(join(sourceDir, "AGENTS.md"), "prefer bun\n");
+    writeFileSync(
+      join(sourceDir, "auth.json"),
+      JSON.stringify({ OPENAI_API_KEY: "sk-o-1" }),
+    );
+    mkdirSync(join(sourceDir, "sessions"), { recursive: true });
+    writeFileSync(
+      join(sourceDir, "sessions", "rollout-x.jsonl"),
+      [
+        line({
+          timestamp: "2026-08-02T10:00:00Z",
+          type: "session_meta",
+          payload: { id: "sess-1", cwd: "/work" },
+        }),
+        line({
+          timestamp: "2026-08-02T10:00:01Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "hello" }],
+          },
+        }),
+      ].join(""),
+    );
+  }
+
+  it("imports skills, instructions, sessions and (opt-in) the key", async () => {
+    seedAll();
+    const report = await buildImporter().run({
+      options: resolveCodexOptions({ migrateSecrets: true }),
+      execute: true,
+      overwrite: false,
+    });
+
+    expect(report.summary.error).toBe(0);
+    expect(report.summary.migrated).toBe(4);
+    expect(existsSync(join(stateDir, "skills", "review", "SKILL.md"))).toBe(true);
+    expect(memoryContents).toEqual(["prefer bun"]);
+    expect(sessionStore.load("codex:sess-1")).not.toBeNull();
+    expect(readFileSync(join(stateDir, ".env"), "utf8")).toContain(
+      "OPENAI_API_KEY=",
+    );
+  });
+
+  it("previews without writing and re-runs idempotently", async () => {
+    seedAll();
+    const preview = await buildImporter().run({
+      options: resolveCodexOptions(),
+      execute: false,
+      overwrite: false,
+    });
+    expect(preview.summary.migrated).toBe(3);
+    expect(existsSync(join(stateDir, "skills", "review"))).toBe(false);
+    expect(sessionStore.load("codex:sess-1")).toBeNull();
+
+    await buildImporter().run({
+      options: resolveCodexOptions(),
+      execute: true,
+      overwrite: false,
+    });
+    const second = await buildImporter().run({
+      options: resolveCodexOptions(),
+      execute: true,
+      overwrite: false,
+    });
+    expect(second.summary.migrated).toBe(0);
+    expect(second.items.every((i) => i.status === "skipped")).toBe(true);
+  });
+
+  it("reports empty domains as skipped with a reason", async () => {
+    const report = await buildImporter().run({
+      options: resolveCodexOptions({ migrateSecrets: true }),
+      execute: true,
+      overwrite: false,
+    });
+    expect(report.summary.migrated).toBe(0);
+    expect(report.items.map((i) => [i.kind, i.status])).toEqual([
+      ["skills", "skipped"],
+      ["memory", "skipped"],
+      ["sessions", "skipped"],
+      ["secrets", "skipped"],
+    ]);
+  });
+});

--- a/src/import/codex/codex-importer.ts
+++ b/src/import/codex/codex-importer.ts
@@ -1,0 +1,340 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { setDotenvKey } from "../../config/dotenv-writer.js";
+import type { SessionStore } from "../../session/index.js";
+import type { SessionState } from "../../session/session-state.js";
+import { installSkill } from "../../skills/skill-installer.js";
+import { parseSkillFile } from "../../skills/skill-manifest.js";
+import { MEMORY_CONTENT_MAX_LENGTH } from "../../memory/index.js";
+import type { ImportMemoryTarget } from "../claude-code/claude-code-importer.js";
+import { readDotenvValue } from "../dotenv-read.js";
+import {
+  buildReport,
+  type ImportItemResult,
+  type ImportReport,
+} from "../import-report.js";
+import { splitMemoryNote } from "../split-note.js";
+import type { CodexSource } from "./codex-source.js";
+import type { CodexOptionId } from "./import-options.js";
+import { mapCodexSession } from "./map-session.js";
+
+/** The only key ever read from Codex's `auth.json` or written to `.env`. */
+export const CODEX_SECRET_ALLOWLIST = ["OPENAI_API_KEY"] as const;
+
+/** Tag stamped on the imported AGENTS.md note, for later retrieval/cleanup. */
+export const CODEX_MEMORY_TAG = "imported:codex";
+
+export interface CodexImporterDeps {
+  source: CodexSource;
+  sessionStore: SessionStore;
+  memoryStore: ImportMemoryTarget;
+  /** State dir whose `.env` receives the migrated provider key. */
+  stateDir: string;
+  /** Root the imported skills are installed under. */
+  globalSkillsDir: string;
+  /** Working dir applied to sessions whose rollout recorded no cwd. */
+  workingDirFallback: string;
+}
+
+export interface CodexRunOptions {
+  /** Resolved option set (already gated by `resolveCodexOptions`). */
+  options: readonly CodexOptionId[];
+  /** When false, compute the report without writing anything. */
+  execute: boolean;
+  /** Overwrite differing destinations instead of flagging a conflict. */
+  overwrite: boolean;
+  /** Cap on the number of sessions processed (newest first). */
+  limit?: number;
+}
+
+/**
+ * Orchestrates a one-shot Codex -> atomic-agent import. Same contract as
+ * the other importers: each option contributes independently, unchanged
+ * destinations skip on re-run, differing ones require `overwrite`.
+ */
+export class CodexImporter {
+  constructor(private readonly deps: CodexImporterDeps) {}
+
+  async run(options: CodexRunOptions): Promise<ImportReport<CodexOptionId>> {
+    const items: ImportItemResult<CodexOptionId>[] = [];
+    const selected = new Set(options.options);
+
+    if (selected.has("skills")) {
+      await this.importSkills(items, options);
+    }
+    if (selected.has("memory")) {
+      this.importMemory(items, options);
+    }
+    if (selected.has("sessions")) {
+      this.importSessions(items, options);
+    }
+    if (selected.has("secrets")) {
+      this.importSecrets(items, options);
+    }
+
+    return buildReport(items, options.execute);
+  }
+
+  private async importSkills(
+    items: ImportItemResult<CodexOptionId>[],
+    options: CodexRunOptions,
+  ): Promise<void> {
+    const skills = this.deps.source.listSkills();
+    if (skills.length === 0) {
+      items.push({
+        kind: "skills",
+        status: "skipped",
+        reason: `no skills found in ${this.deps.source.skillsDir()}`,
+      });
+      return;
+    }
+    for (const skill of skills) {
+      const base: ImportItemResult<CodexOptionId> = {
+        kind: "skills",
+        source: skill.name,
+        status: "migrated",
+      };
+      let manifestName: string;
+      try {
+        const manifestRaw = readFileSync(join(skill.dir, "SKILL.md"), "utf8");
+        manifestName = parseSkillFile(manifestRaw).manifest.name;
+      } catch (err) {
+        items.push({
+          ...base,
+          status: "error",
+          reason: `invalid SKILL.md: ${errorMessage(err)}`,
+        });
+        continue;
+      }
+      const destination = join(this.deps.globalSkillsDir, manifestName);
+      const exists = existsSync(destination);
+      if (exists) {
+        if (manifestsMatch(skill.dir, destination)) {
+          items.push({
+            ...base,
+            destination: manifestName,
+            status: "skipped",
+            reason: "already installed",
+          });
+          continue;
+        }
+        if (!options.overwrite) {
+          items.push({
+            ...base,
+            destination: manifestName,
+            status: "conflict",
+            reason: "skill exists with a different SKILL.md; use --overwrite",
+          });
+          continue;
+        }
+      }
+      if (options.execute) {
+        try {
+          await installSkill({
+            sourceDir: skill.dir,
+            targetRoot: this.deps.globalSkillsDir,
+            force: exists,
+          });
+        } catch (err) {
+          items.push({ ...base, status: "error", reason: errorMessage(err) });
+          continue;
+        }
+      }
+      items.push({
+        ...base,
+        destination: manifestName,
+        ...(exists ? { reason: "overwritten" } : {}),
+      });
+    }
+  }
+
+  private importMemory(
+    items: ImportItemResult<CodexOptionId>[],
+    options: CodexRunOptions,
+  ): void {
+    const content = this.deps.source.readAgentsMd();
+    if (content === null) {
+      items.push({
+        kind: "memory",
+        status: "skipped",
+        reason: `no AGENTS.md at ${this.deps.source.agentsMdPath()}`,
+      });
+      return;
+    }
+    const base: ImportItemResult<CodexOptionId> = {
+      kind: "memory",
+      source: "AGENTS.md",
+      status: "migrated",
+    };
+    const existing = new Set(
+      this.deps.memoryStore
+        .list({ scope: "all", limit: 100_000 })
+        .map((entry) => entry.content),
+    );
+    // Longer than the store's cap arrives as several notes, not an error.
+    const chunks = splitMemoryNote(content, MEMORY_CONTENT_MAX_LENGTH);
+    const missing = chunks.filter((chunk) => !existing.has(chunk));
+    if (missing.length === 0) {
+      items.push({ ...base, status: "skipped", reason: "already imported" });
+      return;
+    }
+    if (options.execute) {
+      try {
+        for (const chunk of missing) {
+          this.deps.memoryStore.store({
+            content: chunk,
+            tags: [CODEX_MEMORY_TAG],
+            source: "user",
+          });
+        }
+      } catch (err) {
+        items.push({ ...base, status: "error", reason: errorMessage(err) });
+        return;
+      }
+    }
+    items.push({
+      ...base,
+      ...(chunks.length > 1
+        ? { reason: `split into ${chunks.length} notes` }
+        : {}),
+    });
+  }
+
+  private importSessions(
+    items: ImportItemResult<CodexOptionId>[],
+    options: CodexRunOptions,
+  ): void {
+    if (!this.deps.source.hasSessions()) {
+      items.push({
+        kind: "sessions",
+        status: "skipped",
+        reason: `no sessions dir at ${this.deps.source.sessionsDir()}`,
+      });
+      return;
+    }
+    let metas = this.deps.source.listSessions();
+    if (options.limit !== undefined && options.limit >= 0) {
+      metas = metas.slice(0, options.limit);
+    }
+    for (const meta of metas) {
+      let mapped: SessionState;
+      try {
+        const session = this.deps.source.readSession(meta);
+        if (session.messages.length === 0) {
+          // Meta-only rollout (no conversation): nothing to keep.
+          continue;
+        }
+        mapped = mapCodexSession(session, this.deps.workingDirFallback);
+      } catch (err) {
+        items.push({
+          kind: "sessions",
+          source: meta.id,
+          status: "error",
+          reason: errorMessage(err),
+        });
+        continue;
+      }
+      items.push(this.reconcileSession(mapped, meta.id, options));
+    }
+  }
+
+  private reconcileSession(
+    mapped: SessionState,
+    sourceId: string,
+    options: CodexRunOptions,
+  ): ImportItemResult<CodexOptionId> {
+    const base: ImportItemResult<CodexOptionId> = {
+      kind: "sessions",
+      source: sourceId,
+      destination: mapped.id,
+      status: "migrated",
+    };
+    const existing = this.deps.sessionStore.load(mapped.id);
+    if (!existing) {
+      if (options.execute) this.deps.sessionStore.save(mapped);
+      return base;
+    }
+    if (sessionsMatch(existing, mapped)) {
+      return { ...base, status: "skipped", reason: "already matches" };
+    }
+    if (!options.overwrite) {
+      return {
+        ...base,
+        status: "conflict",
+        reason: "destination differs; use --overwrite",
+      };
+    }
+    if (options.execute) this.deps.sessionStore.save(mapped);
+    return { ...base, status: "migrated", reason: "overwritten" };
+  }
+
+  private importSecrets(
+    items: ImportItemResult<CodexOptionId>[],
+    options: CodexRunOptions,
+  ): void {
+    const authMap = this.deps.source.readAuthKeys(CODEX_SECRET_ALLOWLIST);
+    if (authMap.size === 0) {
+      items.push({
+        kind: "secrets",
+        status: "skipped",
+        reason:
+          "no migratable provider key found in Codex auth.json (ChatGPT logins carry none)",
+      });
+      return;
+    }
+    const targetEnvPath = join(this.deps.stateDir, ".env");
+    for (const key of CODEX_SECRET_ALLOWLIST) {
+      const value = authMap.get(key);
+      if (value === undefined) continue;
+      const current = readDotenvValue(targetEnvPath, key);
+      const base: ImportItemResult<CodexOptionId> = {
+        kind: "secrets",
+        source: key,
+        destination: key,
+        status: "migrated",
+      };
+      if (current === undefined) {
+        if (options.execute) setDotenvKey(this.deps.stateDir, key, value);
+        items.push(base);
+        continue;
+      }
+      if (current === value) {
+        items.push({ ...base, status: "skipped", reason: "already set" });
+        continue;
+      }
+      if (!options.overwrite) {
+        items.push({
+          ...base,
+          status: "conflict",
+          reason: "key exists with a different value; use --overwrite",
+        });
+        continue;
+      }
+      if (options.execute) setDotenvKey(this.deps.stateDir, key, value);
+      items.push({ ...base, reason: "overwritten" });
+    }
+  }
+}
+
+/** Whether two skill dirs carry byte-identical `SKILL.md` manifests. */
+function manifestsMatch(sourceDir: string, targetDir: string): boolean {
+  try {
+    return (
+      readFileSync(join(sourceDir, "SKILL.md"), "utf8") ===
+      readFileSync(join(targetDir, "SKILL.md"), "utf8")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Structural equality of two sessions' transcripts. */
+function sessionsMatch(a: SessionState, b: SessionState): boolean {
+  if (a.turns.length !== b.turns.length) return false;
+  return JSON.stringify(a.turns) === JSON.stringify(b.turns);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/import/codex/codex-source.test.ts
+++ b/src/import/codex/codex-source.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CodexSource } from "./codex-source.js";
+
+function line(obj: unknown): string {
+  return `${JSON.stringify(obj)}\n`;
+}
+
+describe("CodexSource", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "codex-src-"));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("reads AGENTS.md and only allowlisted auth keys", () => {
+    writeFileSync(join(stateDir, "AGENTS.md"), "prefer bun\n");
+    writeFileSync(
+      join(stateDir, "auth.json"),
+      JSON.stringify({
+        auth_mode: "chatgpt",
+        OPENAI_API_KEY: "sk-x",
+        tokens: { access: "not-this" },
+      }),
+    );
+    const source = new CodexSource(stateDir);
+    expect(source.readAgentsMd()).toBe("prefer bun");
+    expect([...source.readAuthKeys(["OPENAI_API_KEY"]).entries()]).toEqual([
+      ["OPENAI_API_KEY", "sk-x"],
+    ]);
+  });
+
+  it("treats a null OPENAI_API_KEY (ChatGPT login) as nothing to migrate", () => {
+    writeFileSync(
+      join(stateDir, "auth.json"),
+      JSON.stringify({ auth_mode: "chatgpt", OPENAI_API_KEY: null }),
+    );
+    const source = new CodexSource(stateDir);
+    expect(source.readAuthKeys(["OPENAI_API_KEY"]).size).toBe(0);
+  });
+
+  it("lists rollouts recursively across date shards, newest first", () => {
+    const dayA = join(stateDir, "sessions", "2026", "08", "01");
+    const dayB = join(stateDir, "sessions", "2026", "08", "02");
+    mkdirSync(dayA, { recursive: true });
+    mkdirSync(dayB, { recursive: true });
+    const older = join(dayA, "rollout-2026-08-01-aaa.jsonl");
+    const newer = join(dayB, "rollout-2026-08-02-bbb.jsonl");
+    writeFileSync(older, "");
+    writeFileSync(newer, "");
+    utimesSync(older, new Date("2026-08-01T10:00:00Z"), new Date("2026-08-01T10:00:00Z"));
+    utimesSync(newer, new Date("2026-08-02T10:00:00Z"), new Date("2026-08-02T10:00:00Z"));
+
+    const metas = new CodexSource(stateDir).listSessions();
+    expect(metas.map((m) => m.id)).toEqual([
+      "2026-08-02-bbb",
+      "2026-08-01-aaa",
+    ]);
+  });
+
+  it("projects a rollout's response items and drops the wrappers", () => {
+    const dir = join(stateDir, "sessions");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "rollout-x.jsonl");
+    writeFileSync(
+      file,
+      [
+        line({
+          timestamp: "2026-08-02T10:00:00Z",
+          type: "session_meta",
+          payload: { id: "sess-1", cwd: "/work" },
+        }),
+        line({
+          timestamp: "2026-08-02T10:00:01Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "<user_instructions>be terse</user_instructions>" }],
+          },
+        }),
+        line({
+          timestamp: "2026-08-02T10:00:02Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "list the files" }],
+          },
+        }),
+        line({
+          timestamp: "2026-08-02T10:00:03Z",
+          type: "response_item",
+          payload: {
+            type: "reasoning",
+            summary: [{ type: "summary_text", text: "an ls will do" }],
+          },
+        }),
+        line({
+          timestamp: "2026-08-02T10:00:04Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "shell",
+            call_id: "c1",
+            arguments: JSON.stringify({ command: ["ls"] }),
+          },
+        }),
+        line({
+          timestamp: "2026-08-02T10:00:05Z",
+          type: "response_item",
+          payload: {
+            type: "function_call_output",
+            call_id: "c1",
+            output: "README.md",
+          },
+        }),
+        line({
+          timestamp: "2026-08-02T10:00:06Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "just README.md" }],
+          },
+        }),
+        line({ timestamp: "2026-08-02T10:00:07Z", type: "event_msg", payload: { type: "noise" } }),
+      ].join(""),
+    );
+
+    const source = new CodexSource(stateDir);
+    const session = source.readSession(source.listSessions()[0]!);
+    expect(session.id).toBe("sess-1");
+    expect(session.cwd).toBe("/work");
+    expect(session.startedAtMs).toBe(Date.parse("2026-08-02T10:00:00Z"));
+    expect(session.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "tool",
+      "assistant",
+    ]);
+    expect(session.messages[0]!.blocks).toEqual([
+      { type: "text", text: "list the files" },
+    ]);
+    expect(session.messages[2]!.blocks).toEqual([
+      { type: "toolCall", id: "c1", name: "shell", args: { command: ["ls"] } },
+    ]);
+    expect(session.messages[3]!.blocks).toEqual([
+      { type: "toolResult", callId: "c1", text: "README.md" },
+    ]);
+  });
+});

--- a/src/import/codex/codex-source.ts
+++ b/src/import/codex/codex-source.ts
@@ -1,0 +1,374 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Read-only access to a `~/.codex` state directory (Codex CLI). This is
+ * the **only** file in the Codex import feature that touches its
+ * physical layout; everything downstream operates on the neutral types
+ * exported here.
+ *
+ * Layout:
+ *  - `sessions/**∕rollout-*.jsonl` — rollout transcripts, one JSON event
+ *    per line (date-sharded subdirs on current builds, flat on old ones;
+ *    the listing scans recursively and takes any `.jsonl`).
+ *  - `skills/<name>/SKILL.md`      — agent skills (same manifest family).
+ *  - `AGENTS.md`                   — global user instructions.
+ *  - `auth.json` `OPENAI_API_KEY`  — provider key (opt-in).
+ */
+export class CodexSourceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexSourceError";
+  }
+}
+
+/** A skill directory holding a `SKILL.md` manifest. */
+export interface CodexSkill {
+  name: string;
+  dir: string;
+}
+
+/** Lightweight rollout header; the transcript is read separately. */
+export interface CodexSessionMeta {
+  /** Session id from the `session_meta` line, or the file basename. */
+  id: string;
+  /** Absolute path to the rollout `.jsonl`. */
+  file: string;
+  /** File mtime in ms — the cheap recency key the listing sorts by. */
+  mtimeMs: number;
+}
+
+/** A content block inside a projected rollout item. */
+export type CodexBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string }
+  | { type: "toolCall"; id: string | null; name: string; args: Record<string, unknown> }
+  | { type: "toolResult"; callId: string | null; text: string };
+
+/** A projected rollout `response_item`. */
+export interface CodexMessage {
+  role: "user" | "assistant" | "tool";
+  blocks: CodexBlock[];
+  atMs: number;
+}
+
+/** A fully-read rollout: header fields plus the projected items. */
+export interface CodexSessionData {
+  id: string;
+  cwd: string | null;
+  startedAtMs: number;
+  messages: CodexMessage[];
+}
+
+export class CodexSource {
+  constructor(private readonly sourceDir: string) {}
+
+  sessionsDir(): string {
+    return join(this.sourceDir, "sessions");
+  }
+
+  skillsDir(): string {
+    return join(this.sourceDir, "skills");
+  }
+
+  agentsMdPath(): string {
+    return join(this.sourceDir, "AGENTS.md");
+  }
+
+  authPath(): string {
+    return join(this.sourceDir, "auth.json");
+  }
+
+  hasSessions(): boolean {
+    return existsSync(this.sessionsDir());
+  }
+
+  /** Skill dirs that hold a `SKILL.md`, sorted by name. */
+  listSkills(): CodexSkill[] {
+    const root = this.skillsDir();
+    if (!existsSync(root)) return [];
+    const skills: CodexSkill[] = [];
+    for (const entry of readdirSync(root).sort()) {
+      const dir = join(root, entry);
+      if (!existsSync(join(dir, "SKILL.md"))) continue;
+      skills.push({ name: entry, dir });
+    }
+    return skills;
+  }
+
+  /** `AGENTS.md` content, or `null` when absent or empty. */
+  readAgentsMd(): string | null {
+    const path = this.agentsMdPath();
+    if (!existsSync(path)) return null;
+    let content: string;
+    try {
+      content = readFileSync(path, "utf8").trim();
+    } catch {
+      return null;
+    }
+    return content.length > 0 ? content : null;
+  }
+
+  /**
+   * Read `auth.json` and return only the keys present in `allowlist`
+   * with non-empty string values (ChatGPT-token logins keep the key
+   * `null`, which reads as "nothing to migrate").
+   */
+  readAuthKeys(allowlist: readonly string[]): Map<string, string> {
+    const result = new Map<string, string>();
+    const path = this.authPath();
+    if (!existsSync(path)) return result;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(path, "utf8"));
+    } catch {
+      return result;
+    }
+    if (!parsed || typeof parsed !== "object") return result;
+    const obj = parsed as Record<string, unknown>;
+    for (const key of allowlist) {
+      const value = obj[key];
+      if (typeof value === "string" && value.length > 0) result.set(key, value);
+    }
+    return result;
+  }
+
+  /**
+   * List rollout headers, newest-first by file mtime. Recency comes from
+   * the mtime rather than a parse for the same reason the Claude Code
+   * listing does it: sorting must not read what a `limit` then discards.
+   */
+  listSessions(): CodexSessionMeta[] {
+    const root = this.sessionsDir();
+    if (!existsSync(root)) return [];
+    const metas: CodexSessionMeta[] = [];
+    walkJsonlFiles(root, (file) => {
+      let mtimeMs: number;
+      try {
+        const stats = statSync(file);
+        if (!stats.isFile()) return;
+        mtimeMs = stats.mtimeMs;
+      } catch {
+        return;
+      }
+      const basename = file.slice(file.lastIndexOf("/") + 1);
+      metas.push({
+        id: basename.replace(/^rollout-/, "").replace(/\.jsonl$/, ""),
+        file,
+        mtimeMs,
+      });
+    });
+    metas.sort(
+      (a, b) =>
+        b.mtimeMs - a.mtimeMs || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+    );
+    return metas;
+  }
+
+  /**
+   * Read one rollout into a neutral session. `session_meta` supplies the
+   * id/cwd/start; `response_item` rows project onto messages; event and
+   * turn-context rows are skipped. Instruction wrappers Codex injects as
+   * user messages (`<user_instructions>`, `<environment_context>`) are
+   * not things the operator said, and are dropped.
+   */
+  readSession(meta: CodexSessionMeta): CodexSessionData {
+    let text: string;
+    try {
+      text = readFileSync(meta.file, "utf8");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new CodexSourceError(`failed to read ${meta.file}: ${message}`);
+    }
+    let id = meta.id;
+    let cwd: string | null = null;
+    let startedAtMs = 0;
+    const messages: CodexMessage[] = [];
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      let event: Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (!parsed || typeof parsed !== "object") continue;
+        event = parsed as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const payload = event.payload;
+      if (!payload || typeof payload !== "object") continue;
+      const p = payload as Record<string, unknown>;
+      const atMs =
+        typeof event.timestamp === "string"
+          ? isoToMs(event.timestamp) ?? 0
+          : 0;
+      if (event.type === "session_meta") {
+        if (typeof p.id === "string") id = p.id;
+        if (typeof p.cwd === "string") cwd = p.cwd;
+        if (startedAtMs === 0) startedAtMs = atMs;
+        continue;
+      }
+      if (event.type !== "response_item") continue;
+      const projected = projectResponseItem(p, atMs);
+      if (projected) messages.push(projected);
+    }
+    return { id, cwd, startedAtMs, messages };
+  }
+}
+
+/** Depth-first walk collecting every `.jsonl` under `root`. */
+function walkJsonlFiles(root: string, visit: (file: string) => void): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(root).sort();
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const path = join(root, entry);
+    let stats;
+    try {
+      stats = statSync(path);
+    } catch {
+      continue;
+    }
+    if (stats.isDirectory()) {
+      walkJsonlFiles(path, visit);
+    } else if (entry.endsWith(".jsonl")) {
+      visit(path);
+    }
+  }
+}
+
+function projectResponseItem(
+  p: Record<string, unknown>,
+  atMs: number,
+): CodexMessage | null {
+  switch (p.type) {
+    case "message": {
+      if (p.role !== "user" && p.role !== "assistant") return null;
+      const blocks = projectMessageContent(p.content);
+      if (blocks.length === 0) return null;
+      if (p.role === "user" && isInstructionWrapper(blocks)) return null;
+      return { role: p.role, blocks, atMs };
+    }
+    case "reasoning": {
+      const summary = joinSummary(p.summary);
+      if (summary.length === 0) return null;
+      return {
+        role: "assistant",
+        blocks: [{ type: "thinking", thinking: summary }],
+        atMs,
+      };
+    }
+    case "function_call": {
+      const name = typeof p.name === "string" ? p.name : null;
+      if (!name) return null;
+      return {
+        role: "assistant",
+        blocks: [
+          {
+            type: "toolCall",
+            id: typeof p.call_id === "string" ? p.call_id : null,
+            name,
+            args: parseArguments(p.arguments),
+          },
+        ],
+        atMs,
+      };
+    }
+    case "function_call_output": {
+      return {
+        role: "tool",
+        blocks: [
+          {
+            type: "toolResult",
+            callId: typeof p.call_id === "string" ? p.call_id : null,
+            text: flattenOutput(p.output),
+          },
+        ],
+        atMs,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function projectMessageContent(content: unknown): CodexBlock[] {
+  if (!Array.isArray(content)) return [];
+  const blocks: CodexBlock[] = [];
+  for (const raw of content) {
+    if (!raw || typeof raw !== "object") continue;
+    const block = raw as Record<string, unknown>;
+    const type = block.type;
+    if (type !== "input_text" && type !== "output_text" && type !== "text") {
+      continue;
+    }
+    if (typeof block.text === "string" && block.text.length > 0) {
+      blocks.push({ type: "text", text: block.text });
+    }
+  }
+  return blocks;
+}
+
+/** True when every text block is a `<user_instructions>`-style wrapper. */
+function isInstructionWrapper(blocks: readonly CodexBlock[]): boolean {
+  const texts = blocks.filter(
+    (b): b is Extract<CodexBlock, { type: "text" }> => b.type === "text",
+  );
+  if (texts.length === 0) return false;
+  return texts.every((b) => /^<[a-z_]+>/i.test(b.text.trimStart()));
+}
+
+function joinSummary(summary: unknown): string {
+  if (!Array.isArray(summary)) return "";
+  const parts: string[] = [];
+  for (const raw of summary) {
+    if (!raw || typeof raw !== "object") continue;
+    const block = raw as Record<string, unknown>;
+    if (typeof block.text === "string" && block.text.length > 0) {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function parseArguments(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === "string") {
+    if (value.trim().length === 0) return {};
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return { _raw: parsed };
+    } catch {
+      return { _raw: value };
+    }
+  }
+  return {};
+}
+
+/** Outputs arrive as a string or as `{ content, … }`; flatten both. */
+function flattenOutput(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (output && typeof output === "object" && !Array.isArray(output)) {
+    const content = (output as { content?: unknown }).content;
+    if (typeof content === "string") return content;
+  }
+  return "";
+}
+
+function isoToMs(value: string): number | null {
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : ms;
+}

--- a/src/import/codex/import-options.test.ts
+++ b/src/import/codex/import-options.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexOptionError, resolveCodexOptions } from "./import-options.js";
+
+describe("resolveCodexOptions", () => {
+  it("defaults to every non-secret option", () => {
+    expect(resolveCodexOptions()).toEqual(["skills", "memory", "sessions"]);
+  });
+
+  it("applies exclude and keeps registry order", () => {
+    expect(resolveCodexOptions({ exclude: ["memory"] })).toEqual([
+      "skills",
+      "sessions",
+    ]);
+  });
+
+  it("adds secrets only through the explicit flag", () => {
+    expect(resolveCodexOptions({ migrateSecrets: true })).toContain("secrets");
+    expect(() => resolveCodexOptions({ include: ["secrets"] })).toThrow(
+      CodexOptionError,
+    );
+  });
+
+  it("rejects unknown option ids", () => {
+    expect(() => resolveCodexOptions({ include: ["mcp"] })).toThrow(
+      CodexOptionError,
+    );
+  });
+});

--- a/src/import/codex/import-options.ts
+++ b/src/import/codex/import-options.ts
@@ -1,0 +1,106 @@
+/**
+ * Codex-specific import domains and their selection logic. Same contract
+ * as the other sources' option modules; `secrets` never enters the
+ * default set — the explicit flag is the single gate for credentials.
+ */
+export type CodexOptionId = "skills" | "memory" | "sessions" | "secrets";
+
+export interface CodexOptionMeta {
+  id: CodexOptionId;
+  label: string;
+  description: string;
+}
+
+/** Registry of every importable Codex option. */
+export const CODEX_IMPORT_OPTIONS: readonly CodexOptionMeta[] = [
+  {
+    id: "skills",
+    label: "Skills",
+    description: "Skill directories (skills/*/SKILL.md) -> global skills dir",
+  },
+  {
+    id: "memory",
+    label: "Instructions",
+    description: "AGENTS.md -> memory.sqlite",
+  },
+  {
+    id: "sessions",
+    label: "Sessions",
+    description: "Rollouts (sessions/**/*.jsonl) -> sessions.sqlite",
+  },
+  {
+    id: "secrets",
+    label: "Provider key",
+    description: "OPENAI_API_KEY (auth.json) -> <stateDir>/.env",
+  },
+];
+
+export class CodexOptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexOptionError";
+  }
+}
+
+const KNOWN_OPTION_IDS: ReadonlySet<string> = new Set(
+  CODEX_IMPORT_OPTIONS.map((o) => o.id),
+);
+
+/** Everything except `secrets`, which only `migrateSecrets` can add. */
+const DEFAULT_OPTIONS: readonly CodexOptionId[] = [
+  "skills",
+  "memory",
+  "sessions",
+];
+
+export interface ResolveCodexOptionsInput {
+  include?: readonly string[];
+  exclude?: readonly string[];
+  /** When true, `secrets` is added to the resolved set. */
+  migrateSecrets?: boolean;
+}
+
+/**
+ * Resolve the final option set: the non-secret default, `include` /
+ * `exclude` applied, every id validated against the registry, and
+ * `secrets` added only through the explicit flag.
+ */
+export function resolveCodexOptions(
+  input: ResolveCodexOptionsInput = {},
+): CodexOptionId[] {
+  const selected = new Set<CodexOptionId>(DEFAULT_OPTIONS);
+
+  for (const raw of input.include ?? []) {
+    const id = raw.trim();
+    if (id.length === 0) continue;
+    if (!KNOWN_OPTION_IDS.has(id)) {
+      throw new CodexOptionError(`unknown option in --include: ${id}`);
+    }
+    if (id === "secrets") {
+      throw new CodexOptionError(
+        "secrets cannot be selected via --include; use --migrate-secrets",
+      );
+    }
+    selected.add(id as CodexOptionId);
+  }
+
+  for (const raw of input.exclude ?? []) {
+    const id = raw.trim();
+    if (id.length === 0) continue;
+    if (!KNOWN_OPTION_IDS.has(id)) {
+      throw new CodexOptionError(`unknown option in --exclude: ${id}`);
+    }
+    selected.delete(id as CodexOptionId);
+  }
+
+  if (input.migrateSecrets) {
+    selected.add("secrets");
+  } else {
+    selected.delete("secrets");
+  }
+
+  // Preserve registry order for deterministic output.
+  return CODEX_IMPORT_OPTIONS.map((o) => o.id).filter((id) =>
+    selected.has(id),
+  );
+}

--- a/src/import/codex/index.ts
+++ b/src/import/codex/index.ts
@@ -1,0 +1,25 @@
+export { CodexSource, CodexSourceError } from "./codex-source.js";
+export type {
+  CodexBlock,
+  CodexMessage,
+  CodexSessionData,
+  CodexSessionMeta,
+  CodexSkill,
+} from "./codex-source.js";
+export {
+  CODEX_IMPORT_OPTIONS,
+  CodexOptionError,
+  resolveCodexOptions,
+} from "./import-options.js";
+export type {
+  CodexOptionId,
+  CodexOptionMeta,
+  ResolveCodexOptionsInput,
+} from "./import-options.js";
+export {
+  CODEX_MEMORY_TAG,
+  CODEX_SECRET_ALLOWLIST,
+  CodexImporter,
+} from "./codex-importer.js";
+export type { CodexImporterDeps, CodexRunOptions } from "./codex-importer.js";
+export { CODEX_SESSION_ID_PREFIX, mapCodexSession } from "./map-session.js";

--- a/src/import/codex/map-session.test.ts
+++ b/src/import/codex/map-session.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { CODEX_SESSION_ID_PREFIX, mapCodexSession } from "./map-session.js";
+import type { CodexSessionData } from "./codex-source.js";
+
+const T0 = Date.parse("2026-08-02T10:00:00Z");
+
+function session(partial: Partial<CodexSessionData>): CodexSessionData {
+  return {
+    id: "sess-1",
+    cwd: "/work",
+    startedAtMs: T0,
+    messages: [],
+    ...partial,
+  };
+}
+
+describe("mapCodexSession", () => {
+  it("maps the full user → reasoning → call → result → reply chain", () => {
+    const mapped = mapCodexSession(
+      session({
+        messages: [
+          { role: "user", blocks: [{ type: "text", text: "list files" }], atMs: T0 },
+          {
+            role: "assistant",
+            blocks: [{ type: "thinking", thinking: "an ls will do" }],
+            atMs: T0 + 1,
+          },
+          {
+            role: "assistant",
+            blocks: [
+              { type: "toolCall", id: "c1", name: "shell", args: { command: ["ls"] } },
+            ],
+            atMs: T0 + 2,
+          },
+          {
+            role: "tool",
+            blocks: [{ type: "toolResult", callId: "c1", text: "README.md" }],
+            atMs: T0 + 3,
+          },
+          {
+            role: "assistant",
+            blocks: [{ type: "text", text: "just README.md" }],
+            atMs: T0 + 4,
+          },
+        ],
+      }),
+      "/fallback",
+    );
+
+    expect(mapped.id).toBe(`${CODEX_SESSION_ID_PREFIX}sess-1`);
+    expect(mapped.workingDir).toBe("/work");
+    expect(mapped.createdAt).toBe(T0);
+    expect(mapped.turns).toEqual([
+      { kind: "user", text: "list files", at: T0 },
+      {
+        kind: "assistant_tool_call",
+        tool: "shell",
+        args: { command: ["ls"] },
+        at: T0 + 2,
+        // The reasoning row rode forward onto the call that followed it.
+        reasoning: "an ls will do",
+      },
+      {
+        kind: "tool_result",
+        tool: "shell",
+        status: "ok",
+        summary: "README.md",
+        at: T0 + 3,
+      },
+      { kind: "assistant_reply", text: "just README.md", at: T0 + 4 },
+    ]);
+    expect(mapped.turnCount).toBe(1);
+    expect(mapped.metadata).toMatchObject({
+      importedFrom: "codex",
+      codexSessionId: "sess-1",
+    });
+  });
+
+  it("attaches pending reasoning to a reply when no call intervenes", () => {
+    const mapped = mapCodexSession(
+      session({
+        messages: [
+          {
+            role: "assistant",
+            blocks: [{ type: "thinking", thinking: "short answer" }],
+            atMs: T0,
+          },
+          {
+            role: "assistant",
+            blocks: [{ type: "text", text: "42" }],
+            atMs: T0 + 1,
+          },
+        ],
+      }),
+      "/fallback",
+    );
+    expect(mapped.turns).toEqual([
+      { kind: "assistant_reply", text: "42", at: T0 + 1, reasoning: "short answer" },
+    ]);
+  });
+
+  it("falls back to the provided working dir", () => {
+    expect(mapCodexSession(session({ cwd: null }), "/fb").workingDir).toBe("/fb");
+  });
+});

--- a/src/import/codex/map-session.ts
+++ b/src/import/codex/map-session.ts
@@ -1,0 +1,145 @@
+import {
+  assistantReplyTurn,
+  assistantToolCallTurn,
+  toolResultTurn,
+  userTurn,
+  type ConversationTurn,
+} from "../../session/conversation-turn.js";
+import type { SessionState } from "../../session/session-state.js";
+import type { CodexBlock, CodexSessionData } from "./codex-source.js";
+
+/** Prefix applied to imported session ids so they never collide with native ids. */
+export const CODEX_SESSION_ID_PREFIX = "codex:";
+
+/**
+ * Map one Codex rollout into a native `SessionState`. Pure — no I/O.
+ * The projected items fold onto the four-kind `ConversationTurn` model:
+ *
+ *  - user `text`       → `user` turn (joined).
+ *  - assistant `text`  → `assistant_reply`; a `reasoning` summary row
+ *    immediately before it rides along as the reply's reasoning.
+ *  - `toolCall`        → `assistant_tool_call` (pending reasoning
+ *    attaches when no reply claimed it).
+ *  - `toolResult`      → `tool_result`, named through the `call_id`
+ *    seen on the matching call.
+ */
+export function mapCodexSession(
+  session: CodexSessionData,
+  fallbackWorkingDir: string,
+): SessionState {
+  const turns: ConversationTurn[] = [];
+  const toolNames = new Map<string, string>();
+  /** A reasoning row waits for the reply or call it belongs to. */
+  let pendingReasoning = "";
+
+  for (const message of session.messages) {
+    const at = message.atMs;
+    if (message.role === "user") {
+      const text = joinText(message.blocks);
+      if (text.length > 0) turns.push(userTurn(text, at));
+      continue;
+    }
+    if (message.role === "tool") {
+      for (const block of message.blocks) {
+        if (block.type !== "toolResult") continue;
+        turns.push(
+          toolResultTurn({
+            tool:
+              (block.callId !== null
+                ? toolNames.get(block.callId)
+                : undefined) ?? "unknown",
+            status: "ok",
+            summary: block.text,
+            at,
+          }),
+        );
+      }
+      continue;
+    }
+    // assistant
+    const thinking = joinThinking(message.blocks);
+    if (thinking.length > 0) {
+      pendingReasoning =
+        pendingReasoning.length > 0
+          ? `${pendingReasoning}\n${thinking}`
+          : thinking;
+    }
+    const text = joinText(message.blocks);
+    if (text.length > 0) {
+      turns.push(
+        assistantReplyTurn(text, {
+          at,
+          ...(pendingReasoning.length > 0
+            ? { reasoning: pendingReasoning }
+            : {}),
+        }),
+      );
+      pendingReasoning = "";
+    }
+    for (const block of message.blocks) {
+      if (block.type !== "toolCall") continue;
+      if (block.id !== null) toolNames.set(block.id, block.name);
+      turns.push(
+        assistantToolCallTurn({
+          tool: block.name,
+          args: block.args,
+          at,
+          ...(pendingReasoning.length > 0
+            ? { reasoning: pendingReasoning }
+            : {}),
+        }),
+      );
+      pendingReasoning = "";
+    }
+  }
+
+  const createdAt =
+    session.startedAtMs > 0
+      ? session.startedAtMs
+      : session.messages.length > 0
+        ? session.messages[0]!.atMs
+        : 0;
+  const lastMessageAt =
+    session.messages.length > 0
+      ? session.messages[session.messages.length - 1]!.atMs
+      : createdAt;
+  const turnCount = turns.filter((t) => t.kind === "assistant_reply").length;
+
+  return {
+    id: `${CODEX_SESSION_ID_PREFIX}${session.id}`,
+    workingDir: session.cwd ?? fallbackWorkingDir,
+    status: "completed",
+    knownFacts: [],
+    latestResult: null,
+    loadedSkills: [],
+    loadedTools: [],
+    worldSnapshot: null,
+    stepCount: 0,
+    turnCount,
+    turns,
+    createdAt,
+    updatedAt: lastMessageAt,
+    lastError: null,
+    metadata: {
+      importedFrom: "codex",
+      codexSessionId: session.id,
+    },
+  };
+}
+
+function joinText(blocks: readonly CodexBlock[]): string {
+  return blocks
+    .filter((b): b is Extract<CodexBlock, { type: "text" }> => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+}
+
+function joinThinking(blocks: readonly CodexBlock[]): string {
+  return blocks
+    .filter(
+      (b): b is Extract<CodexBlock, { type: "thinking" }> =>
+        b.type === "thinking",
+    )
+    .map((b) => b.thinking)
+    .join("\n");
+}

--- a/src/import/detect-import-agents.test.ts
+++ b/src/import/detect-import-agents.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  detectImportAgents,
+  importAgentDir,
+} from "./detect-import-agents.js";
+
+describe("detectImportAgents", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "detect-agents-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("detects nothing on a clean machine", () => {
+    expect(detectImportAgents({ home, env: {} })).toEqual([]);
+  });
+
+  it("ignores a bare state dir with no importable artefact", () => {
+    mkdirSync(join(home, ".hermes"), { recursive: true });
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    expect(detectImportAgents({ home, env: {} })).toEqual([]);
+  });
+
+  it("detects each agent from its own artefact, in pick order", () => {
+    mkdirSync(join(home, ".hermes"), { recursive: true });
+    writeFileSync(join(home, ".hermes", "state.db"), "");
+    mkdirSync(join(home, ".openclaw", "agents"), { recursive: true });
+    mkdirSync(join(home, ".claude", "skills"), { recursive: true });
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(join(home, ".codex", "auth.json"), "{}");
+
+    const detected = detectImportAgents({ home, env: {} });
+    expect(detected.map((d) => d.id)).toEqual([
+      "hermes",
+      "openclaw",
+      "claude-code",
+      "codex",
+    ]);
+    expect(detected.map((d) => d.label)).toEqual([
+      "Hermes",
+      "OpenClaw",
+      "Claude Code",
+      "Codex",
+    ]);
+    expect(detected[0]!.dir).toBe(join(home, ".hermes"));
+  });
+
+  it("honours the *_STATE_DIR env overrides", () => {
+    const custom = join(home, "elsewhere");
+    mkdirSync(join(custom, "projects"), { recursive: true });
+    const detected = detectImportAgents({
+      home,
+      env: { CLAUDE_CODE_STATE_DIR: custom },
+    });
+    expect(detected).toEqual([
+      { id: "claude-code", label: "Claude Code", dir: custom },
+    ]);
+  });
+
+  it("resolves default dirs off the injected home", () => {
+    expect(importAgentDir("codex", { home, env: {} })).toBe(
+      join(home, ".codex"),
+    );
+    expect(importAgentDir("codex", { home, env: { CODEX_STATE_DIR: "/x" } })).toBe(
+      "/x",
+    );
+  });
+});

--- a/src/import/detect-import-agents.ts
+++ b/src/import/detect-import-agents.ts
@@ -1,0 +1,105 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Which other agents' state this machine actually holds, answered from
+ * the filesystem alone. Shared by the first-run flow (which only offers
+ * an import when there is something to import) and by anything else that
+ * wants to name the sources without hard-coding their layouts.
+ *
+ * Detection is deliberately shallow — "does the state dir hold at least
+ * one artefact this importer knows how to read" — because the price of a
+ * false positive is one preview that reports nothing to migrate, while
+ * the price of a probe that opens databases is paying the full read on
+ * every launch that reaches the check.
+ */
+export type ImportAgentId = "hermes" | "openclaw" | "claude-code" | "codex";
+
+export interface DetectedImportAgent {
+  id: ImportAgentId;
+  /** Human name, as the pick list prints it. */
+  label: string;
+  /** Resolved state dir the importer would read. */
+  dir: string;
+}
+
+export interface DetectImportAgentsOptions {
+  /** Home dir the default state dirs hang off. Injectable for tests. */
+  home?: string;
+  /** Env map consulted for the `*_STATE_DIR` overrides. */
+  env?: Record<string, string | undefined>;
+}
+
+/** Display names, in the order the pick list shows them. */
+export const IMPORT_AGENT_LABELS: Record<ImportAgentId, string> = {
+  hermes: "Hermes",
+  openclaw: "OpenClaw",
+  "claude-code": "Claude Code",
+  codex: "Codex",
+};
+
+/** Resolve the state dir an agent would be imported from. */
+export function importAgentDir(
+  id: ImportAgentId,
+  options: DetectImportAgentsOptions = {},
+): string {
+  const home = options.home ?? homedir();
+  const env = options.env ?? process.env;
+  switch (id) {
+    case "hermes":
+      return env.HERMES_STATE_DIR ?? join(home, ".hermes");
+    case "openclaw":
+      return env.OPENCLAW_STATE_DIR ?? join(home, ".openclaw");
+    case "claude-code":
+      return env.CLAUDE_CODE_STATE_DIR ?? join(home, ".claude");
+    case "codex":
+      return env.CODEX_STATE_DIR ?? join(home, ".codex");
+  }
+}
+
+/**
+ * Scan for known agents with importable state, in pick-list order. An
+ * agent is detected when its state dir holds at least one artefact the
+ * matching importer reads — a bare empty dir does not count, so an
+ * uninstalled tool whose installer only made the folder is not offered.
+ */
+export function detectImportAgents(
+  options: DetectImportAgentsOptions = {},
+): DetectedImportAgent[] {
+  const detected: DetectedImportAgent[] = [];
+  for (const id of Object.keys(IMPORT_AGENT_LABELS) as ImportAgentId[]) {
+    const dir = importAgentDir(id, options);
+    if (!hasImportableState(id, dir)) continue;
+    detected.push({ id, label: IMPORT_AGENT_LABELS[id], dir });
+  }
+  return detected;
+}
+
+function hasImportableState(id: ImportAgentId, dir: string): boolean {
+  switch (id) {
+    case "hermes":
+      return (
+        existsSync(join(dir, "state.db")) ||
+        existsSync(join(dir, "cron", "jobs.json"))
+      );
+    case "openclaw":
+      return (
+        existsSync(join(dir, "agents")) ||
+        existsSync(join(dir, "state", "openclaw.sqlite"))
+      );
+    case "claude-code":
+      return (
+        existsSync(join(dir, "projects")) ||
+        existsSync(join(dir, "skills")) ||
+        existsSync(join(dir, "settings.json"))
+      );
+    case "codex":
+      return (
+        existsSync(join(dir, "sessions")) ||
+        existsSync(join(dir, "skills")) ||
+        existsSync(join(dir, "auth.json")) ||
+        existsSync(join(dir, "AGENTS.md"))
+      );
+  }
+}

--- a/src/import/dotenv-read.test.ts
+++ b/src/import/dotenv-read.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readDotenvValue, stripDotenvQuotes } from "./dotenv-read.js";
+
+describe("readDotenvValue", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dotenv-read-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns undefined for a missing file or key", () => {
+    expect(readDotenvValue(join(dir, "nope"), "K")).toBeUndefined();
+    writeFileSync(join(dir, ".env"), "OTHER=x\n");
+    expect(readDotenvValue(join(dir, ".env"), "K")).toBeUndefined();
+  });
+
+  it("reads a key, strips quotes, skips comments", () => {
+    writeFileSync(
+      join(dir, ".env"),
+      ["# comment", "", "A=1", 'B="two words"', "C='three'", "BROKEN"].join("\n"),
+    );
+    const path = join(dir, ".env");
+    expect(readDotenvValue(path, "A")).toBe("1");
+    expect(readDotenvValue(path, "B")).toBe("two words");
+    expect(readDotenvValue(path, "C")).toBe("three");
+  });
+});
+
+describe("stripDotenvQuotes", () => {
+  it("strips only one matching pair", () => {
+    expect(stripDotenvQuotes('"x"')).toBe("x");
+    expect(stripDotenvQuotes("'x'")).toBe("x");
+    expect(stripDotenvQuotes('"x\'')).toBe('"x\'');
+    expect(stripDotenvQuotes('""x""')).toBe('"x"');
+  });
+});

--- a/src/import/dotenv-read.ts
+++ b/src/import/dotenv-read.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync } from "node:fs";
+
+/**
+ * Read a single key's value from a dotenv file without mutating it.
+ * Mirrors the `loadDotenvFromStateDir` parse (trim, strip one surrounding
+ * quote pair, ignore comments). Returns `undefined` when absent.
+ *
+ * Shared by the importers that reconcile migrated provider keys against
+ * the agent's own `<stateDir>/.env`.
+ */
+export function readDotenvValue(path: string, key: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+  const text = readFileSync(path, "utf8");
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    if (trimmed.slice(0, eq).trim() !== key) continue;
+    return stripDotenvQuotes(trimmed.slice(eq + 1).trim());
+  }
+  return undefined;
+}
+
+/** Strip a single matching pair of surrounding single or double quotes. */
+export function stripDotenvQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -62,3 +62,62 @@ export type {
   OpenclawSessionMeta,
   ResolveOpenclawOptionsInput,
 } from "./openclaw/index.js";
+
+// Claude Code source.
+export {
+  CLAUDE_CODE_IMPORT_OPTIONS,
+  CLAUDE_CODE_MEMORY_TAG,
+  CLAUDE_CODE_SECRET_ALLOWLIST,
+  CLAUDE_CODE_SESSION_ID_PREFIX,
+  ClaudeCodeImporter,
+  ClaudeCodeOptionError,
+  ClaudeCodeSource,
+  ClaudeCodeSourceError,
+  mapClaudeCodeMcpServer,
+  mapClaudeCodeSession,
+  ONBOARDING_SESSION_LIMIT,
+  resolveClaudeCodeOptions,
+} from "./claude-code/index.js";
+export type {
+  ClaudeCodeImporterDeps,
+  ClaudeCodeOptionId,
+  ClaudeCodeOptionMeta,
+  ClaudeCodeRunOptions,
+  ImportMemoryTarget,
+  MapMcpResult,
+  ResolveClaudeCodeOptionsInput,
+} from "./claude-code/index.js";
+
+// Codex source.
+export {
+  CODEX_IMPORT_OPTIONS,
+  CODEX_MEMORY_TAG,
+  CODEX_SECRET_ALLOWLIST,
+  CODEX_SESSION_ID_PREFIX,
+  CodexImporter,
+  CodexOptionError,
+  CodexSource,
+  CodexSourceError,
+  mapCodexSession,
+  resolveCodexOptions,
+} from "./codex/index.js";
+export type {
+  CodexImporterDeps,
+  CodexOptionId,
+  CodexOptionMeta,
+  CodexRunOptions,
+  ResolveCodexOptionsInput,
+} from "./codex/index.js";
+
+// Source detection (shared by the first-run flow and anything that
+// wants to name the sources without hard-coding their layouts).
+export {
+  detectImportAgents,
+  IMPORT_AGENT_LABELS,
+  importAgentDir,
+} from "./detect-import-agents.js";
+export type {
+  DetectedImportAgent,
+  DetectImportAgentsOptions,
+  ImportAgentId,
+} from "./detect-import-agents.js";

--- a/src/import/split-note.test.ts
+++ b/src/import/split-note.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { splitMemoryNote } from "./split-note.js";
+
+describe("splitMemoryNote", () => {
+  it("returns a fitting note whole, trimmed", () => {
+    expect(splitMemoryNote("  short note \n", 100)).toEqual(["short note"]);
+    expect(splitMemoryNote("   \n  ", 100)).toEqual([]);
+  });
+
+  it("splits on line boundaries under the cap", () => {
+    const note = ["a".repeat(40), "b".repeat(40), "c".repeat(40)].join("\n");
+    const chunks = splitMemoryNote(note, 90);
+    expect(chunks).toEqual([
+      `${"a".repeat(40)}\n${"b".repeat(40)}`,
+      "c".repeat(40),
+    ]);
+    for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(90);
+  });
+
+  it("hard-slices a single line longer than the cap", () => {
+    const chunks = splitMemoryNote("x".repeat(250), 100);
+    expect(chunks).toHaveLength(3);
+    expect(chunks.join("")).toBe("x".repeat(250));
+    for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(100);
+  });
+
+  it("is deterministic, so re-runs dedup against the same chunks", () => {
+    const note = Array.from({ length: 50 }, (_, i) => `line ${i}`).join("\n");
+    expect(splitMemoryNote(note, 64)).toEqual(splitMemoryNote(note, 64));
+  });
+
+  it("never emits an over-cap or empty chunk", () => {
+    const note = ["", "para one", "", "x".repeat(500), "tail"].join("\n");
+    const chunks = splitMemoryNote(note, 120);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeGreaterThan(0);
+      expect(chunk.length).toBeLessThanOrEqual(120);
+    }
+  });
+});

--- a/src/import/split-note.ts
+++ b/src/import/split-note.ts
@@ -1,0 +1,40 @@
+/**
+ * Split an imported note to fit the memory store's content cap
+ * (`MEMORY_CONTENT_MAX_LENGTH`). Source notes are whatever size the
+ * other agent allowed — Claude Code's auto-memory files routinely run
+ * past 4k chars — and an import that errors on them silently loses the
+ * exact notes worth keeping.
+ *
+ * Splits on line boundaries, packing lines greedily; a single line
+ * longer than the cap (rare, but nothing stops a one-line file) is
+ * hard-sliced. Deterministic, so a re-run produces the same chunks and
+ * the importer's exact-content dedup still recognises them.
+ */
+export function splitMemoryNote(content: string, maxChars: number): string[] {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return [];
+  if (trimmed.length <= maxChars) return [trimmed];
+  const chunks: string[] = [];
+  let current = "";
+  const flush = (): void => {
+    const chunk = current.trim();
+    if (chunk.length > 0) chunks.push(chunk);
+    current = "";
+  };
+  for (const line of trimmed.split("\n")) {
+    const pieces: string[] = [];
+    if (line.length > maxChars) {
+      for (let i = 0; i < line.length; i += maxChars) {
+        pieces.push(line.slice(i, i + maxChars));
+      }
+    } else {
+      pieces.push(line);
+    }
+    for (const piece of pieces) {
+      if (current.length + piece.length + 1 > maxChars) flush();
+      current = current.length > 0 ? `${current}\n${piece}` : piece;
+    }
+  }
+  flush();
+  return chunks;
+}

--- a/src/tui/components/onboarding-import-step.tsx
+++ b/src/tui/components/onboarding-import-step.tsx
@@ -1,0 +1,227 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import type { ImportReport } from "../../import/index.js";
+import { MouseListRow } from "../mouse/mouse-list-row.js";
+import { plainKey } from "../mouse/synthetic-key.js";
+import { widestLine } from "../onboarding/centre-onboarding-block.js";
+import {
+  summarizeImportReport,
+  type OnboardingImportAgentRow,
+  type OnboardingImportOptionRow,
+} from "../onboarding/import-step.js";
+import { handleOnboardingStepKey } from "../onboarding/onboarding-step-keys.js";
+import { ROW_INDENT, rowPrefix } from "../onboarding/onboarding-rows.js";
+import { theme } from "../theme/theme.js";
+
+/**
+ * The first-run import screens: pick the agents found on this machine,
+ * toggle what to bring over, read the dry-run, read the result. All
+ * three are pure renders of `OnboardingUiState`; the keys live in
+ * `onboarding-step-keys.ts` and the runs in the import orchestrator.
+ */
+
+const PICK_EXPLAINER: readonly string[] = [
+  "Other agents keep skills, memory, sessions and keys on this machine.",
+  "Pick which ones to bring into atomic-agent — nothing is written before",
+  "you see a preview, and nothing is ever removed from the source.",
+];
+
+const CHECKBOX_ON = "[x] ";
+const CHECKBOX_OFF = "[ ] ";
+
+/** A toggled list row: checkbox, label, detail; click toggles like space. */
+function ToggleRow(props: {
+  selected: boolean;
+  enabled: boolean;
+  index: number;
+  label: string;
+  detail: string;
+  /** The action a click's second press sends (space, via the key table). */
+  onToggle: Parameters<typeof MouseListRow>[0]["onActivate"];
+}): ReactElement {
+  return (
+    <MouseListRow
+      selected={props.selected}
+      onSelect={(mouse) =>
+        mouse.dispatch({ type: "onboarding_cursor_set", cursor: props.index })
+      }
+      onActivate={props.onToggle}
+    >
+      <Box flexDirection="column" marginBottom={1}>
+        <Text
+          color={props.selected ? theme.colors.accent : undefined}
+          bold={props.selected}
+        >
+          {`${rowPrefix(props.selected)}${props.enabled ? CHECKBOX_ON : CHECKBOX_OFF}${props.label}`}
+        </Text>
+        <Text color={theme.colors.muted}>
+          {`${ROW_INDENT}    ${props.detail}`}
+        </Text>
+      </Box>
+    </MouseListRow>
+  );
+}
+
+/**
+ * Sends the same space-toggle the keyboard does, through the key table —
+ * the checkbox analogue of `pressEnter`, so a click on the selected row
+ * flips it exactly like the spacebar would.
+ */
+function pressSpace(): NonNullable<Parameters<typeof MouseListRow>[0]["onActivate"]> {
+  return (mouse) => {
+    handleOnboardingStepKey(" ", plainKey(), {
+      state: mouse.getState(),
+      dispatch: mouse.dispatch,
+      callbacks: mouse.callbacks,
+    });
+  };
+}
+
+export function measureOnboardingImportPickStep(
+  agents: readonly OnboardingImportAgentRow[],
+): number {
+  return widestLine([
+    ...PICK_EXPLAINER,
+    ...agents.flatMap((row) => [
+      `${ROW_INDENT}${CHECKBOX_ON}${row.label}`,
+      `${ROW_INDENT}    ${row.dir}`,
+    ]),
+  ]);
+}
+
+export function OnboardingImportPickStep(props: {
+  agents: readonly OnboardingImportAgentRow[];
+  cursor: number;
+}): ReactElement {
+  const count = Math.max(1, props.agents.length);
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      <Box flexDirection="column" marginBottom={1}>
+        {PICK_EXPLAINER.map((line) => (
+          <Text key={line} color={theme.colors.muted}>
+            {line}
+          </Text>
+        ))}
+      </Box>
+      {props.agents.map((row, index) => (
+        <ToggleRow
+          key={row.id}
+          selected={props.cursor % count === index}
+          enabled={row.enabled}
+          index={index}
+          label={row.label}
+          detail={row.dir}
+          onToggle={pressSpace()}
+        />
+      ))}
+    </Box>
+  );
+}
+
+export function measureOnboardingImportOptionsStep(
+  options: readonly OnboardingImportOptionRow[],
+): number {
+  return widestLine(
+    options.flatMap((row) => [
+      `${ROW_INDENT}${CHECKBOX_ON}${row.agentLabel} · ${row.label}`,
+      `${ROW_INDENT}    ${row.description}`,
+    ]),
+  );
+}
+
+export function OnboardingImportOptionsStep(props: {
+  options: readonly OnboardingImportOptionRow[];
+  cursor: number;
+  busy: boolean;
+  error: string | null;
+}): ReactElement {
+  const count = Math.max(1, props.options.length);
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      {props.options.map((row, index) => (
+        <ToggleRow
+          key={`${row.agent}:${row.option}`}
+          selected={props.cursor % count === index}
+          enabled={row.enabled}
+          index={index}
+          label={`${row.agentLabel} · ${row.label}`}
+          detail={row.description}
+          onToggle={pressSpace()}
+        />
+      ))}
+      {props.busy ? (
+        <Text color={theme.colors.muted}>scanning the sources…</Text>
+      ) : null}
+      {props.error !== null ? (
+        <Text color={theme.colors.error}>{props.error}</Text>
+      ) : null}
+    </Box>
+  );
+}
+
+export function measureOnboardingImportReportStep(
+  report: ImportReport | null,
+  executed: boolean,
+): number {
+  return widestLine([
+    reportHeadline(report, executed),
+    ...(report ? summarizeImportReport(report) : []),
+  ]);
+}
+
+function reportHeadline(report: ImportReport | null, executed: boolean): string {
+  if (!report) return "";
+  const s = report.summary;
+  if (executed) {
+    return s.error > 0
+      ? `${theme.glyphs.warn}  Imported with ${s.error} failure${s.error === 1 ? "" : "s"}`
+      : `${theme.glyphs.check}  Imported`;
+  }
+  const actionable = s.migrated + s.conflict;
+  return actionable > 0
+    ? "Here is what an import would do:"
+    : "Nothing new to import — everything is already here or empty.";
+}
+
+/**
+ * The preview and the result are the same surface — a headline and one
+ * line per domain — differing only in tense and in what Enter means,
+ * which the footer says.
+ */
+export function OnboardingImportReportStep(props: {
+  report: ImportReport | null;
+  executed: boolean;
+  busy: boolean;
+  error: string | null;
+}): ReactElement {
+  const headline = reportHeadline(props.report, props.executed);
+  const success = props.executed && (props.report?.summary.error ?? 0) === 0;
+  return (
+    <Box flexDirection="column" flexShrink={0}>
+      {headline.length > 0 ? (
+        <Text color={success ? theme.colors.success : undefined}>
+          {headline}
+        </Text>
+      ) : null}
+      {props.report ? (
+        <Box flexDirection="column" marginTop={1}>
+          {summarizeImportReport(props.report).map((line) => (
+            <Text key={line} color={theme.colors.muted}>
+              {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+      {props.busy ? (
+        <Box marginTop={1}>
+          <Text color={theme.colors.muted}>importing…</Text>
+        </Box>
+      ) : null}
+      {props.error !== null ? (
+        <Box marginTop={1}>
+          <Text color={theme.colors.error}>{props.error}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/tui/components/onboarding-screen.tsx
+++ b/src/tui/components/onboarding-screen.tsx
@@ -52,6 +52,11 @@ export interface OnboardingScreenCallbacks {
   onOnboardingStep?(step: string, outcome?: string): void;
   /** Start a model pull. Owned by `LocalModelsOrchestrator`. */
   onLocalModelsPullRequested?(modelId: LocalModelId): void;
+  /** Run the import step's preview (`execute: false`) or write (`true`). */
+  onOnboardingImportRequested?(
+    plan: import("../onboarding/import-step.js").OnboardingImportPlan,
+    execute: boolean,
+  ): void;
 }
 
 /** Named once — the offer screens quote it back at the operator. */
@@ -178,6 +183,9 @@ export function OnboardingScreen(props: {
     cloudLabel: CLOUD_READY_LABEL,
     hfRepo: onboarding.hfRepo,
     hfError: onboarding.step === "local_hf_ref" ? onboarding.error : null,
+    importAgents: onboarding.importAgents,
+    importOptions: onboarding.importOptions,
+    importReport: onboarding.importReport,
   });
 
   return (

--- a/src/tui/components/onboarding-step-body.tsx
+++ b/src/tui/components/onboarding-step-body.tsx
@@ -10,6 +10,11 @@ import { describeDownloadingModel } from "../onboarding/local-model-picks.js";
 import { OnboardingChooseStep } from "./onboarding-choose-step.js";
 import { OnboardingDownloadStep } from "./onboarding-download-step.js";
 import { OnboardingHuggingFaceFlow } from "./onboarding-hf-flow.js";
+import {
+  OnboardingImportOptionsStep,
+  OnboardingImportPickStep,
+  OnboardingImportReportStep,
+} from "./onboarding-import-step.js";
 import { OnboardingHeader } from "./onboarding-header.js";
 import { OnboardingIntroStep } from "./onboarding-intro-step.js";
 import { OnboardingLocalPickStep } from "./onboarding-local-pick-step.js";
@@ -96,6 +101,28 @@ export function OnboardingStepBody(props: {
           dispatch={dispatch}
           ramGb={props.ramGb}
         />
+        {onboarding.step === "import_pick" ? (
+          <OnboardingImportPickStep
+            agents={onboarding.importAgents}
+            cursor={onboarding.cursor}
+          />
+        ) : null}
+        {onboarding.step === "import_options" ? (
+          <OnboardingImportOptionsStep
+            options={onboarding.importOptions}
+            cursor={onboarding.cursor}
+            busy={onboarding.busy}
+            error={onboarding.error}
+          />
+        ) : null}
+        {onboarding.step === "import_preview" || onboarding.step === "import_done" ? (
+          <OnboardingImportReportStep
+            report={onboarding.importReport}
+            executed={onboarding.step === "import_done"}
+            busy={onboarding.busy}
+            error={onboarding.error}
+          />
+        ) : null}
         {onboarding.step === "propose_second" && onboarding.offer ? (
           <OnboardingProposeStep
             offer={onboarding.offer}

--- a/src/tui/components/onboarding-surface-layout.ts
+++ b/src/tui/components/onboarding-surface-layout.ts
@@ -21,11 +21,17 @@ import type {
   OnboardingHuggingFaceRepo,
   OnboardingStep,
 } from "../onboarding/onboarding-state.js";
+import type { OnboardingUiState } from "../onboarding/onboarding-state.js";
 import type { SecondBackendOffer } from "../onboarding/propose-second-backend.js";
 import { measureOnboardingChooseStep } from "./onboarding-choose-step.js";
 import { measureOnboardingDownloadStep } from "./onboarding-download-step.js";
 import { measureOnboardingHeader } from "./onboarding-header.js";
 import { measureOnboardingHfPickStep } from "./onboarding-hf-pick-step.js";
+import {
+  measureOnboardingImportOptionsStep,
+  measureOnboardingImportPickStep,
+  measureOnboardingImportReportStep,
+} from "./onboarding-import-step.js";
 import { measureOnboardingHfRefStep } from "./onboarding-hf-ref-step.js";
 import { measureOnboardingLocalPickStep } from "./onboarding-local-pick-step.js";
 import { measureOnboardingProposeStep } from "./onboarding-propose-step.js";
@@ -59,6 +65,10 @@ export interface OnboardingBlockInput {
   hfRepo: OnboardingHuggingFaceRepo | null;
   /** The reference screen's error, which widens its block when long. */
   hfError?: string | null;
+  /** The import screens' rows and report, while the flow is on them. */
+  importAgents?: OnboardingUiState["importAgents"];
+  importOptions?: OnboardingUiState["importOptions"];
+  importReport?: OnboardingUiState["importReport"];
 }
 
 export function layOutOnboardingSurface(
@@ -134,6 +144,26 @@ function measureStepBody(input: MeasureInput): number {
             configuredLabel: input.configuredLabel,
           })
         : 0;
+    case "import_pick":
+      return Math.min(
+        input.available,
+        measureOnboardingImportPickStep(input.importAgents ?? []),
+      );
+    case "import_options":
+      return Math.min(
+        input.available,
+        measureOnboardingImportOptionsStep(input.importOptions ?? []),
+      );
+    case "import_preview":
+      return Math.min(
+        input.available,
+        measureOnboardingImportReportStep(input.importReport ?? null, false),
+      );
+    case "import_done":
+      return Math.min(
+        input.available,
+        measureOnboardingImportReportStep(input.importReport ?? null, true),
+      );
     case "wait_or_jump":
       return measureOnboardingWaitOrJumpStep({
         pull: input.pull,

--- a/src/tui/hooks/use-onboarding-lifecycle-import.test.tsx
+++ b/src/tui/hooks/use-onboarding-lifecycle-import.test.tsx
@@ -1,0 +1,142 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { render } from "ink-testing-library";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getConfig, resetConfigCache } from "../../config/index.js";
+import type { DetectedImportAgent } from "../../import/index.js";
+import {
+  createOnboardingState,
+  type OnboardingOutcome,
+  type OnboardingUiState,
+} from "../onboarding/onboarding-state.js";
+import type { TuiAction } from "../tui-action.js";
+import { useOnboardingLifecycle } from "./use-onboarding-lifecycle.js";
+
+const STATE_DIR_ENV = "ATOMIC_AGENT_STATE_DIR";
+
+const ONE_AGENT: DetectedImportAgent[] = [
+  { id: "hermes", label: "Hermes", dir: "/tmp/h" },
+];
+
+function Harness(props: {
+  outcome: OnboardingOutcome;
+  skipSecondOffer?: boolean;
+  detectAgents(): DetectedImportAgent[];
+  dispatch(action: TuiAction): void;
+}): React.ReactElement {
+  const onboarding: OnboardingUiState = {
+    ...createOnboardingState("http://127.0.0.1:8080"),
+    step: "finished",
+    outcome: props.outcome,
+    skipSecondOffer: props.skipSecondOffer ?? false,
+  };
+  useOnboardingLifecycle({
+    onboarding,
+    dispatch: props.dispatch,
+    detectAgents: props.detectAgents,
+  });
+  return <></>;
+}
+
+/**
+ * The settle effect's import intercept. Outcome `custom` throughout,
+ * because it is the one outcome `decideSecondBackendOffer` never
+ * intercepts first — these tests pin the *import* offer's contract.
+ */
+describe("useOnboardingLifecycle import offer", () => {
+  let stateDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "onboarding-import-"));
+    originalEnv = process.env[STATE_DIR_ENV];
+    process.env[STATE_DIR_ENV] = stateDir;
+    resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[STATE_DIR_ENV];
+    } else {
+      process.env[STATE_DIR_ENV] = originalEnv;
+    }
+    resetConfigCache();
+    rmSync(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  it("raises the import step instead of settling when agents exist", () => {
+    const actions: TuiAction[] = [];
+    render(
+      <Harness
+        outcome="custom"
+        detectAgents={() => ONE_AGENT}
+        dispatch={(a) => actions.push(a)}
+      />,
+    );
+    expect(actions).toEqual([
+      {
+        type: "onboarding_import_opened",
+        agents: [{ id: "hermes", label: "Hermes", dir: "/tmp/h", enabled: true }],
+      },
+    ]);
+    // Offered once, stamped now; the flow itself is not yet retired.
+    expect(getConfig().tui.onboarding.importOfferedAt).not.toBeNull();
+    expect(getConfig().tui.onboarding.completedAt).toBeNull();
+  });
+
+  it("settles once the offer was already made", () => {
+    render(
+      <Harness outcome="custom" detectAgents={() => ONE_AGENT} dispatch={() => {}} />,
+    );
+    const actions: TuiAction[] = [];
+    render(
+      <Harness
+        outcome="custom"
+        detectAgents={() => ONE_AGENT}
+        dispatch={(a) => actions.push(a)}
+      />,
+    );
+    expect(actions).toContainEqual({ type: "onboarding_set", onboarding: null });
+    expect(getConfig().tui.onboarding.completedAt).not.toBeNull();
+  });
+
+  it("settles straight through when nothing is detected", () => {
+    const actions: TuiAction[] = [];
+    render(
+      <Harness outcome="custom" detectAgents={() => []} dispatch={(a) => actions.push(a)} />,
+    );
+    expect(actions).toContainEqual({ type: "onboarding_set", onboarding: null });
+    // An offer that never appeared must not claim its once-only slot.
+    expect(getConfig().tui.onboarding.importOfferedAt).toBeNull();
+  });
+
+  it("never pitches an operator who skipped setup", () => {
+    const detect = vi.fn(() => ONE_AGENT);
+    const actions: TuiAction[] = [];
+    render(
+      <Harness outcome="skipped" detectAgents={detect} dispatch={(a) => actions.push(a)} />,
+    );
+    expect(detect).not.toHaveBeenCalled();
+    expect(actions).toContainEqual({ type: "onboarding_set", onboarding: null });
+    expect(getConfig().tui.onboarding.skippedAt).not.toBeNull();
+  });
+
+  it("honours the download skip's straight-to-the-agent promise", () => {
+    const detect = vi.fn(() => ONE_AGENT);
+    const actions: TuiAction[] = [];
+    render(
+      <Harness
+        outcome="local"
+        skipSecondOffer
+        detectAgents={detect}
+        dispatch={(a) => actions.push(a)}
+      />,
+    );
+    expect(detect).not.toHaveBeenCalled();
+    expect(actions).toContainEqual({ type: "onboarding_set", onboarding: null });
+    expect(getConfig().tui.onboarding.importOfferedAt).toBeNull();
+  });
+});

--- a/src/tui/hooks/use-onboarding-lifecycle.ts
+++ b/src/tui/hooks/use-onboarding-lifecycle.ts
@@ -1,9 +1,17 @@
 import { useEffect, useRef } from "react";
 import { getConfig } from "../../config/index.js";
 import {
+  detectImportAgents,
+  type DetectedImportAgent,
+} from "../../import/index.js";
+import {
   isCloudTextProviderReady,
   isLocalBackendConfigured,
 } from "../local-backend-readiness.js";
+import {
+  buildImportAgentRows,
+  shouldOfferImport,
+} from "../onboarding/import-step.js";
 import type {
   OnboardingOutcome,
   OnboardingUiState,
@@ -26,8 +34,11 @@ export function useOnboardingLifecycle(input: {
   dispatch(action: TuiAction): void;
   onFinished?(outcome: OnboardingOutcome): void;
   onStep?(step: string, outcome?: string): void;
+  /** Injectable source scan, so tests never read the real home dir. */
+  detectAgents?(): DetectedImportAgent[];
 }): void {
   const { onboarding, dispatch, onFinished, onStep } = input;
+  const detectAgents = input.detectAgents ?? detectImportAgents;
   const settling = useRef(false);
   // Steps already reported, so a re-render — or a second visit to the
   // same screen — does not double-count it. `finished` in particular is
@@ -98,6 +109,29 @@ export function useOnboardingLifecycle(input: {
       persistOnboardingState({ proposedSecondBackendAt: new Date().toISOString() });
       dispatch({ type: "onboarding_second_backend_offered", offer });
       return;
+    }
+    // The import step is the flow's actual last screen: it runs after
+    // the second-backend offer settles (in either direction), and only
+    // when a known agent's state dir exists on this machine. Same
+    // once-only contract as the offer above — stamped when shown. The
+    // download screen's skip exit bypasses this screen too: "skip to
+    // the agent" is a promise, and `/import` keeps working later.
+    if (
+      !onboarding.skipSecondOffer &&
+      shouldOfferImport({
+        outcome,
+        alreadyOffered: config.tui.onboarding.importOfferedAt !== null,
+      })
+    ) {
+      const detected = detectAgents();
+      if (detected.length > 0) {
+        persistOnboardingState({ importOfferedAt: new Date().toISOString() });
+        dispatch({
+          type: "onboarding_import_opened",
+          agents: buildImportAgentRows(detected),
+        });
+        return;
+      }
     }
     settling.current = true;
     const now = new Date().toISOString();

--- a/src/tui/import/import-orchestrator.ts
+++ b/src/tui/import/import-orchestrator.ts
@@ -1,17 +1,29 @@
 import type { AgentRuntime } from "../../runtime/bootstrap.js";
 import {
+  buildReport,
+  ClaudeCodeImporter,
+  ClaudeCodeSource,
+  CodexImporter,
+  CodexSource,
   HermesImporter,
   HermesSource,
+  IMPORT_AGENT_LABELS,
   ImportOptionError,
+  ONBOARDING_SESSION_LIMIT,
   resolveSelectedOptions,
   OpenclawImporter,
   OpenclawSource,
   OPENCLAW_DEFAULT_AGENT,
   resolveOpenclawOptions,
+  type ClaudeCodeOptionId,
+  type CodexOptionId,
+  type ImportAgentId,
+  type ImportItemResult,
   type ImportOptionId,
   type OpenclawOptionId,
   type ImportReport,
 } from "../../import/index.js";
+import type { OnboardingImportPlan } from "../onboarding/import-step.js";
 import type { TuiEventBus } from "../tui-app.js";
 import type { ImportFormState } from "./import-panel-state.js";
 
@@ -180,11 +192,153 @@ export class ImportOrchestrator {
     }
   }
 
+  /**
+   * The first-run flow's multi-source run: every picked agent in plan
+   * order, each with its own importer, folded into one report whose
+   * item kinds carry the agent's name (`Claude Code sessions`) so the
+   * summary reads without a legend. Conflicts stay conflicts —
+   * onboarding never overwrites — and the answer lands on the bus as
+   * `onboarding_import_report` / `onboarding_import_failed`.
+   */
+  async runOnboarding(plan: OnboardingImportPlan, execute: boolean): Promise<void> {
+    // Let the busy frame paint before the synchronous SQLite work begins.
+    await Promise.resolve();
+    const items: ImportItemResult[] = [];
+    let cronImported = false;
+    try {
+      for (const agent of plan.agents) {
+        if (!agent.enabled) continue;
+        const enabled = plan.options
+          .filter((row) => row.agent === agent.id && row.enabled)
+          .map((row) => row.option);
+        if (enabled.length === 0) continue;
+        const report = await this.runOnboardingAgent(agent.id, agent.dir, enabled, execute);
+        if (report === null) continue;
+        if (execute && enabled.includes("cron")) cronImported = true;
+        for (const item of report.items) {
+          items.push({ ...item, kind: `${IMPORT_AGENT_LABELS[agent.id]} ${item.kind}` });
+        }
+      }
+    } catch (err) {
+      this.bus.emit({
+        type: "onboarding_import_failed",
+        error: errorMessage(err),
+      });
+      return;
+    }
+    const report = buildReport(items, execute);
+    this.bus.emit({ type: "onboarding_import_report", report, executed: execute });
+    if (execute) {
+      this.bus.emit({
+        type: "runtime_info",
+        line: `import done: ${formatSummary(report)}`,
+      });
+      if (cronImported) this.deps.refreshTasks?.();
+    }
+  }
+
+  private async runOnboardingAgent(
+    id: ImportAgentId,
+    dir: string,
+    enabled: readonly string[],
+    execute: boolean,
+  ): Promise<ImportReport | null> {
+    const config = this.runtime.config;
+    const common = { execute, overwrite: false } as const;
+    switch (id) {
+      case "hermes": {
+        const options = enabled.filter(isHermesOption);
+        if (options.length === 0) return null;
+        const source = new HermesSource(dir);
+        try {
+          return new HermesImporter({
+            source,
+            sessionStore: this.runtime.sessionStore,
+            taskStore: this.runtime.taskStore,
+            stateDir: config.paths.stateDir,
+            maxAttempts: config.tasks.maxAttempts,
+            workingDirFallback: process.cwd(),
+          }).run({ ...common, options });
+        } finally {
+          source.close();
+        }
+      }
+      case "openclaw": {
+        const options = enabled.filter(isOpenclawOption);
+        if (options.length === 0) return null;
+        const source = new OpenclawSource(dir, OPENCLAW_DEFAULT_AGENT);
+        try {
+          return new OpenclawImporter({
+            source,
+            sessionStore: this.runtime.sessionStore,
+            taskStore: this.runtime.taskStore,
+            maxAttempts: config.tasks.maxAttempts,
+            workingDirFallback: process.cwd(),
+          }).run({ ...common, options });
+        } finally {
+          source.close();
+        }
+      }
+      case "claude-code": {
+        const options = enabled.filter(isClaudeCodeOption);
+        if (options.length === 0) return null;
+        return new ClaudeCodeImporter({
+          source: new ClaudeCodeSource(dir),
+          sessionStore: this.runtime.sessionStore,
+          memoryStore: this.runtime.notesStore,
+          stateDir: config.paths.stateDir,
+          userConfigFile: config.paths.userConfigFile,
+          globalSkillsDir: config.paths.globalSkillsDir,
+          workingDirFallback: process.cwd(),
+        }).run({ ...common, options, limit: ONBOARDING_SESSION_LIMIT });
+      }
+      case "codex": {
+        const options = enabled.filter(isCodexOption);
+        if (options.length === 0) return null;
+        return new CodexImporter({
+          source: new CodexSource(dir),
+          sessionStore: this.runtime.sessionStore,
+          memoryStore: this.runtime.notesStore,
+          stateDir: config.paths.stateDir,
+          globalSkillsDir: config.paths.globalSkillsDir,
+          workingDirFallback: process.cwd(),
+        }).run({ ...common, options, limit: ONBOARDING_SESSION_LIMIT });
+      }
+    }
+  }
+
   shutdown(): void {
     // No timers or open handles to release — the per-run source is always
     // closed inside the runHermes/runOpenclaw finally. Present for symmetry
     // with the other tab orchestrators.
   }
+}
+
+// The plan's option ids are already source-scoped by construction (each
+// row was built from that source's registry); the guards restate that
+// for the type system at the seam where the unions meet.
+function isHermesOption(id: string): id is ImportOptionId {
+  return id === "sessions" || id === "cron" || id === "secrets";
+}
+
+function isOpenclawOption(id: string): id is OpenclawOptionId {
+  return id === "sessions" || id === "cron";
+}
+
+function isClaudeCodeOption(id: string): id is ClaudeCodeOptionId {
+  return (
+    id === "skills" ||
+    id === "memory" ||
+    id === "mcp" ||
+    id === "sessions" ||
+    id === "secrets"
+  );
+}
+
+function isCodexOption(id: string): id is CodexOptionId {
+  return (
+    id === "skills" || id === "memory" || id === "sessions" || id === "secrets"
+  );
 }
 
 function parseLimit(raw: string): number | undefined {

--- a/src/tui/onboarding/import-step.test.ts
+++ b/src/tui/onboarding/import-step.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { buildReport, type ImportItemResult } from "../../import/index.js";
+import {
+  buildImportAgentRows,
+  buildImportOptionRows,
+  shouldOfferImport,
+  summarizeImportReport,
+} from "./import-step.js";
+
+describe("shouldOfferImport", () => {
+  it("offers once, and never to an operator who skipped setup", () => {
+    expect(shouldOfferImport({ outcome: "local", alreadyOffered: false })).toBe(true);
+    expect(shouldOfferImport({ outcome: "cloud", alreadyOffered: false })).toBe(true);
+    expect(shouldOfferImport({ outcome: "custom", alreadyOffered: false })).toBe(true);
+    expect(shouldOfferImport({ outcome: "skipped", alreadyOffered: false })).toBe(false);
+    expect(shouldOfferImport({ outcome: "local", alreadyOffered: true })).toBe(false);
+  });
+});
+
+describe("buildImportOptionRows", () => {
+  it("builds each picked agent's registry, secrets off by default", () => {
+    const agents = buildImportAgentRows([
+      { id: "hermes", label: "Hermes", dir: "/h" },
+      { id: "claude-code", label: "Claude Code", dir: "/c" },
+    ]);
+    expect(agents.every((a) => a.enabled)).toBe(true);
+
+    const rows = buildImportOptionRows(agents);
+    expect(rows.map((r) => `${r.agent}:${r.option}`)).toEqual([
+      "hermes:sessions",
+      "hermes:cron",
+      "hermes:secrets",
+      "claude-code:skills",
+      "claude-code:memory",
+      "claude-code:mcp",
+      "claude-code:sessions",
+      "claude-code:secrets",
+    ]);
+    for (const row of rows) {
+      expect(row.enabled).toBe(!row.secret);
+      expect(row.secret).toBe(row.option === "secrets");
+    }
+  });
+
+  it("skips unticked agents", () => {
+    const agents = buildImportAgentRows([
+      { id: "hermes", label: "Hermes", dir: "/h" },
+      { id: "codex", label: "Codex", dir: "/x" },
+    ]).map((row) => (row.id === "hermes" ? { ...row, enabled: false } : row));
+    const rows = buildImportOptionRows(agents);
+    expect(rows.every((r) => r.agent === "codex")).toBe(true);
+  });
+});
+
+describe("summarizeImportReport", () => {
+  const items: ImportItemResult[] = [
+    { kind: "Claude Code skills", status: "migrated" },
+    { kind: "Claude Code skills", status: "skipped" },
+    { kind: "Claude Code sessions", status: "migrated" },
+    { kind: "Claude Code sessions", status: "conflict" },
+    { kind: "Codex secrets", status: "error" },
+  ];
+
+  it("reads in the future tense for a preview", () => {
+    expect(summarizeImportReport(buildReport(items, false))).toEqual([
+      "Claude Code skills: 1 to migrate, 1 skipped",
+      "Claude Code sessions: 1 to migrate, 1 in conflict",
+      "Codex secrets: 1 failed",
+    ]);
+  });
+
+  it("reads in the past tense once executed", () => {
+    expect(summarizeImportReport(buildReport(items, true))[0]).toBe(
+      "Claude Code skills: 1 migrated, 1 skipped",
+    );
+  });
+});

--- a/src/tui/onboarding/import-step.ts
+++ b/src/tui/onboarding/import-step.ts
@@ -1,0 +1,152 @@
+import {
+  CLAUDE_CODE_IMPORT_OPTIONS,
+  CODEX_IMPORT_OPTIONS,
+  IMPORT_OPTIONS,
+  OPENCLAW_IMPORT_OPTIONS,
+  type DetectedImportAgent,
+  type ImportAgentId,
+  type ImportReport,
+} from "../../import/index.js";
+import type { OnboardingOutcome } from "./onboarding-state.js";
+
+/**
+ * The pure model behind the first-run import screens: which agents were
+ * detected and picked, which of their domains are toggled on, and how a
+ * finished report reads. Everything here is data in and data out — the
+ * effects (detection, the importer runs) live with the host, the same
+ * split every other step keeps.
+ */
+
+/** One row on the agent pick screen. */
+export interface OnboardingImportAgentRow {
+  id: ImportAgentId;
+  label: string;
+  /** Resolved state dir, printed under the label. */
+  dir: string;
+  enabled: boolean;
+}
+
+/** One row on the option toggle screen, grouped by agent. */
+export interface OnboardingImportOptionRow {
+  agent: ImportAgentId;
+  agentLabel: string;
+  /** Source-specific option id (`skills`, `sessions`, `secrets`, …). */
+  option: string;
+  label: string;
+  description: string;
+  /** Credential rows start off and say so — nothing migrates keys silently. */
+  secret: boolean;
+  enabled: boolean;
+}
+
+/** What the host needs to actually run the import. */
+export interface OnboardingImportPlan {
+  agents: readonly OnboardingImportAgentRow[];
+  options: readonly OnboardingImportOptionRow[];
+}
+
+export interface ImportOfferInputs {
+  /** How the flow finished. */
+  outcome: OnboardingOutcome;
+  /** `tui.onboarding.importOfferedAt` — the offer was already made. */
+  alreadyOffered: boolean;
+}
+
+/**
+ * Whether the closing flow should raise the import step at all. Made
+ * once, recorded in config when shown; an operator who esc-skipped the
+ * whole setup asked to be left alone and is not pitched a migration on
+ * the way out either.
+ */
+export function shouldOfferImport(inputs: ImportOfferInputs): boolean {
+  if (inputs.alreadyOffered) return false;
+  return inputs.outcome !== "skipped";
+}
+
+/** Detected agents as pick rows, all enabled — the preview is the gate. */
+export function buildImportAgentRows(
+  detected: readonly DetectedImportAgent[],
+): OnboardingImportAgentRow[] {
+  return detected.map((agent) => ({
+    id: agent.id,
+    label: agent.label,
+    dir: agent.dir,
+    enabled: true,
+  }));
+}
+
+/**
+ * The option rows for the picked agents, in pick order, each agent
+ * contributing its own registry. Non-secret options start on; `secrets`
+ * rows start off, mirroring the CLI where only an explicit flag selects
+ * them.
+ */
+export function buildImportOptionRows(
+  agents: readonly OnboardingImportAgentRow[],
+): OnboardingImportOptionRow[] {
+  const rows: OnboardingImportOptionRow[] = [];
+  for (const agent of agents) {
+    if (!agent.enabled) continue;
+    for (const meta of optionRegistryFor(agent.id)) {
+      const secret = meta.id === "secrets";
+      rows.push({
+        agent: agent.id,
+        agentLabel: agent.label,
+        option: meta.id,
+        label: meta.label,
+        description: meta.description,
+        secret,
+        enabled: !secret,
+      });
+    }
+  }
+  return rows;
+}
+
+interface OptionMetaLike {
+  id: string;
+  label: string;
+  description: string;
+}
+
+function optionRegistryFor(id: ImportAgentId): readonly OptionMetaLike[] {
+  switch (id) {
+    case "hermes":
+      return IMPORT_OPTIONS;
+    case "openclaw":
+      return OPENCLAW_IMPORT_OPTIONS;
+    case "claude-code":
+      return CLAUDE_CODE_IMPORT_OPTIONS;
+    case "codex":
+      return CODEX_IMPORT_OPTIONS;
+  }
+}
+
+/**
+ * The preview / result screens' body: one line per domain that has
+ * anything to say, plus the summary. Pure formatting over the report so
+ * the render and its test read the same lines.
+ */
+export function summarizeImportReport(report: ImportReport): string[] {
+  const byKind = new Map<string, { migrated: number; skipped: number; conflict: number; error: number }>();
+  for (const item of report.items) {
+    let counts = byKind.get(item.kind);
+    if (!counts) {
+      counts = { migrated: 0, skipped: 0, conflict: 0, error: 0 };
+      byKind.set(item.kind, counts);
+    }
+    counts[item.status] += 1;
+  }
+  const lines: string[] = [];
+  const migratedLabel = report.executed ? "migrated" : "to migrate";
+  for (const [kind, counts] of byKind) {
+    const parts: string[] = [];
+    if (counts.migrated > 0) parts.push(`${counts.migrated} ${migratedLabel}`);
+    if (counts.skipped > 0) parts.push(`${counts.skipped} skipped`);
+    if (counts.conflict > 0) parts.push(`${counts.conflict} in conflict`);
+    if (counts.error > 0) parts.push(`${counts.error} failed`);
+    if (parts.length === 0) continue;
+    lines.push(`${kind}: ${parts.join(", ")}`);
+  }
+  return lines;
+}

--- a/src/tui/onboarding/onboarding-actions.ts
+++ b/src/tui/onboarding/onboarding-actions.ts
@@ -1,3 +1,8 @@
+import type { ImportReport } from "../../import/index.js";
+import type {
+  OnboardingImportAgentRow,
+  OnboardingImportOptionRow,
+} from "./import-step.js";
 import type {
   OnboardingHuggingFaceRepo,
   OnboardingOutcome,
@@ -31,6 +36,28 @@ export type OnboardingAction =
   | { type: "onboarding_hf_repo_resolved"; repo: OnboardingHuggingFaceRepo }
   /** `c` on the download screen: set up cloud while the pull runs. */
   | { type: "onboarding_cloud_meanwhile_opened" }
+  /**
+   * The closing flow found other agents' state on disk and raises the
+   * import step instead of settling. Carries the detected rows so the
+   * pick screen renders in the same commit that opened it.
+   */
+  | { type: "onboarding_import_opened"; agents: OnboardingImportAgentRow[] }
+  /** Space on an agent row of the pick screen. */
+  | { type: "onboarding_import_agent_toggled"; index: number }
+  /**
+   * Enter on the pick screen: move to the domain toggles. Carries the
+   * rows built from the picked agents, for the same one-commit reason
+   * the HF resolve carries its repo.
+   */
+  | { type: "onboarding_import_options_opened"; options: OnboardingImportOptionRow[] }
+  /** Space on a domain row of the options screen. */
+  | { type: "onboarding_import_option_toggled"; index: number }
+  /** A preview or execute run left for the importers; keys freeze. */
+  | { type: "onboarding_import_run_started" }
+  /** The importers answered. Preview lands on `import_preview`, an executed run on `import_done`. */
+  | { type: "onboarding_import_report"; report: ImportReport; executed: boolean }
+  /** A run failed outright (option resolution, source access, …). */
+  | { type: "onboarding_import_failed"; error: string }
   /** Offer the other backend once the first one works. */
   | { type: "onboarding_second_backend_offered"; offer: "local" | "cloud" }
   /** The flow reached its end; the host persists and closes it. */

--- a/src/tui/onboarding/onboarding-chrome.ts
+++ b/src/tui/onboarding/onboarding-chrome.ts
@@ -19,6 +19,10 @@ export const ONBOARDING_SUBTITLES: Record<OnboardingStep, string> = {
   local_download: "local models · downloading",
   propose_second: "one more thing",
   wait_or_jump: "almost there",
+  import_pick: "bring your data · one last step",
+  import_options: "bring your data · choose what",
+  import_preview: "bring your data · preview",
+  import_done: "bring your data · done",
   cloud: "cloud model · step 2 of 2",
   custom_chat_url: "custom endpoint · step 2 of 2",
   custom_embedding_url: "custom endpoint · embeddings",
@@ -64,6 +68,19 @@ export function onboardingFooterFor(
       return `c set up cloud meanwhile   s skip to the agent   ${quit}`;
     case "propose_second":
       return `↑/↓ move   enter select   esc skip   ${quit}`;
+    case "import_pick":
+      return `↑/↓ move   space toggle   enter continue   esc skip   ${quit}`;
+    case "import_options":
+      // While a run is out with the importers, Enter would double-run.
+      return onboarding.busy
+        ? `scanning…   ${quit}`
+        : `↑/↓ move   space toggle   enter preview   esc back   ${quit}`;
+    case "import_preview":
+      return onboarding.busy
+        ? `importing…   ${quit}`
+        : `enter import   esc adjust   ${quit}`;
+    case "import_done":
+      return `any key to start   ${quit}`;
     case "wait_or_jump":
       return `↑/↓ move   enter start or add a provider   ${quit}`;
     case "finished":

--- a/src/tui/onboarding/onboarding-import-flow.test.ts
+++ b/src/tui/onboarding/onboarding-import-flow.test.ts
@@ -1,0 +1,246 @@
+import type { Key } from "ink";
+import { describe, expect, it } from "vitest";
+
+import { buildReport } from "../../import/index.js";
+import { reduceTuiState } from "../agent-event-reducer.js";
+import { arrowKey, plainKey, returnKey } from "../mouse/synthetic-key.js";
+import { fakeSession } from "../test-fixtures.js";
+import type { TuiAction } from "../tui-action.js";
+import { createInitialTuiState, type TuiState } from "../tui-state.js";
+import type { OnboardingImportPlan } from "./import-step.js";
+import { handleOnboardingStepKey } from "./onboarding-step-keys.js";
+import { createOnboardingState, type OnboardingStep } from "./onboarding-state.js";
+
+function escKey(): Key {
+  return { ...returnKey(), return: false, escape: true };
+}
+
+const AGENTS = [
+  { id: "hermes" as const, label: "Hermes", dir: "/h", enabled: true },
+  { id: "claude-code" as const, label: "Claude Code", dir: "/c", enabled: true },
+];
+
+function stateAt(
+  step: OnboardingStep,
+  over: Partial<NonNullable<TuiState["onboarding"]>> = {},
+): TuiState {
+  const onboarding = {
+    ...createOnboardingState("http://127.0.0.1:8080"),
+    step,
+    outcome: "local" as const,
+    importAgents: AGENTS,
+    ...over,
+  };
+  return { ...createInitialTuiState(fakeSession(), 50), onboarding };
+}
+
+interface Driven {
+  actions: TuiAction[];
+  runs: Array<{ plan: OnboardingImportPlan; execute: boolean }>;
+  handle(input: string, key: Key): boolean;
+}
+
+function drive(state: TuiState): Driven {
+  const actions: TuiAction[] = [];
+  const runs: Driven["runs"] = [];
+  return {
+    actions,
+    runs,
+    handle: (input, key) =>
+      handleOnboardingStepKey(input, key, {
+        state,
+        dispatch: (action) => actions.push(action),
+        callbacks: {
+          onOnboardingImportRequested: (plan, execute) =>
+            runs.push({ plan, execute }),
+        },
+      }),
+  };
+}
+
+describe("import flow reducer", () => {
+  it("opens the pick screen with the detected agents", () => {
+    const state = reduceTuiState(stateAt("finished"), {
+      type: "onboarding_import_opened",
+      agents: AGENTS,
+    });
+    expect(state.onboarding?.step).toBe("import_pick");
+    expect(state.onboarding?.importAgents).toHaveLength(2);
+    expect(state.onboarding?.cursor).toBe(0);
+  });
+
+  it("toggles agent and option rows by index", () => {
+    let state = reduceTuiState(stateAt("finished"), {
+      type: "onboarding_import_opened",
+      agents: AGENTS,
+    });
+    state = reduceTuiState(state, {
+      type: "onboarding_import_agent_toggled",
+      index: 1,
+    });
+    expect(state.onboarding?.importAgents.map((a) => a.enabled)).toEqual([
+      true,
+      false,
+    ]);
+
+    state = reduceTuiState(state, {
+      type: "onboarding_import_options_opened",
+      options: [
+        {
+          agent: "hermes",
+          agentLabel: "Hermes",
+          option: "sessions",
+          label: "Sessions",
+          description: "d",
+          secret: false,
+          enabled: true,
+        },
+      ],
+    });
+    expect(state.onboarding?.step).toBe("import_options");
+    state = reduceTuiState(state, {
+      type: "onboarding_import_option_toggled",
+      index: 0,
+    });
+    expect(state.onboarding?.importOptions[0]?.enabled).toBe(false);
+  });
+
+  it("routes a preview report to import_preview and an executed one to import_done", () => {
+    const report = buildReport([], false);
+    let state = stateAt("import_options");
+    state = reduceTuiState(state, { type: "onboarding_import_run_started" });
+    expect(state.onboarding?.busy).toBe(true);
+    state = reduceTuiState(state, {
+      type: "onboarding_import_report",
+      report,
+      executed: false,
+    });
+    expect(state.onboarding?.step).toBe("import_preview");
+    expect(state.onboarding?.busy).toBe(false);
+    expect(state.onboarding?.importReport).toBe(report);
+
+    const done = reduceTuiState(state, {
+      type: "onboarding_import_report",
+      report: buildReport([], true),
+      executed: true,
+    });
+    expect(done.onboarding?.step).toBe("import_done");
+  });
+
+  it("drops a late report once the flow moved on", () => {
+    const state = reduceTuiState(stateAt("finished"), {
+      type: "onboarding_import_report",
+      report: buildReport([], false),
+      executed: false,
+    });
+    expect(state.onboarding?.step).toBe("finished");
+    expect(state.onboarding?.importReport).toBeNull();
+  });
+
+  it("surfaces a failed run as an inline error", () => {
+    let state = stateAt("import_options", { busy: true });
+    state = reduceTuiState(state, {
+      type: "onboarding_import_failed",
+      error: "boom",
+    });
+    expect(state.onboarding?.busy).toBe(false);
+    expect(state.onboarding?.error).toBe("boom");
+    expect(state.onboarding?.step).toBe("import_options");
+  });
+});
+
+describe("import flow keys", () => {
+  it("space toggles the agent under the cursor", () => {
+    const driven = drive(stateAt("import_pick", { cursor: 1 }));
+    expect(driven.handle(" ", plainKey())).toBe(true);
+    expect(driven.actions).toEqual([
+      { type: "onboarding_import_agent_toggled", index: 1 },
+    ]);
+  });
+
+  it("enter on the pick screen opens the option toggles for the picked agents", () => {
+    const driven = drive(stateAt("import_pick"));
+    driven.handle("", returnKey());
+    expect(driven.actions).toHaveLength(1);
+    const action = driven.actions[0]!;
+    if (action.type !== "onboarding_import_options_opened") {
+      throw new Error(`unexpected ${action.type}`);
+    }
+    expect(action.options.some((o) => o.agent === "hermes")).toBe(true);
+    expect(action.options.some((o) => o.agent === "claude-code")).toBe(true);
+  });
+
+  it("enter with every agent unticked finishes the flow instead", () => {
+    const driven = drive(
+      stateAt("import_pick", {
+        importAgents: AGENTS.map((a) => ({ ...a, enabled: false })),
+      }),
+    );
+    driven.handle("", returnKey());
+    expect(driven.actions).toEqual([
+      { type: "onboarding_finished", outcome: "local" },
+    ]);
+  });
+
+  it("esc skips out of the pick screen with the earned outcome", () => {
+    const driven = drive(stateAt("import_pick"));
+    driven.handle("", escKey());
+    expect(driven.actions).toEqual([
+      { type: "onboarding_finished", outcome: "local" },
+    ]);
+  });
+
+  it("enter on the options screen asks the host for a dry-run", () => {
+    const options = [
+      {
+        agent: "hermes" as const,
+        agentLabel: "Hermes",
+        option: "sessions",
+        label: "Sessions",
+        description: "d",
+        secret: false,
+        enabled: true,
+      },
+    ];
+    const driven = drive(stateAt("import_options", { importOptions: options }));
+    driven.handle("", returnKey());
+    expect(driven.actions).toEqual([{ type: "onboarding_import_run_started" }]);
+    expect(driven.runs).toEqual([
+      { plan: { agents: AGENTS, options }, execute: false },
+    ]);
+  });
+
+  it("enter on an actionable preview asks for the write", () => {
+    const report = buildReport([{ kind: "Hermes sessions", status: "migrated" }], false);
+    const driven = drive(stateAt("import_preview", { importReport: report }));
+    driven.handle("", returnKey());
+    expect(driven.actions).toEqual([{ type: "onboarding_import_run_started" }]);
+    expect(driven.runs.map((r) => r.execute)).toEqual([true]);
+  });
+
+  it("enter on an empty preview finishes without writing", () => {
+    const report = buildReport([{ kind: "Hermes sessions", status: "skipped" }], false);
+    const driven = drive(stateAt("import_preview", { importReport: report }));
+    driven.handle("", returnKey());
+    expect(driven.actions).toEqual([
+      { type: "onboarding_finished", outcome: "local" },
+    ]);
+    expect(driven.runs).toEqual([]);
+  });
+
+  it("keys freeze while a run is out", () => {
+    const driven = drive(stateAt("import_options", { busy: true }));
+    expect(driven.handle("", returnKey())).toBe(true);
+    expect(driven.handle("", arrowKey("down"))).toBe(true);
+    expect(driven.actions).toEqual([]);
+    expect(driven.runs).toEqual([]);
+  });
+
+  it("any key on the report screen hands over to the agent", () => {
+    const driven = drive(stateAt("import_done"));
+    expect(driven.handle("x", plainKey())).toBe(true);
+    expect(driven.actions).toEqual([
+      { type: "onboarding_finished", outcome: "local" },
+    ]);
+  });
+});

--- a/src/tui/onboarding/onboarding-reducer.ts
+++ b/src/tui/onboarding/onboarding-reducer.ts
@@ -123,6 +123,93 @@ export function reduceOnboardingAction(
         },
       };
     }
+    case "onboarding_import_opened": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          step: "import_pick",
+          importAgents: action.agents,
+          importOptions: [],
+          importReport: null,
+          cursor: 0,
+          error: null,
+          busy: false,
+        },
+      };
+    }
+    case "onboarding_import_agent_toggled": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          importAgents: state.onboarding.importAgents.map((row, index) =>
+            index === action.index ? { ...row, enabled: !row.enabled } : row,
+          ),
+        },
+      };
+    }
+    case "onboarding_import_options_opened": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          step: "import_options",
+          importOptions: action.options,
+          cursor: 0,
+          error: null,
+          busy: false,
+        },
+      };
+    }
+    case "onboarding_import_option_toggled": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          importOptions: state.onboarding.importOptions.map((row, index) =>
+            index === action.index ? { ...row, enabled: !row.enabled } : row,
+          ),
+        },
+      };
+    }
+    case "onboarding_import_run_started": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: { ...state.onboarding, busy: true, error: null },
+      };
+    }
+    case "onboarding_import_report": {
+      if (!state.onboarding) return state;
+      // Only the import screens may receive a report: a late answer must
+      // not yank a flow that moved on (or finished) back onto a result
+      // screen nobody is waiting for.
+      const step = state.onboarding.step;
+      if (step !== "import_options" && step !== "import_preview") return state;
+      return {
+        ...state,
+        onboarding: {
+          ...state.onboarding,
+          step: action.executed ? "import_done" : "import_preview",
+          importReport: action.report,
+          cursor: 0,
+          busy: false,
+          error: null,
+        },
+      };
+    }
+    case "onboarding_import_failed": {
+      if (!state.onboarding) return state;
+      return {
+        ...state,
+        onboarding: { ...state.onboarding, busy: false, error: action.error },
+      };
+    }
     case "onboarding_second_backend_offered": {
       if (!state.onboarding) return state;
       return {

--- a/src/tui/onboarding/onboarding-state.ts
+++ b/src/tui/onboarding/onboarding-state.ts
@@ -2,6 +2,11 @@ import type {
   HuggingFaceFile,
   HuggingFaceGgufChoice,
 } from "../../local-llm/index.js";
+import type { ImportReport } from "../../import/index.js";
+import type {
+  OnboardingImportAgentRow,
+  OnboardingImportOptionRow,
+} from "./import-step.js";
 
 /**
  * First-run flow state. Lives on `TuiState.onboarding` and is `null`
@@ -27,6 +32,14 @@ export type OnboardingStep =
   | "custom_embedding_url"
   | "propose_second"
   | "wait_or_jump"
+  /** Last step: bring data over from other agents found on this machine. */
+  | "import_pick"
+  /** Per-agent domain toggles for the picked agents. */
+  | "import_options"
+  /** The dry-run result, awaiting a confirm before anything is written. */
+  | "import_preview"
+  /** The executed import's report; any key hands over to the agent. */
+  | "import_done"
   | "finished";
 
 /**
@@ -78,6 +91,12 @@ export interface OnboardingUiState {
   hfReference: string;
   /** The repo those choices came from; `null` before anything resolves. */
   hfRepo: OnboardingHuggingFaceRepo | null;
+  /** Detected agents on the import pick screen; empty until offered. */
+  importAgents: OnboardingImportAgentRow[];
+  /** Domain toggles for the picked agents; empty until that screen opens. */
+  importOptions: OnboardingImportOptionRow[];
+  /** The last dry-run or executed report the import screens render. */
+  importReport: ImportReport | null;
 }
 
 /**
@@ -152,6 +171,9 @@ export function createOnboardingState(chatUrl: string): OnboardingUiState {
     error: null,
     hfReference: "",
     hfRepo: null,
+    importAgents: [],
+    importOptions: [],
+    importReport: null,
   };
 }
 

--- a/src/tui/onboarding/onboarding-step-keys.ts
+++ b/src/tui/onboarding/onboarding-step-keys.ts
@@ -19,6 +19,7 @@ import {
 } from "./local-model-picks.js";
 import { handleHfPickKey } from "./onboarding-hf-keys.js";
 import { handleOnboardingKey } from "./onboarding-key-bindings.js";
+import { buildImportOptionRows } from "./import-step.js";
 import type { OnboardingUiState } from "./onboarding-state.js";
 
 /**
@@ -77,6 +78,14 @@ export function handleOnboardingStepKey(
       return handleWaitOrJumpKey(input, key, ctx, onboarding);
     case "propose_second":
       return handleProposeKey(input, key, ctx, onboarding);
+    case "import_pick":
+      return handleImportPickKey(input, key, ctx, onboarding);
+    case "import_options":
+      return handleImportOptionsKey(input, key, ctx, onboarding);
+    case "import_preview":
+      return handleImportPreviewKey(input, key, ctx, onboarding);
+    case "import_done":
+      return handleImportDoneKey(input, key, ctx, onboarding);
     case "cloud":
       return handleCloudKey(input, key, ctx);
     default:
@@ -290,6 +299,149 @@ function handleProposeKey(
     return true;
   }
   return false;
+}
+
+/** Hand over to the agent with whatever outcome the flow already earned. */
+function finishImport(ctx: OnboardingKeyContext, onboarding: OnboardingUiState): void {
+  ctx.dispatch({
+    type: "onboarding_finished",
+    outcome: onboarding.outcome ?? "skipped",
+  });
+}
+
+function moveImportCursor(
+  input: string,
+  key: Key,
+  ctx: OnboardingKeyContext,
+  length: number,
+): boolean {
+  if (key.upArrow || key.downArrow || input === "j" || input === "k") {
+    ctx.dispatch({
+      type: "onboarding_cursor_moved",
+      delta: key.upArrow || input === "k" ? -1 : 1,
+      length,
+    });
+    return true;
+  }
+  return false;
+}
+
+function handleImportPickKey(
+  input: string,
+  key: Key,
+  ctx: OnboardingKeyContext,
+  onboarding: OnboardingUiState,
+): boolean {
+  if (onboarding.busy) return true;
+  if (key.escape) {
+    finishImport(ctx, onboarding);
+    return true;
+  }
+  const rows = onboarding.importAgents;
+  if (moveImportCursor(input, key, ctx, rows.length)) return true;
+  if (input === " " && !key.ctrl) {
+    ctx.dispatch({
+      type: "onboarding_import_agent_toggled",
+      index: onboarding.cursor % Math.max(1, rows.length),
+    });
+    return true;
+  }
+  if (key.return) {
+    const picked = rows.filter((row) => row.enabled);
+    if (picked.length === 0) {
+      // Everything unticked and Enter is the same answer Esc gives.
+      finishImport(ctx, onboarding);
+      return true;
+    }
+    ctx.dispatch({
+      type: "onboarding_import_options_opened",
+      options: buildImportOptionRows(rows),
+    });
+    return true;
+  }
+  return false;
+}
+
+function handleImportOptionsKey(
+  input: string,
+  key: Key,
+  ctx: OnboardingKeyContext,
+  onboarding: OnboardingUiState,
+): boolean {
+  if (onboarding.busy) return true;
+  if (key.escape) {
+    ctx.dispatch({ type: "onboarding_step_set", step: "import_pick" });
+    return true;
+  }
+  const rows = onboarding.importOptions;
+  if (moveImportCursor(input, key, ctx, rows.length)) return true;
+  if (input === " " && !key.ctrl) {
+    ctx.dispatch({
+      type: "onboarding_import_option_toggled",
+      index: onboarding.cursor % Math.max(1, rows.length),
+    });
+    return true;
+  }
+  if (key.return) {
+    if (!rows.some((row) => row.enabled)) {
+      finishImport(ctx, onboarding);
+      return true;
+    }
+    ctx.dispatch({ type: "onboarding_import_run_started" });
+    ctx.callbacks.onOnboardingImportRequested?.(
+      { agents: onboarding.importAgents, options: rows },
+      false,
+    );
+    return true;
+  }
+  return false;
+}
+
+function handleImportPreviewKey(
+  input: string,
+  key: Key,
+  ctx: OnboardingKeyContext,
+  onboarding: OnboardingUiState,
+): boolean {
+  void input;
+  if (onboarding.busy) return true;
+  if (key.escape) {
+    // Back to the toggles, not out of the flow: a preview that showed
+    // too much (or too little) is an invitation to adjust, and the
+    // skip exit is one more Esc away from there.
+    ctx.dispatch({ type: "onboarding_step_set", step: "import_options" });
+    return true;
+  }
+  if (key.return) {
+    const report = onboarding.importReport;
+    const actionable =
+      report !== null &&
+      report.summary.migrated + report.summary.conflict > 0;
+    if (!actionable) {
+      finishImport(ctx, onboarding);
+      return true;
+    }
+    ctx.dispatch({ type: "onboarding_import_run_started" });
+    ctx.callbacks.onOnboardingImportRequested?.(
+      { agents: onboarding.importAgents, options: onboarding.importOptions },
+      true,
+    );
+    return true;
+  }
+  return false;
+}
+
+function handleImportDoneKey(
+  input: string,
+  key: Key,
+  ctx: OnboardingKeyContext,
+  onboarding: OnboardingUiState,
+): boolean {
+  void input;
+  if (key.ctrl) return false;
+  // The report was read (or not); any key hands over to the agent.
+  finishImport(ctx, onboarding);
+  return true;
 }
 
 // The cloud step *is* the providers wizard — same keys, same

--- a/src/tui/persist-onboarding-state.test.ts
+++ b/src/tui/persist-onboarding-state.test.ts
@@ -46,6 +46,7 @@ describe("persistOnboardingState", () => {
       skippedAt: null,
       proposedSecondBackendAt: null,
       localSetupSeenAt: null,
+      importOfferedAt: null,
     });
   });
 

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -493,6 +493,16 @@ export interface TuiAppCallbacks {
    * funnel so a drop-off can be attributed to a screen.
    */
   onOnboardingStep?(step: string, outcome?: string): void;
+  /**
+   * The first-run import step asked for a run. `execute: false` is the
+   * dry-run behind the preview screen, `true` the confirmed write. The
+   * answer comes back on the bus as `onboarding_import_report` /
+   * `onboarding_import_failed`.
+   */
+  onOnboardingImportRequested?(
+    plan: import("./onboarding/import-step.js").OnboardingImportPlan,
+    execute: boolean,
+  ): void;
   /** Providers tab: remove a provider by id from config + registry. */
   onProvidersRemove?(id: string): void;
   /** Slash-command surface: enable a skill explicitly (`/skill enable <name>`). */

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -573,6 +573,8 @@ export async function tuiCommand(args: string[]): Promise<number> {
           void orchestrator.providers.removeProviderById(id),
         onImportPreview: (form) => orchestrator.import.preview(form),
         onImportExecute: (form) => orchestrator.import.execute(form),
+        onOnboardingImportRequested: (plan, execute) =>
+          void orchestrator.import.runOnboarding(plan, execute),
         onMcpDetailRequested: (serverName) =>
           orchestrator.mcp.openDetail(serverName),
         onMcpAddServerSubmit: (json) => orchestrator.mcp.addServerFromJson(json),


### PR DESCRIPTION
## What

The first run now ends with a **"bring your data over"** step. When setup finishes and a known agent's state dir exists on the machine, the flow offers to import from **Hermes, OpenClaw, Claude Code, and Codex** — pick the agents, toggle what to bring, read a dry-run preview, confirm. Esc skips at any point, the offer is made once ever, and an operator who esc-skipped the whole setup (or took the download screen's "skip to the agent" exit) is not pitched on the way out.

The same importers are also exposed on the CLI: `atomic-agent import claude-code` and `atomic-agent import codex`, with the same flag surface as the existing `hermes` / `openclaw` subcommands.

## What each source brings

| Source | Domains |
|---|---|
| Hermes | sessions, cron, keys (opt-in) — existing importer |
| OpenClaw | sessions, cron — existing importer |
| **Claude Code** (`~/.claude`) | skills (`skills/*/SKILL.md` → global skills dir — same manifest family, a validated directory copy), memory (auto-memory notes + `CLAUDE.md` → `memory.sqlite`), MCP servers (`~/.claude.json` `mcpServers` → `config.mcp.servers` through the canonical validator), sessions (`projects/*/*.jsonl` → `sessions.sqlite`), `ANTHROPIC_API_KEY` (opt-in) |
| **Codex** (`~/.codex`) | skills, instructions (`AGENTS.md` → memory), sessions (rollout JSONL → `sessions.sqlite`), `OPENAI_API_KEY` from `auth.json` (opt-in; a ChatGPT-token login carries no key and honestly reads as nothing to migrate) |

## Invariants kept (and one new one)

- **Keys never migrate silently.** `secrets` never enters a preset or a default toggle — the CLI gate is `--migrate-secrets`, the TUI gate is an off-by-default checkbox that says what it is.
- **Preview before write.** The onboarding step always runs a dry-run first; the executed report is what the operator confirmed.
- **Idempotent re-runs.** Unchanged destinations skip, differing ones flag a conflict (`--overwrite` to force); onboarding never overwrites at all. MCP name collisions always skip — the existing entry may carry the operator's own edits.
- **Nothing is removed from the source**, ever.
- New: a memory note longer than the store's 4k cap is **split on line boundaries into several notes** instead of erroring — losing the biggest notes would invert what an import is for. Deterministic, so re-runs dedup against the same chunks.

## How it's built

- `src/import/claude-code/` and `src/import/codex/` follow the Hermes/OpenClaw shape exactly: a source class is the only file touching the physical layout, pure mappers project onto `ConversationTurn`s, an options module gates selection, the importer reconciles and reports through the shared `ImportReport` layer. Plus `detect-import-agents.ts` (shallow existence probes, `*_STATE_DIR` env overrides respected).
- The onboarding step is four screens on the existing step machine (`import_pick` → `import_options` → `import_preview` → `import_done`), raised by the lifecycle's settle effect **after** the second-backend offer resolves, stamped once in `tui.onboarding.importOfferedAt` (config **v49**, additive). Keys, reducer cases, chrome, measure functions and mouse rows all follow the established per-step pattern.
- The runs go through `ImportOrchestrator.runOnboarding` (one merged report, item kinds prefixed with the agent's name), reusing the runtime's open stores. Session import in onboarding caps at the **100 newest** transcripts so a 1 GB `~/.claude/projects` doesn't stall the first run; the CLI imports everything unless `--limit` says otherwise.

## Testing

- 78 new tests across 16 files (sources, mappers, options, importers, detection, note splitting, the pure step model, reducer + key tables, the lifecycle intercept).
- `tsc --noEmit` clean; full suite: 6846 passed, 1 failed — `src/sidecar/send-message-concurrency.test.ts`, which fails identically on a clean `origin/main` checkout on this machine (pre-existing, unrelated).
- Real-world smoke test on a machine with a live `~/.claude`: dry-run and executed import into a throwaway state dir — 2 skills, 66 memory notes (12 auto-split), 3 MCP servers, sessions all land with `error=0`; second run skips everything ("Nothing to import"). Codex with an empty state dir reports every domain skipped with a reason.
