### PR TITLE
fix(install): say why an unpublished platform has no binary

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -375,6 +375,48 @@ else
   SHA_URL="${BASE}/releases/latest/download/${TAR_NAME}.sha256"
 fi
 
+# Preflight: is there a build for this platform at all?
+#
+# Not every slug the installer can *name* is one the release matrix
+# *publishes* — darwin-x64 is commented out of .github/workflows/release.yml,
+# so an Intel Mac used to reach `download` and die on a bare
+# "download failed: <url>" with a 404 behind it and no hint that the binary
+# had never existed. Say so instead, and say what to do about it.
+#
+# Only a literal 404 counts as "not published". Everything else — offline
+# (000), a proxy, a 5xx, no curl at all — falls through to the real
+# download, which reports failures as it always has. curl's own exit code
+# is no good here: a 404 after -L follows the release redirect surfaces as
+# 56, not 22, so read the status directly.
+asset_missing() {
+  have curl || return 1
+  _am_code="$(curl -sIL --retry 2 -o /dev/null -w '%{http_code}' "$1" 2>/dev/null || echo 000)"
+  [ "$_am_code" = "404" ]
+}
+
+no_build_published() {
+  echo "no published build for ${SLUG}." >&2
+  echo >&2
+  if [ "$SLUG" = "darwin-x64" ]; then
+    echo "atomic-agent does not publish a macOS Intel binary yet, and the Apple" >&2
+    echo "Silicon build will not run on this machine. Tracking:" >&2
+    echo "  https://github.com/${REPO}/issues/300" >&2
+  else
+    echo "${TAR_NAME} is not attached to this release. See what is published:" >&2
+    echo "  https://github.com/${REPO}/releases" >&2
+  fi
+  echo >&2
+  echo "to run atomic-agent here, build it from source (needs Node 25.7+):" >&2
+  echo "  git clone https://github.com/${REPO}.git" >&2
+  echo "  cd atomic-agent && npm install && npm run build" >&2
+  echo "  node dist/cli/index.js" >&2
+  exit 1
+}
+
+if asset_missing "$TAR_URL"; then
+  no_build_published
+fi
+
 TMPDIR="${TMPDIR:-/tmp}"
 WORK="$(mktemp -d "$TMPDIR/atomic-agent-install.XXXXXX")"
 TMP_BIN=""


### PR DESCRIPTION
## What

Issue #300, option 2 — the cheap half that is worth doing regardless of the cost decision on option 1.

`install.sh` resolves `uname -m` = `x86_64` on a Mac to `SLUG=darwin-x64`, a slug the release matrix does not publish (it is commented out in `.github/workflows/release.yml`). The user got:

```
downloading atomic-agent
curl: (56) The requested URL returned error: 404
```

No indication that the binary had never existed, and no suggestion of what to do instead.

Now the installer probes the asset first and, on a **literal 404**, explains itself:

```
no published build for darwin-x64.

atomic-agent does not publish a macOS Intel binary yet, and the Apple
Silicon build will not run on this machine. Tracking:
  https://github.com/AtomicBot-ai/atomic-agent/issues/300

to run atomic-agent here, build it from source (needs Node 25.7+):
  git clone https://github.com/AtomicBot-ai/atomic-agent.git
  cd atomic-agent && npm install && npm run build
  node dist/cli/index.js
```

Any other slug that goes missing gets the same treatment, pointed at the releases page rather than a hardcoded platform list — nothing to keep in sync when the matrix changes.

## Why it reads the status code

`curl -f`'s exit code is unusable for this. A 404 that arrives *after* `-L` follows the `releases/latest/download` redirect surfaces as **56**, not 22 — verified against the live repo. So the probe reads `%{http_code}` and treats only `404` as "not published". Offline (`000`), a proxy, a 5xx, or a machine with no `curl` all fall through to the real download, which reports failures exactly as before. A flaky network cannot turn into a false "unsupported platform".

## Testing

`sh -n scripts/install.sh` clean. All three paths exercised against the live repo on macOS:

| case | result |
|---|---|
| missing asset (`ATOMIC_AGENT_VERSION=v0.0.0-nope`) | new message, exit 1 — was `curl: (56)`, exit 56 |
| `darwin-x64` (slug forced on an arm64 host) | Intel-specific wording, exit 1 |
| happy path (real latest, scratch `ATOMIC_AGENT_INSTALL_DIR`) | installs, exit 0, binary + `atag` + grammars + starter-skills in place |

## Left to you

- **Option 1**, publishing the build: one uncommented matrix line, and everything downstream (`bundle-targets.ts`, `fetch-assets.ts`, `print-matrix.ts`) already knows `darwin-x64`. The issue frames it as a cost question — macOS runner minutes plus signing and notarization — so that is your call, not something to slip into this PR. If you take it, the preflight above simply stops firing.
- `install.ps1` is untouched: `win32-x64` is published, so there is no equivalent hole to plug there today.

Fixes #300