### PR TITLE
fix(telegram): report a dead polling loop instead of staying "up"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1766,6 +1766,10 @@ Locked invariants (pinned by [src/tui/mcp/mcp-reducer.test.ts](src/tui/mcp/mcp-r
 4. **The editor is disabled on the MCP tab while a modal is open.** `mcpTabBusy` in `app-key-bindings.ts` covers both `addModal !== null` (lets the `MultiLineEditor` capture every keystroke) and `removeConfirm !== null` (claims the `y`/`n` confirmation keys against the global nav cycler).
 5. **Variant γ surface is opt-in but on by default.** Restarting the runtime is no longer required after add/remove — the prompt's `### tools` catalog and GBNF grammar are rebuilt on the next step. KV-cache for in-flight sessions is invalidated once per add/remove (the persona stays byte-stable; only the rendered tools block changes).
 
+### Poller liveness
+
+`bot.start()` is fire-and-forget, so for a long time the channel could report `up` while its polling loop was dead — a second process on the same token gets a 409 from Telegram, the loop ends, and every message afterwards went unanswered with the status still green. The `BotInstance.start` contract now takes an `onStopped(error?)` callback; the grammy adapter wires it to that promise's settlement instead of swallowing it with `.catch(() => undefined)`, and the channel transitions to `down` (releasing the lock, scrubbing the reason) unless it asked to stop. Pinned by the four "polling loop dies" cases in [telegram-channel.test.ts](src/channels/telegram/telegram-channel.test.ts) — verified to fail without the fix.
+
 ## Discord channel
 
 A Discord bot that relays DMs and @mentions to the agent and posts replies back — the same shape as the Telegram channel, sharing its `ChannelStatus` contract so the runtime, the TUI and the Integrations hub treat both alike. Code lives in [src/channels/discord/](src/channels/discord/); bootstrap constructs it unconditionally (so the hub can report state) and starts it only when `config.discord.enabled`.

--- a/src/channels/telegram/telegram-bot-factory.ts
+++ b/src/channels/telegram/telegram-bot-factory.ts
@@ -97,8 +97,15 @@ export const defaultGrammyBotFactory: BotFactory = async (token) => {
     setCallbackHandler(handler) {
       callbackHandler = handler;
     },
-    start(onStart) {
-      void bot.start({ onStart }).catch(() => undefined);
+    start(onStart, onStopped) {
+      // grammy's `bot.start()` promise settles when polling ends —
+      // resolving on a clean stop, rejecting on a fatal error (409
+      // conflict, revoked token). Swallowing it, as this did, made a
+      // dead poller indistinguishable from a healthy one.
+      void bot
+        .start({ onStart })
+        .then(() => onStopped?.())
+        .catch((err: unknown) => onStopped?.(err));
     },
     async stop() {
       await bot.stop();

--- a/src/channels/telegram/telegram-channel-types.ts
+++ b/src/channels/telegram/telegram-channel-types.ts
@@ -32,13 +32,18 @@ export interface BotInstance {
     handler: (u: InboundCallbackUpdate) => void | Promise<void>,
   ): void;
   /**
-   * Begin long-polling. Implementations are fire-and-forget — the
-   * polling loop runs in the background until `stop()` is called and
-   * any internal promise from grammy's `bot.start()` is left unawaited.
+   * Begin long-polling. Still fire-and-forget from the caller's point
+   * of view — the loop runs in the background — but the loop's *death*
+   * is now reported.
+   *
    * `onStart` fires once the first `getUpdates` request has been
-   * dispatched.
+   * dispatched. `onStopped` fires when the polling loop ends for any
+   * reason: a clean `stop()`, or a fatal error such as Telegram's 409
+   * when a second process starts polling the same token. Without it the
+   * channel had no way to learn its poller had died and went on
+   * reporting `up` while silently receiving nothing.
    */
-  start(onStart: () => void): void;
+  start(onStart: () => void, onStopped?: (error?: unknown) => void): void;
   /** Stop polling. Resolves when the in-flight update settles. */
   stop(): Promise<void>;
 }

--- a/src/channels/telegram/telegram-channel.test.ts
+++ b/src/channels/telegram/telegram-channel.test.ts
@@ -33,6 +33,8 @@ interface FakeBotState {
   callbackHandler: ((u: unknown) => void | Promise<void>) | null;
   /** Aggregated `sendMessage` invocations across every bot the factory has created. */
   sendMessageCalls: Array<{ chatId: number; text: string }>;
+  /** Simulate the polling loop ending. Set once `start()` has run. */
+  killPolling: ((error?: unknown) => void) | null;
 }
 
 interface FakeBotOptions {
@@ -53,6 +55,7 @@ function makeBotFactory(opts: FakeBotOptions = {}): {
     textHandler: null,
     callbackHandler: null,
     sendMessageCalls: [],
+    killPolling: null,
   };
   const factory: BotFactory = () => {
     const bot: BotInstance = {
@@ -80,8 +83,11 @@ function makeBotFactory(opts: FakeBotOptions = {}): {
       setCallbackHandler(handler) {
         state.callbackHandler = handler;
       },
-      start(_onStart) {
+      start(_onStart, onStopped) {
         state.startCalls += 1;
+        // Captured so a test can simulate the polling loop dying the
+        // way grammy reports it (409 conflict, revoked token, …).
+        state.killPolling = (err?: unknown) => onStopped?.(err);
       },
       async stop() {
         state.stopCalls += 1;
@@ -141,6 +147,112 @@ describe("TelegramChannel", () => {
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("goes down when the polling loop dies underneath it", async () => {
+    // The bug this pins: `bot.start()` is fire-and-forget, so when
+    // Telegram killed the poller (a second process on the same token
+    // gets a 409) the channel stayed at `up` and silently received
+    // nothing. A dead poller must read as `down`, with the reason.
+    const { factory, state } = makeBotFactory();
+    const { lock } = fakeLock();
+    const statuses: ChannelStatus[] = [];
+    const channel = new TelegramChannel({
+      runtime: fakeRuntime(),
+      config: makeConfig(dir),
+      token: "1234:abcdef",
+      logger,
+      botFactory: factory,
+      lock,
+      emitStatus: (s) => statuses.push(s),
+    });
+    await channel.start();
+    expect(channel.state()).toBe("up");
+
+    state.killPolling?.(new Error("409: Conflict: terminated by other getUpdates"));
+
+    expect(channel.state()).toBe("down");
+    expect(channel.lastError()).toMatch(/Conflict/);
+    expect(statuses.map((s) => s.state)).toEqual(["starting", "up", "down"]);
+  });
+
+  it("releases the lock when the poller dies, so a restart can re-acquire", async () => {
+    // Holding the lock after the poller is gone would make the channel
+    // permanently unstartable in this process.
+    const { factory, state } = makeBotFactory();
+    const lockState = fakeLock();
+    const channel = new TelegramChannel({
+      runtime: fakeRuntime(),
+      config: makeConfig(dir),
+      token: "1234:abcdef",
+      logger,
+      botFactory: factory,
+      lock: lockState.lock,
+    });
+    await channel.start();
+    expect(lockState.acquired).toBe(1);
+    state.killPolling?.(new Error("boom"));
+    expect(lockState.released).toBe(1);
+    await channel.start();
+    expect(channel.state()).toBe("up");
+    expect(lockState.acquired).toBe(2);
+  });
+
+  it("reports a reason even when the poller ends without an error", async () => {
+    const { factory, state } = makeBotFactory();
+    const { lock } = fakeLock();
+    const channel = new TelegramChannel({
+      runtime: fakeRuntime(),
+      config: makeConfig(dir),
+      token: "1234:abcdef",
+      logger,
+      botFactory: factory,
+      lock,
+    });
+    await channel.start();
+    state.killPolling?.();
+    expect(channel.state()).toBe("down");
+    expect(channel.lastError()).toBe("polling stopped unexpectedly");
+  });
+
+  it("does not report a deliberate stop as a failure", async () => {
+    // stop() ends the poller too; that must settle as `disabled`.
+    const { factory, state } = makeBotFactory();
+    const { lock } = fakeLock();
+    const statuses: ChannelStatus[] = [];
+    const channel = new TelegramChannel({
+      runtime: fakeRuntime(),
+      config: makeConfig(dir),
+      token: "1234:abcdef",
+      logger,
+      botFactory: factory,
+      lock,
+      emitStatus: (s) => statuses.push(s),
+    });
+    await channel.start();
+    await channel.stop();
+    state.killPolling?.();
+    expect(channel.state()).toBe("disabled");
+    expect(statuses.map((s) => s.state)).not.toContain("down");
+  });
+
+  it("scrubs the token out of a polling-death reason", async () => {
+    const { factory, state } = makeBotFactory();
+    const { lock } = fakeLock();
+    const channel = new TelegramChannel({
+      runtime: fakeRuntime(),
+      config: makeConfig(dir),
+      token: "1234:abcdef",
+      logger,
+      botFactory: factory,
+      lock,
+    });
+    await channel.start();
+    state.killPolling?.(
+      new Error(`polling https://api.telegram.org/bot123456789:${"A".repeat(35)}/getUpdates failed`),
+    );
+    expect(channel.lastError()).toContain("<token>");
+    expect(channel.lastError()).not.toContain("A".repeat(35));
   });
 
   it("starts up with valid token and emits starting then up", async () => {

--- a/src/channels/telegram/telegram-channel.ts
+++ b/src/channels/telegram/telegram-channel.ts
@@ -143,6 +143,11 @@ export class TelegramChannel {
   private currentState: ChannelStatus["state"] = "disabled";
   private currentError: string | null = null;
   private startInFlight = false;
+  /**
+   * True between `stop()` being called and the poller actually ending,
+   * so a deliberate shutdown is not misread as the poller dying.
+   */
+  private stopRequested = false;
 
   constructor(deps: TelegramChannelDeps) {
     this.deps = deps;
@@ -259,9 +264,13 @@ export class TelegramChannel {
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      bot.start(() => {
-        this.deps.logger.info("telegram: polling started");
-      });
+      this.stopRequested = false;
+      bot.start(
+        () => {
+          this.deps.logger.info("telegram: polling started");
+        },
+        (err) => this.handlePollingStopped(bot, err),
+      );
       this.bot = bot;
       this.transition("up", null);
     } catch (err) {
@@ -276,6 +285,33 @@ export class TelegramChannel {
     }
   }
 
+  /**
+   * The polling loop ended. Anything other than a `stop()` we asked for
+   * is a failure: the channel is no longer receiving updates, so it
+   * must say so rather than sit at `up` looking healthy while every
+   * message goes unanswered.
+   *
+   * Guarded on the bot identity so a late callback from a previous
+   * generation (restart, token change) cannot knock down the live one.
+   */
+  private handlePollingStopped(bot: BotInstance, err?: unknown): void {
+    if (this.stopRequested) return;
+    if (this.bot !== bot) return;
+    const reason =
+      err === undefined
+        ? "polling stopped unexpectedly"
+        : scrubErrorMessage(err);
+    this.deps.logger.warn("telegram: polling loop ended", { reason });
+    this.bot = null;
+    this.currentBotIdentity = null;
+    try {
+      this.lock.release();
+    } catch {
+      // best effort — a stale lock is reclaimed on the next acquire
+    }
+    this.transition("down", reason);
+  }
+
   /** Stop polling, abort in-flight turns, cancel pairing, release the lock. Idempotent. */
   async stop(): Promise<void> {
     if (this.currentState === "disabled" && !this.bot) {
@@ -284,6 +320,7 @@ export class TelegramChannel {
       this.pairing.cancel();
       return;
     }
+    this.stopRequested = true;
     this.transition("stopping", null);
     this.pairing.cancel();
     for (const controller of this.inflight.values()) {


### PR DESCRIPTION
> **Stacked on #332 → #331 → #330 → #329 → #328 → #327.** Retarget down the stack as each lands. The fix itself is independent of the stack and can be cherry-picked onto `main` if you'd rather land it first.

## The bug

`bot.start()` is fire-and-forget, and the grammy adapter threw away the promise it returns:

```ts
void bot.start({ onStart }).catch(() => undefined);
```

That promise settles when polling **ends** — resolving on a clean stop, rejecting on a fatal error. Discarding it meant the channel could never learn its poller had died. So after, say, Telegram's 409 (a second process polling the same token), the channel sat at `up`:

- every message afterwards went **silently unanswered**
- the TUI badge stayed **green**
- the rejection was **unhandled**

## How I found it

While testing the Telegram channel for real. One of my own diagnostic `getUpdates` calls took the poller down; the channel reported `up` for several minutes while messages queued at Telegram (`pending_update_count: 1` and climbing). Nothing in the product would have told an operator why their bot had gone quiet.

## The fix

`BotInstance.start` gains an `onStopped(error?)` callback. The adapter wires it to the settlement instead of swallowing it, and the channel:

- transitions to **`down`** with a scrubbed reason
- **releases the lock**, so a restart can re-acquire rather than being permanently unstartable in that process
- clears the cached bot identity

Two guards keep it honest:

- `stopRequested` is set before a deliberate `stop()`, so a normal shutdown still settles as `disabled` and never flashes `down`
- the callback is checked against the current bot instance, so a late callback from a previous generation (restart, token change) can't knock down the live one

## Testing

`npm run lint` and `npm test` green (7315 tests). Four new cases:

| case | asserts |
|---|---|
| poller dies with an error | `down`, reason contains `Conflict`, statuses `starting → up → down` |
| poller dies with no error | `down`, reason `polling stopped unexpectedly` |
| lock released on death | `release()` called, and a subsequent `start()` re-acquires and reaches `up` |
| deliberate `stop()` | settles `disabled`, never emits `down` |
| token in the death message | scrubbed to `<token>` |

**Verified non-vacuous**: with the `onStopped` wiring removed, 4 of the 5 fail. (This repo has a history of tests that pass against nothing, so I checked.)
