### PR TITLE
fix(cli): default NODE_ENV to production so the TUI stops leaking to OOM

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+// Must stay first: it defaults NODE_ENV to production before `ink`
+// pulls in react-reconciler, which picks its build at require time.
+// See src/cli/node-env-bootstrap.ts.
+import "./node-env-bootstrap.js";
 import { isSea } from "node:sea";
 import { argv, exit } from "node:process";
 import { runAgentCommand } from "./run-agent.js";

--- a/src/cli/node-env-bootstrap.test.ts
+++ b/src/cli/node-env-bootstrap.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { applyProductionNodeEnvDefault } from "./node-env-bootstrap.js";
+
+describe("applyProductionNodeEnvDefault", () => {
+  it("fills in an unset NODE_ENV", () => {
+    const env: NodeJS.ProcessEnv = {};
+    expect(applyProductionNodeEnvDefault(env)).toBe(true);
+    expect(env.NODE_ENV).toBe("production");
+  });
+
+  it("fills in an empty NODE_ENV", () => {
+    const env: NodeJS.ProcessEnv = { NODE_ENV: "" };
+    expect(applyProductionNodeEnvDefault(env)).toBe(true);
+    expect(env.NODE_ENV).toBe("production");
+  });
+
+  it("leaves an explicit NODE_ENV alone", () => {
+    for (const value of ["development", "test", "staging"]) {
+      const env: NodeJS.ProcessEnv = { NODE_ENV: value };
+      expect(applyProductionNodeEnvDefault(env)).toBe(false);
+      expect(env.NODE_ENV).toBe(value);
+    }
+  });
+});
+
+describe("cli entry import order", () => {
+  /**
+   * The whole fix is the *position* of this import. ES modules evaluate
+   * their dependency graph before the importing module's own body, so
+   * anything that lands after `ink` in the import list runs too late to
+   * decide which react-reconciler build was loaded. An import sorter or a
+   * casual reorder would silently reintroduce the heap-OOM leak, and the
+   * symptom takes eleven hours to appear — hence a test on the source.
+   */
+  it("imports the NODE_ENV bootstrap before every other module", () => {
+    const entry = readFileSync(
+      fileURLToPath(new URL("./index.ts", import.meta.url)),
+      "utf8",
+    );
+    const firstImport = entry
+      .split("\n")
+      .find((line) => line.startsWith("import "));
+
+    expect(firstImport).toBe('import "./node-env-bootstrap.js";');
+  });
+});

--- a/src/cli/node-env-bootstrap.ts
+++ b/src/cli/node-env-bootstrap.ts
@@ -1,0 +1,48 @@
+/**
+ * Default `NODE_ENV` to `production` before anything else loads.
+ *
+ * React ships two builds behind a runtime
+ * `process.env.NODE_ENV === "production" ? prod : dev` switch.
+ * `scripts/bundle-sea.ts` defines the constant away for the SEA binary,
+ * so a released install always gets the production reconciler. Every
+ * other way of starting the CLI — `node dist/cli/index.js`, `npm run
+ * cli`, `npm run dev:cli`, a `npx`/`npm link` checkout — leaves NODE_ENV
+ * unset, which is how `react-reconciler` resolves to its *development*
+ * build on machines whose shell does not export it. That is every
+ * machine.
+ *
+ * The development reconciler carries React 19's Component Performance
+ * Track: eight `performance.measure()` call sites, fired on every
+ * commit. The production build has none. A TUI commits continuously —
+ * spinners, timers, streaming deltas — and nothing in Node ever drains
+ * the global performance entry buffer, so the entries accumulate for the
+ * life of the process at roughly 35-40 per second. Node warns at one
+ * million (`MaxPerformanceEntryBufferExceededWarning`), and V8 aborts at
+ * its ~4 GB ceiling: `FATAL ERROR: Ineffective mark-compacts near heap
+ * limit`, a native abort with no JS stack, around the eleven-hour mark.
+ * An unattended agent simply goes silent, and takes its tmux server with
+ * it if that was the only session.
+ *
+ * An explicit NODE_ENV is always honoured — this only fills in the
+ * blank.
+ *
+ * **This module must stay the first import in `src/cli/index.ts`.** ES
+ * module bodies run after their whole dependency graph is evaluated, so
+ * assigning `process.env.NODE_ENV` from inside `index.ts` would land
+ * long after `ink` had already required the reconciler and chosen a
+ * build. Only a side-effect import placed ahead of the others runs early
+ * enough. `src/cli/node-env-bootstrap.test.ts` guards the ordering.
+ */
+
+/**
+ * Set `env.NODE_ENV` to `production` when it carries no value.
+ *
+ * @returns whether the default was applied.
+ */
+export function applyProductionNodeEnvDefault(env: NodeJS.ProcessEnv): boolean {
+  if (env.NODE_ENV !== undefined && env.NODE_ENV !== "") return false;
+  env.NODE_ENV = "production";
+  return true;
+}
+
+applyProductionNodeEnvDefault(process.env);


### PR DESCRIPTION
## What

`scripts/bundle-sea.ts` already defines `process.env.NODE_ENV` to `"production"` for the SEA binary, and its comment spells out exactly why: without it the *development* `react-reconciler` runs, its Component Performance Track calls `performance.measure()` on every commit, and the process dies of heap exhaustion after several hours.

Every other way of starting the CLI has the same problem and none of the protection — `node dist/cli/index.js tui`, `npm run cli`, `npm run dev:cli`, a linked checkout. `NODE_ENV` is unset, so `react-reconciler/index.js` takes its `else` branch. Nothing in Node ever drains the global performance entry buffer, so the entries accumulate for the life of the process: `MaxPerformanceEntryBufferExceededWarning` at one million, then `FATAL ERROR: Ineffective mark-compacts near heap limit` at V8's ~4 GB ceiling. A native abort, no JS stack, roughly eleven hours in — an unattended agent simply goes silent, and takes the tmux server with it if that was the only session.

## The change

A side-effect module, `src/cli/node-env-bootstrap.ts`, imported **first** in `src/cli/index.ts`. It sets `NODE_ENV` to `production` only when the variable carries no value; an explicit setting of any kind is left alone.

Position is the entire fix. ES module bodies run after their whole dependency graph is evaluated, so an assignment inside `index.ts` would land long after `ink` had required the reconciler and picked a build. Only a side-effect import ahead of the others runs early enough.

## Testing

Measured directly — render an Ink tree, rerender it 50 times, count `performance.getEntriesByType("measure")`:

```
main:       NODE_ENV=undefined     measures 0 -> 206   (+206)
this branch: NODE_ENV="production"  measures 0 -> 0     (+0)
```

~4 entries per commit is consistent with the ~35-40/s the reporter measured against a live TUI's redraw rate.

`src/cli/node-env-bootstrap.test.ts` covers the default (unset and empty both fill in; `development`/`test`/`staging` are preserved) plus a guard asserting the bootstrap is still the first `import` line in `index.ts`. That guard is deliberate: an import sorter or a casual reorder reintroduces the leak silently, and the symptom takes eleven hours to show up.

```
npx vitest run src/cli   # 15 files, 159 passed
npm run lint             # clean
npm run build            # clean
```

## Not included

The issue also suggests a periodic `performance.clearMeasures()` as defence in depth. Left out on purpose: with this change the buffer has no producer in any default deployment, the repository has no `performance.mark`/`measure` call sites of its own, and a background timer to clean up after a build nobody loads is cost without a case. Happy to add it if you would rather cover an operator who sets `NODE_ENV=development` explicitly.

Fixes #307