### PR TITLE
feat(local-llm): resumable model downloads with retry and stall recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ atomic-agent tui --cwd /path/to/work
 
 Managed mode downloads the backend, pulls GGUF models, selects the active model, and starts detached chat / embedding daemons when configured.
 
+Model downloads resume. An interrupted pull (a dropped connection, Ctrl+C, a closed terminal) keeps what it has fetched next to the destination as `<file>.part`, and the next `models pull` of the same model continues from that point with a `Range` request rather than starting over. The downloader validates the partial against the server's `ETag` before appending, so a file re-uploaded under the same name is fetched afresh; within one pull, transport errors and stalls retry from the partial with backoff before giving up.
+
 The managed chat daemon stops when the last session exits, freeing the RAM and VRAM the model was holding; set `localModels.managed.stopOnExit: false` in `config.json` to keep the model warm between sessions. Daemons started standalone with `models start` are never touched.
 
 On Windows the backend zip is picked per machine (CUDA when a capable NVIDIA driver is present, Vulkan otherwise). If the GPU build cannot serve a model on your hardware — typical for iGPU-only boxes — the start falls back to the CPU build automatically and records `localModels.managed.backendVariant: "cpu"` in `config.json`; set it to `"auto"`, `"vulkan"`, `"cuda-12.4"` or `"cuda-13.3"` to pick a build yourself (e.g. after a driver update).

--- a/src/cli/models-handlers.ts
+++ b/src/cli/models-handlers.ts
@@ -10,6 +10,7 @@ import {
   downloadModel,
   EMBEDDING_MODELS_CATALOG,
   fallBackToCpuBackend,
+  formatGgufSize,
   getConfiguredBackendVariant,
   getDaemonStatus,
   getEmbeddingDaemonStatus,
@@ -25,11 +26,13 @@ import {
   listVulkanDevices,
   maybeAutoUpdateBackend,
   readBackendVersion,
+  readPartialDownload,
   removeModel,
   resolveChatTemplatePath,
   resolveDownloadAsset,
   resolveManagedDevice,
   resolveMmprojFilePath,
+  resolveModelFilePath,
   resolvePlatformAsset,
   resolveServerBinPath,
   shouldFallBackToCpuBackend,
@@ -45,6 +48,20 @@ export function readCliOption(args: string[], name: string): string | undefined 
 
 function formatGb(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/**
+ * One line per retry so a flaky link reads as "retrying", not "hung".
+ * Goes to stderr on its own row: the progress line is `\r`-rewritten
+ * in place, and the note must survive the next rewrite.
+ */
+export function renderPullRetry(info: {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  error: Error;
+}): string {
+  return `download interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s, resuming from the partial file`;
 }
 
 export function renderPullProgress(
@@ -109,9 +126,19 @@ export async function runLocalModelsPull(idArg: string | undefined): Promise<num
     }
     lastLine = line;
   };
+  const onRetry = (info: Parameters<typeof renderPullRetry>[0]): void => {
+    process.stderr.write(`${tty ? "\n" : ""}${renderPullRetry(info)}\n`);
+  };
   try {
-    process.stderr.write(`downloading ${m.id} (${m.filename}, ${m.sizeLabel})\n`);
-    await downloadModel(dataDir, m, { onProgress });
+    const partial = readPartialDownload(
+      resolveModelFilePath(dataDir, m.id, m.filename),
+    );
+    process.stderr.write(
+      partial
+        ? `resuming ${m.id} (${m.filename}, ${m.sizeLabel}) — ${formatGgufSize(partial.transferred)} already on disk\n`
+        : `downloading ${m.id} (${m.filename}, ${m.sizeLabel})\n`,
+    );
+    await downloadModel(dataDir, m, { onProgress, onRetry });
     if (tty) process.stderr.write(`\n`);
     else if (lastLine) process.stderr.write(`done: ${lastLine}\n`);
     const savedPath = join(dataDir, "models", m.id, m.filename);
@@ -608,11 +635,19 @@ export async function runLocalModelsPullEmbedding(
       process.stderr.write(`${line}\n`);
     lastLine = line;
   };
+  const onRetry = (info: Parameters<typeof renderPullRetry>[0]): void => {
+    process.stderr.write(`${tty ? "\n" : ""}${renderPullRetry(info)}\n`);
+  };
   try {
-    process.stderr.write(
-      `downloading embedding model ${m.id} (${m.filename}, ${m.sizeLabel})\n`,
+    const partial = readPartialDownload(
+      resolveModelFilePath(dataDir, m.id, m.filename),
     );
-    await downloadEmbeddingModel(dataDir, m, { onProgress });
+    process.stderr.write(
+      partial
+        ? `resuming embedding model ${m.id} (${m.filename}, ${m.sizeLabel}) — ${formatGgufSize(partial.transferred)} already on disk\n`
+        : `downloading embedding model ${m.id} (${m.filename}, ${m.sizeLabel})\n`,
+    );
+    await downloadEmbeddingModel(dataDir, m, { onProgress, onRetry });
     if (tty) process.stderr.write(`\n`);
     else if (lastLine) process.stderr.write(`done: ${lastLine}\n`);
     const savedPath = join(dataDir, "models", m.id, m.filename);

--- a/src/local-llm/backend-installer.test.ts
+++ b/src/local-llm/backend-installer.test.ts
@@ -248,7 +248,11 @@ describe("backend-installer", () => {
     }) as typeof fetch;
 
     try {
-      await expect(downloadBackend(dir)).rejects.toThrow(/socket hang up/);
+      // One quick retry: the failure has to survive the downloader's own
+      // resume-and-retry loop before the staging cleanup is exercised.
+      await expect(
+        downloadBackend(dir, { maxRetries: 1, retryDelayMs: 1 }),
+      ).rejects.toThrow(/socket hang up/);
 
       const binPath = resolveServerBinPath(dir, "llama-server");
       expect(existsSync(binPath)).toBe(true);

--- a/src/local-llm/backend-installer.ts
+++ b/src/local-llm/backend-installer.ts
@@ -7,7 +7,7 @@ import {
   rmDirQuiet,
   swapInStagedBackend,
 } from "./backend-staging.js";
-import { downloadFile } from "./download-file.js";
+import { downloadFile, type DownloadFileOptions } from "./download-file.js";
 import { readBackendVersion, writeBackendVersionAt } from "./backend-version.js";
 import { resolvePlatformAsset, UnsupportedPlatformError } from "./platform-assets.js";
 import { resolveDownloadAsset } from "./windows-backend-variant.js";
@@ -241,10 +241,10 @@ export function isBackendDownloaded(dataDir: string): boolean {
 
 export async function downloadBackend(
   dataDir: string,
-  opts?: {
-    onProgress?: (percent: number, transferred: number, total: number) => void;
-    signal?: AbortSignal;
-  },
+  opts?: Pick<
+    DownloadFileOptions,
+    "onProgress" | "onRetry" | "signal" | "maxRetries" | "retryDelayMs"
+  >,
 ): Promise<{ ok: true; tag: string }> {
   const { assetName, binaryName } = resolveDownloadAsset();
   // Always hit GitHub for an actual install so we don't grab a stale
@@ -283,9 +283,8 @@ export async function downloadBackend(
   try {
     const archivePath = join(stagingDir, assetName);
     await downloadFile(asset.browser_download_url, archivePath, {
-      onProgress: opts?.onProgress,
+      ...opts,
       userAgent: "atomic-agent/local-llm-backend-download",
-      signal: opts?.signal,
     });
 
     await extractBackendArchive(archivePath, stagingDir, binaryName);

--- a/src/local-llm/download-file.test.ts
+++ b/src/local-llm/download-file.test.ts
@@ -3,6 +3,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -137,7 +138,10 @@ describe("download-file", () => {
       signal: controller.signal,
     });
 
-    await waitFor(() => releaseSecondChunk !== null);
+    // The stream may pull chunk two (and park on it) before the first
+    // chunk has been written, so wait for the byte on disk, not for the
+    // source's second pull, before cancelling.
+    await waitFor(() => releaseSecondChunk !== null && partialBytes(dest) === 1);
     controller.abort();
     releaseSecondChunk?.();
 
@@ -537,6 +541,14 @@ function seedPartial(
     resolvePartialMetaPath(dest),
     JSON.stringify({ url, total: meta.total, etag: meta.etag, lastModified: null }),
   );
+}
+
+function partialBytes(dest: string): number {
+  try {
+    return statSync(resolvePartialPath(dest)).size;
+  } catch {
+    return -1;
+  }
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/src/local-llm/download-file.test.ts
+++ b/src/local-llm/download-file.test.ts
@@ -1,10 +1,69 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { downloadFile } from "./download-file.js";
+import {
+  discardPartialDownload,
+  downloadFile,
+  readPartialDownload,
+  resolvePartialMetaPath,
+  resolvePartialPath,
+} from "./download-file.js";
+
+/** A body that hands out `chunks` one per pull, then closes. */
+function bodyOf(chunks: readonly (string | Buffer)[]): ReadableStream {
+  const queue = chunks.map((c) => (typeof c === "string" ? Buffer.from(c) : c));
+  return new ReadableStream({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(next);
+    },
+  });
+}
+
+/** A body that delivers `chunks` and then dies with a transport error. */
+function dyingBodyOf(chunks: readonly string[], error: Error): ReadableStream {
+  const queue = [...chunks];
+  return new ReadableStream({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.error(error);
+        return;
+      }
+      controller.enqueue(Buffer.from(next));
+    },
+  });
+}
+
+/** Records each request's headers; answers from `responders` in order. */
+function mockFetch(
+  responders: readonly ((headers: Headers) => Response)[],
+): { calls: Headers[]; fn: typeof fetch } {
+  const calls: Headers[] = [];
+  const fn = vi.fn(async (_url: unknown, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    calls.push(headers);
+    const responder = responders[calls.length - 1];
+    if (!responder) throw new Error(`unexpected fetch #${calls.length}`);
+    return responder(headers);
+  }) as unknown as typeof fetch;
+  return { calls, fn };
+}
+
+const FAST = { retryDelayMs: 1, stallTimeoutMs: 0 };
 
 describe("download-file", () => {
   let dir: string;
@@ -20,17 +79,9 @@ describe("download-file", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("streams body to dest with progress and removes tmp on success", async () => {
-    const chunks = [Buffer.from("a"), Buffer.from("b"), Buffer.from("c")];
-    const body = new ReadableStream({
-      start(controller) {
-        for (const c of chunks) controller.enqueue(c);
-        controller.close();
-      },
-    });
-
+  it("streams body to dest with progress and leaves no partial on success", async () => {
     globalThis.fetch = vi.fn(async () => {
-      return new Response(body, {
+      return new Response(bodyOf(["a", "b", "c"]), {
         status: 200,
         headers: { "content-length": "3" },
       });
@@ -39,14 +90,17 @@ describe("download-file", () => {
     const dest = join(dir, "out.bin");
     const progress: number[] = [];
     await downloadFile("https://example.com/x", dest, {
+      ...FAST,
       onProgress: (p) => progress.push(p),
     });
 
     expect(readFileSync(dest, "utf-8")).toBe("abc");
     expect(progress.includes(100)).toBe(true);
+    expect(existsSync(resolvePartialPath(dest))).toBe(false);
+    expect(existsSync(resolvePartialMetaPath(dest))).toBe(false);
   });
 
-  it("removes tmp and does not publish partial file when aborted", async () => {
+  it("keeps the partial and its sidecar when aborted, and does not publish it", async () => {
     let releaseSecondChunk: (() => void) | null = null;
     let chunkIndex = 0;
     const body = new ReadableStream({
@@ -72,13 +126,14 @@ describe("download-file", () => {
     globalThis.fetch = vi.fn(async () => {
       return new Response(body, {
         status: 200,
-        headers: { "content-length": "2" },
+        headers: { "content-length": "2", etag: '"v1"' },
       });
     }) as typeof fetch;
 
     const dest = join(dir, "out.bin");
     const controller = new AbortController();
     const pending = downloadFile("https://example.com/x", dest, {
+      ...FAST,
       signal: controller.signal,
     });
 
@@ -88,7 +143,306 @@ describe("download-file", () => {
 
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });
     expect(existsSync(dest)).toBe(false);
+    // The bytes that made it to disk are the whole point: they are what
+    // the next run resumes from.
+    expect(readFileSync(resolvePartialPath(dest), "utf-8")).toBe("a");
+    expect(readPartialDownload(dest)).toEqual({ transferred: 1, total: 2 });
+  });
+
+  it("resumes a partial with a Range request and appends the 206 body", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abc", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["de", "f"]), {
+          status: 206,
+          headers: {
+            "content-range": "bytes 3-5/6",
+            "content-length": "3",
+            etag: '"v1"',
+          },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const seen: Array<[number, number, number]> = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      onProgress: (p, t, tot) => seen.push([p, t, tot]),
+    });
+
+    expect(calls[0].get("range")).toBe("bytes=3-");
+    expect(calls[0].get("if-range")).toBe('"v1"');
+    expect(readFileSync(dest, "utf-8")).toBe("abcdef");
+    // The bar opens at the partial's position, not at zero.
+    expect(seen[0]).toEqual([50, 3, 6]);
+    expect(seen.at(-1)).toEqual([100, 6, 6]);
+    expect(existsSync(resolvePartialPath(dest))).toBe(false);
+    expect(existsSync(resolvePartialMetaPath(dest))).toBe(false);
+  });
+
+  it("starts over when the server ignores the Range and answers 200", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "OLD", { total: 6, etag: '"v1"' });
+
+    globalThis.fetch = mockFetch([
+      () =>
+        new Response(bodyOf(["new", "six"]), {
+          status: 200,
+          headers: { "content-length": "6", etag: '"v2"' },
+        }),
+    ]).fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(readFileSync(dest, "utf-8")).toBe("newsix");
+  });
+
+  it("refuses to append a 206 whose ETag differs from the partial's, then re-downloads", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abc", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["XYZ"]), {
+          status: 206,
+          headers: { "content-range": "bytes 3-5/6", etag: '"v2"' },
+        }),
+      () =>
+        new Response(bodyOf(["fresh1"]), {
+          status: 200,
+          headers: { "content-length": "6", etag: '"v2"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, { ...FAST, maxRetries: 1 });
+
+    expect(calls).toHaveLength(2);
+    // The partial was discarded, so the second request is a plain GET.
+    expect(calls[1].has("range")).toBe(false);
+    expect(readFileSync(dest, "utf-8")).toBe("fresh1");
+  });
+
+  it("ignores a partial that belongs to a different URL", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/other", "abc", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["abcdef"]), {
+          status: 200,
+          headers: { "content-length": "6" },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(calls[0].has("range")).toBe(false);
+    expect(readFileSync(dest, "utf-8")).toBe("abcdef");
+  });
+
+  it("retries a mid-body transport failure from the partial", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+          status: 200,
+          headers: { "content-length": "5", etag: '"v1"' },
+        }),
+      () =>
+        new Response(bodyOf(["cde"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-4/5", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const retries: number[] = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      onRetry: (info) => retries.push(info.attempt),
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].get("range")).toBe("bytes=2-");
+    expect(retries).toEqual([1]);
+    expect(readFileSync(dest, "utf-8")).toBe("abcde");
+  });
+
+  it("treats a body that ends short of content-length as retryable", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["ab"]), {
+          status: 200,
+          headers: { "content-length": "4", etag: '"v1"' },
+        }),
+      () =>
+        new Response(bodyOf(["cd"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-3/4", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(calls).toHaveLength(2);
+    expect(readFileSync(dest, "utf-8")).toBe("abcd");
+  });
+
+  it("gives up after maxRetries and keeps the partial for the next call", async () => {
+    const dest = join(dir, "out.bin");
+    globalThis.fetch = mockFetch([
+      () =>
+        new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+          status: 200,
+          headers: { "content-length": "5", etag: '"v1"' },
+        }),
+      () =>
+        new Response(dyingBodyOf([], new Error("read ECONNRESET")), {
+          status: 206,
+          headers: { "content-range": "bytes 2-4/5", etag: '"v1"' },
+        }),
+    ]).fn;
+
+    await expect(
+      downloadFile("https://example.com/x", dest, { ...FAST, maxRetries: 1 }),
+    ).rejects.toThrow(/ECONNRESET/);
+    expect(existsSync(dest)).toBe(false);
+    expect(readPartialDownload(dest)).toEqual({ transferred: 2, total: 5 });
+  });
+
+  it("does not retry a 404", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () => new Response(null, { status: 404, statusText: "Not Found" }),
+    ]);
+    globalThis.fetch = fn;
+
+    await expect(
+      downloadFile("https://example.com/x", dest, FAST),
+    ).rejects.toThrow(/HTTP 404/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("retries a 503", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+      () =>
+        new Response(bodyOf(["ok"]), {
+          status: 200,
+          headers: { "content-length": "2" },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(calls).toHaveLength(2);
+    expect(readFileSync(dest, "utf-8")).toBe("ok");
+  });
+
+  it("does not retry after the caller aborts during the backoff", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+      () => new Response(bodyOf(["ok"]), { status: 200 }),
+    ]);
+    globalThis.fetch = fn;
+
+    const controller = new AbortController();
+    const pending = downloadFile("https://example.com/x", dest, {
+      stallTimeoutMs: 0,
+      retryDelayMs: 10_000,
+      signal: controller.signal,
+    });
+    await waitFor(() => calls.length === 1);
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("declares a silent connection stalled and resumes from the partial", async () => {
+    const dest = join(dir, "out.bin");
+    // First body: one chunk, then silence forever.
+    const silent = new ReadableStream({
+      pull(controller) {
+        controller.enqueue(Buffer.from("ab"));
+        return new Promise<void>(() => undefined);
+      },
+    });
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(silent, {
+          status: 200,
+          headers: { "content-length": "4", etag: '"v1"' },
+        }),
+      () =>
+        new Response(bodyOf(["cd"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-3/4", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const retries: string[] = [];
+    await downloadFile("https://example.com/x", dest, {
+      retryDelayMs: 1,
+      stallTimeoutMs: 50,
+      onRetry: (info) => retries.push(info.error.message),
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].get("range")).toBe("bytes=2-");
+    expect(retries[0]).toMatch(/stalled/);
+    expect(readFileSync(dest, "utf-8")).toBe("abcd");
+  });
+
+  it("publishes a partial that already holds every byte when the server answers 416", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abcdef", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(null, {
+          status: 416,
+          statusText: "Range Not Satisfiable",
+          headers: { "content-range": "bytes */6" },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const seen: number[] = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      onProgress: (p) => seen.push(p),
+    });
+    expect(calls[0].get("range")).toBe("bytes=6-");
+    expect(readFileSync(dest, "utf-8")).toBe("abcdef");
+    expect(seen).toEqual([100]);
+  });
+
+  it("removes a pre-resume .tmp leftover", async () => {
+    const dest = join(dir, "out.bin");
+    writeFileSync(`${dest}.tmp`, "junk");
+    globalThis.fetch = mockFetch([
+      () => new Response(bodyOf(["ok"]), { status: 200 }),
+    ]).fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
     expect(existsSync(`${dest}.tmp`)).toBe(false);
+    expect(readFileSync(dest, "utf-8")).toBe("ok");
+  });
+
+  it("discardPartialDownload drops both files and readPartialDownload sees nothing", () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abc", { total: 6, etag: null });
+    expect(readPartialDownload(dest)).toEqual({ transferred: 3, total: 6 });
+    discardPartialDownload(dest);
+    expect(readPartialDownload(dest)).toBeNull();
+    expect(existsSync(resolvePartialPath(dest))).toBe(false);
+    expect(existsSync(resolvePartialMetaPath(dest))).toBe(false);
   });
 
   it("keeps the byte counter moving when chunks are smaller than one percent", async () => {
@@ -119,11 +473,15 @@ describe("download-file", () => {
     }) as typeof fetch;
 
     const seen: Array<{ percent: number; transferred: number }> = [];
-    await downloadFile("https://example.invalid/big.bin", join(dir, "big.bin"), {
-      onProgress: (percent, transferred) => {
-        seen.push({ percent, transferred });
-      },
-    });
+    await expect(
+      downloadFile("https://example.invalid/big.bin", join(dir, "big.bin"), {
+        ...FAST,
+        maxRetries: 0,
+        onProgress: (percent, transferred) => {
+          seen.push({ percent, transferred });
+        },
+      }),
+    ).rejects.toThrow(/ended early/);
 
     // Percent rounds to 0 throughout — the bytes are the only signal the
     // user has, and they must keep arriving.
@@ -157,6 +515,7 @@ describe("download-file", () => {
 
     const seen: number[] = [];
     await downloadFile("https://example.invalid/nolen.bin", join(dir, "nolen.bin"), {
+      ...FAST,
       onProgress: (_percent, transferred) => {
         seen.push(transferred);
       },
@@ -165,8 +524,20 @@ describe("download-file", () => {
     expect(seen.length).toBeGreaterThan(1);
     expect(seen.at(-1)).toBe(5_000);
   });
-
 });
+
+function seedPartial(
+  dest: string,
+  url: string,
+  bytes: string,
+  meta: { total: number; etag: string | null },
+): void {
+  writeFileSync(resolvePartialPath(dest), bytes);
+  writeFileSync(
+    resolvePartialMetaPath(dest),
+    JSON.stringify({ url, total: meta.total, etag: meta.etag, lastModified: null }),
+  );
+}
 
 async function waitFor(predicate: () => boolean): Promise<void> {
   for (let attempt = 0; attempt < 50; attempt += 1) {

--- a/src/local-llm/download-file.ts
+++ b/src/local-llm/download-file.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
+import { dirname } from "node:path";
 
 import { huggingFaceToken } from "./huggingface-api.js";
 
@@ -9,6 +8,96 @@ export type DownloadProgressFn = (
   transferred: number,
   total: number,
 ) => void;
+
+/**
+ * Called before each retry. `attempt` is the retry about to run (1-based),
+ * `delayMs` how long the downloader is about to wait, `error` why the
+ * previous attempt died. Surfaces a stalled link to the operator instead
+ * of leaving the progress bar frozen while the backoff runs.
+ */
+export type DownloadRetryFn = (info: {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  error: Error;
+}) => void;
+
+export interface DownloadFileOptions {
+  onProgress?: DownloadProgressFn;
+  onRetry?: DownloadRetryFn;
+  userAgent?: string;
+  signal?: AbortSignal;
+  /** Retries after a network failure before giving up. Default 5. */
+  maxRetries?: number;
+  /** Base of the exponential backoff between retries. Default 1s. */
+  retryDelayMs?: number;
+  /**
+   * How long the body may go without a single byte before the attempt is
+   * declared dead and retried from the partial. Default 60s. `0` disables
+   * the watchdog.
+   */
+  stallTimeoutMs?: number;
+}
+
+/** Sidecar next to the `.part` file: what the partial bytes belong to. */
+export interface PartialDownloadMeta {
+  url: string;
+  /** Total length the server declared, or `0` when it did not. */
+  total: number;
+  etag: string | null;
+  lastModified: string | null;
+}
+
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+const DEFAULT_STALL_TIMEOUT_MS = 60_000;
+
+export function resolvePartialPath(destPath: string): string {
+  return `${destPath}.part`;
+}
+
+export function resolvePartialMetaPath(destPath: string): string {
+  return `${destPath}.part.json`;
+}
+
+/**
+ * Bytes already on disk for an unfinished download of `destPath`, or
+ * `null` when there is no resumable partial. Lets a UI show "12.4 GB of
+ * 20.1 GB already here" before any request is made.
+ */
+export function readPartialDownload(
+  destPath: string,
+): { transferred: number; total: number } | null {
+  const meta = readPartialMeta(destPath);
+  if (!meta) return null;
+  const transferred = partialSize(destPath);
+  if (transferred <= 0) return null;
+  return { transferred, total: meta.total };
+}
+
+/** Drop a partial download and its sidecar. No-op when neither exists. */
+export function discardPartialDownload(destPath: string): void {
+  rmQuiet(resolvePartialPath(destPath));
+  rmQuiet(resolvePartialMetaPath(destPath));
+}
+
+class DownloadHttpError extends Error {
+  constructor(
+    readonly status: number,
+    statusText: string,
+  ) {
+    super(`Download failed: HTTP ${status} ${statusText}`);
+    this.name = "DownloadHttpError";
+  }
+}
+
+class StalledError extends Error {
+  constructor(ms: number) {
+    super(`Download stalled: no data for ${Math.round(ms / 1000)}s`);
+    this.name = "StalledError";
+  }
+}
 
 function createAbortError(): Error {
   const err = new Error("Download aborted");
@@ -22,20 +111,177 @@ function throwIfAborted(signal?: AbortSignal): void {
   }
 }
 
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
 /**
- * Download a file from `url` to `destPath` with optional progress tracking.
- * Writes to a `.tmp` file first, then renames atomically on success.
+ * Whether another attempt can reasonably succeed. Transport-level
+ * failures (reset, timeout, DNS blip, a socket the CDN dropped mid-body)
+ * and server-side throttling are; a 404 or a 401 is not — the retries
+ * would only delay the same answer.
+ */
+export function isRetryableDownloadError(err: unknown): boolean {
+  if (isAbortError(err)) return false;
+  if (err instanceof StalledError) return true;
+  if (err instanceof DownloadHttpError) {
+    return err.status === 408 || err.status === 429 || err.status >= 500;
+  }
+  return true;
+}
+
+function partialSize(destPath: string): number {
+  try {
+    return fs.statSync(resolvePartialPath(destPath)).size;
+  } catch {
+    return 0;
+  }
+}
+
+function readPartialMeta(destPath: string): PartialDownloadMeta | null {
+  try {
+    const raw = JSON.parse(
+      fs.readFileSync(resolvePartialMetaPath(destPath), "utf-8"),
+    ) as Partial<PartialDownloadMeta>;
+    if (typeof raw.url !== "string") return null;
+    return {
+      url: raw.url,
+      total: typeof raw.total === "number" && raw.total > 0 ? raw.total : 0,
+      etag: typeof raw.etag === "string" ? raw.etag : null,
+      lastModified: typeof raw.lastModified === "string" ? raw.lastModified : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writePartialMeta(destPath: string, meta: PartialDownloadMeta): void {
+  fs.writeFileSync(resolvePartialMetaPath(destPath), JSON.stringify(meta), "utf-8");
+}
+
+function rmQuiet(path: string): void {
+  try {
+    fs.rmSync(path, { force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+function parseContentRange(
+  header: string | null,
+): { start: number; total: number } | null {
+  if (!header) return null;
+  const m = /^bytes (\d+)-(\d+)\/(\d+|\*)$/.exec(header.trim());
+  if (!m) return null;
+  return {
+    start: Number(m[1]),
+    total: m[3] === "*" ? 0 : Number(m[3]),
+  };
+}
+
+/**
+ * The partial on disk is only worth continuing when the server still
+ * serves the same bytes: same URL, and the same validator when one was
+ * recorded. A file re-uploaded under the same name has a new ETag, and
+ * appending the tail of the new file to the head of the old one would
+ * produce a GGUF that loads up to the seam and then crashes llama-server.
+ */
+function validatorsMatch(
+  stored: PartialDownloadMeta,
+  res: Response,
+): boolean {
+  const etag = res.headers.get("etag");
+  if (stored.etag && etag && stored.etag !== etag) return false;
+  const lastModified = res.headers.get("last-modified");
+  if (
+    !stored.etag &&
+    stored.lastModified &&
+    lastModified &&
+    stored.lastModified !== lastModified
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(createAbortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Download a file from `url` to `destPath`, resuming and retrying.
+ *
+ * Bytes stream into `<dest>.part`, with `<dest>.part.json` recording the
+ * URL, declared length and validators they belong to. The partial is
+ * **kept** on abort, on error and when the process dies, and the next
+ * call for the same destination asks the server for the remainder with a
+ * `Range` request. A `206` continues from where the last run stopped; a
+ * `200`, a changed validator or a length mismatch restarts from zero.
+ * Only a completed transfer is renamed onto `destPath`.
+ *
+ * Within one call, transport failures and stalls retry from the partial
+ * with exponential backoff (`maxRetries`, default 5). The caller's
+ * `signal` cancels everything, including a backoff wait, and is never
+ * retried.
+ *
+ * Progress counts from the resumed offset, so a UI picking up a 12 GB
+ * partial of a 20 GB file starts its bar at 60%, not 0%.
  */
 export async function downloadFile(
   url: string,
   destPath: string,
-  opts?: {
-    onProgress?: DownloadProgressFn;
-    userAgent?: string;
-    signal?: AbortSignal;
-  },
+  opts?: DownloadFileOptions,
 ): Promise<void> {
   throwIfAborted(opts?.signal);
+  const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelay = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+  // Pre-resume `.tmp` files are unusable: nothing records what they hold.
+  rmQuiet(`${destPath}.tmp`);
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await downloadAttempt(url, destPath, opts);
+      return;
+    } catch (err) {
+      throwIfAborted(opts?.signal);
+      if (attempt >= maxRetries || !isRetryableDownloadError(err)) {
+        throw err;
+      }
+      const delayMs = Math.min(baseDelay * 2 ** attempt, MAX_RETRY_DELAY_MS);
+      opts?.onRetry?.({
+        attempt: attempt + 1,
+        maxRetries,
+        delayMs,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+      await sleep(delayMs, opts?.signal);
+    }
+  }
+}
+
+async function downloadAttempt(
+  url: string,
+  destPath: string,
+  opts?: DownloadFileOptions,
+): Promise<void> {
+  const partPath = resolvePartialPath(destPath);
+  const stallTimeoutMs = opts?.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
+
   const headers: Record<string, string> = {
     "User-Agent": opts?.userAgent ?? "atomic-agent/local-llm",
   };
@@ -51,80 +297,233 @@ export async function downloadFile(
     if (token) headers.Authorization = `Bearer ${token}`;
   }
 
-  const res = await fetch(url, {
-    headers,
-    redirect: "follow",
-    signal: opts?.signal,
-  });
-  throwIfAborted(opts?.signal);
-  if (!res.ok || !res.body) {
-    throw new Error(`Download failed: HTTP ${res.status} ${res.statusText}`);
+  // Resume only what we can vouch for: a sidecar naming this URL and a
+  // non-empty partial. Anything else starts over.
+  const stored = readPartialMeta(destPath);
+  let offset = 0;
+  if (stored && stored.url === url) {
+    offset = partialSize(destPath);
+  }
+  if (offset > 0 && stored && stored.total > 0 && offset > stored.total) {
+    // More bytes than the file has: a stray append. Not salvageable.
+    offset = 0;
+  }
+  // `offset === stored.total` is left alone on purpose: the last run
+  // wrote every byte and died before the rename. The range request then
+  // asks for nothing, and the 416 branch below publishes the file once
+  // the server has confirmed it still is that file.
+  if (offset === 0) discardPartialDownload(destPath);
+  if (offset > 0) {
+    headers.Range = `bytes=${offset}-`;
+    // `If-Range` makes a server that still has the same file answer 206
+    // and one that has a new one answer 200 with the whole body — the
+    // restart case, handled below without a second round-trip.
+    const validator = stored?.etag ?? stored?.lastModified;
+    if (validator) headers["If-Range"] = validator;
   }
 
-  const totalRaw = res.headers.get("content-length");
-  const total = totalRaw ? parseInt(totalRaw, 10) : 0;
-  let transferred = 0;
-  let lastEmitAt = 0;
-  let lastEmittedBytes = -1;
-
-  /**
-   * Progress used to be emitted only when the whole-number percentage
-   * changed, which left the byte counter frozen between those moments: one
-   * percent of a 4 GB GGUF is ~41 MB, so at realistic speeds the UI sat
-   * still for seconds at a time and the download looked stalled. Worse, a
-   * response without `content-length` pins `percent` at 0 forever, so after
-   * the first chunk the counter never moved again.
-   *
-   * Emit on a time base instead. The percentage still only changes when it
-   * changes; the bytes advance visibly, which is the part that tells the
-   * user the transfer is alive.
-   */
-  const PROGRESS_INTERVAL_MS = 200;
-
-  const emitProgress = (now: number): void => {
-    if (transferred === lastEmittedBytes) return;
-    lastEmitAt = now;
-    lastEmittedBytes = transferred;
-    const percent = total > 0 ? Math.round((transferred / total) * 100) : 0;
-    opts?.onProgress?.(percent, transferred, total);
+  // One controller for both the caller's cancel and the stall watchdog;
+  // which of the two fired is decided after the fact.
+  const attemptAbort = new AbortController();
+  const onCallerAbort = (): void => attemptAbort.abort();
+  if (opts?.signal?.aborted) throw createAbortError();
+  opts?.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  let stalled = false;
+  let stallTimer: NodeJS.Timeout | null = null;
+  const armStallTimer = (): void => {
+    if (stallTimeoutMs <= 0) return;
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      stalled = true;
+      attemptAbort.abort();
+    }, stallTimeoutMs);
+  };
+  const disarmStallTimer = (): void => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = null;
   };
 
-  const reader = res.body.getReader();
-  const trackingStream = new ReadableStream({
-    async pull(controller) {
-      throwIfAborted(opts?.signal);
-      const { done, value } = await reader.read();
-      throwIfAborted(opts?.signal);
-      if (done) {
-        // The last partial interval still owes the user its final numbers,
-        // including the terminal 100%.
-        emitProgress(Date.now());
-        controller.close();
+  try {
+    armStallTimer();
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers,
+        redirect: "follow",
+        signal: attemptAbort.signal,
+      });
+    } catch (err) {
+      throw translateAttemptFailure(err, opts?.signal, stalled, stallTimeoutMs);
+    }
+    throwIfAborted(opts?.signal);
+
+    if (res.status === 416 && offset > 0) {
+      // Range not satisfiable. When the partial already holds the whole
+      // declared length this is "nothing left to send" — publish it.
+      // Otherwise the server's idea of the file differs from ours.
+      const cr = parseContentRange(res.headers.get("content-range"));
+      const total = cr?.total ?? stored?.total ?? 0;
+      if (total > 0 && offset === total && stored) {
+        finalize(destPath, offset, total, opts);
         return;
       }
-      transferred += value.byteLength;
-      const now = Date.now();
-      if (now - lastEmitAt >= PROGRESS_INTERVAL_MS) {
-        emitProgress(now);
-      }
-      controller.enqueue(value);
-    },
-  });
-
-  const nodeReadable = Readable.fromWeb(
-    trackingStream as import("node:stream/web").ReadableStream,
-  );
-  const tmpPath = `${destPath}.tmp`;
-  try {
-    const writeStream = fs.createWriteStream(tmpPath);
-    await pipeline(nodeReadable, writeStream);
-    throwIfAborted(opts?.signal);
-    fs.renameSync(tmpPath, destPath);
-  } finally {
-    try {
-      fs.rmSync(tmpPath, { force: true });
-    } catch {
-      /* ignore */
+      discardPartialDownload(destPath);
+      throw new DownloadHttpError(res.status, res.statusText);
     }
+    if (!res.ok || !res.body) {
+      throw new DownloadHttpError(res.status, res.statusText);
+    }
+
+    let resumed = false;
+    let total = 0;
+    if (res.status === 206 && offset > 0 && stored) {
+      const cr = parseContentRange(res.headers.get("content-range"));
+      if (cr && cr.start === offset && validatorsMatch(stored, res)) {
+        resumed = true;
+        total = cr.total || stored.total;
+      } else {
+        // A 206 whose range does not line up with our offset cannot be
+        // appended; drain nothing, start over on the next attempt.
+        discardPartialDownload(destPath);
+        await res.body.cancel().catch(() => undefined);
+        throw new Error(
+          "Download resume rejected: server range did not match the partial file",
+        );
+      }
+    } else {
+      // A full body (200) — either a fresh download or the server would
+      // not (or could not, validators changed) honour the range. Whatever
+      // is on disk is not this file's prefix.
+      discardPartialDownload(destPath);
+      offset = 0;
+      const totalRaw = res.headers.get("content-length");
+      total = totalRaw ? parseInt(totalRaw, 10) : 0;
+      if (!Number.isFinite(total) || total < 0) total = 0;
+    }
+
+    fs.mkdirSync(dirname(destPath), { recursive: true });
+    writePartialMeta(destPath, {
+      url,
+      total,
+      etag: res.headers.get("etag"),
+      lastModified: res.headers.get("last-modified"),
+    });
+
+    let transferred = offset;
+    let lastEmitAt = 0;
+    let lastEmittedBytes = -1;
+
+    /**
+     * Progress used to be emitted only when the whole-number percentage
+     * changed, which left the byte counter frozen between those moments:
+     * one percent of a 4 GB GGUF is ~41 MB, so at realistic speeds the UI
+     * sat still for seconds at a time and the download looked stalled.
+     * Worse, a response without `content-length` pins `percent` at 0
+     * forever, so after the first chunk the counter never moved again.
+     *
+     * Emit on a time base instead. The percentage still only changes
+     * when it changes; the bytes advance visibly, which is the part that
+     * tells the user the transfer is alive.
+     */
+    const PROGRESS_INTERVAL_MS = 200;
+
+    const emitProgress = (now: number): void => {
+      if (transferred === lastEmittedBytes) return;
+      lastEmitAt = now;
+      lastEmittedBytes = transferred;
+      const percent = total > 0 ? Math.round((transferred / total) * 100) : 0;
+      opts?.onProgress?.(percent, transferred, total);
+    };
+
+    // A resumed transfer owes the UI its starting point at once: the
+    // bar must open at the partial's percentage, not at zero.
+    if (resumed) emitProgress(Date.now());
+
+    // Chunks are written one at a time with an explicit `write` rather
+    // than piped through a WriteStream: a pipeline that fails destroys
+    // its destination and drops whatever it had buffered, which is
+    // exactly the tail the next attempt needs on disk. Here a chunk is
+    // either fully written or never counted.
+    const reader = res.body.getReader();
+    const aborted = new Promise<never>((_resolve, reject) => {
+      const fail = (): void => reject(createAbortError());
+      if (attemptAbort.signal.aborted) fail();
+      else attemptAbort.signal.addEventListener("abort", fail, { once: true });
+    });
+    // Never awaited on its own: an abort must not wait for a source that
+    // has stopped answering.
+    aborted.catch(() => undefined);
+    const handle = await fs.promises.open(partPath, resumed ? "a" : "w");
+    try {
+      for (;;) {
+        let next: Awaited<ReturnType<typeof reader.read>>;
+        try {
+          next = await Promise.race([reader.read(), aborted]);
+        } catch (err) {
+          reader.cancel().catch(() => undefined);
+          throw translateAttemptFailure(err, opts?.signal, stalled, stallTimeoutMs);
+        }
+        if (next.done) break;
+        armStallTimer();
+        await handle.write(next.value);
+        transferred += next.value.byteLength;
+        const now = Date.now();
+        if (now - lastEmitAt >= PROGRESS_INTERVAL_MS) {
+          emitProgress(now);
+        }
+      }
+    } finally {
+      await handle.close();
+    }
+    // The last partial interval still owes the user its final numbers.
+    emitProgress(Date.now());
+    throwIfAborted(opts?.signal);
+
+    if (total > 0 && transferred !== total) {
+      // The body ended early (a CDN closing the connection is reported
+      // as a clean end by some stacks). The bytes are good as far as they
+      // go; the retry loop asks for the rest.
+      throw new Error(
+        `Download ended early: ${transferred} of ${total} bytes received`,
+      );
+    }
+    finalize(destPath, transferred, total, opts);
+  } finally {
+    disarmStallTimer();
+    opts?.signal?.removeEventListener("abort", onCallerAbort);
   }
+}
+
+function finalize(
+  destPath: string,
+  transferred: number,
+  total: number,
+  opts?: DownloadFileOptions,
+): void {
+  fs.renameSync(resolvePartialPath(destPath), destPath);
+  rmQuiet(resolvePartialMetaPath(destPath));
+  // A 416-finalised partial never streamed, so it never reported; and a
+  // streamed one may have emitted its last progress inside the throttle
+  // window. Either way the terminal number goes out exactly once here.
+  if (total > 0 && transferred === total) {
+    opts?.onProgress?.(100, transferred, total);
+  }
+}
+
+/**
+ * Sort out whose abort this was. The caller's cancel surfaces as
+ * `AbortError` and is never retried; the watchdog's surfaces as a
+ * `StalledError`, which is. Anything else passes through as the
+ * transport error it is.
+ */
+function translateAttemptFailure(
+  err: unknown,
+  callerSignal: AbortSignal | undefined,
+  stalled: boolean,
+  stallTimeoutMs: number,
+): Error {
+  if (callerSignal?.aborted) return createAbortError();
+  if (stalled) return new StalledError(stallTimeoutMs);
+  if (err instanceof Error) return err;
+  return new Error(String(err));
 }

--- a/src/local-llm/download-file.ts
+++ b/src/local-llm/download-file.ts
@@ -459,6 +459,11 @@ async function downloadAttempt(
         let next: Awaited<ReturnType<typeof reader.read>>;
         try {
           next = await Promise.race([reader.read(), aborted]);
+          // A chunk that was already queued can win the race against an
+          // abort that fired during the previous write. Nothing is
+          // written past a cancel: the partial ends exactly where the
+          // caller stopped it.
+          if (attemptAbort.signal.aborted) throw createAbortError();
         } catch (err) {
           reader.cancel().catch(() => undefined);
           throw translateAttemptFailure(err, opts?.signal, stalled, stallTimeoutMs);

--- a/src/local-llm/index.ts
+++ b/src/local-llm/index.ts
@@ -50,7 +50,18 @@ export {
   resolveEmbeddingLogFilePath,
 } from "./backend-paths.js";
 
-export { downloadFile, type DownloadProgressFn } from "./download-file.js";
+export {
+  downloadFile,
+  discardPartialDownload,
+  isRetryableDownloadError,
+  readPartialDownload,
+  resolvePartialMetaPath,
+  resolvePartialPath,
+  type DownloadFileOptions,
+  type DownloadProgressFn,
+  type DownloadRetryFn,
+  type PartialDownloadMeta,
+} from "./download-file.js";
 export {
   readBackendVersion,
   writeBackendVersion,
@@ -78,6 +89,7 @@ export {
   isEmbeddingModelDownloaded,
   downloadEmbeddingModel,
   removeEmbeddingModel,
+  type ModelDownloadOptions,
 } from "./model-installer.js";
 export { resolveChatTemplatePath } from "./chat-templates.js";
 export {

--- a/src/local-llm/model-installer.ts
+++ b/src/local-llm/model-installer.ts
@@ -13,7 +13,13 @@ import {
   resolveModelFilePath,
   resolveMmprojFilePath,
 } from "./backend-paths.js";
-import { downloadFile, type DownloadProgressFn } from "./download-file.js";
+import { downloadFile, type DownloadFileOptions } from "./download-file.js";
+
+/** What a model pull lets its caller steer: progress, retry notices, cancel. */
+export type ModelDownloadOptions = Pick<
+  DownloadFileOptions,
+  "onProgress" | "onRetry" | "signal"
+>;
 
 export function isModelDownloaded(dataDir: string, model: LocalModelDef): boolean {
   return existsSync(resolveModelFilePath(dataDir, model.id, model.filename));
@@ -44,7 +50,7 @@ export function isMmprojDownloaded(
 export async function downloadModel(
   dataDir: string,
   model: LocalModelDef,
-  opts?: { onProgress?: DownloadProgressFn; signal?: AbortSignal },
+  opts?: ModelDownloadOptions,
 ): Promise<void> {
   const dest = resolveModelFilePath(dataDir, model.id, model.filename);
   if (existsSync(dest)) return;
@@ -60,7 +66,7 @@ export async function downloadModel(
 export async function downloadMmproj(
   dataDir: string,
   model: LocalModelDef,
-  opts?: { onProgress?: DownloadProgressFn; signal?: AbortSignal },
+  opts?: ModelDownloadOptions,
 ): Promise<void> {
   if (!model.supportsVision || !model.mmprojUrl || !model.mmprojFilename) {
     throw new Error(
@@ -111,7 +117,7 @@ export function isEmbeddingModelDownloaded(
 export async function downloadEmbeddingModel(
   dataDir: string,
   model: EmbeddingModelDef,
-  opts?: { onProgress?: DownloadProgressFn; signal?: AbortSignal },
+  opts?: ModelDownloadOptions,
 ): Promise<void> {
   const dest = resolveModelFilePath(dataDir, model.id, model.filename);
   if (existsSync(dest)) return;

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -70,6 +70,7 @@ import {
 } from "../persist-embedding-hybrid-recall.js";
 import { persistUserLocalModelsConfig } from "../persist-user-local-models-config.js";
 import { ChatPullMirror, downloadProgressFor } from "../local-turn-gate.js";
+import type { DownloadRetryFn } from "../../local-llm/index.js";
 import type { TuiEventBus } from "../tui-app.js";
 
 /**
@@ -244,6 +245,22 @@ export class LocalModelsOrchestrator {
         await this.stopDaemonSilent();
       }
     }
+  }
+
+  /**
+   * A retrying download must say so: between attempts the bar stands
+   * still, and a still bar with no explanation reads as a hang. The
+   * partial stays on disk, so every retry resumes rather than restarts.
+   */
+  private downloadRetryNotice(label: string): DownloadRetryFn {
+    return (info) => {
+      this.bus.emit({
+        type: "runtime_info",
+        line:
+          `local-llm: ${label} download interrupted (${info.error.message}) — ` +
+          `retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s, resuming`,
+      });
+    };
   }
 
   async refresh(): Promise<void> {
@@ -573,6 +590,7 @@ export class LocalModelsOrchestrator {
     });
     await downloadModel(dataDir, def, {
       signal,
+      onRetry: this.downloadRetryNotice(`${def.name} (gguf)`),
       onProgress: (percent, transferred, total) => {
         this.bus.emit({
           type: "local_models_pull_progress",
@@ -612,6 +630,7 @@ export class LocalModelsOrchestrator {
     });
     await downloadMmproj(dataDir, def, {
       signal,
+      onRetry: this.downloadRetryNotice(`${def.name} (mmproj)`),
       onProgress: (percent, transferred, total) => {
         this.bus.emit({
           type: "local_models_pull_progress",
@@ -1572,6 +1591,7 @@ export class LocalModelsOrchestrator {
     try {
       await downloadEmbeddingModel(dataDir, def, {
         signal: controller.signal,
+        onRetry: this.downloadRetryNotice(def.name),
         onProgress: (percent, transferred, total) => {
           this.bus.emit({
             type: "local_models_pull_progress",


### PR DESCRIPTION
## Problem

Every model, mmproj, embedding and backend download streams into `<file>.tmp`, which is deleted on abort or error, and truncated by the next run after a kill. There is no retry. A dropped connection, Ctrl+C, a closed terminal or a TUI quit at 90% of a 20 GB GGUF loses the whole transfer. For the biggest catalog models on an ordinary link that is hours of work gone.

## Change

`downloadFile` (`src/local-llm/download-file.ts`) is now resumable and self-healing:

- Streams into `<file>.part` with a `<file>.part.json` sidecar (URL, declared length, ETag / Last-Modified). The partial is **kept** on abort, on error and when the process dies. Only a completed transfer is renamed onto the destination.
- The next call for the same destination sends `Range: bytes=<size>-` plus `If-Range`. A `206` with a matching validator and offset is appended to; a `200`, a changed ETag or a mis-aligned range restarts from zero; a `416` on a partial that already holds every byte publishes it.
- Within one call, transport errors, `5xx`/`429`/`408` and stalls (no bytes for 60 s) retry from the partial with exponential backoff (5 retries by default, capped at 30 s). Non-retryable HTTP errors (404, 401) and the caller's own abort are never retried.
- Chunks are written with an explicit per-chunk `write` instead of `stream.pipeline`: a failing pipeline destroys its destination and drops the buffered tail, which is exactly what the next attempt needs on disk.
- Progress counts from the resumed offset, so the existing CLI bar and TUI chip open at the partial's percentage.

Surfaces:

- `atag models pull` / `pull-embedding` print `resuming <id> … 72 MB already on disk` when a partial exists, and one line per retry.
- The TUI emits a runtime line per retry (`local-llm: <model> download interrupted (…) — retry 2/5 in 2s, resuming`).
- `downloadModel` / `downloadMmproj` / `downloadEmbeddingModel` accept `onRetry`; `downloadBackend` forwards `onRetry` / `maxRetries` / `retryDelayMs`.
- New helpers exported from `local-llm/index.ts`: `readPartialDownload`, `discardPartialDownload`, `resolvePartialPath`, `resolvePartialMetaPath`, `isRetryableDownloadError`.
- A pre-resume `.tmp` leftover is removed on the next download.

Applies to all four download paths (model, mmproj, embedding, backend zip). The backend keeps its staging-dir all-or-nothing semantics; its retries happen inside the single call.

## Tests

`download-file.test.ts` rewritten (18 cases): resume via 206, ignored Range → restart, ETag mismatch → discard and re-download, foreign-URL partial ignored, mid-body ECONNRESET retried from the partial, short body retried, max retries exhausted keeps the partial, 404 not retried, 503 retried, abort during backoff, stall watchdog resumes, 416 on a complete partial publishes, `.tmp` cleanup, plus the two existing progress-cadence cases. `backend-installer.test.ts` bounds the backoff on its mid-flight failure case.

`npm run lint` clean; `npm test` 7143 passed, 1 failed (`sidecar/send-message-concurrency`, fails identically on clean `main`).

## Real-world check

`atag models pull-embedding nomic-embed-text-v1.5` (84 MB) against Hugging Face on a slow link:

1. SIGKILL after 3 s → `.part` 0.8 MB + sidecar with the CDN ETag left on disk.
2. Re-run → `resuming … 72 MB already on disk`, killed again at 75 MB by a shell timeout.
3. Re-run → progress opened at 90%, finished, no `.part` left.
4. `sha256` of the result equals the LFS oid Hugging Face publishes for the file (`d4e38889…95ac`).

## Follow-ups

Foundation for a detached background downloader (survives a closed terminal) and TUI pulls that keep running after quit; both come as separate PRs on top of this.
