### PR TITLE
fix(cli): default NODE_ENV to production for unbundled runs

### DIFF
--- a/src/cli/env-defaults.test.ts
+++ b/src/cli/env-defaults.test.ts
@@ -37,6 +37,12 @@ describe("env-defaults", () => {
     expect(process.env.NODE_ENV).toBe("production");
   });
 
+  it("treats an empty NODE_ENV as unset", async () => {
+    process.env.NODE_ENV = "";
+    await import("./env-defaults.js");
+    expect(process.env.NODE_ENV).toBe("production");
+  });
+
   it("leaves an explicit NODE_ENV alone", async () => {
     process.env.NODE_ENV = "development";
     await import("./env-defaults.js");

--- a/src/cli/env-defaults.test.ts
+++ b/src/cli/env-defaults.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * `env-defaults.ts` keeps `dist` runs on the production React build
+ * (issue #307: the development reconciler floods the global performance
+ * buffer until V8 aborts). Two things have to stay true, and only the
+ * second is visible to a unit test:
+ *
+ *  1. an unset `NODE_ENV` becomes `"production"`, an explicit one wins;
+ *  2. the module is evaluated before `react-reconciler` — which means
+ *     it must be the first import of the CLI entrypoint, checked here
+ *     against the source because import order leaves no runtime trace.
+ */
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+describe("env-defaults", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it("defaults an unset NODE_ENV to production", async () => {
+    delete process.env.NODE_ENV;
+    await import("./env-defaults.js");
+    expect(process.env.NODE_ENV).toBe("production");
+  });
+
+  it("leaves an explicit NODE_ENV alone", async () => {
+    process.env.NODE_ENV = "development";
+    await import("./env-defaults.js");
+    expect(process.env.NODE_ENV).toBe("development");
+  });
+
+  it("is the first import of the CLI entrypoint", () => {
+    const source = readFileSync(
+      resolve(repoRoot, "src", "cli", "index.ts"),
+      "utf8",
+    );
+    const firstImport = source.match(/^import .*$/m)?.[0];
+    expect(firstImport).toBe('import "./env-defaults.js";');
+  });
+});

--- a/src/cli/env-defaults.ts
+++ b/src/cli/env-defaults.ts
@@ -24,6 +24,11 @@
  * the ordering.
  *
  * An explicitly exported `NODE_ENV` — `development` for React
- * debugging, `test` under a runner — is left alone.
+ * debugging, `test` under a runner — is left alone. An *empty* value
+ * (`NODE_ENV=` in a shell export or dotenv line) counts as unset: the
+ * reconciler switch compares `=== "production"`, so an empty string
+ * would silently pick the development build all the same.
  */
-process.env.NODE_ENV ??= "production";
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = "production";
+}

--- a/src/cli/env-defaults.ts
+++ b/src/cli/env-defaults.ts
@@ -1,0 +1,29 @@
+/**
+ * Defaults `NODE_ENV` to `"production"` before React can read it.
+ *
+ * React ships as two builds behind a runtime
+ * `process.env.NODE_ENV === "production" ? prod : dev` switch, and the
+ * development reconciler calls `performance.measure()` for every
+ * component render. Node keeps every user-timing entry alive for the
+ * life of the process, and the TUI redraws on a timer even while idle,
+ * so a `dist` run with `NODE_ENV` unset — the default outcome of
+ * `npm run build` + `node dist/cli/index.js` — grows the heap without
+ * bound and aborts with `FATAL ERROR: Ineffective mark-compacts near
+ * heap limit` roughly eleven hours after boot (issue #307).
+ *
+ * The SEA binary is immune because `scripts/bundle-sea.ts` inlines the
+ * same constant as an esbuild define; this module is the equivalent for
+ * the unbundled paths (`dist/cli/index.js`, `npm run cli`, `dev:cli`),
+ * which `tsc` compiles without defines.
+ *
+ * It must be the **first import of the CLI entrypoint**: ES modules
+ * evaluate imports depth-first before the importer's body, so by the
+ * time any statement in `index.ts` runs, the `tuiCommand` import chain
+ * has already loaded `react-reconciler` and the build choice is made.
+ * Only this position runs early enough. `env-defaults.test.ts` guards
+ * the ordering.
+ *
+ * An explicitly exported `NODE_ENV` — `development` for React
+ * debugging, `test` under a runner — is left alone.
+ */
+process.env.NODE_ENV ??= "production";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Must stay the first import: it defaults NODE_ENV before the imports
+// below load react-reconciler, which picks its build off that variable.
+import "./env-defaults.js";
 import { isSea } from "node:sea";
 import { argv, exit } from "node:process";
 import { runAgentCommand } from "./run-agent.js";

--- a/src/tui/terminal-restore.ts
+++ b/src/tui/terminal-restore.ts
@@ -34,7 +34,8 @@
  * of memory` is the one that bit us — calls `abort()` from inside the
  * engine. No JavaScript runs after it, so no handler here (or anywhere)
  * fires. The only defence against that is not running out of heap; see
- * the `process.env.NODE_ENV` define in `scripts/bundle-sea.ts`.
+ * the `process.env.NODE_ENV` define in `scripts/bundle-sea.ts` (SEA
+ * binary) and `src/cli/env-defaults.ts` (unbundled `dist` runs).
  */
 
 type RestoreFn = () => void;


### PR DESCRIPTION
## What

Adds `src/cli/env-defaults.ts` — a side-effect module that defaults `NODE_ENV` to `"production"` when unset — imported **first** in `src/cli/index.ts`, before the `tuiCommand` import chain loads `react-reconciler`. An explicit `NODE_ENV` (`development`, `test`) still wins. Also updates the `terminal-restore.ts` heap-OOM comment to name both defences.

## Why

Running the TUI from a source build (`node dist/cli/index.js tui`, `npm run cli`, `dev:cli`) leaves `NODE_ENV` unset, so `react-reconciler` resolves to its **development** build, whose Component Performance Track calls `performance.measure()` on every React commit. Node keeps user-timing entries alive for the life of the process and nothing drains the buffer, so a continuously redrawing TUI grows the heap without bound until V8 aborts: `FATAL ERROR: Ineffective mark-compacts near heap limit` at roughly the 11-hour mark — a silent native death (no JS runs after it) that takes the tmux server down with it when it is the only session.

`scripts/bundle-sea.ts` already defines `NODE_ENV` away for the SEA binary (same hazard, same words in its comment); the tsc-compiled `dist` path had no equivalent. The import has to be first because ESM evaluates imports depth-first before the importer's body — a plain assignment in the entry body runs after the reconciler has already picked its build.

## Test evidence

- `npm run lint` clean; `npx vitest run src/cli/env-defaults.test.ts src/cli/bin-alias.test.ts` — 7/7 pass. New tests cover both env branches plus a source-level guard that the import stays first (import order leaves no runtime trace).
- Installed `react-reconciler@0.33.0`: **8** `performance.measure(` call sites in `cjs/react-reconciler.development.js`, **0** in `cjs/react-reconciler.production.js`.
- Live TUI boot under a PTY at `--max-old-space-size=64` with a `--import` probe sampling the global performance buffer:
  - fixed run (`NODE_ENV` unset): reports `env=production`, **0 measure entries**, flat, survives.
  - control (`NODE_ENV=development`): measure entries grow monotonically (idle onboarding screen, ~2.5/s here; last sample name is React measuring Ink's `Box`), nothing ever drains them — the reporter's ~35–40/s with an active channel extrapolates to the observed ~11 h death at the 4 GB default ceiling.

Fixes #307
