### PR TITLE
fix(tools): route source files from read_document to os.fs.read

### DIFF
--- a/src/prompt/build-prompt.test.ts
+++ b/src/prompt/build-prompt.test.ts
@@ -5,6 +5,7 @@ import {
   QWEN_THINK_PROFILE,
 } from "../llm/model-profile.js";
 import { buildPrompt } from "./build-prompt.js";
+import { DEFAULT_TOOL_DESCRIPTORS } from "./tool-descriptors.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import type { SessionState } from "../session/session-state.js";
 import type {
@@ -230,6 +231,27 @@ describe("buildPrompt", () => {
     expect(prompt.stablePrefix).toContain("Large directories:");
     expect(prompt.stablePrefix).toContain("Large trees:");
     expect(prompt.stablePrefix).toContain("os.fs.read_document");
+  });
+
+  it("frequent-tool summaries send source files to os.fs.read, not read_document", () => {
+    // Issue #113: the stable prefix is where a model decides between the
+    // two readers, and it ships on every turn. Pinning the wording here
+    // (against the real descriptors, not the stub TOOLS above) keeps a
+    // future summary edit from quietly dropping the routing hint that
+    // stops models bouncing off read_document's unsupported-extension
+    // error on `.py` / `.ts` files.
+    const prompt = buildPrompt({
+      session: mkSession(),
+      toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    expect(prompt.stablePrefix).toContain(
+      "the default for source code and text files",
+    );
+    expect(prompt.stablePrefix).toContain(
+      "NOT for source code or text files: use os.fs.read",
+    );
   });
 
   it("stable prefix changes deterministically when a skill is removed from the catalog (skills.disabled)", () => {

--- a/src/prompt/build-prompt.test.ts
+++ b/src/prompt/build-prompt.test.ts
@@ -250,7 +250,16 @@ describe("buildPrompt", () => {
       "the default for source code and text files",
     );
     expect(prompt.stablePrefix).toContain(
-      "NOT for source code or text files: use os.fs.read",
+      "NOT for source code: use os.fs.read",
+    );
+    // The summary must not claim read_document rejects text files — it
+    // extracts .txt/.md/.csv as `plain`, and a summary that contradicts the
+    // tool re-creates the very ambiguity this change removes.
+    expect(prompt.stablePrefix).not.toContain("NOT for source code or text files");
+    // The bad guess in issue #113 was `format: "text"`. The stable prefix
+    // carries the closed set so the guess is never reachable.
+    expect(prompt.stablePrefix).toContain(
+      "format?: 'pdf' | 'docx' | 'doc' | 'xlsx' | 'rtf' | 'odt' | 'pptx' | 'plain'",
     );
   });
 

--- a/src/prompt/default-tool-args-schemas.test.ts
+++ b/src/prompt/default-tool-args-schemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 
+import { DOCUMENT_FORMATS } from "../tools/os/read-document/extractors/extractor-types.js";
 import { DEFAULT_TOOL_DESCRIPTORS } from "./tool-descriptors.js";
 import {
   attachDefaultArgsJsonSchema,
@@ -85,6 +86,38 @@ describe("default tool argsJsonSchema map", () => {
       items: { type: "string" },
       maxItems: 4,
     });
+  });
+
+  // Issue #113: `format` was an open string in both the JSON Schema and the
+  // stable-prefix argsSchema, so nothing stopped a model emitting the
+  // invented `format: "text"` that the issue is about. Both surfaces now
+  // carry the closed set, derived from the runtime declaration.
+  it("pins os.fs.read_document format as the closed DOCUMENT_FORMATS enum", () => {
+    const properties = (
+      getDefaultArgsJsonSchema("os.fs.read_document") as {
+        properties: Record<string, unknown>;
+      }
+    ).properties;
+    expect(properties.format).toEqual({
+      type: "string",
+      enum: ["pdf", "docx", "doc", "xlsx", "rtf", "odt", "pptx", "plain"],
+    });
+    // Verbatim against the runtime validator, not a second hand-written
+    // copy of it — that is the drift this module's header promises to avoid.
+    expect((properties.format as { enum: string[] }).enum).toEqual([
+      ...DOCUMENT_FORMATS,
+    ]);
+  });
+
+  it("spells the same closed format set into the read_document argsSchema", () => {
+    const descriptor = DEFAULT_TOOL_DESCRIPTORS.find(
+      (d) => d.name === "os.fs.read_document",
+    );
+    expect(descriptor).toBeDefined();
+    expect(descriptor!.argsSchema).toContain(
+      "format?: 'pdf' | 'docx' | 'doc' | 'xlsx' | 'rtf' | 'odt' | 'pptx' | 'plain'",
+    );
+    expect(descriptor!.argsSchema).not.toContain("format?: string");
   });
 
   it("does not leak vision.describe's maxItems onto other string[] schemas", () => {

--- a/src/prompt/default-tool-args-schemas.ts
+++ b/src/prompt/default-tool-args-schemas.ts
@@ -29,6 +29,7 @@
  *     guards the **shape**.
  */
 
+import { DOCUMENT_FORMATS } from "../tools/os/read-document/extractors/extractor-types.js";
 import type { ToolDescriptor } from "./stable-prefix.js";
 
 type Schema = Record<string, unknown>;
@@ -238,7 +239,11 @@ const DEFAULT_TOOL_ARGS_SCHEMAS: ReadonlyMap<string, Schema> = new Map<
     obj(
       {
         path: stringSchema,
-        format: stringSchema,
+        // Closed set, per the "enums match the runtime validators verbatim"
+        // convention above: `detectFormat` accepts exactly DOCUMENT_FORMATS
+        // and rejects anything else. Leaving it an open string is what let
+        // models emit the invented `format: "text"` (issue #113).
+        format: { type: "string", enum: [...DOCUMENT_FORMATS] },
         maxBytes: numberSchema,
         maxPages: numberSchema,
         pagesFrom: numberSchema,

--- a/src/prompt/default-tool-descriptors-a.ts
+++ b/src/prompt/default-tool-descriptors-a.ts
@@ -47,7 +47,8 @@ export const DEFAULT_TOOL_DESCRIPTORS_A: readonly ToolDescriptor[] = [
   },
   {
     name: "os.fs.read",
-    summary: "Read a UTF-8 file; use offset/limit for ranges, lineNumbers for 'LINE|'.",
+    summary:
+      "Read a UTF-8 file — the default for source code and text files; use offset/limit for ranges, lineNumbers for 'LINE|'.",
     argsSchema:
       "{ path: string, maxBytes?: number, offset?: number /* 1-based; neg=from end */, limit?: number, lineNumbers?: boolean }",
   },
@@ -96,8 +97,13 @@ export const DEFAULT_TOOL_DESCRIPTORS_A: readonly ToolDescriptor[] = [
     argsSchema: "{ path: string, oldString: string, newString: string, replaceAll?: boolean }",
   },
   {
+    // Models reach for read_document on `.py` / `.ts` source files, hit the
+    // unsupported-extension error and burn a step guessing `format`. The
+    // summary therefore names the sibling tool explicitly: source and text
+    // go to os.fs.read, this one is for document extraction only.
     name: "os.fs.read_document",
-    summary: "Extract plain text from PDF, Office, ODF, etc. (markers in output). Read-only.",
+    summary:
+      "Extract plain text from documents — PDF, Office, ODF, RTF (markers in output). NOT for source code or text files: use os.fs.read. Read-only.",
     argsSchema:
       "{ path: string, format?: string, maxBytes?: number, maxPages?: number, pagesFrom?: number, pagesTo?: number, sheets?: (string | number)[], pageSeparators?: boolean, includeTables?: boolean }",
   },

--- a/src/prompt/default-tool-descriptors-a.ts
+++ b/src/prompt/default-tool-descriptors-a.ts
@@ -99,13 +99,20 @@ export const DEFAULT_TOOL_DESCRIPTORS_A: readonly ToolDescriptor[] = [
   {
     // Models reach for read_document on `.py` / `.ts` source files, hit the
     // unsupported-extension error and burn a step guessing `format`. The
-    // summary therefore names the sibling tool explicitly: source and text
-    // go to os.fs.read, this one is for document extraction only.
+    // summary therefore names the sibling tool explicitly: source code goes
+    // to os.fs.read, this one is for document extraction. It deliberately
+    // does NOT say "not for text files" — this tool does read .txt/.md/.csv
+    // as `plain`, and a summary that contradicts the tool is the same
+    // ambiguity one level up.
+    //
+    // `format` is spelled out as a closed set for the same reason: the bad
+    // guess in issue #113 was `format: "text"`, and a model that guesses it
+    // preemptively never sees the runtime hint.
     name: "os.fs.read_document",
     summary:
-      "Extract plain text from documents — PDF, Office, ODF, RTF (markers in output). NOT for source code or text files: use os.fs.read. Read-only.",
+      "Extract plain text from documents — PDF, Office, ODF, RTF (markers in output). NOT for source code: use os.fs.read. Read-only.",
     argsSchema:
-      "{ path: string, format?: string, maxBytes?: number, maxPages?: number, pagesFrom?: number, pagesTo?: number, sheets?: (string | number)[], pageSeparators?: boolean, includeTables?: boolean }",
+      "{ path: string, format?: 'pdf' | 'docx' | 'doc' | 'xlsx' | 'rtf' | 'odt' | 'pptx' | 'plain', maxBytes?: number, maxPages?: number, pagesFrom?: number, pagesTo?: number, sheets?: (string | number)[], pageSeparators?: boolean, includeTables?: boolean }",
   },
   {
     name: "os.fs.archive.list",

--- a/src/tools/os/read-document/extractors/extractor-types.ts
+++ b/src/tools/os/read-document/extractors/extractor-types.ts
@@ -6,15 +6,24 @@
  * keeps extractors pure and easy to test.
  */
 
-export type DocumentFormat =
-  | "pdf"
-  | "docx"
-  | "doc"
-  | "xlsx"
-  | "rtf"
-  | "odt"
-  | "pptx"
-  | "plain";
+/**
+ * The closed set of formats the dispatcher accepts, as a value so that the
+ * runtime validator, the error message that lists the valid overrides and
+ * the prompt-side arg schemas can all be derived from one declaration
+ * instead of three hand-maintained copies that drift (issue #113).
+ */
+export const DOCUMENT_FORMATS = [
+  "pdf",
+  "docx",
+  "doc",
+  "xlsx",
+  "rtf",
+  "odt",
+  "pptx",
+  "plain",
+] as const;
+
+export type DocumentFormat = (typeof DOCUMENT_FORMATS)[number];
 
 export interface ExtractorInput {
   data: Buffer;

--- a/src/tools/os/read-document/read-document.test.ts
+++ b/src/tools/os/read-document/read-document.test.ts
@@ -104,6 +104,112 @@ describe("os.fs.read_document dispatcher", () => {
     );
   });
 
+  // Issue #113: a `.py` handed to read_document used to produce a generic
+  // "unsupported extension (override with `format`)" error, which sent
+  // models into `format: "text"` — not a known format — instead of over to
+  // os.fs.read. These pin both halves of the recovery hint.
+  it.each(["py", "ts", "rs"])(
+    "points .%s source files at os.fs.read and names format: \"plain\"",
+    async (ext) => {
+      const tool = buildOsFsReadDocumentTool({});
+      const path = join(dir, `module.${ext}`);
+      await writeFile(path, Buffer.from("print(1)\n"));
+
+      const error = await tool
+        .run({ path }, makeCtx(dir))
+        .then(() => undefined)
+        .catch((e: unknown) => e as Error);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toContain(`".${ext}" is a source/text file`);
+      expect(message).toContain("use os.fs.read instead");
+      expect(message).toContain('format: "plain"');
+      // The ambiguous bare-`format` phrasing is what produced the bad
+      // `format: "text"` guesses; it must not come back.
+      expect(message).not.toMatch(/override with `format`/);
+    },
+  );
+
+  it("offers os.fs.read and format: \"plain\" for an unknown binary extension", async () => {
+    const tool = buildOsFsReadDocumentTool({});
+    const path = join(dir, "blob.qzx");
+    await writeFile(path, Buffer.from([0x00, 0x01, 0x02]));
+
+    const error = await tool
+      .run({ path }, makeCtx(dir))
+      .then(() => undefined)
+      .catch((e: unknown) => e as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain('unsupported extension ".qzx"');
+    expect(message).toContain("os.fs.read");
+    expect(message).toContain('format: "plain"');
+  });
+
+  it('reads a source file when format: "plain" is passed explicitly', async () => {
+    const tool = buildOsFsReadDocumentTool({
+      extractors: {
+        plain: fakeExtractor({ format: "plain", text: "print(1)" }),
+      },
+    });
+    const path = join(dir, "script.py");
+    await writeFile(path, Buffer.from("print(1)\n"));
+
+    const result = await tool.run({ path, format: "plain" }, makeCtx(dir));
+
+    expect(result.details.format).toBe("plain");
+    expect(result.summary).toContain("print(1)");
+  });
+
+  it("keeps document extensions routed to their own extractors", async () => {
+    // Guards the other half of issue #113: the new source-file branch must
+    // not have moved any real document format into the reject path.
+    const seen: string[] = [];
+    const tool = buildOsFsReadDocumentTool({
+      extractors: {
+        pdf: fakeExtractor({ format: "pdf", text: "p" }, () => seen.push("pdf")),
+        docx: fakeExtractor({ format: "docx", text: "d" }, () => seen.push("docx")),
+        xlsx: fakeExtractor({ format: "xlsx", text: "x" }, () => seen.push("xlsx")),
+        rtf: fakeExtractor({ format: "rtf", text: "r" }, () => seen.push("rtf")),
+        odt: fakeExtractor({ format: "odt", text: "o" }, () => seen.push("odt")),
+        pptx: fakeExtractor({ format: "pptx", text: "s" }, () => seen.push("pptx")),
+        plain: fakeExtractor({ format: "plain", text: "t" }, () => seen.push("plain")),
+      },
+    });
+    for (const name of [
+      "a.pdf",
+      "a.docx",
+      "a.xlsx",
+      "a.rtf",
+      "a.odt",
+      "a.pptx",
+      "a.txt",
+      "a.md",
+      "a.csv",
+      "a.json",
+      "a.yaml",
+    ]) {
+      const path = join(dir, name);
+      await writeFile(path, Buffer.from("x"));
+      await tool.run({ path }, makeCtx(dir));
+    }
+    expect(seen).toEqual([
+      "pdf",
+      "docx",
+      "xlsx",
+      "rtf",
+      "odt",
+      "pptx",
+      "plain",
+      "plain",
+      "plain",
+      "plain",
+      "plain",
+    ]);
+  });
+
   it("rejects unknown format overrides", async () => {
     const tool = buildOsFsReadDocumentTool({});
     const path = join(dir, "any.txt");

--- a/src/tools/os/read-document/read-document.test.ts
+++ b/src/tools/os/read-document/read-document.test.ts
@@ -122,7 +122,7 @@ describe("os.fs.read_document dispatcher", () => {
 
       expect(error).toBeInstanceOf(Error);
       const message = (error as Error).message;
-      expect(message).toContain(`".${ext}" is a source/text file`);
+      expect(message).toContain(`".${ext}" is a source or config file`);
       expect(message).toContain("use os.fs.read instead");
       expect(message).toContain('format: "plain"');
       // The ambiguous bare-`format` phrasing is what produced the bad
@@ -163,6 +163,23 @@ describe("os.fs.read_document dispatcher", () => {
     expect(result.summary).toContain("print(1)");
   });
 
+  it("advertises the os.fs.read hand-off in the tool description", async () => {
+    // The description is what lands in `### loaded-tools` after tool.view,
+    // i.e. the text the model reads at the moment it picks between the two
+    // readers — the same argument that earned the stable-prefix summary a
+    // pin test. Without this, a future edit can drop the routing hint (or
+    // re-introduce the `format: "text"` ambiguity) with a green suite.
+    const description = buildOsFsReadDocumentTool({}).description;
+    expect(description).toContain("NOT for source code");
+    expect(description).toContain("os.fs.read");
+    expect(description).toContain(
+      "pdf, docx, doc, xlsx, rtf, odt, pptx, plain",
+    );
+    // It must not claim the tool refuses text files: it reads .txt/.md/.csv
+    // as `plain`, and the whole point of issue #113 is removing ambiguity.
+    expect(description).not.toMatch(/NOT for source code or other UTF-8 text/);
+  });
+
   it("keeps document extensions routed to their own extractors", async () => {
     // Guards the other half of issue #113: the new source-file branch must
     // not have moved any real document format into the reject path.
@@ -171,6 +188,7 @@ describe("os.fs.read_document dispatcher", () => {
       extractors: {
         pdf: fakeExtractor({ format: "pdf", text: "p" }, () => seen.push("pdf")),
         docx: fakeExtractor({ format: "docx", text: "d" }, () => seen.push("docx")),
+        doc: fakeExtractor({ format: "doc", text: "l" }, () => seen.push("doc")),
         xlsx: fakeExtractor({ format: "xlsx", text: "x" }, () => seen.push("xlsx")),
         rtf: fakeExtractor({ format: "rtf", text: "r" }, () => seen.push("rtf")),
         odt: fakeExtractor({ format: "odt", text: "o" }, () => seen.push("odt")),
@@ -178,18 +196,28 @@ describe("os.fs.read_document dispatcher", () => {
         plain: fakeExtractor({ format: "plain", text: "t" }, () => seen.push("plain")),
       },
     });
+    // Every arm of the switch is represented, including the ones the first
+    // version of this guard missed: legacy `.doc`, markup, `.log`, `.yml`,
+    // the delimited pair (`.csv`/`.tsv`) and the extensionless `case ""`.
     for (const name of [
       "a.pdf",
       "a.docx",
+      "a.doc",
       "a.xlsx",
       "a.rtf",
       "a.odt",
       "a.pptx",
       "a.txt",
       "a.md",
+      "a.log",
       "a.csv",
+      "a.tsv",
       "a.json",
+      "a.html",
+      "a.xml",
       "a.yaml",
+      "a.yml",
+      "Makefile",
     ]) {
       const path = join(dir, name);
       await writeFile(path, Buffer.from("x"));
@@ -198,15 +226,12 @@ describe("os.fs.read_document dispatcher", () => {
     expect(seen).toEqual([
       "pdf",
       "docx",
+      "doc",
       "xlsx",
       "rtf",
       "odt",
       "pptx",
-      "plain",
-      "plain",
-      "plain",
-      "plain",
-      "plain",
+      ...Array<string>(11).fill("plain"),
     ]);
   });
 
@@ -217,6 +242,27 @@ describe("os.fs.read_document dispatcher", () => {
     await expect(
       tool.run({ path, format: "quuxml" }, makeCtx(dir)),
     ).rejects.toThrow(/unknown format override/);
+  });
+
+  it('names the accepted formats and os.fs.read when rejecting format: "text"', async () => {
+    // A model can guess `format: "text"` before it ever sees detectFormat's
+    // hint (it reads "override with `format`" in the description and fills
+    // in a plausible value). This branch is that model's only feedback, so
+    // it has to carry both exits: the valid values, and the other tool.
+    const tool = buildOsFsReadDocumentTool({});
+    const path = join(dir, "script.py");
+    await writeFile(path, Buffer.from("print(1)\n"));
+
+    const error = await tool
+      .run({ path, format: "text" }, makeCtx(dir))
+      .then(() => undefined)
+      .catch((e: unknown) => e as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain('unknown format override "text"');
+    expect(message).toContain("pdf, docx, doc, xlsx, rtf, odt, pptx, plain");
+    expect(message).toContain("os.fs.read");
   });
 
   it("forwards pagination args to the extractor", async () => {

--- a/src/tools/os/read-document/read-document.ts
+++ b/src/tools/os/read-document/read-document.ts
@@ -40,7 +40,7 @@ export function buildOsFsReadDocumentTool(
   return {
     name: "os.fs.read_document",
     description:
-      "Extract plain text (with light structure markers) from PDF, DOCX, DOC (legacy), XLSX, RTF, ODT, PPTX, and plain-text files. Auto-detects format by extension; override with `format`. Read-only, no approval required.",
+      'Extract plain text (with light structure markers) from PDF, DOCX, DOC (legacy), XLSX, RTF, ODT, PPTX, and plain-text files. NOT for source code or other UTF-8 text files — read those with os.fs.read. Auto-detects format by extension; override with `format` (the plain-text value is `format: "plain"`). Read-only, no approval required.',
     readonly: true,
     async run(rawArgs, ctx) {
       const args = await parseArgs(rawArgs, ctx.workingDir);
@@ -198,6 +198,24 @@ function parseSheetsArg(
 }
 
 /**
+ * Extensions that are almost certainly source code or other line-oriented
+ * text. They are deliberately NOT mapped to `plain`: `os.fs.read` is the
+ * right tool for them (offset/limit pagination, `lineNumbers`, no document
+ * extractor in the way). The set exists only so the rejection can say which
+ * tool to reach for next — without that, models retry `read_document` with
+ * an invented `format: "text"` and burn another step before discovering
+ * `os.fs.read` (issue #113).
+ */
+const SOURCE_LIKE_EXTENSIONS: ReadonlySet<string> = new Set([
+  "bash", "c", "cc", "cfg", "cjs", "clj", "conf", "cpp", "cs", "css", "cxx",
+  "dart", "env", "erl", "ex", "exs", "fish", "go", "gradle", "h", "hh", "hpp",
+  "hs", "ini", "ipynb", "java", "js", "jsonc", "jsx", "kt", "kts", "less",
+  "lua", "m", "mjs", "mm", "php", "pl", "pm", "properties", "proto", "ps1",
+  "py", "pyi", "r", "rb", "rs", "sass", "scala", "scss", "sh", "sql", "svelte",
+  "swift", "tf", "toml", "ts", "tsv", "tsx", "vue", "zsh",
+]);
+
+/**
  * Resolve extension → canonical format. `.html/.xml/.json/.csv` currently
  * fall through to `plain` — it's the safest default until we need format-
  * specific pretty-printing for them.
@@ -238,8 +256,16 @@ function detectFormat(absolute: string, override: unknown): DocumentFormat {
     case "yml":
       return "plain";
     default:
+      // Two shapes on purpose: for a source-like extension the answer is
+      // almost always "wrong tool", so name os.fs.read first and mention the
+      // override second; for anything else the extension carries no signal,
+      // so offer both. Either way the message spells out the accepted value
+      // `format: "plain"` — the bare word `format` invited `format: "text"`,
+      // which is not a known format and costs another failed step.
       throw new Error(
-        `os.fs.read_document: unsupported extension ".${ext}" (override with \`format\`)`,
+        SOURCE_LIKE_EXTENSIONS.has(ext)
+          ? `os.fs.read_document: ".${ext}" is a source/text file — use os.fs.read instead; if you intended document extraction, retry with \`format: "plain"\``
+          : `os.fs.read_document: unsupported extension ".${ext}" — use os.fs.read for source or text files, or retry with an explicit format (e.g. \`format: "plain"\`)`,
       );
   }
 }

--- a/src/tools/os/read-document/read-document.ts
+++ b/src/tools/os/read-document/read-document.ts
@@ -4,6 +4,7 @@ import { extname } from "node:path";
 import { compressToolResult } from "../../../compressor/result-compressor.js";
 import { resolveUserPath } from "../expand-home.js";
 import type { ToolDefinition } from "../../tool-registry.js";
+import { DOCUMENT_FORMATS } from "./extractors/extractor-types.js";
 import type {
   DocumentFormat,
   Extractor,
@@ -40,7 +41,7 @@ export function buildOsFsReadDocumentTool(
   return {
     name: "os.fs.read_document",
     description:
-      'Extract plain text (with light structure markers) from PDF, DOCX, DOC (legacy), XLSX, RTF, ODT, PPTX, and plain-text files. NOT for source code or other UTF-8 text files — read those with os.fs.read. Auto-detects format by extension; override with `format` (the plain-text value is `format: "plain"`). Read-only, no approval required.',
+      'Extract plain text (with light structure markers) from PDF, DOCX, DOC (legacy), XLSX, RTF, ODT, PPTX, and plain-text files. NOT for source code — read code with os.fs.read, which pages with offset/limit. Auto-detects format by extension; override with `format`, one of: pdf, docx, doc, xlsx, rtf, odt, pptx, plain. Read-only, no approval required.',
     readonly: true,
     async run(rawArgs, ctx) {
       const args = await parseArgs(rawArgs, ctx.workingDir);
@@ -198,13 +199,22 @@ function parseSheetsArg(
 }
 
 /**
- * Extensions that are almost certainly source code or other line-oriented
- * text. They are deliberately NOT mapped to `plain`: `os.fs.read` is the
- * right tool for them (offset/limit pagination, `lineNumbers`, no document
- * extractor in the way). The set exists only so the rejection can say which
- * tool to reach for next — without that, models retry `read_document` with
- * an invented `format: "text"` and burn another step before discovering
- * `os.fs.read` (issue #113).
+ * Extensions that are almost certainly source code or configuration — both
+ * line-oriented, both better served by `os.fs.read` (offset/limit
+ * pagination, `lineNumbers`, no document extractor in the way), so they are
+ * deliberately NOT mapped to `plain`. The set exists only so the rejection
+ * can say which tool to reach for next — without that, models retry
+ * `read_document` with an invented `format: "text"` and burn another step
+ * before discovering `os.fs.read` (issue #113).
+ *
+ * Deliberately absent: delimited data (`csv`, `tsv`) and markup (`html`,
+ * `xml`, `md`, `log`, `json`, `yaml`) — those route to `plain` in the switch
+ * below, and a set entry here would make the error message assert a
+ * classification the switch contradicts.
+ *
+ * `env` only fires for the `name.env` shape: `extname("/x/.env")` is `""`,
+ * so a bare dotfile lands on the extensionless `case ""` arm and extracts as
+ * `plain`. That asymmetry is inherited from `extname`, not introduced here.
  */
 const SOURCE_LIKE_EXTENSIONS: ReadonlySet<string> = new Set([
   "bash", "c", "cc", "cfg", "cjs", "clj", "conf", "cpp", "cs", "css", "cxx",
@@ -212,20 +222,24 @@ const SOURCE_LIKE_EXTENSIONS: ReadonlySet<string> = new Set([
   "hs", "ini", "ipynb", "java", "js", "jsonc", "jsx", "kt", "kts", "less",
   "lua", "m", "mjs", "mm", "php", "pl", "pm", "properties", "proto", "ps1",
   "py", "pyi", "r", "rb", "rs", "sass", "scala", "scss", "sh", "sql", "svelte",
-  "swift", "tf", "toml", "ts", "tsv", "tsx", "vue", "zsh",
+  "swift", "tf", "toml", "ts", "tsx", "vue", "zsh",
 ]);
 
 /**
- * Resolve extension → canonical format. `.html/.xml/.json/.csv` currently
- * fall through to `plain` — it's the safest default until we need format-
- * specific pretty-printing for them.
+ * Resolve extension → canonical format. `.html/.xml/.json/.csv/.tsv`
+ * currently fall through to `plain` — it's the safest default until we need
+ * format-specific pretty-printing for them.
  */
 function detectFormat(absolute: string, override: unknown): DocumentFormat {
   if (typeof override === "string" && override.length > 0) {
     const norm = override.toLowerCase();
     if (isKnownFormat(norm)) return norm;
+    // Naming the accepted set here matters as much as it does in the
+    // extension branches below: a model that guesses `format: "text"`
+    // preemptively never sees the detectFormat hint, and a bare "unknown
+    // format override" leaves it with nowhere to go (issue #113).
     throw new Error(
-      `os.fs.read_document: unknown format override ${JSON.stringify(override)}`,
+      `os.fs.read_document: unknown format override ${JSON.stringify(override)} — expected one of ${DOCUMENT_FORMATS.join(", ")}; for source or text files use os.fs.read`,
     );
   }
   const ext = extname(absolute).toLowerCase().replace(/^\./, "");
@@ -249,6 +263,7 @@ function detectFormat(absolute: string, override: unknown): DocumentFormat {
     case "md":
     case "log":
     case "csv":
+    case "tsv":
     case "json":
     case "html":
     case "xml":
@@ -264,23 +279,14 @@ function detectFormat(absolute: string, override: unknown): DocumentFormat {
       // which is not a known format and costs another failed step.
       throw new Error(
         SOURCE_LIKE_EXTENSIONS.has(ext)
-          ? `os.fs.read_document: ".${ext}" is a source/text file — use os.fs.read instead; if you intended document extraction, retry with \`format: "plain"\``
+          ? `os.fs.read_document: ".${ext}" is a source or config file — use os.fs.read instead; if you intended document extraction, retry with \`format: "plain"\``
           : `os.fs.read_document: unsupported extension ".${ext}" — use os.fs.read for source or text files, or retry with an explicit format (e.g. \`format: "plain"\`)`,
       );
   }
 }
 
 function isKnownFormat(value: string): value is DocumentFormat {
-  return (
-    value === "pdf" ||
-    value === "docx" ||
-    value === "doc" ||
-    value === "xlsx" ||
-    value === "rtf" ||
-    value === "odt" ||
-    value === "pptx" ||
-    value === "plain"
-  );
+  return (DOCUMENT_FORMATS as readonly string[]).includes(value);
 }
 
 /**


### PR DESCRIPTION
## Problem

A model that reaches for `os.fs.read_document` on a source file used to get no useful way out:

- The frequent-tool summaries said `os.fs.read` = "Read a UTF-8 file" and `os.fs.read_document` = "Extract plain text from PDF, Office, ODF, etc." — neither said which one owns `.py` / `.ts` / `.rs`.
- `detectFormat` rejected every unlisted extension with the same line: `unsupported extension ".py" (override with \`format\`)`. The bare word `format` invited the guess `format: "text"`, which is not a known format, so the next step failed too — and only after that did the model find `os.fs.read`.
- Nothing stopped that guess in the first place: `format` was an open `string` in both the stable-prefix `argsSchema` and the cloud `native_tools` JSON Schema, even though the runtime accepts a closed 8-value set.

Finding §10 of the Yabloko Labs evaluation. It is partly model behaviour, but the descriptors, the schemas and the error text were leaving the recovery to chance.

## Fix

Three surfaces, no refactor.

**Stable-prefix summaries** (`src/prompt/default-tool-descriptors-a.ts`) now split the two readers explicitly:

- `os.fs.read` — "Read a UTF-8 file — **the default for source code and text files**; use offset/limit for ranges, lineNumbers for 'LINE|'."
- `os.fs.read_document` — "Extract plain text from documents — PDF, Office, ODF, RTF (markers in output). **NOT for source code: use os.fs.read.** Read-only."

The summary deliberately stops at "source code" rather than "source code or text files": `read_document` really does extract `.txt/.md/.csv/.json/.yaml/.html` as `plain`, and a summary that contradicts the tool would re-create, one level up, exactly the ambiguity this PR removes. Both stay one line — this block ships on every turn.

**The `format` argument is a closed set on every surface.** The 8 accepted values now live once, as `DOCUMENT_FORMATS` in `extractors/extractor-types.ts`, with `DocumentFormat` derived from it. `isKnownFormat`, the rejection message, the stable-prefix `argsSchema` (`format?: 'pdf' | 'docx' | ... | 'plain'`) and the cloud JSON Schema (`enum: [...DOCUMENT_FORMATS]`) all read that one declaration. This follows the repo convention stated in the header of `default-tool-args-schemas.ts` ("Enums match the runtime validators verbatim") and already applied to `os.fs.archive.*`. On native-tools transports the bad guess is now unrepresentable; everywhere else the rejection carries the exits:

```
os.fs.read_document: unknown format override "text" — expected one of pdf, docx,
doc, xlsx, rtf, odt, pptx, plain; for source or text files use os.fs.read
```

**Rejection text** (`src/tools/os/read-document/read-document.ts`): `detectFormat` keeps a `SOURCE_LIKE_EXTENSIONS` set (py, ts, tsx, rs, go, java, rb, sh, sql, toml, …). Those extensions are still *not* mapped to `plain` — `os.fs.read` really is the better tool for them (offset/limit pagination, `lineNumbers`, no extractor in the way) — but they now reject with a message that names the next tool first:

```
os.fs.read_document: ".py" is a source or config file — use os.fs.read instead;
if you intended document extraction, retry with `format: "plain"`
```

An extension outside that set carries no signal about what it is, so it gets both paths, and also the concrete value rather than the bare word:

```
os.fs.read_document: unsupported extension ".qzx" — use os.fs.read for source
or text files, or retry with an explicit format (e.g. `format: "plain"`)
```

The two shapes exist so the common case (wrong tool) leads with the tool switch and the ambiguous case does not over-claim. The tool's own `description` — the text loaded into `### loaded-tools` after `tool.view`, i.e. what the model reads at the moment it picks the tool — carries the same two facts and has its own pin test.

**One behaviour change beyond routing:** `.tsv` used to fall into the source-like branch and be told it was a "source/text file" while its twin `.csv` extracted fine as `plain`. `.tsv` now joins `.csv` on the `plain` arm, so the message no longer asserts a classification the switch next to it contradicts. Everything else is untouched: pdf/docx/doc/xlsx/rtf/odt/pptx and the plain-text set (`.txt/.md/.log/.csv/.json/.html/.xml/.yaml/.yml`, no extension) route exactly as before, and `format: "plain"` on a source file still works.

Also written down in the code, because it surprised a reviewer: the `env` entry only fires for the `name.env` shape — `extname("/x/.env")` is `""`, so a bare `.env` dotfile lands on the extensionless arm and extracts as `plain`. That is inherited from `extname` and pre-dates this PR.

## Test evidence

```
npm run lint                       # tsc -p tsconfig.json --noEmit — clean, no output
npx vitest run src/tools/os/read-document/read-document.test.ts \
               src/prompt/build-prompt.test.ts \
               src/tui/commands/tools-listing.test.ts \
               src/prompt/default-tool-args-schemas.test.ts \
               src/tools/os/os-tools.test.ts
#  Test Files  5 passed (5)
#       Tests  145 passed (145)

npx vitest run src/prompt src/tools/os src/llm src/tui/commands
#  Test Files  128 passed (128)
#       Tests  1395 passed | 3 skipped (1398)
```

New tests that **fail on the parent commit** (`Tests  5 failed | 76 passed (81)` with only the two non-test files stashed):

- `read-document.test.ts` — `.py`, `.ts`, `.rs` each reject with "is a source or config file", "use os.fs.read instead" and `format: "plain"`, and no longer with the old `override with \`format\`` phrasing.
- `read-document.test.ts` — unknown binary extension `.qzx` names both `os.fs.read` and `format: "plain"`.
- `build-prompt.test.ts` — building with the real `DEFAULT_TOOL_DESCRIPTORS` pins both halves of the routing hint, the absence of the "or text files" wording, and the enumerated `format` in `prompt.stablePrefix`.

Regression guards (these pass on the parent too — that is the point of them):

- `read-document.test.ts` — `format: "plain"` on `script.py` succeeds and returns `details.format === "plain"`.
- `read-document.test.ts` — every arm of the `detectFormat` switch reaches its own extractor in order: pdf/docx/**doc**/xlsx/rtf/odt/pptx plus txt/md/log/csv/tsv/json/html/xml/yaml/yml and an extensionless `Makefile`. (The first version of this loop covered 11 of the arms and omitted legacy `.doc` entirely — its extractor was not even in the injected bag, so deleting the `case "doc"` arm would not have failed it. It does now.)

New tests from the follow-up commit, each verified non-vacuous by reverting exactly one hunk and re-running:

| reverted hunk | failing tests |
| --- | --- |
| tool `description` | 1 failed / 18 passed |
| `argsSchema` format enum | 2 failed / 73 passed |
| JSON Schema format enum | 1 failed / 10 passed |
| `.tsv` → `plain` | 1 failed / 18 passed |
| accepted-values in the unknown-override message | 1 failed / 18 passed |
| stable-prefix summary wording | 1 failed / 63 passed |
| `case "doc"` arm | 1 failed / 18 passed |
| `SOURCE_LIKE_EXTENSIONS` lookup | 3 failed / 16 passed |

End-to-end probe against the **real** extractors (no injected fakes): `a.tsv {} -> OK plain`, `a.csv {} -> OK plain`, `Makefile {} -> OK plain`, `.env {} -> OK plain`, `script.py {} -> ERR "source or config file … os.fs.read"`, `script.py {format:"text"} -> ERR "expected one of pdf, docx, doc, xlsx, rtf, odt, pptx, plain; … use os.fs.read"`, `script.py {format:"plain"} -> OK plain`, `a.d.ts` and `a.Py` both hit the source branch.

## Deliberately left out

- **No new plain-text extensions for source code.** Mapping `.py` & co. to `plain` would make `read_document` "work" on source and defeat the point: `os.fs.read` is the tool with pagination and line numbers. The set steers, it does not silently accept. (`.tsv` is the one exception, and it is delimited data, not source — see above.)
- **No content sniffing.** Extension-only keeps `detectFormat` synchronous and cheap; a magic-byte probe is a different change with its own failure modes.
- **No new persona/rules line.** The two summaries already sit next to each other in the frequent-tool block; another `### rules` sentence would cost prompt budget on every turn for the same information.
- **The extension list is not exhaustive** (no `.f90`, `.asm`, …). Anything missed falls into the unknown-extension branch, which now also names `os.fs.read` — so the worst case is a slightly less pointed message, never a wrong one.
- **`extname` is not worked around** for dotfiles: `.env`/`.gitignore` still resolve to the extensionless arm and extract as `plain`. Special-casing basenames is a bigger behaviour change than this PR wants, and reading a dotfile as text is not a failure.
- The promotional comment on the issue asking for a README badge is unrelated to this change and was ignored.

Fixes #113
