### PR TITLE
fix(onboarding): never skip the bring-your-data step; one-screen tick list

### DIFF
--- a/src/tui/components/onboarding-import-step.tsx
+++ b/src/tui/components/onboarding-import-step.tsx
@@ -2,29 +2,33 @@ import { Box, Text } from "ink";
 import type { ReactElement } from "react";
 import type { ImportReport } from "../../import/index.js";
 import { MouseListRow } from "../mouse/mouse-list-row.js";
-import { plainKey } from "../mouse/synthetic-key.js";
+import { plainKey, returnKey } from "../mouse/synthetic-key.js";
 import { widestLine } from "../onboarding/centre-onboarding-block.js";
 import {
+  buildImportPickRows,
+  importActionLabel,
+  IMPORT_SKIP_LABEL,
   summarizeImportReport,
   type OnboardingImportAgentRow,
-  type OnboardingImportOptionRow,
 } from "../onboarding/import-step.js";
 import { handleOnboardingStepKey } from "../onboarding/onboarding-step-keys.js";
 import { ROW_INDENT, rowPrefix } from "../onboarding/onboarding-rows.js";
 import { theme } from "../theme/theme.js";
 
 /**
- * The first-run import screens: pick the agents found on this machine,
- * toggle what to bring over, read the dry-run, read the result. All
- * three are pure renders of `OnboardingUiState`; the keys live in
+ * The first-run import screens: tick the agents found on this machine
+ * (or take the skip row), read the dry-run, read the result. All pure
+ * renders of `OnboardingUiState`; the keys live in
  * `onboarding-step-keys.ts` and the runs in the import orchestrator.
  */
 
 const PICK_EXPLAINER: readonly string[] = [
   "Other agents keep skills, memory, sessions and keys on this machine.",
-  "Pick which ones to bring into atomic-agent — nothing is written before",
+  "Tick which ones to bring into atomic-agent — nothing is written before",
   "you see a preview, and nothing is ever removed from the source.",
 ];
+
+const SKIP_DETAIL = "Go straight to your agent — /import works any time later.";
 
 const CHECKBOX_ON = "[x] ";
 const CHECKBOX_OFF = "[ ] ";
@@ -77,6 +81,48 @@ function pressSpace(): NonNullable<Parameters<typeof MouseListRow>[0]["onActivat
   };
 }
 
+/** The action rows' click: the Enter the key table already routes. */
+function pressReturn(): NonNullable<Parameters<typeof MouseListRow>[0]["onActivate"]> {
+  return (mouse) => {
+    handleOnboardingStepKey("", returnKey(), {
+      state: mouse.getState(),
+      dispatch: mouse.dispatch,
+      callbacks: mouse.callbacks,
+    });
+  };
+}
+
+/** A plain action row: label, optional detail, Enter on click. */
+function ActionRow(props: {
+  selected: boolean;
+  index: number;
+  label: string;
+  detail: string | null;
+  bold?: boolean;
+}): ReactElement {
+  return (
+    <MouseListRow
+      selected={props.selected}
+      onSelect={(mouse) =>
+        mouse.dispatch({ type: "onboarding_cursor_set", cursor: props.index })
+      }
+      onActivate={pressReturn()}
+    >
+      <Box flexDirection="column" marginBottom={1}>
+        <Text
+          color={props.selected ? theme.colors.accent : undefined}
+          bold={props.selected || props.bold}
+        >
+          {`${rowPrefix(props.selected)}${props.label}`}
+        </Text>
+        {props.detail !== null ? (
+          <Text color={theme.colors.muted}>{`${ROW_INDENT}${props.detail}`}</Text>
+        ) : null}
+      </Box>
+    </MouseListRow>
+  );
+}
+
 export function measureOnboardingImportPickStep(
   agents: readonly OnboardingImportAgentRow[],
 ): number {
@@ -86,14 +132,20 @@ export function measureOnboardingImportPickStep(
       `${ROW_INDENT}${CHECKBOX_ON}${row.label}`,
       `${ROW_INDENT}    ${row.dir}`,
     ]),
+    `${ROW_INDENT}${IMPORT_SKIP_LABEL}`,
+    `${ROW_INDENT}${SKIP_DETAIL}`,
+    `${ROW_INDENT}${importActionLabel(agents.length)}`,
   ]);
 }
 
 export function OnboardingImportPickStep(props: {
   agents: readonly OnboardingImportAgentRow[];
   cursor: number;
+  busy: boolean;
+  error: string | null;
 }): ReactElement {
-  const count = Math.max(1, props.agents.length);
+  const rows = buildImportPickRows(props.agents);
+  const selected = props.cursor % rows.length;
   return (
     <Box flexDirection="column" flexShrink={0}>
       <Box flexDirection="column" marginBottom={1}>
@@ -103,52 +155,28 @@ export function OnboardingImportPickStep(props: {
           </Text>
         ))}
       </Box>
-      {props.agents.map((row, index) => (
-        <ToggleRow
-          key={row.id}
-          selected={props.cursor % count === index}
-          enabled={row.enabled}
-          index={index}
-          label={row.label}
-          detail={row.dir}
-          onToggle={pressSpace()}
-        />
-      ))}
-    </Box>
-  );
-}
-
-export function measureOnboardingImportOptionsStep(
-  options: readonly OnboardingImportOptionRow[],
-): number {
-  return widestLine(
-    options.flatMap((row) => [
-      `${ROW_INDENT}${CHECKBOX_ON}${row.agentLabel} · ${row.label}`,
-      `${ROW_INDENT}    ${row.description}`,
-    ]),
-  );
-}
-
-export function OnboardingImportOptionsStep(props: {
-  options: readonly OnboardingImportOptionRow[];
-  cursor: number;
-  busy: boolean;
-  error: string | null;
-}): ReactElement {
-  const count = Math.max(1, props.options.length);
-  return (
-    <Box flexDirection="column" flexShrink={0}>
-      {props.options.map((row, index) => (
-        <ToggleRow
-          key={`${row.agent}:${row.option}`}
-          selected={props.cursor % count === index}
-          enabled={row.enabled}
-          index={index}
-          label={`${row.agentLabel} · ${row.label}`}
-          detail={row.description}
-          onToggle={pressSpace()}
-        />
-      ))}
+      {rows.map((row, index) =>
+        row.kind === "agent" ? (
+          <ToggleRow
+            key={row.agent.id}
+            selected={selected === index}
+            enabled={row.agent.enabled}
+            index={index}
+            label={row.agent.label}
+            detail={row.agent.dir}
+            onToggle={pressSpace()}
+          />
+        ) : (
+          <ActionRow
+            key={row.kind}
+            selected={selected === index}
+            index={index}
+            label={row.kind === "skip" ? IMPORT_SKIP_LABEL : importActionLabel(row.picked)}
+            detail={row.kind === "skip" ? SKIP_DETAIL : null}
+            bold={row.kind === "import"}
+          />
+        ),
+      )}
       {props.busy ? (
         <Text color={theme.colors.muted}>scanning the sources…</Text>
       ) : null}

--- a/src/tui/components/onboarding-screen.test.tsx
+++ b/src/tui/components/onboarding-screen.test.tsx
@@ -466,8 +466,13 @@ describe("OnboardingScreen", () => {
      * outcome local, no cloud provider on disk (fresh state dir), so
      * `decideSecondBackendOffer` WOULD pitch cloud — the flag is the
      * only thing standing between the operator and a second pitch.
+     * The import scan is injected so the machine the suite runs on
+     * cannot decide whether the import step appears.
      */
-    function renderFinished(skipSecondOffer: boolean) {
+    function renderFinished(
+      skipSecondOffer: boolean,
+      detected: Array<{ id: "hermes"; label: string; dir: string }> = [],
+    ) {
       const actions: TuiAction[] = [];
       const onboarding = {
         ...createOnboardingState("http://127.0.0.1:8080"),
@@ -483,6 +488,7 @@ describe("OnboardingScreen", () => {
           onboarding={onboarding}
           dispatch={(action) => actions.push(action)}
           callbacks={{}}
+          detectImportAgents={() => detected}
         />,
       );
       return { view, actions };
@@ -501,6 +507,19 @@ describe("OnboardingScreen", () => {
       // propose screen was never shown, so its stamp stays unset.
       expect(getConfig().tui.onboarding.proposedSecondBackendAt).toBeNull();
       expect(getConfig().tui.onboarding.skippedAt).toBeNull();
+    });
+
+    it("still raises the import step — the skip flag only bypasses the pitch", async () => {
+      const { actions } = renderFinished(true, [
+        { id: "hermes", label: "Hermes", dir: "/tmp/h" },
+      ]);
+      await untilStamped(() => getConfig().tui.onboarding.importOfferedAt !== null);
+      expect(actions.map((a) => a.type)).toContain("onboarding_import_opened");
+      expect(
+        actions.every((action) => action.type !== "onboarding_second_backend_offered"),
+      ).toBe(true);
+      // Import intercepted the close-out, so the flow is not retired yet.
+      expect(getConfig().tui.onboarding.completedAt).toBeNull();
     });
 
     it("a plain local finish still gets the cloud pitch", async () => {

--- a/src/tui/components/onboarding-screen.tsx
+++ b/src/tui/components/onboarding-screen.tsx
@@ -88,6 +88,12 @@ export function OnboardingScreen(props: {
    * 1.5s window has disarmed it, which reads as "Ctrl+C is broken".
    */
   ctrlCArmed?: boolean;
+  /**
+   * Injectable import-source scan for tests — without it the closing
+   * flow reads the real home dir, and whether the import step appears
+   * depends on the machine the suite runs on.
+   */
+  detectImportAgents?(): import("../../import/index.js").DetectedImportAgent[];
 }): ReactElement {
   const { onboarding, dispatch, callbacks } = props;
   const size = useTerminalSize();
@@ -154,6 +160,9 @@ export function OnboardingScreen(props: {
     ...(callbacks.onOnboardingStep === undefined
       ? {}
       : { onStep: callbacks.onOnboardingStep }),
+    ...(props.detectImportAgents === undefined
+      ? {}
+      : { detectAgents: props.detectImportAgents }),
   });
 
   // Both axes are centred on the block as a whole, never line by line:

--- a/src/tui/components/onboarding-step-body.tsx
+++ b/src/tui/components/onboarding-step-body.tsx
@@ -11,7 +11,6 @@ import { OnboardingChooseStep } from "./onboarding-choose-step.js";
 import { OnboardingDownloadStep } from "./onboarding-download-step.js";
 import { OnboardingHuggingFaceFlow } from "./onboarding-hf-flow.js";
 import {
-  OnboardingImportOptionsStep,
   OnboardingImportPickStep,
   OnboardingImportReportStep,
 } from "./onboarding-import-step.js";
@@ -104,12 +103,6 @@ export function OnboardingStepBody(props: {
         {onboarding.step === "import_pick" ? (
           <OnboardingImportPickStep
             agents={onboarding.importAgents}
-            cursor={onboarding.cursor}
-          />
-        ) : null}
-        {onboarding.step === "import_options" ? (
-          <OnboardingImportOptionsStep
-            options={onboarding.importOptions}
             cursor={onboarding.cursor}
             busy={onboarding.busy}
             error={onboarding.error}

--- a/src/tui/components/onboarding-surface-layout.ts
+++ b/src/tui/components/onboarding-surface-layout.ts
@@ -28,7 +28,6 @@ import { measureOnboardingDownloadStep } from "./onboarding-download-step.js";
 import { measureOnboardingHeader } from "./onboarding-header.js";
 import { measureOnboardingHfPickStep } from "./onboarding-hf-pick-step.js";
 import {
-  measureOnboardingImportOptionsStep,
   measureOnboardingImportPickStep,
   measureOnboardingImportReportStep,
 } from "./onboarding-import-step.js";
@@ -148,11 +147,6 @@ function measureStepBody(input: MeasureInput): number {
       return Math.min(
         input.available,
         measureOnboardingImportPickStep(input.importAgents ?? []),
-      );
-    case "import_options":
-      return Math.min(
-        input.available,
-        measureOnboardingImportOptionsStep(input.importOptions ?? []),
       );
     case "import_preview":
       return Math.min(

--- a/src/tui/hooks/use-onboarding-lifecycle-import.test.tsx
+++ b/src/tui/hooks/use-onboarding-lifecycle-import.test.tsx
@@ -79,7 +79,7 @@ describe("useOnboardingLifecycle import offer", () => {
     expect(actions).toEqual([
       {
         type: "onboarding_import_opened",
-        agents: [{ id: "hermes", label: "Hermes", dir: "/tmp/h", enabled: true }],
+        agents: [{ id: "hermes", label: "Hermes", dir: "/tmp/h", enabled: false }],
       },
     ]);
     // Offered once, stamped now; the flow itself is not yet retired.
@@ -113,18 +113,18 @@ describe("useOnboardingLifecycle import offer", () => {
     expect(getConfig().tui.onboarding.importOfferedAt).toBeNull();
   });
 
-  it("never pitches an operator who skipped setup", () => {
+  it("is raised even for an operator who esc-skipped setup", () => {
     const detect = vi.fn(() => ONE_AGENT);
     const actions: TuiAction[] = [];
     render(
       <Harness outcome="skipped" detectAgents={detect} dispatch={(a) => actions.push(a)} />,
     );
-    expect(detect).not.toHaveBeenCalled();
-    expect(actions).toContainEqual({ type: "onboarding_set", onboarding: null });
-    expect(getConfig().tui.onboarding.skippedAt).not.toBeNull();
+    expect(detect).toHaveBeenCalled();
+    expect(actions.map((a) => a.type)).toContain("onboarding_import_opened");
+    expect(getConfig().tui.onboarding.importOfferedAt).not.toBeNull();
   });
 
-  it("honours the download skip's straight-to-the-agent promise", () => {
+  it("is raised even through the download skip's straight-to-the-agent exit", () => {
     const detect = vi.fn(() => ONE_AGENT);
     const actions: TuiAction[] = [];
     render(
@@ -135,8 +135,8 @@ describe("useOnboardingLifecycle import offer", () => {
         dispatch={(a) => actions.push(a)}
       />,
     );
-    expect(detect).not.toHaveBeenCalled();
-    expect(actions).toContainEqual({ type: "onboarding_set", onboarding: null });
-    expect(getConfig().tui.onboarding.importOfferedAt).toBeNull();
+    expect(detect).toHaveBeenCalled();
+    expect(actions.map((a) => a.type)).toContain("onboarding_import_opened");
+    expect(getConfig().tui.onboarding.importOfferedAt).not.toBeNull();
   });
 });

--- a/src/tui/hooks/use-onboarding-lifecycle.ts
+++ b/src/tui/hooks/use-onboarding-lifecycle.ts
@@ -113,13 +113,12 @@ export function useOnboardingLifecycle(input: {
     // The import step is the flow's actual last screen: it runs after
     // the second-backend offer settles (in either direction), and only
     // when a known agent's state dir exists on this machine. Same
-    // once-only contract as the offer above — stamped when shown. The
-    // download screen's skip exit bypasses this screen too: "skip to
-    // the agent" is a promise, and `/import` keeps working later.
+    // once-only contract as the offer above — stamped when shown. No
+    // path routes around it — not the download screen's skip exit, not
+    // an esc-skipped setup: every first run passes this screen once,
+    // and the screen's own skip row is the only way past it.
     if (
-      !onboarding.skipSecondOffer &&
       shouldOfferImport({
-        outcome,
         alreadyOffered: config.tui.onboarding.importOfferedAt !== null,
       })
     ) {

--- a/src/tui/onboarding/import-step.test.ts
+++ b/src/tui/onboarding/import-step.test.ts
@@ -4,17 +4,45 @@ import { buildReport, type ImportItemResult } from "../../import/index.js";
 import {
   buildImportAgentRows,
   buildImportOptionRows,
+  buildImportPickRows,
+  importActionLabel,
   shouldOfferImport,
   summarizeImportReport,
 } from "./import-step.js";
 
 describe("shouldOfferImport", () => {
-  it("offers once, and never to an operator who skipped setup", () => {
-    expect(shouldOfferImport({ outcome: "local", alreadyOffered: false })).toBe(true);
-    expect(shouldOfferImport({ outcome: "cloud", alreadyOffered: false })).toBe(true);
-    expect(shouldOfferImport({ outcome: "custom", alreadyOffered: false })).toBe(true);
-    expect(shouldOfferImport({ outcome: "skipped", alreadyOffered: false })).toBe(false);
-    expect(shouldOfferImport({ outcome: "local", alreadyOffered: true })).toBe(false);
+  it("offers exactly once — the stamp is the only gate", () => {
+    expect(shouldOfferImport({ alreadyOffered: false })).toBe(true);
+    expect(shouldOfferImport({ alreadyOffered: true })).toBe(false);
+  });
+});
+
+describe("buildImportPickRows", () => {
+  const detected = [
+    { id: "hermes" as const, label: "Hermes", dir: "/h" },
+    { id: "claude-code" as const, label: "Claude Code", dir: "/c" },
+  ];
+
+  it("starts every agent unticked, with the skip row last and no import row", () => {
+    const agents = buildImportAgentRows(detected);
+    expect(agents.every((a) => !a.enabled)).toBe(true);
+    const rows = buildImportPickRows(agents);
+    expect(rows.map((r) => r.kind)).toEqual(["agent", "agent", "skip"]);
+  });
+
+  it("grows the import row once something is ticked", () => {
+    const agents = buildImportAgentRows(detected).map((row, index) =>
+      index === 0 ? { ...row, enabled: true } : row,
+    );
+    const rows = buildImportPickRows(agents);
+    expect(rows.map((r) => r.kind)).toEqual(["agent", "agent", "skip", "import"]);
+    const last = rows[rows.length - 1];
+    expect(last?.kind === "import" && last.picked).toBe(1);
+  });
+
+  it("labels the import row with the ticked count", () => {
+    expect(importActionLabel(1)).toBe("Import from 1 agent");
+    expect(importActionLabel(3)).toBe("Import from 3 agents");
   });
 });
 
@@ -23,8 +51,7 @@ describe("buildImportOptionRows", () => {
     const agents = buildImportAgentRows([
       { id: "hermes", label: "Hermes", dir: "/h" },
       { id: "claude-code", label: "Claude Code", dir: "/c" },
-    ]);
-    expect(agents.every((a) => a.enabled)).toBe(true);
+    ]).map((row) => ({ ...row, enabled: true }));
 
     const rows = buildImportOptionRows(agents);
     expect(rows.map((r) => `${r.agent}:${r.option}`)).toEqual([
@@ -47,8 +74,9 @@ describe("buildImportOptionRows", () => {
     const agents = buildImportAgentRows([
       { id: "hermes", label: "Hermes", dir: "/h" },
       { id: "codex", label: "Codex", dir: "/x" },
-    ]).map((row) => (row.id === "hermes" ? { ...row, enabled: false } : row));
+    ]).map((row) => (row.id === "codex" ? { ...row, enabled: true } : row));
     const rows = buildImportOptionRows(agents);
+    expect(rows.length).toBeGreaterThan(0);
     expect(rows.every((r) => r.agent === "codex")).toBe(true);
   });
 });

--- a/src/tui/onboarding/import-step.test.ts
+++ b/src/tui/onboarding/import-step.test.ts
@@ -30,14 +30,14 @@ describe("buildImportPickRows", () => {
     expect(rows.map((r) => r.kind)).toEqual(["agent", "agent", "skip"]);
   });
 
-  it("grows the import row once something is ticked", () => {
+  it("grows the import row above skip once something is ticked", () => {
     const agents = buildImportAgentRows(detected).map((row, index) =>
       index === 0 ? { ...row, enabled: true } : row,
     );
     const rows = buildImportPickRows(agents);
-    expect(rows.map((r) => r.kind)).toEqual(["agent", "agent", "skip", "import"]);
-    const last = rows[rows.length - 1];
-    expect(last?.kind === "import" && last.picked).toBe(1);
+    expect(rows.map((r) => r.kind)).toEqual(["agent", "agent", "import", "skip"]);
+    const action = rows[2];
+    expect(action?.kind === "import" && action.picked).toBe(1);
   });
 
   it("labels the import row with the ticked count", () => {

--- a/src/tui/onboarding/import-step.ts
+++ b/src/tui/onboarding/import-step.ts
@@ -92,10 +92,11 @@ export type OnboardingImportPickRow =
 
 /**
  * The pick screen's full row list: every detected agent as a tickbox,
- * then the skip row — always there, so leaving is never more than a
- * cursor-down away — and, once at least one agent is ticked, the import
- * action. One derivation shared by the render, the measure and the key
- * handler, so the three cannot disagree about what a cursor index means.
+ * then — once at least one agent is ticked — the import action, and the
+ * skip row always last, so leaving is never more than a cursor-down
+ * away. The primary action sits above the escape hatch. One derivation
+ * shared by the render, the measure and the key handler, so the three
+ * cannot disagree about what a cursor index means.
  */
 export function buildImportPickRows(
   agents: readonly OnboardingImportAgentRow[],
@@ -105,9 +106,9 @@ export function buildImportPickRows(
     index,
     agent,
   }));
-  rows.push({ kind: "skip" });
   const picked = agents.filter((agent) => agent.enabled).length;
   if (picked > 0) rows.push({ kind: "import", picked });
+  rows.push({ kind: "skip" });
   return rows;
 }
 

--- a/src/tui/onboarding/import-step.ts
+++ b/src/tui/onboarding/import-step.ts
@@ -7,7 +7,6 @@ import {
   type ImportAgentId,
   type ImportReport,
 } from "../../import/index.js";
-import type { OnboardingOutcome } from "./onboarding-state.js";
 
 /**
  * The pure model behind the first-run import screens: which agents were
@@ -46,24 +45,26 @@ export interface OnboardingImportPlan {
 }
 
 export interface ImportOfferInputs {
-  /** How the flow finished. */
-  outcome: OnboardingOutcome;
   /** `tui.onboarding.importOfferedAt` — the offer was already made. */
   alreadyOffered: boolean;
 }
 
 /**
- * Whether the closing flow should raise the import step at all. Made
- * once, recorded in config when shown; an operator who esc-skipped the
- * whole setup asked to be left alone and is not pitched a migration on
- * the way out either.
+ * Whether the closing flow should raise the import step. Once per
+ * machine, recorded in config when shown — and that stamp is the ONLY
+ * gate: no outcome, shortcut or skip flag may route around this screen.
+ * The screen carries its own always-present skip row, so declining costs
+ * one keypress there instead.
  */
 export function shouldOfferImport(inputs: ImportOfferInputs): boolean {
-  if (inputs.alreadyOffered) return false;
-  return inputs.outcome !== "skipped";
+  return !inputs.alreadyOffered;
 }
 
-/** Detected agents as pick rows, all enabled — the preview is the gate. */
+/**
+ * Detected agents as pick rows, all unticked — importing someone's data
+ * is opt-in per agent, and the import row only appears once something
+ * is ticked.
+ */
 export function buildImportAgentRows(
   detected: readonly DetectedImportAgent[],
 ): OnboardingImportAgentRow[] {
@@ -71,8 +72,43 @@ export function buildImportAgentRows(
     id: agent.id,
     label: agent.label,
     dir: agent.dir,
-    enabled: true,
+    enabled: false,
   }));
+}
+
+/** The always-present last list row: straight to the agent, no import. */
+export const IMPORT_SKIP_LABEL = "Skip adding data from other agents";
+
+/** The action row's label, sized to what is ticked. */
+export function importActionLabel(picked: number): string {
+  return picked === 1 ? "Import from 1 agent" : `Import from ${picked} agents`;
+}
+
+/** One navigable row on the redesigned pick screen. */
+export type OnboardingImportPickRow =
+  | { kind: "agent"; index: number; agent: OnboardingImportAgentRow }
+  | { kind: "skip" }
+  | { kind: "import"; picked: number };
+
+/**
+ * The pick screen's full row list: every detected agent as a tickbox,
+ * then the skip row — always there, so leaving is never more than a
+ * cursor-down away — and, once at least one agent is ticked, the import
+ * action. One derivation shared by the render, the measure and the key
+ * handler, so the three cannot disagree about what a cursor index means.
+ */
+export function buildImportPickRows(
+  agents: readonly OnboardingImportAgentRow[],
+): OnboardingImportPickRow[] {
+  const rows: OnboardingImportPickRow[] = agents.map((agent, index) => ({
+    kind: "agent",
+    index,
+    agent,
+  }));
+  rows.push({ kind: "skip" });
+  const picked = agents.filter((agent) => agent.enabled).length;
+  if (picked > 0) rows.push({ kind: "import", picked });
+  return rows;
 }
 
 /**

--- a/src/tui/onboarding/onboarding-actions.ts
+++ b/src/tui/onboarding/onboarding-actions.ts
@@ -45,15 +45,12 @@ export type OnboardingAction =
   /** Space on an agent row of the pick screen. */
   | { type: "onboarding_import_agent_toggled"; index: number }
   /**
-   * Enter on the pick screen: move to the domain toggles. Carries the
-   * rows built from the picked agents, for the same one-commit reason
-   * the HF resolve carries its repo.
+   * A preview or execute run left for the importers; keys freeze. The
+   * pick screen's import row sends the default option rows it built for
+   * the ticked agents (everything but secrets); the preview's confirm
+   * re-runs whatever is already stored and sends none.
    */
-  | { type: "onboarding_import_options_opened"; options: OnboardingImportOptionRow[] }
-  /** Space on a domain row of the options screen. */
-  | { type: "onboarding_import_option_toggled"; index: number }
-  /** A preview or execute run left for the importers; keys freeze. */
-  | { type: "onboarding_import_run_started" }
+  | { type: "onboarding_import_run_started"; options?: OnboardingImportOptionRow[] }
   /** The importers answered. Preview lands on `import_preview`, an executed run on `import_done`. */
   | { type: "onboarding_import_report"; report: ImportReport; executed: boolean }
   /** A run failed outright (option resolution, source access, …). */

--- a/src/tui/onboarding/onboarding-chrome.ts
+++ b/src/tui/onboarding/onboarding-chrome.ts
@@ -20,7 +20,6 @@ export const ONBOARDING_SUBTITLES: Record<OnboardingStep, string> = {
   propose_second: "one more thing",
   wait_or_jump: "almost there",
   import_pick: "bring your data · one last step",
-  import_options: "bring your data · choose what",
   import_preview: "bring your data · preview",
   import_done: "bring your data · done",
   cloud: "cloud model · step 2 of 2",
@@ -69,12 +68,10 @@ export function onboardingFooterFor(
     case "propose_second":
       return `↑/↓ move   enter select   esc skip   ${quit}`;
     case "import_pick":
-      return `↑/↓ move   space toggle   enter continue   esc skip   ${quit}`;
-    case "import_options":
-      // While a run is out with the importers, Enter would double-run.
+      // While a dry-run is out with the importers, Enter would double-run.
       return onboarding.busy
         ? `scanning…   ${quit}`
-        : `↑/↓ move   space toggle   enter preview   esc back   ${quit}`;
+        : `↑/↓ move   space tick   enter select   esc skip   ${quit}`;
     case "import_preview":
       return onboarding.busy
         ? `importing…   ${quit}`

--- a/src/tui/onboarding/onboarding-import-flow.test.ts
+++ b/src/tui/onboarding/onboarding-import-flow.test.ts
@@ -21,9 +21,9 @@ const AGENTS = [
 ];
 
 // Pick-screen row indices for the AGENTS fixture with both ticked:
-// 0-1 the agents, 2 the skip row, 3 the import row.
-const SKIP_ROW = 2;
-const IMPORT_ROW = 3;
+// 0-1 the agents, 2 the import row, 3 the skip row (always last).
+const IMPORT_ROW = 2;
+const SKIP_ROW = 3;
 
 function stateAt(
   step: OnboardingStep,
@@ -197,12 +197,12 @@ describe("import flow keys", () => {
     expect(driven.runs).toEqual([]);
   });
 
-  it("with everything unticked the import row does not exist and the list wraps past skip", () => {
+  it("with everything unticked the import row does not exist and the list wraps past it", () => {
     const unticked = AGENTS.map((a) => ({ ...a, enabled: false }));
-    // Rows are the two agents plus skip; the old import index wraps to
+    // Rows are the two agents plus skip; the old skip index wraps to
     // the first agent instead of importing nothing.
     const driven = drive(
-      stateAt("import_pick", { importAgents: unticked, cursor: IMPORT_ROW }),
+      stateAt("import_pick", { importAgents: unticked, cursor: SKIP_ROW }),
     );
     driven.handle("", returnKey());
     expect(driven.actions).toEqual([

--- a/src/tui/onboarding/onboarding-import-flow.test.ts
+++ b/src/tui/onboarding/onboarding-import-flow.test.ts
@@ -20,6 +20,11 @@ const AGENTS = [
   { id: "claude-code" as const, label: "Claude Code", dir: "/c", enabled: true },
 ];
 
+// Pick-screen row indices for the AGENTS fixture with both ticked:
+// 0-1 the agents, 2 the skip row, 3 the import row.
+const SKIP_ROW = 2;
+const IMPORT_ROW = 3;
+
 function stateAt(
   step: OnboardingStep,
   over: Partial<NonNullable<TuiState["onboarding"]>> = {},
@@ -69,7 +74,7 @@ describe("import flow reducer", () => {
     expect(state.onboarding?.cursor).toBe(0);
   });
 
-  it("toggles agent and option rows by index", () => {
+  it("toggles agent rows by index", () => {
     let state = reduceTuiState(stateAt("finished"), {
       type: "onboarding_import_opened",
       agents: AGENTS,
@@ -82,32 +87,31 @@ describe("import flow reducer", () => {
       true,
       false,
     ]);
+  });
 
-    state = reduceTuiState(state, {
-      type: "onboarding_import_options_opened",
-      options: [
-        {
-          agent: "hermes",
-          agentLabel: "Hermes",
-          option: "sessions",
-          label: "Sessions",
-          description: "d",
-          secret: false,
-          enabled: true,
-        },
-      ],
+  it("a run started from the pick screen stores the option rows it sent", () => {
+    const options = [
+      {
+        agent: "hermes" as const,
+        agentLabel: "Hermes",
+        option: "sessions",
+        label: "Sessions",
+        description: "d",
+        secret: false,
+        enabled: true,
+      },
+    ];
+    const state = reduceTuiState(stateAt("import_pick"), {
+      type: "onboarding_import_run_started",
+      options,
     });
-    expect(state.onboarding?.step).toBe("import_options");
-    state = reduceTuiState(state, {
-      type: "onboarding_import_option_toggled",
-      index: 0,
-    });
-    expect(state.onboarding?.importOptions[0]?.enabled).toBe(false);
+    expect(state.onboarding?.busy).toBe(true);
+    expect(state.onboarding?.importOptions).toEqual(options);
   });
 
   it("routes a preview report to import_preview and an executed one to import_done", () => {
     const report = buildReport([], false);
-    let state = stateAt("import_options");
+    let state = stateAt("import_pick");
     state = reduceTuiState(state, { type: "onboarding_import_run_started" });
     expect(state.onboarding?.busy).toBe(true);
     state = reduceTuiState(state, {
@@ -138,14 +142,14 @@ describe("import flow reducer", () => {
   });
 
   it("surfaces a failed run as an inline error", () => {
-    let state = stateAt("import_options", { busy: true });
+    let state = stateAt("import_pick", { busy: true });
     state = reduceTuiState(state, {
       type: "onboarding_import_failed",
       error: "boom",
     });
     expect(state.onboarding?.busy).toBe(false);
     expect(state.onboarding?.error).toBe("boom");
-    expect(state.onboarding?.step).toBe("import_options");
+    expect(state.onboarding?.step).toBe("import_pick");
   });
 });
 
@@ -158,28 +162,53 @@ describe("import flow keys", () => {
     ]);
   });
 
-  it("enter on the pick screen opens the option toggles for the picked agents", () => {
-    const driven = drive(stateAt("import_pick"));
+  it("enter on an agent row toggles it too", () => {
+    const driven = drive(stateAt("import_pick", { cursor: 0 }));
+    driven.handle("", returnKey());
+    expect(driven.actions).toEqual([
+      { type: "onboarding_import_agent_toggled", index: 0 },
+    ]);
+  });
+
+  it("enter on the import row asks the host for a dry-run with the defaults", () => {
+    const driven = drive(stateAt("import_pick", { cursor: IMPORT_ROW }));
     driven.handle("", returnKey());
     expect(driven.actions).toHaveLength(1);
     const action = driven.actions[0]!;
-    if (action.type !== "onboarding_import_options_opened") {
+    if (action.type !== "onboarding_import_run_started") {
       throw new Error(`unexpected ${action.type}`);
     }
-    expect(action.options.some((o) => o.agent === "hermes")).toBe(true);
-    expect(action.options.some((o) => o.agent === "claude-code")).toBe(true);
+    // Both ticked agents contribute, non-secret domains on, secrets off.
+    expect(action.options?.some((o) => o.agent === "hermes")).toBe(true);
+    expect(action.options?.some((o) => o.agent === "claude-code")).toBe(true);
+    expect(action.options?.every((o) => o.enabled === !o.secret)).toBe(true);
+    expect(driven.runs).toHaveLength(1);
+    expect(driven.runs[0]?.execute).toBe(false);
+    expect(driven.runs[0]?.plan.agents).toEqual(AGENTS);
+    expect(driven.runs[0]?.plan.options).toEqual(action.options);
   });
 
-  it("enter with every agent unticked finishes the flow instead", () => {
-    const driven = drive(
-      stateAt("import_pick", {
-        importAgents: AGENTS.map((a) => ({ ...a, enabled: false })),
-      }),
-    );
+  it("enter on the skip row hands over to the agent", () => {
+    const driven = drive(stateAt("import_pick", { cursor: SKIP_ROW }));
     driven.handle("", returnKey());
     expect(driven.actions).toEqual([
       { type: "onboarding_finished", outcome: "local" },
     ]);
+    expect(driven.runs).toEqual([]);
+  });
+
+  it("with everything unticked the import row does not exist and the list wraps past skip", () => {
+    const unticked = AGENTS.map((a) => ({ ...a, enabled: false }));
+    // Rows are the two agents plus skip; the old import index wraps to
+    // the first agent instead of importing nothing.
+    const driven = drive(
+      stateAt("import_pick", { importAgents: unticked, cursor: IMPORT_ROW }),
+    );
+    driven.handle("", returnKey());
+    expect(driven.actions).toEqual([
+      { type: "onboarding_import_agent_toggled", index: 0 },
+    ]);
+    expect(driven.runs).toEqual([]);
   });
 
   it("esc skips out of the pick screen with the earned outcome", () => {
@@ -190,23 +219,11 @@ describe("import flow keys", () => {
     ]);
   });
 
-  it("enter on the options screen asks the host for a dry-run", () => {
-    const options = [
-      {
-        agent: "hermes" as const,
-        agentLabel: "Hermes",
-        option: "sessions",
-        label: "Sessions",
-        description: "d",
-        secret: false,
-        enabled: true,
-      },
-    ];
-    const driven = drive(stateAt("import_options", { importOptions: options }));
-    driven.handle("", returnKey());
-    expect(driven.actions).toEqual([{ type: "onboarding_import_run_started" }]);
-    expect(driven.runs).toEqual([
-      { plan: { agents: AGENTS, options }, execute: false },
+  it("esc on the preview goes back to the ticks", () => {
+    const driven = drive(stateAt("import_preview"));
+    driven.handle("", escKey());
+    expect(driven.actions).toEqual([
+      { type: "onboarding_step_set", step: "import_pick" },
     ]);
   });
 
@@ -229,7 +246,7 @@ describe("import flow keys", () => {
   });
 
   it("keys freeze while a run is out", () => {
-    const driven = drive(stateAt("import_options", { busy: true }));
+    const driven = drive(stateAt("import_pick", { busy: true }));
     expect(driven.handle("", returnKey())).toBe(true);
     expect(driven.handle("", arrowKey("down"))).toBe(true);
     expect(driven.actions).toEqual([]);

--- a/src/tui/onboarding/onboarding-reducer.ts
+++ b/src/tui/onboarding/onboarding-reducer.ts
@@ -151,46 +151,29 @@ export function reduceOnboardingAction(
         },
       };
     }
-    case "onboarding_import_options_opened": {
-      if (!state.onboarding) return state;
-      return {
-        ...state,
-        onboarding: {
-          ...state.onboarding,
-          step: "import_options",
-          importOptions: action.options,
-          cursor: 0,
-          error: null,
-          busy: false,
-        },
-      };
-    }
-    case "onboarding_import_option_toggled": {
-      if (!state.onboarding) return state;
-      return {
-        ...state,
-        onboarding: {
-          ...state.onboarding,
-          importOptions: state.onboarding.importOptions.map((row, index) =>
-            index === action.index ? { ...row, enabled: !row.enabled } : row,
-          ),
-        },
-      };
-    }
     case "onboarding_import_run_started": {
       if (!state.onboarding) return state;
       return {
         ...state,
-        onboarding: { ...state.onboarding, busy: true, error: null },
+        onboarding: {
+          ...state.onboarding,
+          busy: true,
+          error: null,
+          // The pick screen's import row sends the defaults it built for
+          // the ticked agents; the preview's confirm sends none and
+          // re-runs what is already here.
+          importOptions: action.options ?? state.onboarding.importOptions,
+        },
       };
     }
     case "onboarding_import_report": {
       if (!state.onboarding) return state;
       // Only the import screens may receive a report: a late answer must
       // not yank a flow that moved on (or finished) back onto a result
-      // screen nobody is waiting for.
+      // screen nobody is waiting for. The dry-run is asked for from the
+      // pick screen, the write from the preview.
       const step = state.onboarding.step;
-      if (step !== "import_options" && step !== "import_preview") return state;
+      if (step !== "import_pick" && step !== "import_preview") return state;
       return {
         ...state,
         onboarding: {

--- a/src/tui/onboarding/onboarding-state.ts
+++ b/src/tui/onboarding/onboarding-state.ts
@@ -32,10 +32,8 @@ export type OnboardingStep =
   | "custom_embedding_url"
   | "propose_second"
   | "wait_or_jump"
-  /** Last step: bring data over from other agents found on this machine. */
+  /** Last step: tick the agents to bring data over from, or skip. */
   | "import_pick"
-  /** Per-agent domain toggles for the picked agents. */
-  | "import_options"
   /** The dry-run result, awaiting a confirm before anything is written. */
   | "import_preview"
   /** The executed import's report; any key hands over to the agent. */

--- a/src/tui/onboarding/onboarding-step-keys.ts
+++ b/src/tui/onboarding/onboarding-step-keys.ts
@@ -19,7 +19,7 @@ import {
 } from "./local-model-picks.js";
 import { handleHfPickKey } from "./onboarding-hf-keys.js";
 import { handleOnboardingKey } from "./onboarding-key-bindings.js";
-import { buildImportOptionRows } from "./import-step.js";
+import { buildImportOptionRows, buildImportPickRows } from "./import-step.js";
 import type { OnboardingUiState } from "./onboarding-state.js";
 
 /**
@@ -80,8 +80,6 @@ export function handleOnboardingStepKey(
       return handleProposeKey(input, key, ctx, onboarding);
     case "import_pick":
       return handleImportPickKey(input, key, ctx, onboarding);
-    case "import_options":
-      return handleImportOptionsKey(input, key, ctx, onboarding);
     case "import_preview":
       return handleImportPreviewKey(input, key, ctx, onboarding);
     case "import_done":
@@ -337,64 +335,36 @@ function handleImportPickKey(
     finishImport(ctx, onboarding);
     return true;
   }
-  const rows = onboarding.importAgents;
+  const rows = buildImportPickRows(onboarding.importAgents);
   if (moveImportCursor(input, key, ctx, rows.length)) return true;
-  if (input === " " && !key.ctrl) {
-    ctx.dispatch({
-      type: "onboarding_import_agent_toggled",
-      index: onboarding.cursor % Math.max(1, rows.length),
-    });
-    return true;
-  }
-  if (key.return) {
-    const picked = rows.filter((row) => row.enabled);
-    if (picked.length === 0) {
-      // Everything unticked and Enter is the same answer Esc gives.
+  const toggle = input === " " && !key.ctrl;
+  if (!toggle && !key.return) return false;
+  const row = rows[onboarding.cursor % rows.length];
+  if (!row) return true;
+  switch (row.kind) {
+    case "agent":
+      // Space and Enter both flip the tick — on a checkbox row there is
+      // nothing else Enter could honestly mean.
+      ctx.dispatch({ type: "onboarding_import_agent_toggled", index: row.index });
+      return true;
+    case "skip":
+      if (toggle) return true;
       finishImport(ctx, onboarding);
       return true;
-    }
-    ctx.dispatch({
-      type: "onboarding_import_options_opened",
-      options: buildImportOptionRows(rows),
-    });
-    return true;
-  }
-  return false;
-}
-
-function handleImportOptionsKey(
-  input: string,
-  key: Key,
-  ctx: OnboardingKeyContext,
-  onboarding: OnboardingUiState,
-): boolean {
-  if (onboarding.busy) return true;
-  if (key.escape) {
-    ctx.dispatch({ type: "onboarding_step_set", step: "import_pick" });
-    return true;
-  }
-  const rows = onboarding.importOptions;
-  if (moveImportCursor(input, key, ctx, rows.length)) return true;
-  if (input === " " && !key.ctrl) {
-    ctx.dispatch({
-      type: "onboarding_import_option_toggled",
-      index: onboarding.cursor % Math.max(1, rows.length),
-    });
-    return true;
-  }
-  if (key.return) {
-    if (!rows.some((row) => row.enabled)) {
-      finishImport(ctx, onboarding);
+    case "import": {
+      if (toggle) return true;
+      // Straight to the dry-run with the defaults — every non-secret
+      // domain of the ticked agents. The preview stays the gate before
+      // anything is written; the per-domain surface is `/import`'s.
+      const options = buildImportOptionRows(onboarding.importAgents);
+      ctx.dispatch({ type: "onboarding_import_run_started", options });
+      ctx.callbacks.onOnboardingImportRequested?.(
+        { agents: onboarding.importAgents, options },
+        false,
+      );
       return true;
     }
-    ctx.dispatch({ type: "onboarding_import_run_started" });
-    ctx.callbacks.onOnboardingImportRequested?.(
-      { agents: onboarding.importAgents, options: rows },
-      false,
-    );
-    return true;
   }
-  return false;
 }
 
 function handleImportPreviewKey(
@@ -406,10 +376,10 @@ function handleImportPreviewKey(
   void input;
   if (onboarding.busy) return true;
   if (key.escape) {
-    // Back to the toggles, not out of the flow: a preview that showed
+    // Back to the ticks, not out of the flow: a preview that showed
     // too much (or too little) is an invitation to adjust, and the
-    // skip exit is one more Esc away from there.
-    ctx.dispatch({ type: "onboarding_step_set", step: "import_options" });
+    // skip row is right there on that screen.
+    ctx.dispatch({ type: "onboarding_step_set", step: "import_pick" });
     return true;
   }
   if (key.return) {


### PR DESCRIPTION
Follow-up to #305, from live testing of the cloud-then-local first run.

## The bug
Configuring cloud, then accepting the "local models too" pitch and finishing the download, could hand over to the agent without ever showing the bring-your-data step: the download screen's skip exit set `skipSecondOffer`, which bypassed the import offer as well as the second-backend pitch. An esc-skipped setup bypassed it too.

## Changes
- **The import step is raised on every path out of the first run.** The once-per-machine `importOfferedAt` stamp is the only remaining gate (plus, as before, at least one agent actually detected on disk). No outcome and no skip flag routes around it.
- **The pick screen is a single tick list.** Agents start unticked; a **Skip adding data from other agents** row sits at the end of the list and is always there (Enter on it goes straight to the agent); an **Import from N agents** action appears below once something is ticked.
- **The per-agent domain-toggle screen is removed from onboarding.** The import runs with the defaults — every non-secret domain of the ticked agents, secrets off. Fine-grained selection stays where it was, in `/import`. The dry-run preview remains the gate before anything is written; Esc there returns to the ticks.
- `OnboardingScreen` takes an injectable `detectImportAgents` so the close-out tests no longer depend on which agents live on the machine running the suite.

## Tests
- `onboarding-import-flow.test.ts` rewritten for the row model (toggle via space *and* enter, skip row, import row, wrap with no import row when nothing is ticked).
- `use-onboarding-lifecycle-import.test.tsx`: the two bypass tests now pin the inverse — the step is raised even for esc-skipped setups and through the download skip.
- `onboarding-screen.test.tsx`: skip exit still closes with no second pitch when nothing is detected, and a new test pins that a detected agent intercepts the close-out.
- New `buildImportPickRows` unit tests. Full `src/tui` onboarding/hooks/components sweep green; `npm run lint` clean.