### PR TITLE
fix(llm): provider-availability failures no longer block fallover

### DIFF
--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -1967,7 +1967,24 @@ function toLlmFailure(err: unknown, ctx: StepContext): LlmFailure {
     );
   }
   if (err instanceof LlamaServerError) {
-    if (err.status === null || err.status >= 500) {
+    // Delegate the status split to `classifyFailure` rather than
+    // restating it. This arm used to carry its own hardcoded copy
+    // (`status === null || >= 500` ⇒ transport, everything else ⇒
+    // grammar), and because `executeStep` rethrows *this* wrapper — and
+    // `classifyFailure`'s first line short-circuits on `LlmFailure` —
+    // the copy, not the classifier, decided the category the user reads.
+    // The two diverged the moment the taxonomy moved: a 404 from a wrong
+    // `localModels.url` still surfaced as `Turn failed [grammar]` with no
+    // unreachable hint. One taxonomy, one place.
+    //
+    // `classifyFailure` cannot return `cancelled`/`model`/`tool` for a
+    // `LlamaServerError` (its own arm returns only `transport` or
+    // `grammar`, and it is reached before the abort/network branches),
+    // and an aborted step has already been claimed by the
+    // `ctx.signal.aborted` check above — so nothing is laundered here.
+    // Only `transport` becomes a `TransportError`; every other answer
+    // keeps the historical `GrammarError`.
+    if (classifyFailure(err) === "transport") {
       return new TransportError(err.message, err.status, err.url, { cause: err });
     }
     return new GrammarError(err.message, "", { cause: err });

--- a/src/llm/fallback/should-advance.test.ts
+++ b/src/llm/fallback/should-advance.test.ts
@@ -9,6 +9,10 @@ import {
   ToolExecutionError,
   CancelledError,
 } from "../reliability/llm-failures.js";
+import {
+  SubscriptionCliAuthError,
+  SubscriptionCliNotInstalledError,
+} from "../provider/subscription-cli/subscription-cli-errors.js";
 
 describe("shouldAdvance", () => {
   it("advances immediately on a cloud 429", () => {
@@ -75,12 +79,63 @@ describe("shouldAdvance", () => {
     });
   });
 
-  it("does NOT advance on a local llama 4xx (grammar category)", () => {
-    // LlamaServerError with a 4xx status classifies as grammar.
+  it("does NOT advance on a local llama 400 (request-shape, grammar category)", () => {
+    // A 400 is the server rejecting THIS request; the next link rejects
+    // it the same way, so falling over buys nothing.
     expect(shouldAdvance(new LlamaServerError("x", 400, "http://local"))).toEqual({
       advance: false,
       immediate: false,
     });
+  });
+
+  it("advances via threshold on a local llama 404 — the URL serves no completions", () => {
+    // The endpoint is permanently wrong (bad `localModels.url`, or a
+    // server that is not a llama-server). Not an immediate signal: 404 is
+    // not in the 429/408/5xx provider-down set, so it advances once the
+    // consecutive-failure threshold trips.
+    expect(shouldAdvance(new LlamaServerError("x", 404, "http://local"))).toEqual({
+      advance: true,
+      immediate: false,
+    });
+  });
+
+  it("advances via threshold on a local llama 405", () => {
+    expect(shouldAdvance(new LlamaServerError("x", 405, "http://local"))).toEqual({
+      advance: true,
+      immediate: false,
+    });
+  });
+
+  it("advances immediately on a local llama 429", () => {
+    // Transport category plus an unambiguous provider-down status — the
+    // `isImmediateSignal` status read already handled 429; it was simply
+    // unreachable while 4xx classified as grammar.
+    expect(shouldAdvance(new LlamaServerError("x", 429, "http://local"))).toEqual({
+      advance: true,
+      immediate: true,
+    });
+  });
+
+  it("advances immediately on a local llama 408", () => {
+    expect(shouldAdvance(new LlamaServerError("x", 408, "http://local"))).toEqual({
+      advance: true,
+      immediate: true,
+    });
+  });
+
+  it("advances on a subscription-CLI binary that is not installed", () => {
+    // No HTTP status to read, so it advances via the threshold — but it
+    // must advance: a missing `claude` binary otherwise pins the chain to
+    // a provider that can never serve a turn.
+    expect(
+      shouldAdvance(new SubscriptionCliNotInstalledError("claude", "Install it.")),
+    ).toEqual({ advance: true, immediate: false });
+  });
+
+  it("advances on a subscription-CLI provider that is signed out", () => {
+    expect(
+      shouldAdvance(new SubscriptionCliAuthError("codex", "Run /login.")),
+    ).toEqual({ advance: true, immediate: false });
   });
 
   it("advances via threshold on a TransportError carrying null status", () => {

--- a/src/llm/fallback/should-advance.test.ts
+++ b/src/llm/fallback/should-advance.test.ts
@@ -88,10 +88,14 @@ describe("shouldAdvance", () => {
     });
   });
 
-  it("advances via threshold on a local llama 404 — the URL serves no completions", () => {
+  it("advances on a local llama 404 without arming the breaker — the URL serves no completions", () => {
     // The endpoint is permanently wrong (bad `localModels.url`, or a
-    // server that is not a llama-server). Not an immediate signal: 404 is
-    // not in the 429/408/5xx provider-down set, so it advances once the
+    // server that is not a llama-server), so the chain must move off this
+    // link — and it moves on THIS failure: `advanceFrom` returns the next
+    // provider whenever `advance` is true, immediate or not.
+    // `immediate: false` is about the breaker, not the switch: 404 is not
+    // in the 429/408/5xx provider-down set, so the cooldown that keeps the
+    // link quarantined across later turns is armed only once the
     // consecutive-failure threshold trips.
     expect(shouldAdvance(new LlamaServerError("x", 404, "http://local"))).toEqual({
       advance: true,
@@ -99,24 +103,25 @@ describe("shouldAdvance", () => {
     });
   });
 
-  it("advances via threshold on a local llama 405", () => {
+  it("advances on a local llama 405 without arming the breaker", () => {
     expect(shouldAdvance(new LlamaServerError("x", 405, "http://local"))).toEqual({
       advance: true,
       immediate: false,
     });
   });
 
-  it("advances immediately on a local llama 429", () => {
+  it("advances on a local llama 429 and arms the breaker on the first failure", () => {
     // Transport category plus an unambiguous provider-down status — the
     // `isImmediateSignal` status read already handled 429; it was simply
-    // unreachable while 4xx classified as grammar.
+    // unreachable while 4xx classified as grammar. The extra `immediate`
+    // buys the cooldown straight away, not an earlier switch.
     expect(shouldAdvance(new LlamaServerError("x", 429, "http://local"))).toEqual({
       advance: true,
       immediate: true,
     });
   });
 
-  it("advances immediately on a local llama 408", () => {
+  it("advances on a local llama 408 and arms the breaker on the first failure", () => {
     expect(shouldAdvance(new LlamaServerError("x", 408, "http://local"))).toEqual({
       advance: true,
       immediate: true,
@@ -124,9 +129,11 @@ describe("shouldAdvance", () => {
   });
 
   it("advances on a subscription-CLI binary that is not installed", () => {
-    // No HTTP status to read, so it advances via the threshold — but it
-    // must advance: a missing `claude` binary otherwise pins the chain to
-    // a provider that can never serve a turn.
+    // It must advance: a missing `claude` binary otherwise pins the chain
+    // to a provider that can never serve a turn — and the switch happens
+    // on this first failure. There is no HTTP status to read, so
+    // `immediate` is false and the breaker cooldown waits for the
+    // consecutive-failure threshold.
     expect(
       shouldAdvance(new SubscriptionCliNotInstalledError("claude", "Install it.")),
     ).toEqual({ advance: true, immediate: false });

--- a/src/llm/fallback/should-advance.ts
+++ b/src/llm/fallback/should-advance.ts
@@ -11,8 +11,14 @@ import { TransportError } from "../reliability/llm-failures.js";
  *    `false` means the error is deterministic (same request fails the
  *    same way everywhere) or is a cancellation — propagate it untouched.
  *  - `immediate`: an unambiguous provider-down signal (429 / 408 / 5xx /
- *    network-null) that should switch on the FIRST occurrence, bypassing
- *    the consecutive-failure threshold.
+ *    network-null). This does NOT control whether the chain switches —
+ *    `ProviderFallbackChain.advanceFrom` returns the next link on the
+ *    FIRST fallover-worthy failure whenever `advance` is true, immediate
+ *    or not. What it controls is the breaker: `registerFailure` arms the
+ *    cooldown right away on an immediate signal, instead of waiting for
+ *    `failureThreshold` consecutive failures. So `immediate` decides how
+ *    long the failed link stays quarantined across later turns, not the
+ *    in-turn switch.
  */
 export interface AdvanceDecision {
   advance: boolean;

--- a/src/llm/fallback/should-advance.ts
+++ b/src/llm/fallback/should-advance.ts
@@ -29,15 +29,21 @@ const NO: AdvanceDecision = { advance: false, immediate: false };
  *  - `transport` → advance (provider unreachable). Note every cloud
  *    `OpenAiHttpError` classifies as `transport` regardless of status, so
  *    a 404 model-not-found or a 401 dead key advances too — a different
- *    link may have the model or a working key. Untyped socket failures
+ *    link may have the model or a working key. The local path now agrees:
+ *    a llama-server 404/405 (the configured URL does not serve
+ *    completions) or 401/403/429 advances for the same reason. A
+ *    subscription-CLI provider whose binary is missing or is signed out
+ *    is the same story with no HTTP in it. Untyped socket failures
  *    (undici's `TypeError: fetch failed` and friends, from surfaces that
  *    do not wrap their own errors) land here too — see `isNetworkError`.
  *  - `model` → advance. This is a *defective completion* from a reachable
  *    provider (truncated / empty / no_stop), not "model not found"; the
  *    same prompt would reproduce it here, so another link is worth a try.
- *  - `grammar` / `tool` / `cancelled` → do not advance. A grammar/4xx
- *    failure is request-shape and repeats identically on every provider;
- *    a tool failure is our own bug; a cancellation is user intent.
+ *  - `grammar` / `tool` / `cancelled` → do not advance. A grammar failure
+ *    is request-shape — an unparseable completion, or the narrow band of
+ *    llama-server 4xx that rejects the request itself (400/413/422) —
+ *    and repeats identically on every provider; a tool failure is our own
+ *    bug; a cancellation is user intent.
  *
  * Immediate signals are read off the typed status carried by
  * `OpenAiHttpError` / `LlamaServerError` / `TransportError`: an explicit

--- a/src/llm/reliability/classify-failure.test.ts
+++ b/src/llm/reliability/classify-failure.test.ts
@@ -8,6 +8,11 @@ import {
   ToolExecutionError,
   TransportError,
 } from "./llm-failures.js";
+import {
+  SubscriptionCliAuthError,
+  SubscriptionCliInvocationError,
+  SubscriptionCliNotInstalledError,
+} from "../provider/subscription-cli/subscription-cli-errors.js";
 import { classifyFailure } from "./classify-failure.js";
 
 describe("classifyFailure", () => {
@@ -29,7 +34,7 @@ describe("classifyFailure", () => {
     expect(classifyFailure(err)).toBe("transport");
   });
 
-  it("maps LlamaServerError 4xx to grammar", () => {
+  it("maps LlamaServerError request-shape 4xx to grammar", () => {
     const err = new LlamaServerError("bad grammar", 400, "http://x");
     expect(classifyFailure(err)).toBe("grammar");
   });
@@ -85,5 +90,64 @@ describe("classifyFailure — raw network failures", () => {
       code: "ECONNRESET",
     });
     expect(classifyFailure(err)).toBe("cancelled");
+  });
+});
+
+describe("classifyFailure — llama-server HTTP statuses", () => {
+  // A 4xx that describes the *endpoint* must not be filed as `grammar`:
+  // that category blocks fallover (`shouldAdvance`) and tells the user
+  // their grammar is broken when the real answer is "that URL is not a
+  // llama-server". A 4xx that rejects the request itself stays grammar.
+  const cases: Array<[number | null, string]> = [
+    [null, "transport"],
+    [400, "grammar"],
+    [401, "transport"],
+    [402, "transport"],
+    [403, "transport"],
+    [404, "transport"],
+    [405, "transport"],
+    [408, "transport"],
+    [409, "transport"],
+    [413, "grammar"],
+    [422, "grammar"],
+    [429, "transport"],
+    [500, "transport"],
+    [503, "transport"],
+  ];
+
+  for (const [status, expected] of cases) {
+    it(`maps status ${status ?? "null"} to ${expected}`, () => {
+      const err = new LlamaServerError("boom", status, "http://x");
+      expect(classifyFailure(err)).toBe(expected);
+    });
+  }
+
+  it("leaves an unlisted 4xx on the request-shape side", () => {
+    // Conservative default: only the statuses we can name as
+    // endpoint/auth/availability earn a fallover.
+    expect(classifyFailure(new LlamaServerError("x", 418, "http://x"))).toBe(
+      "grammar",
+    );
+  });
+});
+
+describe("classifyFailure — subscription-CLI providers", () => {
+  it("maps a missing CLI binary to transport, not tool", () => {
+    // "claude is not on PATH" is a dead provider link, not a bug in our
+    // tool layer — the chain must be free to try the next provider.
+    const err = new SubscriptionCliNotInstalledError("claude", "Install it.");
+    expect(classifyFailure(err)).toBe("transport");
+  });
+
+  it("maps a signed-out CLI to transport, not tool", () => {
+    const err = new SubscriptionCliAuthError("codex", "Run /login.");
+    expect(classifyFailure(err)).toBe("transport");
+  });
+
+  it("still treats a failed CLI invocation as a tool failure", () => {
+    // The binary ran and came back unhappy: that is not evidence the
+    // link is unusable, so it keeps the non-advancing category.
+    const err = new SubscriptionCliInvocationError("claude exited 1", 1);
+    expect(classifyFailure(err)).toBe("tool");
   });
 });

--- a/src/llm/reliability/classify-failure.ts
+++ b/src/llm/reliability/classify-failure.ts
@@ -1,9 +1,30 @@
 import { LlamaServerError } from "../llama-server-client.js";
 import { OpenAiHttpError } from "../provider/openai/openai-http.js";
+import {
+  SubscriptionCliAuthError,
+  SubscriptionCliNotInstalledError,
+} from "../provider/subscription-cli/subscription-cli-errors.js";
 import { ToolCallParseError } from "../grammar/tool-call-grammar.js";
 import type { LlmFailureCategory } from "./failure-category.js";
 import { LlmFailure } from "./llm-failures.js";
 import { isNetworkError } from "./network-error.js";
+
+/**
+ * llama-server 4xx statuses that describe the *endpoint*, not the request
+ * we sent it: the URL does not serve completions (404 — a wrong
+ * `localModels.url`, or a server that is not a llama-server at all), the
+ * method is not allowed (405), a proxy in front of it wants credentials
+ * (401/402/403), or the server is busy / timing us out / conflicting
+ * (408/409/429). None of these repeat identically on a different provider,
+ * so they are `transport`: the link is unusable, try the next one.
+ *
+ * Everything else in the 4xx range stays `grammar` — 400/413/422 are the
+ * server telling us THIS request was malformed or too large, which the
+ * next link would reject the same way.
+ */
+const LLAMA_ENDPOINT_UNAVAILABLE_STATUSES = new Set([
+  401, 402, 403, 404, 405, 408, 409, 429,
+]);
 
 /**
  * Classify any thrown value into the canonical failure taxonomy.
@@ -14,6 +35,13 @@ import { isNetworkError } from "./network-error.js";
  * classifier from legacy surfaces (direct `LlamaServerError` throws,
  * grammar parser errors, abort signals, and anything else treated as
  * a tool-layer problem by default).
+ *
+ * The governing rule across every branch: a failure that means "this
+ * provider is unusable" must not land in a category that blocks
+ * fallover. `shouldAdvance` only advances on `transport` / `model`, so
+ * filing an unusable link under `grammar` or `tool` pins the chain to a
+ * permanently broken provider and hands the user a diagnosis for a
+ * problem they do not have.
  *
  * The `isNetworkError` branch sits between the abort check and that
  * default: an untyped socket failure (MCP streamable-http, embeddings,
@@ -29,6 +57,7 @@ export function classifyFailure(err: unknown): LlmFailureCategory {
   if (err instanceof LlamaServerError) {
     if (err.status === null) return "transport";
     if (err.status >= 500) return "transport";
+    if (LLAMA_ENDPOINT_UNAVAILABLE_STATUSES.has(err.status)) return "transport";
     return "grammar";
   }
   // Cloud provider failures are provider-boundary problems whatever the
@@ -36,6 +65,17 @@ export function classifyFailure(err: unknown): LlmFailureCategory {
   // retry budget was already spent inside the HTTP client, matching the
   // TransportError contract.
   if (err instanceof OpenAiHttpError) return "transport";
+  // A CLI-backed provider whose binary is missing or signed out is the
+  // same shape of problem as an unreachable HTTP endpoint: this link
+  // cannot serve the turn, and no other link is implicated. The default
+  // `tool` arm below would both mislabel it ("Turn failed [tool]" for a
+  // binary the user never installed) and stop the chain dead.
+  if (
+    err instanceof SubscriptionCliNotInstalledError ||
+    err instanceof SubscriptionCliAuthError
+  ) {
+    return "transport";
+  }
   if (isAbortError(err)) return "cancelled";
   // Checked after the abort branch on purpose: an aborted request can
   // surface as ECONNRESET, and a user pressing Esc is not a fallover.

--- a/src/llm/reliability/failure-category.ts
+++ b/src/llm/reliability/failure-category.ts
@@ -1,11 +1,18 @@
 /**
  * Canonical taxonomy of failures surfaced by the agent runtime.
  *
- *  - `transport`: llama-server unreachable, network error, HTTP 5xx.
+ *  - `transport`: the provider link is unusable — llama-server
+ *                 unreachable, network error, HTTP 5xx, a llama-server
+ *                 4xx that describes the endpoint rather than the request
+ *                 (401/402/403/404/405/408/409/429), any cloud HTTP
+ *                 failure, or a CLI-backed provider whose binary is
+ *                 missing or signed out. Everything here is worth
+ *                 retrying on the next link in the fallback chain.
  *  - `grammar`:   the completion payload could not be parsed into a valid
- *                 tool call; also covers HTTP 4xx from llama-server which
- *                 generally means the server rejected the grammar or
- *                 request shape.
+ *                 tool call; also covers the llama-server 4xx statuses
+ *                 that reject THIS request as malformed or oversized
+ *                 (400/413/422 and any other unlisted 4xx), which the
+ *                 next provider would reject identically.
  *  - `model`:     the completion itself is defective (truncated, empty,
  *                 or generated without a stop token). Retrying the same
  *                 prompt is unlikely to help, so the runtime does not.

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { AgentLoop } from "../agent/agent-loop.js";
+import { buildDefaultToolRegistry } from "../tools/index.js";
+import { SlotManager } from "../llm/slot-manager.js";
+import { createEmptySessionState } from "../session/session-state.js";
 import { LlamaServerError } from "../llm/llama-server-client.js";
-import { classifyFailure } from "../llm/reliability/classify-failure.js";
+import type {
+  CapabilitiesSummary,
+  SkillCatalogEntry,
+  ToolDescriptor,
+} from "../prompt/stable-prefix.js";
 import { formatAgentErrorForChat } from "./format-agent-error-for-chat.js";
 
 describe("formatAgentErrorForChat", () => {
@@ -50,47 +61,126 @@ describe("formatAgentErrorForChat", () => {
   });
 });
 
-describe("formatAgentErrorForChat — classified llama failures", () => {
-  // Mirrors the real pipeline: `agent-loop` classifies the thrown error
-  // and the reducer hands that category straight to the formatter. The
-  // hint is gated on `transport`, so the one failure where "check your
-  // llama URL" is exactly right — a 404 from a wrong `localModels.url` —
-  // used to be the one failure that never got it.
-  const local = {
-    activeProviderIsLocal: true,
-    llamaUrl: "http://127.0.0.1:19091",
-  };
+const LOCAL = {
+  activeProviderIsLocal: true,
+  llamaUrl: "http://127.0.0.1:19091",
+};
 
-  it("carries the unreachable hint for a llama 404 on a local provider", () => {
-    const err = new LlamaServerError(
-      "llama-server returned http 404",
-      404,
-      local.llamaUrl,
+const TOOLS: ToolDescriptor[] = [
+  {
+    name: "finish",
+    summary: "Finish the session with a summary.",
+    argsSchema: '{"summary": string}',
+  },
+];
+
+const CAPS: CapabilitiesSummary = {
+  platform: "darwin",
+  arch: "arm64",
+  browserChannel: "chrome",
+  workingDir: "/work",
+  hasClipboard: true,
+  hasWmctrl: false,
+  hasNotifications: true,
+};
+
+const SKILLS: SkillCatalogEntry[] = [];
+
+describe("formatAgentErrorForChat — llama failures through the real pipeline", () => {
+  // Drives the WHOLE production path, not a hand-composed imitation of
+  // it: `AgentLoop` runs a step whose `llmComplete` throws a raw
+  // `LlamaServerError`; `executeStep` normalises it through
+  // `toLlmFailure`; the loop's catch calls `classifyFailure` on THAT
+  // wrapper and emits `loop_failed { category, error }`; the TUI reducer
+  // (`agent-event-reducer.ts`, "loop_failed" case) hands exactly those two
+  // fields plus the local-provider context to the formatter.
+  //
+  // The `toLlmFailure` link is the point of the exercise. It used to carry
+  // its own hardcoded copy of the llama status split, so a 404 reached the
+  // user as `Turn failed [grammar]` however `classifyFailure` was written —
+  // and a test that called `formatAgentErrorForChat(classifyFailure(err), …)`
+  // directly stayed green while production stayed broken. Route the
+  // assertion through the loop and that gap cannot hide.
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(tmpdir(), "atomic-agent-chat-error-"));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run one turn whose only LLM call throws `LlamaServerError(status)`,
+   * and render the resulting `loop_failed` exactly as the reducer does.
+   */
+  async function chatTextForLlamaStatus(status: number): Promise<string> {
+    const failures: Array<{ category: string; message: string }> = [];
+    const loop = new AgentLoop({
+      registry: buildDefaultToolRegistry(),
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        throw new LlamaServerError(
+          `llama-server returned http ${status}`,
+          status,
+          LOCAL.llamaUrl,
+        );
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "loop_failed") {
+          failures.push({
+            category: event.category,
+            message: event.error.message,
+          });
+        }
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: `s-llama-${status}`, workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 3,
+        signal: new AbortController().signal,
+      },
     );
-    const text = formatAgentErrorForChat(
-      classifyFailure(err),
-      err.message,
-      local,
+    expect(result.reason).toBe("failed");
+    expect(failures).toHaveLength(1);
+    return formatAgentErrorForChat(
+      failures[0]!.category,
+      failures[0]!.message,
+      LOCAL,
     );
+  }
+
+  it("carries the unreachable hint for a llama 404 on a local provider", async () => {
+    // The one failure where "check your llama URL" is exactly the right
+    // advice — a wrong `localModels.url`, or a server that is not a
+    // llama-server — was the one failure that never got it.
+    const text = await chatTextForLlamaStatus(404);
     expect(text).toContain("Turn failed [transport]");
     expect(text).toContain(
       "llama-server is not reachable at http://127.0.0.1:19091",
     );
   });
 
-  it("keeps a llama 400 as a grammar failure with no URL advice", () => {
-    const err = new LlamaServerError(
-      "llama-server returned http 400",
-      400,
-      local.llamaUrl,
+  it("carries the unreachable hint for a llama 405 on a local provider", async () => {
+    const text = await chatTextForLlamaStatus(405);
+    expect(text).toContain("Turn failed [transport]");
+    expect(text).toContain(
+      "llama-server is not reachable at http://127.0.0.1:19091",
     );
-    const text = formatAgentErrorForChat(
-      classifyFailure(err),
-      err.message,
-      local,
-    );
-    expect(text).toBe(
-      "Turn failed [grammar]: llama-server returned http 400",
-    );
+  });
+
+  it("keeps a llama 400 as a grammar failure with no URL advice", async () => {
+    // Regression guard for the half that is intentionally unchanged: a
+    // 400 is the server rejecting THIS request, and the next link would
+    // reject it identically.
+    const text = await chatTextForLlamaStatus(400);
+    expect(text).toBe("Turn failed [grammar]: llama-server returned http 400");
   });
 });

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { LlamaServerError } from "../llm/llama-server-client.js";
+import { classifyFailure } from "../llm/reliability/classify-failure.js";
 import { formatAgentErrorForChat } from "./format-agent-error-for-chat.js";
 
 describe("formatAgentErrorForChat", () => {
@@ -45,5 +47,50 @@ describe("formatAgentErrorForChat", () => {
         llamaUrl: "http://127.0.0.1:19091",
       }),
     ).toBe("Turn failed [model]: empty completion");
+  });
+});
+
+describe("formatAgentErrorForChat — classified llama failures", () => {
+  // Mirrors the real pipeline: `agent-loop` classifies the thrown error
+  // and the reducer hands that category straight to the formatter. The
+  // hint is gated on `transport`, so the one failure where "check your
+  // llama URL" is exactly right — a 404 from a wrong `localModels.url` —
+  // used to be the one failure that never got it.
+  const local = {
+    activeProviderIsLocal: true,
+    llamaUrl: "http://127.0.0.1:19091",
+  };
+
+  it("carries the unreachable hint for a llama 404 on a local provider", () => {
+    const err = new LlamaServerError(
+      "llama-server returned http 404",
+      404,
+      local.llamaUrl,
+    );
+    const text = formatAgentErrorForChat(
+      classifyFailure(err),
+      err.message,
+      local,
+    );
+    expect(text).toContain("Turn failed [transport]");
+    expect(text).toContain(
+      "llama-server is not reachable at http://127.0.0.1:19091",
+    );
+  });
+
+  it("keeps a llama 400 as a grammar failure with no URL advice", () => {
+    const err = new LlamaServerError(
+      "llama-server returned http 400",
+      400,
+      local.llamaUrl,
+    );
+    const text = formatAgentErrorForChat(
+      classifyFailure(err),
+      err.message,
+      local,
+    );
+    expect(text).toBe(
+      "Turn failed [grammar]: llama-server returned http 400",
+    );
   });
 });


### PR DESCRIPTION
## What

A failure meaning *"this provider link is unusable"* must not be filed under a category that blocks fallover. Two such failures were.

**(a) llama-server 4xx.** `classifyFailure` mapped every `LlamaServerError` with a non-null status under 500 to `"grammar"`. So an HTTP **404** — the configured `localModels.url` does not expose the completion endpoint (wrong URL, or a server that is not a llama-server) — and a **405** (wrong method) were reported as grammar failures.

**(b) subscription-CLI providers.** `SubscriptionCliNotInstalledError` and `SubscriptionCliAuthError` are plain `Error`s, so `classifyFailure` fell through to its catch-all `return "tool"`.

**(c) a duplicate copy of the same taxonomy in `step-executor.ts`.** `toLlmFailure` carried its own hardcoded `status === null || status >= 500 ⇒ transport, else grammar` split. `executeStep` wraps every escaping error through `toLlmFailure` and rethrows *that* wrapper, and `classifyFailure`'s first line short-circuits on `err instanceof LlmFailure` — so on the path that produces the message the user reads, the duplicate decided the category and (a) never applied. This was found in review of the first commit here and is fixed in `33af1f6`; without it the llama half of this PR would have changed only the fallover decision, not the chat message or the hint.

Three consequences, all in-repo:

1. The user reads `Turn failed [grammar]: llama-server returned http 404`, or `Turn failed [tool]: "claude" was not found on PATH…` — a tool bug it is not. Both are unactionable.
2. `shouldAdvance()` returns `{advance:false}` for `grammar` and `tool`, so the fallback chain **refuses to move to the next provider** even though the current link is permanently broken. Its own doc comment states the opposite intent for the cloud path: every `OpenAiHttpError` classifies as `transport` regardless of status, *"so a 404 model-not-found or a 401 dead key advances too — a different link may have the model or a working key."* The local and CLI paths contradicted that. A configured `claude`/`codex` provider that is simply not installed blocked the chain permanently.
3. `format-agent-error-for-chat.ts` appends `formatLlamaUnreachableHint(local.llamaUrl)` only when `category === "transport"`. The one case where "check your llama URL" is exactly the right advice — a 404 from a wrong URL — was the one case that never got the hint.

Sentry:

- **CLI-B7** — 141 events / 9 users, first seen 2026-08-28, still firing. `category=grammar`, `cause_type=LlamaServerError`, `http_status = 400 (118), 404 (15), 405 (8)`, `release = 0.5.4 (111), 0.4.2 (28), 0.5.3 (2)`.
- **CLI-BE** — 9 events / 6 users, win32. `http_status = 404 (6), 400 (3)`, same `grammar` category, releases 0.4.2 / 0.5.4 / 0.5.1.
- **CLI-BH** — 7 events / 5 users, first seen 2026-08-29. `error_type=ToolExecutionError`, `category=tool`, `cause_type=SubscriptionCliNotInstalledError`, releases 0.5.1 / 0.4.2.

The `grammar` + `LlamaServerError` signature in CLI-B7 / CLI-BE is precisely `new GrammarError(err.message, "", { cause: err })` in `toLlmFailure` — i.e. those two clusters are addressed by `33af1f6`, not by the classifier change alone. The 404/405 slice of them (29 of 150 events) stops being reported as `grammar`; the 400 slice (121 events) is deliberately left where it is, see *Deliberately out of scope*. CLI-BH goes through the catch-all arm, which already defers to `classifyFailure`, so it is fixed by the classifier change on its own.

## How

`src/llm/reliability/classify-failure.ts`:

- The `LlamaServerError` 4xx arm is split against a named set. Statuses that describe the **endpoint / auth / availability** rather than the request return `"transport"`: `401, 402, 403, 404, 405, 408, 409, 429` (joining the existing `null` and `>= 500`). None of these repeat identically on a different provider.
- Statuses that mean *this request was rejected as malformed or oversized* stay `"grammar"`: `400`, `413`, `422`, and — deliberately conservative — any other 4xx not named above. The default stays on the non-advancing side so an unfamiliar status cannot silently start burning the chain.
- `SubscriptionCliNotInstalledError` and `SubscriptionCliAuthError` route to `"transport"`. `SubscriptionCliInvocationError` deliberately does **not**: the binary ran and came back unhappy, which is not evidence the link is unusable.

Imported straight from `../provider/subscription-cli/subscription-cli-errors.js`, not the `subscription-cli/index.js` barrel. `subscription-cli-errors.ts` has zero imports of its own, so there is no cycle; the barrel would have dragged the providers and adapters into the reliability layer. Same shape as the existing `../provider/openai/openai-http.js` import.

`src/agent/step-executor.ts`: the `LlamaServerError` arm of `toLlmFailure` no longer restates the split — it asks `classifyFailure(err)` and maps `transport` to `TransportError(message, status, url)`, anything else to the historical `GrammarError(message, "")`. The `cause` chain is untouched in both arms, so the scrubber's `causeType` still resolves. `classifyFailure` cannot answer `cancelled`/`model`/`tool` for a `LlamaServerError` (its own arm returns only `transport` or `grammar`, ahead of the abort and network branches), and an aborted step is already claimed by the `ctx.signal.aborted` check above this arm, so no other category is laundered into a `TransportError`. This was the last hardcoded llama status split in `src/`; `llama-server-client.ts` (`isRetryableLlamaError`) and `should-advance.ts` (`isImmediateSignal`) read statuses for different decisions and are unchanged.

Doc comments updated to the new rule in `classify-failure.ts`, `failure-category.ts` (its `grammar:` bullet said "also covers HTTP 4xx from llama-server") and `should-advance.ts` (its `grammar` bullet said "A grammar/4xx failure is request-shape").

`isImmediateSignal` in `should-advance.ts` needed no change and does not double-count: it reads the status straight off `LlamaServerError`, so a 429 or 408 that is now `transport` is correctly *immediate*, while 401/402/403/404/405/409 are not, and the CLI errors carry no status field. To be precise about what that buys — `ProviderFallbackChain.advanceFrom` returns the next link on the **first** fallover-worthy failure whether or not it is immediate; `immediate` only arms the breaker cooldown straight away instead of waiting for `failureThreshold` consecutive failures, i.e. it governs how long the failed link stays quarantined across later turns, not the in-turn switch. The `AdvanceDecision` doc said otherwise and has been corrected.

## Trade-offs accepted

**A subscription CLI can be *called* signed-out by its own output.** `mapCliFailure` regex-matches `stderr + "\n" + stdout`, and stdout carries the CLI's own model output. So a non-zero exit whose text merely *discusses* auth — "unauthorized", "not logged in" — is relabelled `SubscriptionCliAuthError`. Before this PR that misfire stopped the chain and printed "not signed in, run /login", which at least named itself. After it, the chain falls over silently, and a genuine sign-out on a multi-link chain becomes a silent, repeated degradation to a paid cloud provider. On balance still the right trade — a CLI that cannot serve should not pin the chain — but it is a real behaviour change and it is undocumented anywhere else. The regex is a pre-existing weakness and is deliberately not touched here.

**`403` and the proxy case.** A llama-compatible endpoint behind LiteLLM / vLLM / a corporate gateway can answer `403` for a *content* rejection, which would fail identically on every link — so the chain burns every provider before giving up. That is consistent with what the cloud path already does for every `OpenAiHttpError` status, and `src/llm/llama-server-auth-probe.ts:31` already treats a llama `401`/`403` as an auth verdict, so `403` is placed with the existing precedent rather than against it; `402` and `409` are almost certainly unreachable from llama.cpp itself and are set members only for the same proxied deployments.

## Tests

- `classify-failure.test.ts`: a table over statuses — `400/413/422 → grammar`, `401/402/403/404/405/408/409/429 → transport`, `500/503 → transport`, `null → transport`, plus an unlisted `418 → grammar` guard for the conservative default; the two subscription-CLI errors → `transport`, and `SubscriptionCliInvocationError` still → `tool`.
- `should-advance.test.ts`: llama 404 and 405 advance without arming the breaker; llama 429 and 408 advance and arm it on the first failure; llama 400 still does not advance; both subscription-CLI errors advance.
- `format-agent-error-for-chat.test.ts`: drives the **whole** production path rather than imitating it — `AgentLoop` runs a step whose `llmComplete` throws a raw `LlamaServerError`, `executeStep` normalises it through `toLlmFailure`, the loop's catch classifies that wrapper and emits `loop_failed { category, error }`, and the assertion formats exactly those fields the way `agent-event-reducer`'s `loop_failed` case does. A llama 404 and 405 now carry the unreachable hint; a llama 400 still renders as a bare grammar failure.

**Not vacuous.**

- With `classify-failure.ts` reverted and the tests kept, **18 of the new tests fail** (10 in `classify-failure.test.ts`, 6 in `should-advance.test.ts`, 2 in `format-agent-error-for-chat.test.ts`). The remaining new rows are regression guards for behaviour that is intentionally unchanged.
- With only the `toLlmFailure` change (`33af1f6`) reverted, the two `format-agent-error-for-chat.test.ts` pipeline rows fail with `Turn failed [grammar]: llama-server returned http 404` / `… 405` — the exact production symptom. The earlier, hand-composed version of that test passed in that state, which is why it was rewritten.

## Verification

- `npm run lint` (`tsc --noEmit`): clean.
- `npx vitest run src/llm/reliability src/llm/fallback src/tui/format-agent-error-for-chat.test.ts src/llm/provider/subscription-cli` — **18 files, 197 tests, all passing**.
- `npx vitest run src/agent` (the suite over the changed `step-executor.ts`) — **15 files, 247 tests, all passing**.
- `npx vitest run agent-loop step-executor error-scrubber llama-server-provider llama-server-client llm-fallback-seam replay-session tasks tracing turn-controller tui/llm-panel` — **44 files, 483 tests, all passing**.
- Full suite not gated on (known flaky); no failure introduced by this change.

## Deliberately out of scope

A llama-server **400** is by far the largest bucket in CLI-B7 (118 of 141) and a good share of those are almost certainly context-overflow — the prompt exceeded the server's `n_ctx`. Sniffing the 400 response body to separate "prompt too long" from "malformed request" is **not** attempted here. It needs a taxonomy change, not a status remap: `ModelFailureReason` has no `context` value, and the correct handling for an overflow (compact or trim, then retry the same provider) is neither `grammar` nor `transport`. Both currently land on the non-advancing side, which is the safer of the two answers, so this change leaves 400 exactly where it was.
