### PR TITLE
fix(llm): key streamed tool calls by id when the provider sends no index

### DIFF
--- a/src/llm/provider/openai/openai-stream-consumer.test.ts
+++ b/src/llm/provider/openai/openai-stream-consumer.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import { createOpenAiStreamConsumer } from "./openai-stream-consumer.js";
+import type { StreamFinalResult } from "../completion-types.js";
+
+function sseFrame(payload: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function toolCallFrame(
+  toolCalls: Array<Record<string, unknown>>,
+): string {
+  return sseFrame({
+    model: "test-model",
+    choices: [{ index: 0, delta: { tool_calls: toolCalls }, finish_reason: null }],
+  });
+}
+
+function bodyOf(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+/** Drain the consumer and return the final result it returns on completion. */
+async function drain(body: string): Promise<StreamFinalResult> {
+  const consumer = createOpenAiStreamConsumer("delta_reasoning");
+  const iterator = consumer.consume(bodyOf(body), undefined);
+  for (;;) {
+    const step = await iterator.next();
+    if (step.done) return step.value as StreamFinalResult;
+  }
+}
+
+const DONE = sseFrame({
+  choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+}) + "data: [DONE]\n\n";
+
+describe("openai stream consumer tool-call assembly", () => {
+  it("keeps unindexed calls with distinct ids apart", async () => {
+    const result = await drain(
+      toolCallFrame([
+        {
+          id: "call_a",
+          type: "function",
+          function: { name: "os__fs__read", arguments: '{"path":"a.txt"}' },
+        },
+      ]) +
+        toolCallFrame([
+          {
+            id: "call_b",
+            type: "function",
+            function: { name: "os__fs__grep", arguments: '{"pattern":"b"}' },
+          },
+        ]) +
+        DONE,
+    );
+
+    expect(result.toolCalls).toEqual([
+      {
+        id: "call_a",
+        type: "function",
+        function: { name: "os__fs__read", arguments: '{"path":"a.txt"}' },
+      },
+      {
+        id: "call_b",
+        type: "function",
+        function: { name: "os__fs__grep", arguments: '{"pattern":"b"}' },
+      },
+    ]);
+  });
+
+  it("reassembles fragments of one unindexed call that repeats its id", async () => {
+    const result = await drain(
+      toolCallFrame([
+        { id: "call_a", type: "function", function: { name: "os__fs__read" } },
+      ]) +
+        toolCallFrame([{ id: "call_a", function: { arguments: '{"path":' } }]) +
+        toolCallFrame([{ id: "call_a", function: { arguments: '"a.txt"}' } }]) +
+        DONE,
+    );
+
+    expect(result.toolCalls).toEqual([
+      {
+        id: "call_a",
+        type: "function",
+        function: { name: "os__fs__read", arguments: '{"path":"a.txt"}' },
+      },
+    ]);
+  });
+
+  it("still folds id-less continuation deltas into the open call", async () => {
+    const result = await drain(
+      toolCallFrame([
+        { id: "call_a", type: "function", function: { name: "os__fs__read" } },
+      ]) +
+        toolCallFrame([{ function: { arguments: '{"path":"a.txt"}' } }]) +
+        DONE,
+    );
+
+    expect(result.toolCalls).toEqual([
+      {
+        id: "call_a",
+        type: "function",
+        function: { name: "os__fs__read", arguments: '{"path":"a.txt"}' },
+      },
+    ]);
+  });
+
+  it("accumulates indexed parallel calls in index order, whatever the arrival order", async () => {
+    const result = await drain(
+      toolCallFrame([
+        {
+          index: 1,
+          id: "call_b",
+          type: "function",
+          function: { name: "os__fs__grep", arguments: '{"pattern"' },
+        },
+      ]) +
+        toolCallFrame([
+          {
+            index: 0,
+            id: "call_a",
+            type: "function",
+            function: { name: "os__fs__read", arguments: '{"path"' },
+          },
+        ]) +
+        toolCallFrame([{ index: 1, function: { arguments: ':"b"}' } }]) +
+        toolCallFrame([{ index: 0, function: { arguments: ':"a.txt"}' } }]) +
+        DONE,
+    );
+
+    expect(result.toolCalls).toEqual([
+      {
+        id: "call_a",
+        type: "function",
+        function: { name: "os__fs__read", arguments: '{"path":"a.txt"}' },
+      },
+      {
+        id: "call_b",
+        type: "function",
+        function: { name: "os__fs__grep", arguments: '{"pattern":"b"}' },
+      },
+    ]);
+  });
+
+  it("merges an id-only delta into the slot the provider opened by index", async () => {
+    const result = await drain(
+      toolCallFrame([
+        {
+          index: 0,
+          id: "call_a",
+          type: "function",
+          function: { name: "os__fs__read" },
+        },
+      ]) +
+        toolCallFrame([{ id: "call_a", function: { arguments: '{"path":"a.txt"}' } }]) +
+        DONE,
+    );
+
+    expect(result.toolCalls).toEqual([
+      {
+        id: "call_a",
+        type: "function",
+        function: { name: "os__fs__read", arguments: '{"path":"a.txt"}' },
+      },
+    ]);
+  });
+
+  it("keeps two unindexed calls in a single event apart", async () => {
+    const result = await drain(
+      toolCallFrame([
+        {
+          id: "call_a",
+          type: "function",
+          function: { name: "os__fs__read", arguments: '{"path":"a.txt"}' },
+        },
+        {
+          id: "call_b",
+          type: "function",
+          function: { name: "os__fs__grep", arguments: '{"pattern":"b"}' },
+        },
+      ]) + DONE,
+    );
+
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls?.map((call) => call.id)).toEqual(["call_a", "call_b"]);
+  });
+});

--- a/src/llm/provider/openai/openai-stream-consumer.ts
+++ b/src/llm/provider/openai/openai-stream-consumer.ts
@@ -13,6 +13,8 @@ import {
 import { extractPartialReplyTextFromToolArguments } from "./tool-arguments-stream-parser.js";
 
 type MutableToolCall = {
+  /** Position in the final array. See `orderFor`. */
+  order: number;
   id?: string;
   type?: "function";
   function: {
@@ -20,6 +22,32 @@ type MutableToolCall = {
     arguments: string;
   };
 };
+
+/**
+ * Cross-event state for assembling streamed tool calls.
+ *
+ * A delta belongs to one call ("slot"), and the provider says which in one
+ * of two ways — or in neither:
+ *
+ *   - `index` — OpenAI's own scheme. Authoritative whenever it is present.
+ *   - `id` — one whole call per event and no index at all, as several
+ *     OpenAI-compatible providers do. Keying those by array position folds
+ *     every call onto slot 0, which merges distinct calls into one (#103).
+ *   - neither — a continuation of a call already opened, matched by
+ *     position against the slots that existed before this event.
+ */
+type ToolCallAccumulator = {
+  /** Slots by resolved key: `#<index>`, `@<id>`, or `~<n>` for neither. */
+  slots: Map<string, MutableToolCall>;
+  /** Slot key per call id, so a later id-only delta finds its own slot. */
+  keyById: Map<string, string>;
+  /** Next `order` to hand out for a slot the provider did not index. */
+  nextOrder: number;
+};
+
+function createToolCallAccumulator(): ToolCallAccumulator {
+  return { slots: new Map(), keyById: new Map(), nextOrder: 0 };
+}
 
 export function createOpenAiStreamConsumer(
   reasoningFormat: ReasoningFormat,
@@ -45,7 +73,7 @@ export function createOpenAiStreamConsumer(
       // NOT be conflated with either, since a still-open tool call's
       // arguments may be mid-stream.
       let terminalObserved = false;
-      const toolCalls = new Map<number, MutableToolCall>();
+      const toolCalls = createToolCallAccumulator();
       try {
         while (true) {
           if (signal?.aborted) break;
@@ -130,14 +158,28 @@ export function createOpenAiStreamConsumer(
 }
 
 function applyToolCallDeltas(
-  toolCalls: Map<number, MutableToolCall>,
+  accumulator: ToolCallAccumulator,
   deltas: readonly OpenAiToolCallDelta[],
 ): void {
+  // Snapshot before the loop: positional fallback matches against the slots
+  // that were open when the event arrived, never against ones it creates.
+  const openKeys = [...accumulator.slots.keys()];
+  let position = 0;
   for (const delta of deltas) {
-    const current = toolCalls.get(delta.index) ?? {
-      function: { name: "", arguments: "" },
-    };
-    if (delta.id) current.id = delta.id;
+    const key = resolveSlotKey(accumulator, delta, position, openKeys);
+    position += 1;
+    let current = accumulator.slots.get(key);
+    if (!current) {
+      current = {
+        order: orderFor(accumulator, delta),
+        function: { name: "", arguments: "" },
+      };
+      accumulator.slots.set(key, current);
+    }
+    if (delta.id) {
+      current.id = delta.id;
+      accumulator.keyById.set(delta.id, key);
+    }
     if (delta.type) current.type = delta.type;
     if (delta.function?.name) {
       current.function.name = mergeToolName(
@@ -148,8 +190,37 @@ function applyToolCallDeltas(
     if (delta.function?.arguments) {
       current.function.arguments += delta.function.arguments;
     }
-    toolCalls.set(delta.index, current);
   }
+}
+
+function resolveSlotKey(
+  accumulator: ToolCallAccumulator,
+  delta: OpenAiToolCallDelta,
+  position: number,
+  openKeys: readonly string[],
+): string {
+  if (typeof delta.index === "number") return `#${delta.index}`;
+  if (delta.id !== undefined) {
+    return accumulator.keyById.get(delta.id) ?? `@${delta.id}`;
+  }
+  return openKeys[position] ?? `~${accumulator.slots.size}`;
+}
+
+/**
+ * Provider indexes double as the output position, so a stream that opens
+ * slot 1 before slot 0 still ends up in the provider's order. Slots the
+ * provider never indexed queue up behind the highest index seen so far, in
+ * arrival order.
+ */
+function orderFor(
+  accumulator: ToolCallAccumulator,
+  delta: OpenAiToolCallDelta,
+): number {
+  if (typeof delta.index === "number") {
+    accumulator.nextOrder = Math.max(accumulator.nextOrder, delta.index + 1);
+    return delta.index;
+  }
+  return accumulator.nextOrder++;
 }
 
 /**
@@ -191,12 +262,12 @@ function buildFinalResult(args: {
   finishReason: string | null;
   modelId: string | null;
   usage?: CompletionUsage;
-  toolCalls: ReadonlyMap<number, MutableToolCall>;
+  toolCalls: ToolCallAccumulator;
   terminalObserved: boolean;
 }): StreamFinalResult {
-  const sortedToolCalls = [...args.toolCalls.entries()]
-    .sort(([a], [b]) => a - b)
-    .map(([, call]) => toOpenAiToolCall(call))
+  const sortedToolCalls = [...args.toolCalls.slots.values()]
+    .sort((a, b) => a.order - b.order)
+    .map((call) => toOpenAiToolCall(call))
     .filter((call): call is OpenAiToolCall => call !== null);
   return {
     content: args.content,

--- a/src/llm/provider/openai/parse-sse-chunk.ts
+++ b/src/llm/provider/openai/parse-sse-chunk.ts
@@ -2,7 +2,14 @@ import type { ReasoningExtractor } from "./reasoning-extractor.js";
 import { extractPartialReplyTextFromToolArguments } from "./tool-arguments-stream-parser.js";
 
 export interface OpenAiToolCallDelta {
-  index: number;
+  /**
+   * The provider's own slot number, when it sends one. Omitted otherwise:
+   * some OpenAI-compatible providers emit one whole call per event with no
+   * `index` at all, and inventing a position here makes every one of them
+   * look like slot 0. Resolving identity needs state across events, so the
+   * stream consumer owns it.
+   */
+  index?: number;
   id?: string;
   type?: "function";
   function?: {
@@ -95,8 +102,8 @@ export function parseOpenAiSseEvent(
         finishReason,
         modelId,
         usage,
-        toolCallDeltas: toolCalls.map((toolCall, fallbackIndex) => ({
-          index: typeof toolCall.index === "number" ? toolCall.index : fallbackIndex,
+        toolCallDeltas: toolCalls.map((toolCall) => ({
+          ...(typeof toolCall.index === "number" ? { index: toolCall.index } : {}),
           ...(typeof toolCall.id === "string" ? { id: toolCall.id } : {}),
           ...(toolCall.type === "function" ? { type: "function" as const } : {}),
           ...(toolCall.function


### PR DESCRIPTION
## What

An OpenAI-compatible provider that streams **one whole tool call per SSE event, with an `id` but no `index`**, had all of its calls merged into one.

Two places conspired:

- `parse-sse-chunk.ts` filled the missing `index` with the call's position *inside its own event* — always `0` when each event carries a single call.
- `openai-stream-consumer.ts` keyed its accumulator `Map` on that number alone.

So `call_a` and `call_b` both landed in slot `0`: names folded together by `mergeToolName`, arguments concatenated. The result is either `tool not registered in this agent` or — worse — the right tool invoked with two calls' arguments spliced into one string.

## Why this shape

Identity can only be resolved with state that spans events, and the parser is per-event by construction. So the parser now reports `index` **only when the provider actually sent one**, and the consumer owns resolution:

1. `index` when present — authoritative, and it doubles as the output position, so a stream that opens slot 1 before slot 0 still comes out in the provider's order.
2. otherwise `id` — first sighting opens a slot, later deltas with the same id find it again.
3. otherwise position among the slots that were **already open** before this event — which is exactly what an id-less continuation delta means. This is the old behaviour, kept intact.

Unindexed slots take order numbers behind the highest index seen, in arrival order.

## Testing

New `src/llm/provider/openai/openai-stream-consumer.test.ts`, 6 cases driving the consumer over real SSE bodies:

- distinct unindexed ids stay apart *(fails on `main`, passes here)*
- fragments of one unindexed call that repeats its id reassemble
- id-less continuation deltas still fold into the open call
- indexed parallel calls come out in index order regardless of arrival order
- an id-only delta merges into a slot the provider opened by index
- two unindexed calls in a single event stay apart

```
npx vitest run src/llm/provider/openai/openai-stream-consumer.test.ts   # 6 passed
npx vitest run src/llm/provider src/agent/step-executor.test.ts         # 35 files, 352 passed
npm run lint                                                            # clean
```

## Note

PR #268 targeted the same issue and was closed by its author on 31 Aug. This is an independent fix; it keeps the identity logic in one place instead of threading callbacks from the consumer into the delta applier, and covers the index-ordering and id-less-continuation paths as well.

Fixes #103