### PR TITLE
feat(cli): background model downloads that survive a closed terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,17 @@ atomic-agent tui --cwd /path/to/work
 
 Managed mode downloads the backend, pulls GGUF models, selects the active model, and starts detached chat / embedding daemons when configured.
 
+Big models can download in the background, detached from the terminal that started them:
+
+```bash
+atomic-agent models pull --background qwen-3.5-35b   # returns at once; keeps running after the terminal closes
+atomic-agent models downloads                        # list background downloads, progress, interrupted ones
+atomic-agent models pull qwen-3.5-35b                # follow a running download in the foreground (Ctrl+C detaches)
+atomic-agent models downloads cancel qwen-3.5-35b    # stop it; what was fetched stays on disk
+```
+
+The worker is a detached copy of the CLI writing its progress to `<stateDir>/models/downloads/<job>.json` and its log next to it, the same arrangement as the managed `llama-server` daemon. A worker that dies mid-way (a reboot, a `kill -9`) shows as `interrupted` in `models downloads`, and running the same `pull` again, with or without `--background`, resumes from the partial file. `pull --mmproj` also fetches a vision model's projector; `pull-embedding --background` works the same way for embedding models.
+
 Model downloads resume. An interrupted pull (a dropped connection, Ctrl+C, a closed terminal) keeps what it has fetched next to the destination as `<file>.part`, and the next `models pull` of the same model continues from that point with a `Range` request rather than starting over. The downloader validates the partial against the server's `ETag` before appending, so a file re-uploaded under the same name is fetched afresh; within one pull, transport errors and stalls retry from the partial with backoff before giving up.
 
 The managed chat daemon stops when the last session exits, freeing the RAM and VRAM the model was holding; set `localModels.managed.stopOnExit: false` in `config.json` to keep the model warm between sessions. Daemons started standalone with `models start` are never touched.

--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ atomic-agent tui --cwd /path/to/work
 
 Managed mode downloads the backend, pulls GGUF models, selects the active model, and starts detached chat / embedding daemons when configured.
 
+Model downloads resume. An interrupted pull (a dropped connection, Ctrl+C, a closed terminal) keeps what it has fetched next to the destination as `<file>.part`, and the next `models pull` of the same model continues from that point with a `Range` request rather than starting over. The downloader validates the partial against the server's `ETag` before appending, so a file re-uploaded under the same name is fetched afresh; within one pull, transport errors and stalls retry from the partial with backoff before giving up.
+
 The managed chat daemon stops when the last session exits, freeing the RAM and VRAM the model was holding; set `localModels.managed.stopOnExit: false` in `config.json` to keep the model warm between sessions. Daemons started standalone with `models start` are never touched.
 
 On Windows the backend zip is picked per machine (CUDA when a capable NVIDIA driver is present, Vulkan otherwise). If the GPU build cannot serve a model on your hardware — typical for iGPU-only boxes — the start falls back to the CPU build automatically and records `localModels.managed.backendVariant: "cpu"` in `config.json`; set it to `"auto"`, `"vulkan"`, `"cuda-12.4"` or `"cuda-13.3"` to pick a build yourself (e.g. after a driver update).

--- a/src/cli/models-command.ts
+++ b/src/cli/models-command.ts
@@ -14,6 +14,10 @@ import {
   runLocalModelsUseDevice,
   runLocalModelsUseEmbedding,
 } from "./models-handlers.js";
+import {
+  runLocalModelsDownloads,
+  runLocalModelsPullWorker,
+} from "./models-downloads.js";
 import { runModelsSearch } from "./models-search-command.js";
 
 const HELP =
@@ -24,7 +28,11 @@ const HELP =
     "",
     "Subcommands:",
     "  list                          Show model catalog + disk presence (active marked with *)",
-    "  pull <id>                     Download a GGUF model from Hugging Face",
+    "  pull <id> [--background]      Download a GGUF model from Hugging Face (resumes a partial;",
+    "            [--mmproj]          --background keeps going after this terminal closes;",
+    "                                --mmproj also fetches the vision projector)",
+    "  downloads [cancel <id>|clear] List background downloads, stop one (partial kept), or",
+    "                                forget finished records",
     "  use <id>                      Set active model and switch mode to \"managed\"",
     "  status                        Show mode, backend version, active model, daemon/health",
     "  start                         Spawn detached llama-server daemon (writes .pid)",
@@ -45,7 +53,7 @@ const HELP =
     "",
     "Embedding subcommands (memory-v2 phase 1B — second daemon for /embedding):",
     "  list-embeddings               Show embedding catalog + disk presence + daemon health",
-    "  pull-embedding <id>           Download an embedding GGUF",
+    "  pull-embedding <id>           Download an embedding GGUF (--background as for pull)",
     "  use-embedding <id>|--disable  Enable + select an embedding model (or turn off)",
     "                                Note: 'start' brings both chat and embedding up;",
     "                                if the embedding daemon fails the chat one stays up.",
@@ -54,6 +62,8 @@ const HELP =
     "  atomic-agent models list",
     "  atomic-agent models search claude vision",
     "  atomic-agent models pull qwen-3.5-4b",
+    "  atomic-agent models pull --background qwen-3.5-35b",
+    "  atomic-agent models downloads",
     "  atomic-agent models use qwen-3.5-4b",
     "  atomic-agent models pull-embedding nomic-embed-text-v1.5",
     "  atomic-agent models use-embedding nomic-embed-text-v1.5",
@@ -76,7 +86,11 @@ export async function modelsCommand(args: string[]): Promise<number> {
       case "list":
         return runLocalModelsList();
       case "pull":
-        return runLocalModelsPull(args[1]);
+        return runLocalModelsPull(args.slice(1));
+      case "pull-worker":
+        return runLocalModelsPullWorker(args.slice(1));
+      case "downloads":
+        return runLocalModelsDownloads(args.slice(1));
       case "use":
         return runLocalModelsUse(args[1]);
       case "status":
@@ -96,7 +110,7 @@ export async function modelsCommand(args: string[]): Promise<number> {
       case "list-embeddings":
         return runLocalModelsListEmbeddings();
       case "pull-embedding":
-        return runLocalModelsPullEmbedding(args[1]);
+        return runLocalModelsPullEmbedding(args.slice(1));
       case "use-embedding":
         return runLocalModelsUseEmbedding(args[1]);
       default:

--- a/src/cli/models-downloads.test.ts
+++ b/src/cli/models-downloads.test.ts
@@ -1,0 +1,254 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChildProcess, spawn as nodeSpawn } from "node:child_process";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `spawn` is a non-configurable export of the built-in, so it cannot be
+// spied on in place; the whole module is mocked with a spawn that hands
+// back a worker pid nothing will ever own.
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: spawnMock };
+});
+
+import { getConfig, resetConfigCache } from "../config/index.js";
+import {
+  downloadJobId,
+  readDownloadJob,
+  resolveDownloadLogPath,
+  writeDownloadJob,
+  type DownloadJob,
+} from "../local-llm/index.js";
+import { modelsCommand } from "./models-command.js";
+import {
+  downloadWorkerArgs,
+  followDownloadJob,
+  spawnDownloadWorker,
+} from "./models-downloads.js";
+
+const DEAD_PID = 2_000_000_000;
+
+function job(patch: Partial<DownloadJob> = {}): DownloadJob {
+  return {
+    version: 1,
+    id: downloadJobId("chat", "qwen-3.5-4b"),
+    kind: "chat",
+    modelId: "qwen-3.5-4b",
+    mode: "gguf-only",
+    pid: process.pid,
+    status: "running",
+    phase: "gguf",
+    label: "Qwen 3.5 4B (gguf)",
+    percent: 40,
+    transferredBytes: 4_000_000,
+    totalBytes: 10_000_000,
+    error: null,
+    startedAt: "2026-09-07T10:00:00.000Z",
+    updatedAt: "2026-09-07T10:00:05.000Z",
+    finishedAt: null,
+    ...patch,
+  };
+}
+
+describe("background model downloads (CLI)", () => {
+  let stateDir: string;
+  let dataDir: string;
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "atomic-dl-cli-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    resetConfigCache();
+    dataDir = getConfig().paths.localModelsDataDir;
+    stdoutChunks = [];
+    stderrChunks = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+  });
+
+  it("spawns a detached copy of this program with the worker argv, logging to the job log", () => {
+    const spawn = vi.fn(() => ({ pid: 777, unref: vi.fn() }) as unknown as ChildProcess);
+
+    const result = spawnDownloadWorker({
+      kind: "chat",
+      modelId: "qwen-3.5-4b",
+      mode: "gguf-only",
+      spawn: spawn as unknown as typeof nodeSpawn,
+      execPath: "/opt/node/bin/node",
+      argv: ["/opt/node/bin/node", "/repo/dist/cli/index.js", "models", "pull"],
+      execArgv: [],
+      sea: false,
+      env: { ATOMIC_AGENT_STATE_DIR: stateDir },
+    });
+
+    expect(result.outcome).toBe("spawned");
+    const [cmd, args, opts] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      { detached: boolean; stdio: unknown[]; env: NodeJS.ProcessEnv },
+    ];
+    expect(cmd).toBe("/opt/node/bin/node");
+    expect(args).toEqual([
+      "/repo/dist/cli/index.js",
+      ...downloadWorkerArgs({ kind: "chat", modelId: "qwen-3.5-4b", mode: "gguf-only" }),
+    ]);
+    expect(opts.detached).toBe(true);
+    expect(opts.stdio[0]).toBe("ignore");
+    expect(opts.env.ATOMIC_AGENT_STATE_DIR).toBe(stateDir);
+    // The record exists before the worker has written a byte.
+    const seeded = readDownloadJob(dataDir, downloadJobId("chat", "qwen-3.5-4b"));
+    expect(seeded).toMatchObject({ pid: 777, status: "interrupted" });
+    expect(existsSync(resolveDownloadLogPath(dataDir, "chat-qwen-3.5-4b"))).toBe(true);
+  });
+
+  it("does not start a second worker for a model whose worker is alive", () => {
+    writeDownloadJob(dataDir, job({ pid: process.pid }));
+    const spawn = vi.fn();
+    const result = spawnDownloadWorker({
+      kind: "chat",
+      modelId: "qwen-3.5-4b",
+      mode: "gguf-only",
+      spawn: spawn as unknown as typeof nodeSpawn,
+      sea: true,
+      execPath: "/bin/atag",
+    });
+    expect(result.outcome).toBe("already-running");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("models pull --background reports how to watch, follow and stop the worker", async () => {
+    vi.spyOn(process, "execPath", "get").mockReturnValue("/opt/node/bin/node");
+    vi.spyOn(process, "argv", "get").mockReturnValue([
+      "/opt/node/bin/node",
+      "/repo/dist/cli/index.js",
+      "models",
+      "pull",
+    ]);
+    // A worker that exits immediately: the record it seeded is what the
+    // command reports on, and the pid dies before anyone reads it.
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue({ pid: DEAD_PID, unref: vi.fn() } as unknown as ChildProcess);
+
+    const code = await modelsCommand(["pull", "--background", "qwen-3.5-4b"]);
+
+    expect(code).toBe(0);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const out = stdoutChunks.join("");
+    expect(out).toMatch(/downloading Qwen.*in the background \(pid 2000000000\)/);
+    expect(out).toMatch(/models downloads/);
+    expect(out).toMatch(/models downloads cancel qwen-3.5-4b/);
+    expect(out).toMatch(/keeps running after this terminal closes/);
+  });
+
+  it("models downloads lists jobs and marks a dead worker as interrupted", async () => {
+    writeDownloadJob(dataDir, job({ pid: DEAD_PID }));
+    writeDownloadJob(
+      dataDir,
+      job({
+        id: downloadJobId("embedding", "nomic-embed-text-v1.5"),
+        kind: "embedding",
+        modelId: "nomic-embed-text-v1.5",
+        status: "done",
+        percent: 100,
+        startedAt: "2026-09-07T11:00:00.000Z",
+      }),
+    );
+
+    const code = await modelsCommand(["downloads"]);
+
+    expect(code).toBe(0);
+    const out = stdoutChunks.join("");
+    const lines = out.split("\n");
+    const chatLine = lines.find((l) => l.startsWith("chat-qwen-3.5-4b"));
+    const embLine = lines.find((l) => l.startsWith("embedding-nomic"));
+    expect(chatLine).toMatch(/interrupted/);
+    expect(chatLine).toMatch(/4 MB \/ 10 MB/);
+    expect(embLine).toMatch(/\bdone\b/);
+    // Newest start first.
+    expect(lines.indexOf(embLine!)).toBeLessThan(lines.indexOf(chatLine!));
+  });
+
+  it("models downloads cancel on a job that is not running says so and succeeds", async () => {
+    writeDownloadJob(dataDir, job({ status: "failed", error: "boom" }));
+    const code = await modelsCommand(["downloads", "cancel", "qwen-3.5-4b"]);
+    expect(code).toBe(0);
+    expect(stdoutChunks.join("")).toMatch(/not running \(failed\)/);
+  });
+
+  it("models downloads clear forgets finished records only", async () => {
+    writeDownloadJob(dataDir, job({ id: "chat-a", status: "done" }));
+    writeDownloadJob(dataDir, job({ id: "chat-b", pid: process.pid }));
+    const code = await modelsCommand(["downloads", "clear"]);
+    expect(code).toBe(0);
+    expect(stdoutChunks.join("")).toMatch(/cleared 1/);
+    expect(readDownloadJob(dataDir, "chat-a")).toBeNull();
+    expect(readDownloadJob(dataDir, "chat-b")?.status).toBe("running");
+  });
+
+  it("followDownloadJob returns 0 once the record says done, 1 on failed", async () => {
+    writeDownloadJob(dataDir, job({ status: "done", percent: 100 }));
+    expect(await followDownloadJob(dataDir, "chat-qwen-3.5-4b", { pollMs: 1, sigint: false })).toBe(0);
+    writeDownloadJob(dataDir, job({ status: "failed", error: "disk full" }));
+    expect(await followDownloadJob(dataDir, "chat-qwen-3.5-4b", { pollMs: 1, sigint: false })).toBe(1);
+    expect(stderrChunks.join("")).toMatch(/background download failed: disk full/);
+  });
+
+  it("followDownloadJob returns 1 when the worker died mid-way and names the resume command", async () => {
+    writeDownloadJob(dataDir, job({ pid: DEAD_PID }));
+    expect(await followDownloadJob(dataDir, "chat-qwen-3.5-4b", { pollMs: 1, sigint: false })).toBe(1);
+    expect(stderrChunks.join("")).toMatch(/interrupted; partial kept.*models pull qwen-3.5-4b/);
+  });
+
+  it("a foreground pull of a model with a live worker follows it instead of downloading", async () => {
+    writeDownloadJob(dataDir, job({ pid: process.pid, status: "done", percent: 100 }));
+    // `done` is not live, so this exercises the read path only; the live
+    // case is the spawn-refusal test above plus followDownloadJob's own.
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 404, statusText: "Not Found" }),
+    ) as typeof fetch;
+    let code: number;
+    try {
+      code = await modelsCommand(["pull", "qwen-3.5-4b"]);
+    } finally {
+      globalThis.fetch = prevFetch;
+    }
+    // No worker alive: the foreground pull runs and fails on the mocked
+    // fetch — proving it did not follow a finished record.
+    expect(code).toBe(1);
+    expect(stderrChunks.join("")).not.toMatch(/already downloading/);
+  });
+
+  it("the worker log path is created next to the record", () => {
+    const spawn = vi.fn(() => ({ pid: 1, unref: vi.fn() }) as unknown as ChildProcess);
+    const result = spawnDownloadWorker({
+      kind: "embedding",
+      modelId: "nomic-embed-text-v1.5",
+      mode: "gguf-only",
+      spawn: spawn as unknown as typeof nodeSpawn,
+      sea: true,
+      execPath: "/bin/atag",
+    });
+    expect(result.outcome).toBe("spawned");
+    if (result.outcome !== "spawned") return;
+    expect(result.logPath).toBe(join(dataDir, "downloads", "embedding-nomic-embed-text-v1.5.log"));
+    expect(readFileSync(result.logPath, "utf-8")).toBe("");
+  });
+});

--- a/src/cli/models-downloads.ts
+++ b/src/cli/models-downloads.ts
@@ -1,0 +1,343 @@
+import { execSync, spawn as nodeSpawn } from "node:child_process";
+import { closeSync, mkdirSync, openSync } from "node:fs";
+
+import { getConfig } from "../config/index.js";
+import {
+  classifyPidLiveness,
+  downloadJobId,
+  initialDownloadJob,
+  isDownloadJobLive,
+  listDownloadJobs,
+  readDownloadJob,
+  removeDownloadJob,
+  resolveDownloadLogPath,
+  resolveDownloadsDir,
+  runDownloadWorker,
+  writeDownloadJob,
+  type DownloadJob,
+  type DownloadJobKind,
+  type DownloadJobMode,
+} from "../local-llm/index.js";
+import { renderPullProgress } from "./pull-progress.js";
+import { isSeaBuild, selfInvocation } from "./self-invocation.js";
+
+/**
+ * Background model downloads on the CLI.
+ *
+ * `models pull --background <id>` launches a detached copy of this
+ * program running `models pull-worker`, wires its output to
+ * `<dataDir>/downloads/<job>.log`, seeds the job record and returns at
+ * once. The worker survives the terminal that started it: it is in its
+ * own process group (`detached`), holds no tty, and its stdio is a
+ * file, so a closed window's SIGHUP never reaches it — the exact
+ * arrangement `startDaemon` uses for llama-server.
+ *
+ * `models downloads` lists jobs; `models downloads cancel <id>` stops
+ * one, keeping its partial file for a later resume. A foreground
+ * `models pull` of a model whose worker is alive follows that worker's
+ * progress instead of racing it for the same bytes.
+ */
+
+export interface SpawnDownloadWorkerInput {
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+  /** Test seams. */
+  spawn?: typeof nodeSpawn;
+  execPath?: string;
+  argv?: readonly string[];
+  execArgv?: readonly string[];
+  sea?: boolean;
+  env?: NodeJS.ProcessEnv;
+}
+
+export type SpawnDownloadWorkerResult =
+  | { outcome: "spawned"; job: DownloadJob; logPath: string }
+  | { outcome: "already-running"; job: DownloadJob };
+
+/**
+ * The argv tail that reaches `modelsCommand` in the child. Exported so
+ * the test can pin the exact shape the dispatcher parses.
+ */
+export function downloadWorkerArgs(input: {
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+}): string[] {
+  return ["models", "pull-worker", input.kind, input.modelId, input.mode];
+}
+
+export function spawnDownloadWorker(
+  input: SpawnDownloadWorkerInput,
+): SpawnDownloadWorkerResult {
+  const dataDir = getConfig().paths.localModelsDataDir;
+  const jobId = downloadJobId(input.kind, input.modelId);
+  const existing = readDownloadJob(dataDir, jobId);
+  if (isDownloadJobLive(existing)) {
+    return { outcome: "already-running", job: existing };
+  }
+
+  const self = selfInvocation({
+    execPath: input.execPath ?? process.execPath,
+    argv: input.argv ?? process.argv,
+    execArgv: input.execArgv ?? process.execArgv,
+    isSea: input.sea ?? isSeaBuild(),
+  });
+  const args = [...self.args, ...downloadWorkerArgs(input)];
+
+  mkdirSync(resolveDownloadsDir(dataDir), { recursive: true });
+  const logPath = resolveDownloadLogPath(dataDir, jobId);
+  const logFd = openSync(logPath, "a");
+  try {
+    const child = (input.spawn ?? nodeSpawn)(self.cmd, args, {
+      stdio: ["ignore", logFd, logFd],
+      detached: true,
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
+      // The state dir and every other ATOMIC_AGENT_* knob travel by
+      // environment; a worker reading a different `~/.atomic-agent`
+      // would download into the wrong place.
+      env: { ...(input.env ?? process.env) },
+    });
+    child.unref();
+    if (child.pid == null) {
+      throw new Error("spawn failed: no pid");
+    }
+    // Seed the record with the child's pid so `models downloads` lists
+    // the job before the worker has written anything. The worker's own
+    // first write replaces this with the same pid and live numbers.
+    const job = initialDownloadJob({
+      dataDir,
+      kind: input.kind,
+      modelId: input.modelId,
+      mode: input.mode,
+      pid: child.pid,
+    });
+    writeDownloadJob(dataDir, job);
+    return { outcome: "spawned", job, logPath };
+  } finally {
+    closeSync(logFd);
+  }
+}
+
+/**
+ * The detached worker's entry point: `models pull-worker <kind> <id>
+ * <mode>`. Hidden from help — nothing invokes it but the spawner. A
+ * SIGTERM (what `downloads cancel` sends) becomes an abort, so the
+ * record ends as `cancelled` rather than as a dead `running` pid.
+ */
+export async function runLocalModelsPullWorker(args: string[]): Promise<number> {
+  const [kindArg, modelId, modeArg] = args;
+  if ((kindArg !== "chat" && kindArg !== "embedding") || !modelId) {
+    process.stderr.write("usage: models pull-worker <chat|embedding> <id> [mode]\n");
+    return 2;
+  }
+  const mode: DownloadJobMode =
+    modeArg === "with-mmproj" || modeArg === "mmproj-only" ? modeArg : "gguf-only";
+  const controller = new AbortController();
+  const onSignal = (): void => controller.abort();
+  process.once("SIGTERM", onSignal);
+  process.once("SIGINT", onSignal);
+  // Detached and tty-less, the worker is outside the group a closing
+  // terminal hangs up on — but Node's default for SIGHUP is to exit, so
+  // any hangup that does reach it (an ssh session torn down around a
+  // job started from it, a shell that forwards the signal) would kill
+  // a download that has nothing to do with the terminal. Ignore it.
+  const onHangup = (): void => undefined;
+  process.on("SIGHUP", onHangup);
+  try {
+    const outcome = await runDownloadWorker({
+      dataDir: getConfig().paths.localModelsDataDir,
+      kind: kindArg,
+      modelId,
+      mode,
+      signal: controller.signal,
+    });
+    return outcome === "done" ? 0 : 1;
+  } finally {
+    process.off("SIGTERM", onSignal);
+    process.off("SIGINT", onSignal);
+    process.off("SIGHUP", onHangup);
+  }
+}
+
+function formatBytes(bytes: number): string {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) return `${gb.toFixed(2)} GB`;
+  return `${Math.round(bytes / (1024 * 1024))} MB`;
+}
+
+export function describeDownloadJob(job: DownloadJob): string {
+  const size =
+    job.totalBytes > 0
+      ? `${formatBytes(job.transferredBytes)} / ${formatBytes(job.totalBytes)}`
+      : formatBytes(job.transferredBytes);
+  const state =
+    job.status === "running"
+      ? `running (pid ${job.pid}) ${job.percent}%`
+      : job.status === "failed"
+        ? `failed: ${job.error ?? "unknown error"}`
+        : job.status;
+  return `${job.id.padEnd(40)} ${state.padEnd(28)} ${size}  ${job.label}`;
+}
+
+/**
+ * `models downloads [cancel <job-or-model-id>] [clear]`.
+ */
+export async function runLocalModelsDownloads(args: string[]): Promise<number> {
+  const dataDir = getConfig().paths.localModelsDataDir;
+  const sub = args[0];
+  if (sub === "cancel") {
+    return cancelDownload(dataDir, args[1]);
+  }
+  if (sub === "clear") {
+    let n = 0;
+    for (const job of listDownloadJobs(dataDir)) {
+      if (job.status === "running") continue;
+      removeDownloadJob(dataDir, job.id);
+      n += 1;
+    }
+    process.stdout.write(`cleared ${n} finished download record(s)\n`);
+    return 0;
+  }
+  if (sub && sub !== "list") {
+    process.stderr.write("usage: models downloads [list|cancel <id>|clear]\n");
+    return 2;
+  }
+  const jobs = listDownloadJobs(dataDir);
+  if (jobs.length === 0) {
+    process.stdout.write("no background downloads\n");
+    return 0;
+  }
+  process.stdout.write(
+    `${"JOB".padEnd(40)} ${"STATE".padEnd(28)} PROGRESS\n`,
+  );
+  for (const job of jobs) {
+    process.stdout.write(`${describeDownloadJob(job)}\n`);
+  }
+  process.stdout.write(
+    `\nlogs: ${resolveDownloadsDir(dataDir)}/<job>.log · resume an interrupted one with 'models pull [--background] <id>'\n`,
+  );
+  return 0;
+}
+
+function findJob(dataDir: string, ref: string): DownloadJob | null {
+  return (
+    readDownloadJob(dataDir, ref) ??
+    readDownloadJob(dataDir, downloadJobId("chat", ref)) ??
+    readDownloadJob(dataDir, downloadJobId("embedding", ref))
+  );
+}
+
+async function cancelDownload(dataDir: string, ref: string | undefined): Promise<number> {
+  if (!ref) {
+    process.stderr.write("usage: models downloads cancel <job-or-model-id>\n");
+    return 2;
+  }
+  const job = findJob(dataDir, ref);
+  if (!job) {
+    process.stderr.write(`no download job matches ${JSON.stringify(ref)}\n`);
+    return 1;
+  }
+  if (job.status !== "running") {
+    process.stdout.write(`${job.id} is not running (${job.status})\n`);
+    return 0;
+  }
+  if (classifyPidLiveness(job.pid) === "foreign") {
+    process.stderr.write(
+      `download worker pid ${job.pid} belongs to another user; cannot stop it\n`,
+    );
+    return 1;
+  }
+  if (process.platform === "win32") {
+    // No signal handlers on Windows: the worker is killed outright and
+    // its record reconciles to `interrupted` on the next read, which is
+    // equally resumable.
+    try {
+      execSync(`taskkill /PID ${job.pid} /T /F`, { timeout: 5000, stdio: "ignore" });
+    } catch {
+      /* ignore */
+    }
+  } else {
+    try {
+      process.kill(job.pid, "SIGTERM");
+    } catch {
+      /* already gone */
+    }
+  }
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const now = readDownloadJob(dataDir, job.id);
+    if (!now || now.status !== "running") {
+      process.stdout.write(
+        `${job.id} stopped (${now?.status ?? "gone"}); ${formatBytes(
+          now?.transferredBytes ?? job.transferredBytes,
+        )} kept on disk — 'models pull ${job.modelId}' resumes it\n`,
+      );
+      return 0;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  process.stderr.write(`sent stop to pid ${job.pid}, but it is still running\n`);
+  return 1;
+}
+
+/**
+ * Sit on a live worker's record and draw its progress until it ends.
+ * Ctrl+C here detaches the watcher only — the worker keeps going, and
+ * says so. Resolves to the exit code the foreground pull would have
+ * produced.
+ */
+export async function followDownloadJob(
+  dataDir: string,
+  jobId: string,
+  opts?: { pollMs?: number; sigint?: boolean },
+): Promise<number> {
+  const pollMs = opts?.pollMs ?? 500;
+  const tty = process.stderr.isTTY;
+  let detached = false;
+  const onSigint = (): void => {
+    detached = true;
+  };
+  if (opts?.sigint !== false) process.once("SIGINT", onSigint);
+  let lastPercent = -1;
+  try {
+    for (;;) {
+      const job = readDownloadJob(dataDir, jobId);
+      if (!job) {
+        process.stderr.write("\ndownload record disappeared\n");
+        return 1;
+      }
+      const line = renderPullProgress(
+        job.label,
+        job.percent,
+        job.transferredBytes,
+        job.totalBytes,
+      );
+      if (tty) process.stderr.write(`\r${line.padEnd(79)}`);
+      else if (job.percent !== lastPercent && (job.percent % 5 === 0 || job.status !== "running")) {
+        process.stderr.write(`${line}\n`);
+      }
+      lastPercent = job.percent;
+      if (job.status !== "running") {
+        if (tty) process.stderr.write("\n");
+        if (job.status === "done") return 0;
+        process.stderr.write(
+          job.status === "failed"
+            ? `background download failed: ${job.error ?? "unknown error"}\n`
+            : `background download ${job.status}; partial kept — run 'models pull ${job.modelId}' to resume\n`,
+        );
+        return 1;
+      }
+      if (detached) {
+        if (tty) process.stderr.write("\n");
+        process.stderr.write(
+          `detached — the download continues in the background (pid ${job.pid}); watch it with 'atomic-agent models downloads'\n`,
+        );
+        return 0;
+      }
+      await new Promise((r) => setTimeout(r, pollMs));
+    }
+  } finally {
+    process.off("SIGINT", onSigint);
+  }
+}

--- a/src/cli/models-handlers.ts
+++ b/src/cli/models-handlers.ts
@@ -10,6 +10,7 @@ import {
   downloadModel,
   EMBEDDING_MODELS_CATALOG,
   fallBackToCpuBackend,
+  formatGgufSize,
   getConfiguredBackendVariant,
   getDaemonStatus,
   getEmbeddingDaemonStatus,
@@ -25,11 +26,13 @@ import {
   listVulkanDevices,
   maybeAutoUpdateBackend,
   readBackendVersion,
+  readPartialDownload,
   removeModel,
   resolveChatTemplatePath,
   resolveDownloadAsset,
   resolveManagedDevice,
   resolveMmprojFilePath,
+  resolveModelFilePath,
   resolvePlatformAsset,
   resolveServerBinPath,
   shouldFallBackToCpuBackend,
@@ -45,6 +48,20 @@ export function readCliOption(args: string[], name: string): string | undefined 
 
 function formatGb(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/**
+ * One line per retry so a flaky link reads as "retrying", not "hung".
+ * Goes to stderr on its own row: the progress line is `\r`-rewritten
+ * in place, and the note must survive the next rewrite.
+ */
+export function renderPullRetry(info: {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  error: Error;
+}): string {
+  return `download interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s, resuming from the partial file`;
 }
 
 export function renderPullProgress(
@@ -109,9 +126,19 @@ export async function runLocalModelsPull(idArg: string | undefined): Promise<num
     }
     lastLine = line;
   };
+  const onRetry = (info: Parameters<typeof renderPullRetry>[0]): void => {
+    process.stderr.write(`${tty ? "\n" : ""}${renderPullRetry(info)}\n`);
+  };
   try {
-    process.stderr.write(`downloading ${m.id} (${m.filename}, ${m.sizeLabel})\n`);
-    await downloadModel(dataDir, m, { onProgress });
+    const partial = readPartialDownload(
+      resolveModelFilePath(dataDir, m.id, m.filename),
+    );
+    process.stderr.write(
+      partial
+        ? `resuming ${m.id} (${m.filename}, ${m.sizeLabel}) — ${formatGgufSize(partial.transferred)} already on disk\n`
+        : `downloading ${m.id} (${m.filename}, ${m.sizeLabel})\n`,
+    );
+    await downloadModel(dataDir, m, { onProgress, onRetry });
     if (tty) process.stderr.write(`\n`);
     else if (lastLine) process.stderr.write(`done: ${lastLine}\n`);
     const savedPath = join(dataDir, "models", m.id, m.filename);
@@ -608,11 +635,19 @@ export async function runLocalModelsPullEmbedding(
       process.stderr.write(`${line}\n`);
     lastLine = line;
   };
+  const onRetry = (info: Parameters<typeof renderPullRetry>[0]): void => {
+    process.stderr.write(`${tty ? "\n" : ""}${renderPullRetry(info)}\n`);
+  };
   try {
-    process.stderr.write(
-      `downloading embedding model ${m.id} (${m.filename}, ${m.sizeLabel})\n`,
+    const partial = readPartialDownload(
+      resolveModelFilePath(dataDir, m.id, m.filename),
     );
-    await downloadEmbeddingModel(dataDir, m, { onProgress });
+    process.stderr.write(
+      partial
+        ? `resuming embedding model ${m.id} (${m.filename}, ${m.sizeLabel}) — ${formatGgufSize(partial.transferred)} already on disk\n`
+        : `downloading embedding model ${m.id} (${m.filename}, ${m.sizeLabel})\n`,
+    );
+    await downloadEmbeddingModel(dataDir, m, { onProgress, onRetry });
     if (tty) process.stderr.write(`\n`);
     else if (lastLine) process.stderr.write(`done: ${lastLine}\n`);
     const savedPath = join(dataDir, "models", m.id, m.filename);

--- a/src/cli/models-handlers.ts
+++ b/src/cli/models-handlers.ts
@@ -7,6 +7,8 @@ import {
   checkForBackendUpdate,
   downloadBackend,
   downloadEmbeddingModel,
+  downloadJobId,
+  downloadMmproj,
   downloadModel,
   EMBEDDING_MODELS_CATALOG,
   fallBackToCpuBackend,
@@ -17,6 +19,7 @@ import {
   getEmbeddingModelDef,
   getLocalModelDef,
   isBackendDownloaded,
+  isDownloadJobLive,
   isEmbeddingModelDownloaded,
   isKnownEmbeddingModelId,
   isKnownLocalModelId,
@@ -26,6 +29,7 @@ import {
   listVulkanDevices,
   maybeAutoUpdateBackend,
   readBackendVersion,
+  readDownloadJob,
   readPartialDownload,
   removeModel,
   resolveChatTemplatePath,
@@ -38,6 +42,8 @@ import {
   shouldFallBackToCpuBackend,
   startChatAndEmbeddingDaemons,
   stopChatAndEmbeddingDaemons,
+  type DownloadJobKind,
+  type DownloadJobMode,
 } from "../local-llm/index.js";
 
 export function readCliOption(args: string[], name: string): string | undefined {
@@ -46,39 +52,12 @@ export function readCliOption(args: string[], name: string): string | undefined 
   return args[i + 1];
 }
 
-function formatGb(bytes: number): string {
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-/**
- * One line per retry so a flaky link reads as "retrying", not "hung".
- * Goes to stderr on its own row: the progress line is `\r`-rewritten
- * in place, and the note must survive the next rewrite.
- */
-export function renderPullRetry(info: {
-  attempt: number;
-  maxRetries: number;
-  delayMs: number;
-  error: Error;
-}): string {
-  return `download interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s, resuming from the partial file`;
-}
-
-export function renderPullProgress(
-  label: string,
-  percent: number,
-  transferred: number,
-  total: number,
-): string {
-  const barW = 20;
-  const filled = Math.min(barW, Math.round((percent / 100) * barW));
-  const bar = `${"=".repeat(filled)}${" ".repeat(barW - filled)}`;
-  const tail =
-    total > 0
-      ? `${formatGb(transferred)} / ${formatGb(total)}`
-      : `${formatGb(transferred)}`;
-  return `[${bar}] ${percent}%  ${tail}  ${label}`;
-}
+export { formatGb, renderPullProgress, renderPullRetry } from "./pull-progress.js";
+import { renderPullProgress, renderPullRetry } from "./pull-progress.js";
+import {
+  followDownloadJob,
+  spawnDownloadWorker,
+} from "./models-downloads.js";
 
 export async function runLocalModelsList(): Promise<number> {
   const cfg = getConfig();
@@ -100,7 +79,15 @@ export async function runLocalModelsList(): Promise<number> {
   return 0;
 }
 
-export async function runLocalModelsPull(idArg: string | undefined): Promise<number> {
+/**
+ * `models pull <id> [--background] [--mmproj]`. A live background
+ * worker for the same model is followed rather than raced; an
+ * interrupted one is resumed in the foreground (or re-spawned with
+ * `--background`) from its partial file.
+ */
+export async function runLocalModelsPull(args: string[]): Promise<number> {
+  const flags = new Set(args.filter((a) => a.startsWith("--")));
+  const idArg = args.find((a) => !a.startsWith("--"));
   if (!idArg || !isKnownLocalModelId(idArg)) {
     process.stderr.write(
       `unknown model id. Valid: ${listLocalModels().map((m) => m.id).join(", ")}\n`,
@@ -109,23 +96,36 @@ export async function runLocalModelsPull(idArg: string | undefined): Promise<num
   }
   const m = getLocalModelDef(idArg);
   const dataDir = getConfig().paths.localModelsDataDir;
+  const mode: DownloadJobMode = flags.has("--mmproj") && m.supportsVision ? "with-mmproj" : "gguf-only";
+  if (flags.has("--mmproj") && !m.supportsVision) {
+    process.stderr.write(`note: ${m.id} is not vision-capable — no mmproj to fetch\n`);
+  }
+
+  const live = readDownloadJob(dataDir, downloadJobId("chat", m.id));
+  if (isDownloadJobLive(live)) {
+    process.stderr.write(
+      `${m.id} is already downloading in the background (pid ${live.pid}) — following it; Ctrl+C detaches\n`,
+    );
+    return followDownloadJob(dataDir, live.id);
+  }
+  if (flags.has("--background")) {
+    return startBackgroundPull({ kind: "chat", modelId: m.id, mode });
+  }
+
   const estTotal = Math.round(m.fileSizeGb * (1024 * 1024 * 1024));
   const tty = process.stderr.isTTY;
   let lastLine = "";
-  const onProgress = (percent: number, transferred: number, total: number): void => {
-    const line = renderPullProgress(
-      `${m.filename} (${m.sizeLabel})`,
-      percent,
-      transferred,
-      total > 0 ? total : estTotal,
-    );
-    if (tty) {
-      process.stderr.write(`\r${line.padEnd(79)}`);
-    } else if (percent % 5 === 0 || percent === 100) {
-      process.stderr.write(`${line}\n`);
-    }
-    lastLine = line;
-  };
+  const progressFor =
+    (label: string, est: number) =>
+    (percent: number, transferred: number, total: number): void => {
+      const line = renderPullProgress(label, percent, transferred, total > 0 ? total : est);
+      if (tty) {
+        process.stderr.write(`\r${line.padEnd(79)}`);
+      } else if (percent % 5 === 0 || percent === 100) {
+        process.stderr.write(`${line}\n`);
+      }
+      lastLine = line;
+    };
   const onRetry = (info: Parameters<typeof renderPullRetry>[0]): void => {
     process.stderr.write(`${tty ? "\n" : ""}${renderPullRetry(info)}\n`);
   };
@@ -138,17 +138,62 @@ export async function runLocalModelsPull(idArg: string | undefined): Promise<num
         ? `resuming ${m.id} (${m.filename}, ${m.sizeLabel}) — ${formatGgufSize(partial.transferred)} already on disk\n`
         : `downloading ${m.id} (${m.filename}, ${m.sizeLabel})\n`,
     );
-    await downloadModel(dataDir, m, { onProgress, onRetry });
+    await downloadModel(dataDir, m, {
+      onProgress: progressFor(`${m.filename} (${m.sizeLabel})`, estTotal),
+      onRetry,
+    });
     if (tty) process.stderr.write(`\n`);
     else if (lastLine) process.stderr.write(`done: ${lastLine}\n`);
     const savedPath = join(dataDir, "models", m.id, m.filename);
     process.stdout.write(`done. model saved to ${savedPath}\n`);
+    if (mode === "with-mmproj" && m.mmprojFilename && !isMmprojDownloaded(dataDir, m)) {
+      process.stderr.write(`downloading mmproj ${m.mmprojFilename}\n`);
+      await downloadMmproj(dataDir, m, {
+        onProgress: progressFor(
+          m.mmprojFilename,
+          Math.round((m.mmprojFileSizeGb ?? 1) * (1024 * 1024 * 1024)),
+        ),
+        onRetry,
+      });
+      if (tty) process.stderr.write(`\n`);
+      process.stdout.write(
+        `done. mmproj saved to ${resolveMmprojFilePath(dataDir, m.id, m.mmprojFilename)}\n`,
+      );
+    }
     return 0;
   } catch (e) {
     if (tty) process.stderr.write(`\n`);
     process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
     return 1;
   }
+}
+
+/**
+ * Launch the detached worker and hand the terminal back. The record it
+ * seeds is what `models downloads` shows a moment later.
+ */
+function startBackgroundPull(input: {
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+}): number {
+  const result = spawnDownloadWorker(input);
+  if (result.outcome === "already-running") {
+    process.stdout.write(
+      `${input.modelId} is already downloading in the background (pid ${result.job.pid})\n`,
+    );
+    return 0;
+  }
+  const { job, logPath } = result;
+  process.stdout.write(
+    `${job.transferredBytes > 0 ? "resuming" : "downloading"} ${job.label} in the background (pid ${job.pid})\n` +
+      `  progress: atomic-agent models downloads\n` +
+      `  follow:   atomic-agent models pull${input.kind === "embedding" ? "-embedding" : ""} ${input.modelId}\n` +
+      `  stop:     atomic-agent models downloads cancel ${input.modelId}\n` +
+      `  log:      ${logPath}\n` +
+      `the download keeps running after this terminal closes.\n`,
+  );
+  return 0;
 }
 
 export async function runLocalModelsUse(idArg: string | undefined): Promise<number> {
@@ -605,9 +650,9 @@ export async function runLocalModelsUseDevice(
  * to the typed `EmbeddingModelId` union so the wrong catalog can't
  * be hit by accident.
  */
-export async function runLocalModelsPullEmbedding(
-  idArg: string | undefined,
-): Promise<number> {
+export async function runLocalModelsPullEmbedding(args: string[]): Promise<number> {
+  const flags = new Set(args.filter((a) => a.startsWith("--")));
+  const idArg = args.find((a) => !a.startsWith("--"));
   if (!idArg || !isKnownEmbeddingModelId(idArg)) {
     process.stderr.write(
       `unknown embedding model id. Valid: ${EMBEDDING_MODELS_CATALOG.map((m) => m.id).join(", ")}\n`,
@@ -616,6 +661,18 @@ export async function runLocalModelsPullEmbedding(
   }
   const m = getEmbeddingModelDef(idArg);
   const dataDir = getConfig().paths.localModelsDataDir;
+
+  const live = readDownloadJob(dataDir, downloadJobId("embedding", m.id));
+  if (isDownloadJobLive(live)) {
+    process.stderr.write(
+      `${m.id} is already downloading in the background (pid ${live.pid}) — following it; Ctrl+C detaches\n`,
+    );
+    return followDownloadJob(dataDir, live.id);
+  }
+  if (flags.has("--background")) {
+    return startBackgroundPull({ kind: "embedding", modelId: m.id, mode: "gguf-only" });
+  }
+
   const estTotal = Math.round(m.fileSizeGb * (1024 * 1024 * 1024));
   const tty = process.stderr.isTTY;
   let lastLine = "";

--- a/src/cli/pull-progress.ts
+++ b/src/cli/pull-progress.ts
@@ -1,0 +1,40 @@
+/**
+ * Progress rendering shared by the foreground pull, the background
+ * follower and the worker log. Kept apart from the handlers so the
+ * two CLI modules can both use it without importing each other.
+ */
+
+export function formatGb(bytes: number): string {
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+/**
+ * One line per retry so a flaky link reads as "retrying", not "hung".
+ * Goes to stderr on its own row: the progress line is `\r`-rewritten
+ * in place, and the note must survive the next rewrite.
+ */
+export function renderPullRetry(info: {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  error: Error;
+}): string {
+  return `download interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s, resuming from the partial file`;
+}
+
+export function renderPullProgress(
+  label: string,
+  percent: number,
+  transferred: number,
+  total: number,
+): string {
+  const barW = 20;
+  const filled = Math.min(barW, Math.round((percent / 100) * barW));
+  const bar = `${"=".repeat(filled)}${" ".repeat(barW - filled)}`;
+  const tail =
+    total > 0
+      ? `${formatGb(transferred)} / ${formatGb(total)}`
+      : `${formatGb(transferred)}`;
+  return `[${bar}] ${percent}%  ${tail}  ${label}`;
+}
+

--- a/src/cli/self-invocation.test.ts
+++ b/src/cli/self-invocation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { selfInvocation } from "./self-invocation.js";
+
+describe("selfInvocation", () => {
+  it("re-runs a SEA binary as itself, with no script path", () => {
+    expect(
+      selfInvocation({
+        execPath: "/usr/local/bin/atomic-agent",
+        argv: ["/usr/local/bin/atomic-agent", "/usr/local/bin/atomic-agent", "models", "pull"],
+        isSea: true,
+      }),
+    ).toEqual({ cmd: "/usr/local/bin/atomic-agent", args: [] });
+  });
+
+  it("re-runs a node script through node with the script path", () => {
+    expect(
+      selfInvocation({
+        execPath: "/opt/node/bin/node",
+        argv: ["/opt/node/bin/node", "/repo/dist/cli/index.js", "models", "pull"],
+        isSea: false,
+      }),
+    ).toEqual({ cmd: "/opt/node/bin/node", args: ["/repo/dist/cli/index.js"] });
+  });
+
+  it("keeps loader flags ahead of the script so a tsx dev run stays runnable", () => {
+    expect(
+      selfInvocation({
+        execPath: "/opt/node/bin/node",
+        argv: ["/opt/node/bin/node", "/repo/src/cli/index.ts"],
+        execArgv: ["--import", "tsx"],
+        isSea: false,
+      }),
+    ).toEqual({
+      cmd: "/opt/node/bin/node",
+      args: ["--import", "tsx", "/repo/src/cli/index.ts"],
+    });
+  });
+
+  it("refuses a node run with no script path rather than guessing", () => {
+    expect(() =>
+      selfInvocation({ execPath: "/opt/node/bin/node", argv: ["/opt/node/bin/node"], isSea: false }),
+    ).toThrow(/no script path/);
+  });
+});

--- a/src/cli/self-invocation.ts
+++ b/src/cli/self-invocation.ts
@@ -1,0 +1,57 @@
+/**
+ * How this very program is re-run as a child: the command and the
+ * leading arguments that land in the same CLI dispatcher, so that
+ * `[...prefix, "models", "pull-worker", …]` reaches `modelsCommand`
+ * whether the parent is the SEA binary or `node dist/cli/index.js`.
+ *
+ * Pure: `process` values arrive as inputs, so every branch is
+ * unit-reachable. The same reasoning lives in `tui-command.ts`'s
+ * self-update relaunch and `build-terminal-launch.ts`'s `agentArgv`.
+ */
+import { createRequire } from "node:module";
+
+/**
+ * `node:sea` cannot be imported statically: Vite's module graph does not
+ * resolve it and every test importing this module would fail to load.
+ * Same lazy `createRequire` as `native/load-better-sqlite3.ts`; outside
+ * a SEA build the require fails and the answer is simply "no".
+ */
+const bootRequire = createRequire(import.meta.url);
+
+export function isSeaBuild(): boolean {
+  try {
+    const sea: typeof import("node:sea") = bootRequire("node:sea");
+    return sea.isSea();
+  } catch {
+    return false;
+  }
+}
+
+export interface SelfInvocationInput {
+  /** `process.execPath`. */
+  readonly execPath: string;
+  /** `process.argv`. */
+  readonly argv: readonly string[];
+  /** `process.execArgv` — loader/inspect flags a dev run needs back. */
+  readonly execArgv?: readonly string[];
+  /** `isSea()` — a SEA binary is its own entry point, no script path. */
+  readonly isSea: boolean;
+}
+
+export interface SelfInvocation {
+  readonly cmd: string;
+  /** Everything before the user command. */
+  readonly args: readonly string[];
+}
+
+export function selfInvocation(input: SelfInvocationInput): SelfInvocation {
+  const execArgv = input.execArgv ?? [];
+  if (input.isSea) {
+    return { cmd: input.execPath, args: [...execArgv] };
+  }
+  const scriptPath = input.argv[1];
+  if (!scriptPath) {
+    throw new Error("cannot re-run this program: no script path in argv");
+  }
+  return { cmd: input.execPath, args: [...execArgv, scriptPath] };
+}

--- a/src/local-llm/backend-installer.test.ts
+++ b/src/local-llm/backend-installer.test.ts
@@ -248,7 +248,11 @@ describe("backend-installer", () => {
     }) as typeof fetch;
 
     try {
-      await expect(downloadBackend(dir)).rejects.toThrow(/socket hang up/);
+      // One quick retry: the failure has to survive the downloader's own
+      // resume-and-retry loop before the staging cleanup is exercised.
+      await expect(
+        downloadBackend(dir, { maxRetries: 1, retryDelayMs: 1 }),
+      ).rejects.toThrow(/socket hang up/);
 
       const binPath = resolveServerBinPath(dir, "llama-server");
       expect(existsSync(binPath)).toBe(true);

--- a/src/local-llm/backend-installer.ts
+++ b/src/local-llm/backend-installer.ts
@@ -7,7 +7,7 @@ import {
   rmDirQuiet,
   swapInStagedBackend,
 } from "./backend-staging.js";
-import { downloadFile } from "./download-file.js";
+import { downloadFile, type DownloadFileOptions } from "./download-file.js";
 import { readBackendVersion, writeBackendVersionAt } from "./backend-version.js";
 import { resolvePlatformAsset, UnsupportedPlatformError } from "./platform-assets.js";
 import { resolveDownloadAsset } from "./windows-backend-variant.js";
@@ -241,10 +241,10 @@ export function isBackendDownloaded(dataDir: string): boolean {
 
 export async function downloadBackend(
   dataDir: string,
-  opts?: {
-    onProgress?: (percent: number, transferred: number, total: number) => void;
-    signal?: AbortSignal;
-  },
+  opts?: Pick<
+    DownloadFileOptions,
+    "onProgress" | "onRetry" | "signal" | "maxRetries" | "retryDelayMs"
+  >,
 ): Promise<{ ok: true; tag: string }> {
   const { assetName, binaryName } = resolveDownloadAsset();
   // Always hit GitHub for an actual install so we don't grab a stale
@@ -283,9 +283,8 @@ export async function downloadBackend(
   try {
     const archivePath = join(stagingDir, assetName);
     await downloadFile(asset.browser_download_url, archivePath, {
-      onProgress: opts?.onProgress,
+      ...opts,
       userAgent: "atomic-agent/local-llm-backend-download",
-      signal: opts?.signal,
     });
 
     await extractBackendArchive(archivePath, stagingDir, binaryName);

--- a/src/local-llm/download-file.test.ts
+++ b/src/local-llm/download-file.test.ts
@@ -3,6 +3,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -137,7 +138,10 @@ describe("download-file", () => {
       signal: controller.signal,
     });
 
-    await waitFor(() => releaseSecondChunk !== null);
+    // The stream may pull chunk two (and park on it) before the first
+    // chunk has been written, so wait for the byte on disk, not for the
+    // source's second pull, before cancelling.
+    await waitFor(() => releaseSecondChunk !== null && partialBytes(dest) === 1);
     controller.abort();
     releaseSecondChunk?.();
 
@@ -537,6 +541,14 @@ function seedPartial(
     resolvePartialMetaPath(dest),
     JSON.stringify({ url, total: meta.total, etag: meta.etag, lastModified: null }),
   );
+}
+
+function partialBytes(dest: string): number {
+  try {
+    return statSync(resolvePartialPath(dest)).size;
+  } catch {
+    return -1;
+  }
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/src/local-llm/download-file.test.ts
+++ b/src/local-llm/download-file.test.ts
@@ -1,10 +1,69 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { downloadFile } from "./download-file.js";
+import {
+  discardPartialDownload,
+  downloadFile,
+  readPartialDownload,
+  resolvePartialMetaPath,
+  resolvePartialPath,
+} from "./download-file.js";
+
+/** A body that hands out `chunks` one per pull, then closes. */
+function bodyOf(chunks: readonly (string | Buffer)[]): ReadableStream {
+  const queue = chunks.map((c) => (typeof c === "string" ? Buffer.from(c) : c));
+  return new ReadableStream({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(next);
+    },
+  });
+}
+
+/** A body that delivers `chunks` and then dies with a transport error. */
+function dyingBodyOf(chunks: readonly string[], error: Error): ReadableStream {
+  const queue = [...chunks];
+  return new ReadableStream({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.error(error);
+        return;
+      }
+      controller.enqueue(Buffer.from(next));
+    },
+  });
+}
+
+/** Records each request's headers; answers from `responders` in order. */
+function mockFetch(
+  responders: readonly ((headers: Headers) => Response)[],
+): { calls: Headers[]; fn: typeof fetch } {
+  const calls: Headers[] = [];
+  const fn = vi.fn(async (_url: unknown, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    calls.push(headers);
+    const responder = responders[calls.length - 1];
+    if (!responder) throw new Error(`unexpected fetch #${calls.length}`);
+    return responder(headers);
+  }) as unknown as typeof fetch;
+  return { calls, fn };
+}
+
+const FAST = { retryDelayMs: 1, stallTimeoutMs: 0 };
 
 describe("download-file", () => {
   let dir: string;
@@ -20,17 +79,9 @@ describe("download-file", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("streams body to dest with progress and removes tmp on success", async () => {
-    const chunks = [Buffer.from("a"), Buffer.from("b"), Buffer.from("c")];
-    const body = new ReadableStream({
-      start(controller) {
-        for (const c of chunks) controller.enqueue(c);
-        controller.close();
-      },
-    });
-
+  it("streams body to dest with progress and leaves no partial on success", async () => {
     globalThis.fetch = vi.fn(async () => {
-      return new Response(body, {
+      return new Response(bodyOf(["a", "b", "c"]), {
         status: 200,
         headers: { "content-length": "3" },
       });
@@ -39,14 +90,17 @@ describe("download-file", () => {
     const dest = join(dir, "out.bin");
     const progress: number[] = [];
     await downloadFile("https://example.com/x", dest, {
+      ...FAST,
       onProgress: (p) => progress.push(p),
     });
 
     expect(readFileSync(dest, "utf-8")).toBe("abc");
     expect(progress.includes(100)).toBe(true);
+    expect(existsSync(resolvePartialPath(dest))).toBe(false);
+    expect(existsSync(resolvePartialMetaPath(dest))).toBe(false);
   });
 
-  it("removes tmp and does not publish partial file when aborted", async () => {
+  it("keeps the partial and its sidecar when aborted, and does not publish it", async () => {
     let releaseSecondChunk: (() => void) | null = null;
     let chunkIndex = 0;
     const body = new ReadableStream({
@@ -72,13 +126,14 @@ describe("download-file", () => {
     globalThis.fetch = vi.fn(async () => {
       return new Response(body, {
         status: 200,
-        headers: { "content-length": "2" },
+        headers: { "content-length": "2", etag: '"v1"' },
       });
     }) as typeof fetch;
 
     const dest = join(dir, "out.bin");
     const controller = new AbortController();
     const pending = downloadFile("https://example.com/x", dest, {
+      ...FAST,
       signal: controller.signal,
     });
 
@@ -88,7 +143,306 @@ describe("download-file", () => {
 
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });
     expect(existsSync(dest)).toBe(false);
+    // The bytes that made it to disk are the whole point: they are what
+    // the next run resumes from.
+    expect(readFileSync(resolvePartialPath(dest), "utf-8")).toBe("a");
+    expect(readPartialDownload(dest)).toEqual({ transferred: 1, total: 2 });
+  });
+
+  it("resumes a partial with a Range request and appends the 206 body", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abc", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["de", "f"]), {
+          status: 206,
+          headers: {
+            "content-range": "bytes 3-5/6",
+            "content-length": "3",
+            etag: '"v1"',
+          },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const seen: Array<[number, number, number]> = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      onProgress: (p, t, tot) => seen.push([p, t, tot]),
+    });
+
+    expect(calls[0].get("range")).toBe("bytes=3-");
+    expect(calls[0].get("if-range")).toBe('"v1"');
+    expect(readFileSync(dest, "utf-8")).toBe("abcdef");
+    // The bar opens at the partial's position, not at zero.
+    expect(seen[0]).toEqual([50, 3, 6]);
+    expect(seen.at(-1)).toEqual([100, 6, 6]);
+    expect(existsSync(resolvePartialPath(dest))).toBe(false);
+    expect(existsSync(resolvePartialMetaPath(dest))).toBe(false);
+  });
+
+  it("starts over when the server ignores the Range and answers 200", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "OLD", { total: 6, etag: '"v1"' });
+
+    globalThis.fetch = mockFetch([
+      () =>
+        new Response(bodyOf(["new", "six"]), {
+          status: 200,
+          headers: { "content-length": "6", etag: '"v2"' },
+        }),
+    ]).fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(readFileSync(dest, "utf-8")).toBe("newsix");
+  });
+
+  it("refuses to append a 206 whose ETag differs from the partial's, then re-downloads", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abc", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["XYZ"]), {
+          status: 206,
+          headers: { "content-range": "bytes 3-5/6", etag: '"v2"' },
+        }),
+      () =>
+        new Response(bodyOf(["fresh1"]), {
+          status: 200,
+          headers: { "content-length": "6", etag: '"v2"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, { ...FAST, maxRetries: 1 });
+
+    expect(calls).toHaveLength(2);
+    // The partial was discarded, so the second request is a plain GET.
+    expect(calls[1].has("range")).toBe(false);
+    expect(readFileSync(dest, "utf-8")).toBe("fresh1");
+  });
+
+  it("ignores a partial that belongs to a different URL", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/other", "abc", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["abcdef"]), {
+          status: 200,
+          headers: { "content-length": "6" },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(calls[0].has("range")).toBe(false);
+    expect(readFileSync(dest, "utf-8")).toBe("abcdef");
+  });
+
+  it("retries a mid-body transport failure from the partial", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+          status: 200,
+          headers: { "content-length": "5", etag: '"v1"' },
+        }),
+      () =>
+        new Response(bodyOf(["cde"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-4/5", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const retries: number[] = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      onRetry: (info) => retries.push(info.attempt),
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].get("range")).toBe("bytes=2-");
+    expect(retries).toEqual([1]);
+    expect(readFileSync(dest, "utf-8")).toBe("abcde");
+  });
+
+  it("treats a body that ends short of content-length as retryable", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["ab"]), {
+          status: 200,
+          headers: { "content-length": "4", etag: '"v1"' },
+        }),
+      () =>
+        new Response(bodyOf(["cd"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-3/4", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(calls).toHaveLength(2);
+    expect(readFileSync(dest, "utf-8")).toBe("abcd");
+  });
+
+  it("gives up after maxRetries and keeps the partial for the next call", async () => {
+    const dest = join(dir, "out.bin");
+    globalThis.fetch = mockFetch([
+      () =>
+        new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+          status: 200,
+          headers: { "content-length": "5", etag: '"v1"' },
+        }),
+      () =>
+        new Response(dyingBodyOf([], new Error("read ECONNRESET")), {
+          status: 206,
+          headers: { "content-range": "bytes 2-4/5", etag: '"v1"' },
+        }),
+    ]).fn;
+
+    await expect(
+      downloadFile("https://example.com/x", dest, { ...FAST, maxRetries: 1 }),
+    ).rejects.toThrow(/ECONNRESET/);
+    expect(existsSync(dest)).toBe(false);
+    expect(readPartialDownload(dest)).toEqual({ transferred: 2, total: 5 });
+  });
+
+  it("does not retry a 404", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () => new Response(null, { status: 404, statusText: "Not Found" }),
+    ]);
+    globalThis.fetch = fn;
+
+    await expect(
+      downloadFile("https://example.com/x", dest, FAST),
+    ).rejects.toThrow(/HTTP 404/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("retries a 503", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+      () =>
+        new Response(bodyOf(["ok"]), {
+          status: 200,
+          headers: { "content-length": "2" },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(calls).toHaveLength(2);
+    expect(readFileSync(dest, "utf-8")).toBe("ok");
+  });
+
+  it("does not retry after the caller aborts during the backoff", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+      () => new Response(bodyOf(["ok"]), { status: 200 }),
+    ]);
+    globalThis.fetch = fn;
+
+    const controller = new AbortController();
+    const pending = downloadFile("https://example.com/x", dest, {
+      stallTimeoutMs: 0,
+      retryDelayMs: 10_000,
+      signal: controller.signal,
+    });
+    await waitFor(() => calls.length === 1);
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("declares a silent connection stalled and resumes from the partial", async () => {
+    const dest = join(dir, "out.bin");
+    // First body: one chunk, then silence forever.
+    const silent = new ReadableStream({
+      pull(controller) {
+        controller.enqueue(Buffer.from("ab"));
+        return new Promise<void>(() => undefined);
+      },
+    });
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(silent, {
+          status: 200,
+          headers: { "content-length": "4", etag: '"v1"' },
+        }),
+      () =>
+        new Response(bodyOf(["cd"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-3/4", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const retries: string[] = [];
+    await downloadFile("https://example.com/x", dest, {
+      retryDelayMs: 1,
+      stallTimeoutMs: 50,
+      onRetry: (info) => retries.push(info.error.message),
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].get("range")).toBe("bytes=2-");
+    expect(retries[0]).toMatch(/stalled/);
+    expect(readFileSync(dest, "utf-8")).toBe("abcd");
+  });
+
+  it("publishes a partial that already holds every byte when the server answers 416", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abcdef", { total: 6, etag: '"v1"' });
+
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(null, {
+          status: 416,
+          statusText: "Range Not Satisfiable",
+          headers: { "content-range": "bytes */6" },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const seen: number[] = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      onProgress: (p) => seen.push(p),
+    });
+    expect(calls[0].get("range")).toBe("bytes=6-");
+    expect(readFileSync(dest, "utf-8")).toBe("abcdef");
+    expect(seen).toEqual([100]);
+  });
+
+  it("removes a pre-resume .tmp leftover", async () => {
+    const dest = join(dir, "out.bin");
+    writeFileSync(`${dest}.tmp`, "junk");
+    globalThis.fetch = mockFetch([
+      () => new Response(bodyOf(["ok"]), { status: 200 }),
+    ]).fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
     expect(existsSync(`${dest}.tmp`)).toBe(false);
+    expect(readFileSync(dest, "utf-8")).toBe("ok");
+  });
+
+  it("discardPartialDownload drops both files and readPartialDownload sees nothing", () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "abc", { total: 6, etag: null });
+    expect(readPartialDownload(dest)).toEqual({ transferred: 3, total: 6 });
+    discardPartialDownload(dest);
+    expect(readPartialDownload(dest)).toBeNull();
+    expect(existsSync(resolvePartialPath(dest))).toBe(false);
+    expect(existsSync(resolvePartialMetaPath(dest))).toBe(false);
   });
 
   it("keeps the byte counter moving when chunks are smaller than one percent", async () => {
@@ -119,11 +473,15 @@ describe("download-file", () => {
     }) as typeof fetch;
 
     const seen: Array<{ percent: number; transferred: number }> = [];
-    await downloadFile("https://example.invalid/big.bin", join(dir, "big.bin"), {
-      onProgress: (percent, transferred) => {
-        seen.push({ percent, transferred });
-      },
-    });
+    await expect(
+      downloadFile("https://example.invalid/big.bin", join(dir, "big.bin"), {
+        ...FAST,
+        maxRetries: 0,
+        onProgress: (percent, transferred) => {
+          seen.push({ percent, transferred });
+        },
+      }),
+    ).rejects.toThrow(/ended early/);
 
     // Percent rounds to 0 throughout — the bytes are the only signal the
     // user has, and they must keep arriving.
@@ -157,6 +515,7 @@ describe("download-file", () => {
 
     const seen: number[] = [];
     await downloadFile("https://example.invalid/nolen.bin", join(dir, "nolen.bin"), {
+      ...FAST,
       onProgress: (_percent, transferred) => {
         seen.push(transferred);
       },
@@ -165,8 +524,20 @@ describe("download-file", () => {
     expect(seen.length).toBeGreaterThan(1);
     expect(seen.at(-1)).toBe(5_000);
   });
-
 });
+
+function seedPartial(
+  dest: string,
+  url: string,
+  bytes: string,
+  meta: { total: number; etag: string | null },
+): void {
+  writeFileSync(resolvePartialPath(dest), bytes);
+  writeFileSync(
+    resolvePartialMetaPath(dest),
+    JSON.stringify({ url, total: meta.total, etag: meta.etag, lastModified: null }),
+  );
+}
 
 async function waitFor(predicate: () => boolean): Promise<void> {
   for (let attempt = 0; attempt < 50; attempt += 1) {

--- a/src/local-llm/download-file.ts
+++ b/src/local-llm/download-file.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
+import { dirname } from "node:path";
 
 import { huggingFaceToken } from "./huggingface-api.js";
 
@@ -9,6 +8,96 @@ export type DownloadProgressFn = (
   transferred: number,
   total: number,
 ) => void;
+
+/**
+ * Called before each retry. `attempt` is the retry about to run (1-based),
+ * `delayMs` how long the downloader is about to wait, `error` why the
+ * previous attempt died. Surfaces a stalled link to the operator instead
+ * of leaving the progress bar frozen while the backoff runs.
+ */
+export type DownloadRetryFn = (info: {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  error: Error;
+}) => void;
+
+export interface DownloadFileOptions {
+  onProgress?: DownloadProgressFn;
+  onRetry?: DownloadRetryFn;
+  userAgent?: string;
+  signal?: AbortSignal;
+  /** Retries after a network failure before giving up. Default 5. */
+  maxRetries?: number;
+  /** Base of the exponential backoff between retries. Default 1s. */
+  retryDelayMs?: number;
+  /**
+   * How long the body may go without a single byte before the attempt is
+   * declared dead and retried from the partial. Default 60s. `0` disables
+   * the watchdog.
+   */
+  stallTimeoutMs?: number;
+}
+
+/** Sidecar next to the `.part` file: what the partial bytes belong to. */
+export interface PartialDownloadMeta {
+  url: string;
+  /** Total length the server declared, or `0` when it did not. */
+  total: number;
+  etag: string | null;
+  lastModified: string | null;
+}
+
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+const DEFAULT_STALL_TIMEOUT_MS = 60_000;
+
+export function resolvePartialPath(destPath: string): string {
+  return `${destPath}.part`;
+}
+
+export function resolvePartialMetaPath(destPath: string): string {
+  return `${destPath}.part.json`;
+}
+
+/**
+ * Bytes already on disk for an unfinished download of `destPath`, or
+ * `null` when there is no resumable partial. Lets a UI show "12.4 GB of
+ * 20.1 GB already here" before any request is made.
+ */
+export function readPartialDownload(
+  destPath: string,
+): { transferred: number; total: number } | null {
+  const meta = readPartialMeta(destPath);
+  if (!meta) return null;
+  const transferred = partialSize(destPath);
+  if (transferred <= 0) return null;
+  return { transferred, total: meta.total };
+}
+
+/** Drop a partial download and its sidecar. No-op when neither exists. */
+export function discardPartialDownload(destPath: string): void {
+  rmQuiet(resolvePartialPath(destPath));
+  rmQuiet(resolvePartialMetaPath(destPath));
+}
+
+class DownloadHttpError extends Error {
+  constructor(
+    readonly status: number,
+    statusText: string,
+  ) {
+    super(`Download failed: HTTP ${status} ${statusText}`);
+    this.name = "DownloadHttpError";
+  }
+}
+
+class StalledError extends Error {
+  constructor(ms: number) {
+    super(`Download stalled: no data for ${Math.round(ms / 1000)}s`);
+    this.name = "StalledError";
+  }
+}
 
 function createAbortError(): Error {
   const err = new Error("Download aborted");
@@ -22,20 +111,177 @@ function throwIfAborted(signal?: AbortSignal): void {
   }
 }
 
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
 /**
- * Download a file from `url` to `destPath` with optional progress tracking.
- * Writes to a `.tmp` file first, then renames atomically on success.
+ * Whether another attempt can reasonably succeed. Transport-level
+ * failures (reset, timeout, DNS blip, a socket the CDN dropped mid-body)
+ * and server-side throttling are; a 404 or a 401 is not — the retries
+ * would only delay the same answer.
+ */
+export function isRetryableDownloadError(err: unknown): boolean {
+  if (isAbortError(err)) return false;
+  if (err instanceof StalledError) return true;
+  if (err instanceof DownloadHttpError) {
+    return err.status === 408 || err.status === 429 || err.status >= 500;
+  }
+  return true;
+}
+
+function partialSize(destPath: string): number {
+  try {
+    return fs.statSync(resolvePartialPath(destPath)).size;
+  } catch {
+    return 0;
+  }
+}
+
+function readPartialMeta(destPath: string): PartialDownloadMeta | null {
+  try {
+    const raw = JSON.parse(
+      fs.readFileSync(resolvePartialMetaPath(destPath), "utf-8"),
+    ) as Partial<PartialDownloadMeta>;
+    if (typeof raw.url !== "string") return null;
+    return {
+      url: raw.url,
+      total: typeof raw.total === "number" && raw.total > 0 ? raw.total : 0,
+      etag: typeof raw.etag === "string" ? raw.etag : null,
+      lastModified: typeof raw.lastModified === "string" ? raw.lastModified : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writePartialMeta(destPath: string, meta: PartialDownloadMeta): void {
+  fs.writeFileSync(resolvePartialMetaPath(destPath), JSON.stringify(meta), "utf-8");
+}
+
+function rmQuiet(path: string): void {
+  try {
+    fs.rmSync(path, { force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+function parseContentRange(
+  header: string | null,
+): { start: number; total: number } | null {
+  if (!header) return null;
+  const m = /^bytes (\d+)-(\d+)\/(\d+|\*)$/.exec(header.trim());
+  if (!m) return null;
+  return {
+    start: Number(m[1]),
+    total: m[3] === "*" ? 0 : Number(m[3]),
+  };
+}
+
+/**
+ * The partial on disk is only worth continuing when the server still
+ * serves the same bytes: same URL, and the same validator when one was
+ * recorded. A file re-uploaded under the same name has a new ETag, and
+ * appending the tail of the new file to the head of the old one would
+ * produce a GGUF that loads up to the seam and then crashes llama-server.
+ */
+function validatorsMatch(
+  stored: PartialDownloadMeta,
+  res: Response,
+): boolean {
+  const etag = res.headers.get("etag");
+  if (stored.etag && etag && stored.etag !== etag) return false;
+  const lastModified = res.headers.get("last-modified");
+  if (
+    !stored.etag &&
+    stored.lastModified &&
+    lastModified &&
+    stored.lastModified !== lastModified
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(createAbortError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Download a file from `url` to `destPath`, resuming and retrying.
+ *
+ * Bytes stream into `<dest>.part`, with `<dest>.part.json` recording the
+ * URL, declared length and validators they belong to. The partial is
+ * **kept** on abort, on error and when the process dies, and the next
+ * call for the same destination asks the server for the remainder with a
+ * `Range` request. A `206` continues from where the last run stopped; a
+ * `200`, a changed validator or a length mismatch restarts from zero.
+ * Only a completed transfer is renamed onto `destPath`.
+ *
+ * Within one call, transport failures and stalls retry from the partial
+ * with exponential backoff (`maxRetries`, default 5). The caller's
+ * `signal` cancels everything, including a backoff wait, and is never
+ * retried.
+ *
+ * Progress counts from the resumed offset, so a UI picking up a 12 GB
+ * partial of a 20 GB file starts its bar at 60%, not 0%.
  */
 export async function downloadFile(
   url: string,
   destPath: string,
-  opts?: {
-    onProgress?: DownloadProgressFn;
-    userAgent?: string;
-    signal?: AbortSignal;
-  },
+  opts?: DownloadFileOptions,
 ): Promise<void> {
   throwIfAborted(opts?.signal);
+  const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelay = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+
+  // Pre-resume `.tmp` files are unusable: nothing records what they hold.
+  rmQuiet(`${destPath}.tmp`);
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await downloadAttempt(url, destPath, opts);
+      return;
+    } catch (err) {
+      throwIfAborted(opts?.signal);
+      if (attempt >= maxRetries || !isRetryableDownloadError(err)) {
+        throw err;
+      }
+      const delayMs = Math.min(baseDelay * 2 ** attempt, MAX_RETRY_DELAY_MS);
+      opts?.onRetry?.({
+        attempt: attempt + 1,
+        maxRetries,
+        delayMs,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+      await sleep(delayMs, opts?.signal);
+    }
+  }
+}
+
+async function downloadAttempt(
+  url: string,
+  destPath: string,
+  opts?: DownloadFileOptions,
+): Promise<void> {
+  const partPath = resolvePartialPath(destPath);
+  const stallTimeoutMs = opts?.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
+
   const headers: Record<string, string> = {
     "User-Agent": opts?.userAgent ?? "atomic-agent/local-llm",
   };
@@ -51,80 +297,233 @@ export async function downloadFile(
     if (token) headers.Authorization = `Bearer ${token}`;
   }
 
-  const res = await fetch(url, {
-    headers,
-    redirect: "follow",
-    signal: opts?.signal,
-  });
-  throwIfAborted(opts?.signal);
-  if (!res.ok || !res.body) {
-    throw new Error(`Download failed: HTTP ${res.status} ${res.statusText}`);
+  // Resume only what we can vouch for: a sidecar naming this URL and a
+  // non-empty partial. Anything else starts over.
+  const stored = readPartialMeta(destPath);
+  let offset = 0;
+  if (stored && stored.url === url) {
+    offset = partialSize(destPath);
+  }
+  if (offset > 0 && stored && stored.total > 0 && offset > stored.total) {
+    // More bytes than the file has: a stray append. Not salvageable.
+    offset = 0;
+  }
+  // `offset === stored.total` is left alone on purpose: the last run
+  // wrote every byte and died before the rename. The range request then
+  // asks for nothing, and the 416 branch below publishes the file once
+  // the server has confirmed it still is that file.
+  if (offset === 0) discardPartialDownload(destPath);
+  if (offset > 0) {
+    headers.Range = `bytes=${offset}-`;
+    // `If-Range` makes a server that still has the same file answer 206
+    // and one that has a new one answer 200 with the whole body — the
+    // restart case, handled below without a second round-trip.
+    const validator = stored?.etag ?? stored?.lastModified;
+    if (validator) headers["If-Range"] = validator;
   }
 
-  const totalRaw = res.headers.get("content-length");
-  const total = totalRaw ? parseInt(totalRaw, 10) : 0;
-  let transferred = 0;
-  let lastEmitAt = 0;
-  let lastEmittedBytes = -1;
-
-  /**
-   * Progress used to be emitted only when the whole-number percentage
-   * changed, which left the byte counter frozen between those moments: one
-   * percent of a 4 GB GGUF is ~41 MB, so at realistic speeds the UI sat
-   * still for seconds at a time and the download looked stalled. Worse, a
-   * response without `content-length` pins `percent` at 0 forever, so after
-   * the first chunk the counter never moved again.
-   *
-   * Emit on a time base instead. The percentage still only changes when it
-   * changes; the bytes advance visibly, which is the part that tells the
-   * user the transfer is alive.
-   */
-  const PROGRESS_INTERVAL_MS = 200;
-
-  const emitProgress = (now: number): void => {
-    if (transferred === lastEmittedBytes) return;
-    lastEmitAt = now;
-    lastEmittedBytes = transferred;
-    const percent = total > 0 ? Math.round((transferred / total) * 100) : 0;
-    opts?.onProgress?.(percent, transferred, total);
+  // One controller for both the caller's cancel and the stall watchdog;
+  // which of the two fired is decided after the fact.
+  const attemptAbort = new AbortController();
+  const onCallerAbort = (): void => attemptAbort.abort();
+  if (opts?.signal?.aborted) throw createAbortError();
+  opts?.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  let stalled = false;
+  let stallTimer: NodeJS.Timeout | null = null;
+  const armStallTimer = (): void => {
+    if (stallTimeoutMs <= 0) return;
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      stalled = true;
+      attemptAbort.abort();
+    }, stallTimeoutMs);
+  };
+  const disarmStallTimer = (): void => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = null;
   };
 
-  const reader = res.body.getReader();
-  const trackingStream = new ReadableStream({
-    async pull(controller) {
-      throwIfAborted(opts?.signal);
-      const { done, value } = await reader.read();
-      throwIfAborted(opts?.signal);
-      if (done) {
-        // The last partial interval still owes the user its final numbers,
-        // including the terminal 100%.
-        emitProgress(Date.now());
-        controller.close();
+  try {
+    armStallTimer();
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers,
+        redirect: "follow",
+        signal: attemptAbort.signal,
+      });
+    } catch (err) {
+      throw translateAttemptFailure(err, opts?.signal, stalled, stallTimeoutMs);
+    }
+    throwIfAborted(opts?.signal);
+
+    if (res.status === 416 && offset > 0) {
+      // Range not satisfiable. When the partial already holds the whole
+      // declared length this is "nothing left to send" — publish it.
+      // Otherwise the server's idea of the file differs from ours.
+      const cr = parseContentRange(res.headers.get("content-range"));
+      const total = cr?.total ?? stored?.total ?? 0;
+      if (total > 0 && offset === total && stored) {
+        finalize(destPath, offset, total, opts);
         return;
       }
-      transferred += value.byteLength;
-      const now = Date.now();
-      if (now - lastEmitAt >= PROGRESS_INTERVAL_MS) {
-        emitProgress(now);
-      }
-      controller.enqueue(value);
-    },
-  });
-
-  const nodeReadable = Readable.fromWeb(
-    trackingStream as import("node:stream/web").ReadableStream,
-  );
-  const tmpPath = `${destPath}.tmp`;
-  try {
-    const writeStream = fs.createWriteStream(tmpPath);
-    await pipeline(nodeReadable, writeStream);
-    throwIfAborted(opts?.signal);
-    fs.renameSync(tmpPath, destPath);
-  } finally {
-    try {
-      fs.rmSync(tmpPath, { force: true });
-    } catch {
-      /* ignore */
+      discardPartialDownload(destPath);
+      throw new DownloadHttpError(res.status, res.statusText);
     }
+    if (!res.ok || !res.body) {
+      throw new DownloadHttpError(res.status, res.statusText);
+    }
+
+    let resumed = false;
+    let total = 0;
+    if (res.status === 206 && offset > 0 && stored) {
+      const cr = parseContentRange(res.headers.get("content-range"));
+      if (cr && cr.start === offset && validatorsMatch(stored, res)) {
+        resumed = true;
+        total = cr.total || stored.total;
+      } else {
+        // A 206 whose range does not line up with our offset cannot be
+        // appended; drain nothing, start over on the next attempt.
+        discardPartialDownload(destPath);
+        await res.body.cancel().catch(() => undefined);
+        throw new Error(
+          "Download resume rejected: server range did not match the partial file",
+        );
+      }
+    } else {
+      // A full body (200) — either a fresh download or the server would
+      // not (or could not, validators changed) honour the range. Whatever
+      // is on disk is not this file's prefix.
+      discardPartialDownload(destPath);
+      offset = 0;
+      const totalRaw = res.headers.get("content-length");
+      total = totalRaw ? parseInt(totalRaw, 10) : 0;
+      if (!Number.isFinite(total) || total < 0) total = 0;
+    }
+
+    fs.mkdirSync(dirname(destPath), { recursive: true });
+    writePartialMeta(destPath, {
+      url,
+      total,
+      etag: res.headers.get("etag"),
+      lastModified: res.headers.get("last-modified"),
+    });
+
+    let transferred = offset;
+    let lastEmitAt = 0;
+    let lastEmittedBytes = -1;
+
+    /**
+     * Progress used to be emitted only when the whole-number percentage
+     * changed, which left the byte counter frozen between those moments:
+     * one percent of a 4 GB GGUF is ~41 MB, so at realistic speeds the UI
+     * sat still for seconds at a time and the download looked stalled.
+     * Worse, a response without `content-length` pins `percent` at 0
+     * forever, so after the first chunk the counter never moved again.
+     *
+     * Emit on a time base instead. The percentage still only changes
+     * when it changes; the bytes advance visibly, which is the part that
+     * tells the user the transfer is alive.
+     */
+    const PROGRESS_INTERVAL_MS = 200;
+
+    const emitProgress = (now: number): void => {
+      if (transferred === lastEmittedBytes) return;
+      lastEmitAt = now;
+      lastEmittedBytes = transferred;
+      const percent = total > 0 ? Math.round((transferred / total) * 100) : 0;
+      opts?.onProgress?.(percent, transferred, total);
+    };
+
+    // A resumed transfer owes the UI its starting point at once: the
+    // bar must open at the partial's percentage, not at zero.
+    if (resumed) emitProgress(Date.now());
+
+    // Chunks are written one at a time with an explicit `write` rather
+    // than piped through a WriteStream: a pipeline that fails destroys
+    // its destination and drops whatever it had buffered, which is
+    // exactly the tail the next attempt needs on disk. Here a chunk is
+    // either fully written or never counted.
+    const reader = res.body.getReader();
+    const aborted = new Promise<never>((_resolve, reject) => {
+      const fail = (): void => reject(createAbortError());
+      if (attemptAbort.signal.aborted) fail();
+      else attemptAbort.signal.addEventListener("abort", fail, { once: true });
+    });
+    // Never awaited on its own: an abort must not wait for a source that
+    // has stopped answering.
+    aborted.catch(() => undefined);
+    const handle = await fs.promises.open(partPath, resumed ? "a" : "w");
+    try {
+      for (;;) {
+        let next: Awaited<ReturnType<typeof reader.read>>;
+        try {
+          next = await Promise.race([reader.read(), aborted]);
+        } catch (err) {
+          reader.cancel().catch(() => undefined);
+          throw translateAttemptFailure(err, opts?.signal, stalled, stallTimeoutMs);
+        }
+        if (next.done) break;
+        armStallTimer();
+        await handle.write(next.value);
+        transferred += next.value.byteLength;
+        const now = Date.now();
+        if (now - lastEmitAt >= PROGRESS_INTERVAL_MS) {
+          emitProgress(now);
+        }
+      }
+    } finally {
+      await handle.close();
+    }
+    // The last partial interval still owes the user its final numbers.
+    emitProgress(Date.now());
+    throwIfAborted(opts?.signal);
+
+    if (total > 0 && transferred !== total) {
+      // The body ended early (a CDN closing the connection is reported
+      // as a clean end by some stacks). The bytes are good as far as they
+      // go; the retry loop asks for the rest.
+      throw new Error(
+        `Download ended early: ${transferred} of ${total} bytes received`,
+      );
+    }
+    finalize(destPath, transferred, total, opts);
+  } finally {
+    disarmStallTimer();
+    opts?.signal?.removeEventListener("abort", onCallerAbort);
   }
+}
+
+function finalize(
+  destPath: string,
+  transferred: number,
+  total: number,
+  opts?: DownloadFileOptions,
+): void {
+  fs.renameSync(resolvePartialPath(destPath), destPath);
+  rmQuiet(resolvePartialMetaPath(destPath));
+  // A 416-finalised partial never streamed, so it never reported; and a
+  // streamed one may have emitted its last progress inside the throttle
+  // window. Either way the terminal number goes out exactly once here.
+  if (total > 0 && transferred === total) {
+    opts?.onProgress?.(100, transferred, total);
+  }
+}
+
+/**
+ * Sort out whose abort this was. The caller's cancel surfaces as
+ * `AbortError` and is never retried; the watchdog's surfaces as a
+ * `StalledError`, which is. Anything else passes through as the
+ * transport error it is.
+ */
+function translateAttemptFailure(
+  err: unknown,
+  callerSignal: AbortSignal | undefined,
+  stalled: boolean,
+  stallTimeoutMs: number,
+): Error {
+  if (callerSignal?.aborted) return createAbortError();
+  if (stalled) return new StalledError(stallTimeoutMs);
+  if (err instanceof Error) return err;
+  return new Error(String(err));
 }

--- a/src/local-llm/download-file.ts
+++ b/src/local-llm/download-file.ts
@@ -459,6 +459,11 @@ async function downloadAttempt(
         let next: Awaited<ReturnType<typeof reader.read>>;
         try {
           next = await Promise.race([reader.read(), aborted]);
+          // A chunk that was already queued can win the race against an
+          // abort that fired during the previous write. Nothing is
+          // written past a cancel: the partial ends exactly where the
+          // caller stopped it.
+          if (attemptAbort.signal.aborted) throw createAbortError();
         } catch (err) {
           reader.cancel().catch(() => undefined);
           throw translateAttemptFailure(err, opts?.signal, stalled, stallTimeoutMs);

--- a/src/local-llm/download-jobs.test.ts
+++ b/src/local-llm/download-jobs.test.ts
@@ -1,0 +1,141 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  downloadJobId,
+  isDownloadJobLive,
+  listDownloadJobs,
+  readDownloadJob,
+  reconcileDownloadJob,
+  removeDownloadJob,
+  resolveDownloadJobPath,
+  resolveDownloadLogPath,
+  resolveDownloadsDir,
+  writeDownloadJob,
+  type DownloadJob,
+} from "./download-jobs.js";
+
+/** A pid no process on any supported OS is handed out. */
+const DEAD_PID = 2_000_000_000;
+
+function job(patch: Partial<DownloadJob> = {}): DownloadJob {
+  return {
+    version: 1,
+    id: downloadJobId("chat", "qwen-3.5-4b"),
+    kind: "chat",
+    modelId: "qwen-3.5-4b",
+    mode: "gguf-only",
+    pid: process.pid,
+    status: "running",
+    phase: "gguf",
+    label: "Qwen 3.5 4B (gguf)",
+    percent: 12,
+    transferredBytes: 1200,
+    totalBytes: 10_000,
+    error: null,
+    startedAt: "2026-09-07T10:00:00.000Z",
+    updatedAt: "2026-09-07T10:00:05.000Z",
+    finishedAt: null,
+    ...patch,
+  };
+}
+
+describe("download-jobs", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "atomic-dl-jobs-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("names paths under <dataDir>/downloads and ids by kind + model", () => {
+    expect(resolveDownloadsDir(dataDir)).toBe(join(dataDir, "downloads"));
+    expect(downloadJobId("embedding", "nomic-embed-text-v1.5")).toBe(
+      "embedding-nomic-embed-text-v1.5",
+    );
+    expect(resolveDownloadJobPath(dataDir, "chat-x")).toBe(
+      join(dataDir, "downloads", "chat-x.json"),
+    );
+    expect(resolveDownloadLogPath(dataDir, "chat-x")).toBe(
+      join(dataDir, "downloads", "chat-x.log"),
+    );
+  });
+
+  it("round-trips a record and leaves no temp file behind", () => {
+    const j = job();
+    writeDownloadJob(dataDir, j);
+    expect(readDownloadJob(dataDir, j.id)).toEqual(j);
+    expect(readdirSync(resolveDownloadsDir(dataDir))).toEqual([`${j.id}.json`]);
+  });
+
+  it("returns null for a missing, malformed or foreign-version record", () => {
+    expect(readDownloadJob(dataDir, "nope")).toBeNull();
+    writeDownloadJob(dataDir, job({ id: "ok" }));
+    writeFileSync(resolveDownloadJobPath(dataDir, "bad"), "{not json");
+    writeFileSync(
+      resolveDownloadJobPath(dataDir, "v9"),
+      JSON.stringify({ ...job({ id: "v9" }), version: 9 }),
+    );
+    expect(readDownloadJob(dataDir, "bad")).toBeNull();
+    expect(readDownloadJob(dataDir, "v9")).toBeNull();
+    expect(listDownloadJobs(dataDir).map((j) => j.id)).toEqual(["ok"]);
+  });
+
+  it("reports a running job whose worker died as interrupted, and persists that", () => {
+    const j = job({ pid: DEAD_PID });
+    writeDownloadJob(dataDir, j);
+    const seen = readDownloadJob(dataDir, j.id);
+    expect(seen?.status).toBe("interrupted");
+    expect(seen?.error).toBe("worker process is gone");
+    expect(seen?.finishedAt).toBe(j.updatedAt);
+    // Written back: a second reader agrees without re-probing the pid.
+    expect(JSON.parse(readFileSync(resolveDownloadJobPath(dataDir, j.id), "utf-8")).status).toBe(
+      "interrupted",
+    );
+    expect(isDownloadJobLive(seen)).toBe(false);
+  });
+
+  it("keeps a running job whose worker is alive (this process) as running", () => {
+    const j = job({ pid: process.pid });
+    writeDownloadJob(dataDir, j);
+    const seen = readDownloadJob(dataDir, j.id);
+    expect(seen?.status).toBe("running");
+    expect(isDownloadJobLive(seen)).toBe(true);
+  });
+
+  it("reconcileDownloadJob only touches running jobs", () => {
+    const dead = (): boolean => false;
+    expect(reconcileDownloadJob(job({ status: "done", pid: DEAD_PID }), dead).status).toBe(
+      "done",
+    );
+    expect(reconcileDownloadJob(job({ status: "failed", error: "x" }), dead).error).toBe("x");
+    const interrupted = reconcileDownloadJob(job(), dead);
+    expect(interrupted.status).toBe("interrupted");
+    // The original error, when there is one, is not overwritten.
+    expect(reconcileDownloadJob(job({ error: "kept" }), dead).error).toBe("kept");
+  });
+
+  it("lists newest start first and removeDownloadJob drops record + log", () => {
+    writeDownloadJob(dataDir, job({ id: "a", startedAt: "2026-09-07T09:00:00.000Z" }));
+    writeDownloadJob(dataDir, job({ id: "b", startedAt: "2026-09-07T11:00:00.000Z" }));
+    writeFileSync(resolveDownloadLogPath(dataDir, "b"), "log");
+    expect(listDownloadJobs(dataDir).map((j) => j.id)).toEqual(["b", "a"]);
+    removeDownloadJob(dataDir, "b");
+    expect(existsSync(resolveDownloadJobPath(dataDir, "b"))).toBe(false);
+    expect(existsSync(resolveDownloadLogPath(dataDir, "b"))).toBe(false);
+    expect(listDownloadJobs(dataDir).map((j) => j.id)).toEqual(["a"]);
+  });
+});

--- a/src/local-llm/download-jobs.ts
+++ b/src/local-llm/download-jobs.ts
@@ -1,0 +1,204 @@
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { classifyPidLiveness } from "./daemon-lifecycle.js";
+
+/**
+ * Background model downloads: the on-disk contract between the worker
+ * that fetches the bytes and whoever is watching it (`models pull`,
+ * `models downloads`, the TUI).
+ *
+ * A download runs in its own detached process — the same way the
+ * llama-server daemon does — so closing the terminal or quitting the
+ * TUI does not kill it. Each job is one file,
+ * `<dataDir>/downloads/<jobId>.json`, rewritten atomically by the
+ * worker as progress arrives, plus `<jobId>.log` with the worker's
+ * stdout/stderr. Watchers only ever read the JSON; nothing here holds
+ * a lock or an open socket, so a watcher can come and go freely.
+ *
+ * Liveness is decided from the recorded pid, as for the daemon's pid
+ * file: a `running` job whose pid is dead was interrupted (a crash, a
+ * reboot, a `kill -9`) and is reported as such. Its partial file is
+ * still on disk (see `download-file.ts`), so starting the same job
+ * again resumes rather than restarts.
+ */
+
+export const DOWNLOAD_JOB_VERSION = 1;
+
+export type DownloadJobKind = "chat" | "embedding";
+
+/** Which files of a chat model the job fetches; embedding jobs ignore it. */
+export type DownloadJobMode = "with-mmproj" | "gguf-only" | "mmproj-only";
+
+export type DownloadJobStatus =
+  | "running"
+  | "done"
+  | "failed"
+  | "cancelled"
+  /** Recorded `running`, but the worker pid is gone. Resumable. */
+  | "interrupted";
+
+export interface DownloadJob {
+  version: typeof DOWNLOAD_JOB_VERSION;
+  id: string;
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+  pid: number;
+  status: DownloadJobStatus;
+  /** Which file the numbers below describe. */
+  phase: "gguf" | "mmproj";
+  label: string;
+  percent: number;
+  transferredBytes: number;
+  totalBytes: number;
+  error: string | null;
+  startedAt: string;
+  updatedAt: string;
+  finishedAt: string | null;
+}
+
+export function resolveDownloadsDir(dataDir: string): string {
+  return join(dataDir, "downloads");
+}
+
+/**
+ * One job per (kind, model). Model ids are already filesystem-safe:
+ * curated ones are hand-written slugs and custom ones go through
+ * `buildCustomModelId`'s character filter.
+ */
+export function downloadJobId(kind: DownloadJobKind, modelId: string): string {
+  return `${kind}-${modelId}`;
+}
+
+export function resolveDownloadJobPath(dataDir: string, jobId: string): string {
+  return join(resolveDownloadsDir(dataDir), `${jobId}.json`);
+}
+
+export function resolveDownloadLogPath(dataDir: string, jobId: string): string {
+  return join(resolveDownloadsDir(dataDir), `${jobId}.log`);
+}
+
+/**
+ * Atomic replace: a watcher polling every few hundred milliseconds must
+ * never read a half-written file. The temp name carries the writer's pid
+ * so two writers (a worker and the spawner seeding the first record)
+ * cannot collide on it.
+ */
+export function writeDownloadJob(dataDir: string, job: DownloadJob): void {
+  const dir = resolveDownloadsDir(dataDir);
+  mkdirSync(dir, { recursive: true });
+  const path = resolveDownloadJobPath(dataDir, job.id);
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(job, null, 2)}\n`, "utf-8");
+  renameSync(tmp, path);
+}
+
+function parseDownloadJob(raw: string): DownloadJob | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const j = parsed as Record<string, unknown>;
+  if (j.version !== DOWNLOAD_JOB_VERSION) return null;
+  if (typeof j.id !== "string" || typeof j.modelId !== "string") return null;
+  if (j.kind !== "chat" && j.kind !== "embedding") return null;
+  if (typeof j.pid !== "number" || typeof j.status !== "string") return null;
+  return j as unknown as DownloadJob;
+}
+
+/**
+ * Reconcile the recorded status with reality. Pure so the transition
+ * is testable without a real dead process: `isAlive` answers for the
+ * recorded pid.
+ */
+export function reconcileDownloadJob(
+  job: DownloadJob,
+  isAlive: (pid: number) => boolean,
+): DownloadJob {
+  if (job.status !== "running") return job;
+  if (isAlive(job.pid)) return job;
+  return {
+    ...job,
+    status: "interrupted",
+    error: job.error ?? "worker process is gone",
+    finishedAt: job.finishedAt ?? job.updatedAt,
+  };
+}
+
+function pidIsAlive(pid: number): boolean {
+  // `foreign` (EPERM) is still alive — a worker started under sudo, say.
+  return classifyPidLiveness(pid) !== "dead";
+}
+
+/**
+ * Read one job, with a dead worker reported as `interrupted`. The
+ * reconciled record is written back so the next reader (and the log of
+ * what happened) agree, and so the interruption timestamp is not lost
+ * to a later rewrite.
+ */
+export function readDownloadJob(dataDir: string, jobId: string): DownloadJob | null {
+  let raw: string;
+  try {
+    raw = readFileSync(resolveDownloadJobPath(dataDir, jobId), "utf-8");
+  } catch {
+    return null;
+  }
+  const job = parseDownloadJob(raw);
+  if (!job) return null;
+  const reconciled = reconcileDownloadJob(job, pidIsAlive);
+  if (reconciled !== job) {
+    try {
+      writeDownloadJob(dataDir, reconciled);
+    } catch {
+      /* the in-memory view is still right */
+    }
+  }
+  return reconciled;
+}
+
+/** Every job on disk, newest start first, reconciled like `readDownloadJob`. */
+export function listDownloadJobs(dataDir: string): DownloadJob[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(resolveDownloadsDir(dataDir));
+  } catch {
+    return [];
+  }
+  const jobs: DownloadJob[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const job = readDownloadJob(dataDir, entry.slice(0, -".json".length));
+    if (job) jobs.push(job);
+  }
+  return jobs.sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
+}
+
+/** Forget a job: its record and its log. The partial file is not touched. */
+export function removeDownloadJob(dataDir: string, jobId: string): void {
+  for (const path of [
+    resolveDownloadJobPath(dataDir, jobId),
+    resolveDownloadLogPath(dataDir, jobId),
+  ]) {
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** A job the worker may still be driving — or one that died mid-way. */
+export function isDownloadJobLive(job: DownloadJob | null): job is DownloadJob {
+  return job !== null && job.status === "running";
+}

--- a/src/local-llm/download-worker.test.ts
+++ b/src/local-llm/download-worker.test.ts
@@ -1,0 +1,202 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveModelFilePath } from "./backend-paths.js";
+import { resolvePartialMetaPath, resolvePartialPath } from "./download-file.js";
+import { downloadJobId, readDownloadJob } from "./download-jobs.js";
+import { initialDownloadJob, runDownloadWorker } from "./download-worker.js";
+import { getEmbeddingModelDef, getLocalModelDef } from "./models-catalog.js";
+
+const EMB = getEmbeddingModelDef("nomic-embed-text-v1.5");
+const CHAT = getLocalModelDef("qwen-3.5-4b");
+
+function bodyOf(chunks: readonly string[]): ReadableStream {
+  const queue = [...chunks];
+  return new ReadableStream({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(Buffer.from(next));
+    },
+  });
+}
+
+describe("download-worker", () => {
+  let dataDir: string;
+  let prevFetch: typeof fetch;
+  let log: string[];
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "atomic-dl-worker-"));
+    prevFetch = globalThis.fetch;
+    log = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = prevFetch;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("fetches an embedding model, keeping the job record current, and ends done", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(bodyOf(["abc", "def"]), {
+        status: 200,
+        headers: { "content-length": "6" },
+      }),
+    ) as typeof fetch;
+
+    const outcome = await runDownloadWorker({
+      dataDir,
+      kind: "embedding",
+      modelId: EMB.id,
+      mode: "gguf-only",
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+    });
+
+    expect(outcome).toBe("done");
+    expect(readFileSync(resolveModelFilePath(dataDir, EMB.id, EMB.filename), "utf-8")).toBe(
+      "abcdef",
+    );
+    const job = readDownloadJob(dataDir, downloadJobId("embedding", EMB.id));
+    expect(job).toMatchObject({
+      kind: "embedding",
+      modelId: EMB.id,
+      status: "done",
+      percent: 100,
+      transferredBytes: 6,
+      totalBytes: 6,
+      pid: process.pid,
+      error: null,
+    });
+    expect(job?.finishedAt).not.toBeNull();
+    expect(log.some((l) => /\bstart\b/.test(l))).toBe(true);
+    expect(log.at(-1)).toMatch(/done/);
+  });
+
+  it("records a failure with its message and keeps the partial", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 404, statusText: "Not Found" }),
+    ) as typeof fetch;
+
+    const outcome = await runDownloadWorker({
+      dataDir,
+      kind: "chat",
+      modelId: CHAT.id,
+      mode: "gguf-only",
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+    });
+
+    expect(outcome).toBe("failed");
+    const job = readDownloadJob(dataDir, downloadJobId("chat", CHAT.id));
+    expect(job?.status).toBe("failed");
+    expect(job?.error).toMatch(/HTTP 404/);
+    expect(log.at(-1)).toMatch(/failed: .*404/);
+  });
+
+  it("ends cancelled when the signal fires, with the partial kept for resume", async () => {
+    let release: (() => void) | null = null;
+    const body = new ReadableStream({
+      async pull(controller) {
+        if (release === null) {
+          controller.enqueue(Buffer.from("ab"));
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          controller.enqueue(Buffer.from("cd"));
+          return;
+        }
+        controller.close();
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(body, { status: 200, headers: { "content-length": "4" } }),
+    ) as typeof fetch;
+
+    const controller = new AbortController();
+    const pending = runDownloadWorker({
+      dataDir,
+      kind: "chat",
+      modelId: CHAT.id,
+      mode: "gguf-only",
+      signal: controller.signal,
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+    });
+    await waitFor(() => release !== null);
+    controller.abort();
+    release?.();
+
+    expect(await pending).toBe("cancelled");
+    const job = readDownloadJob(dataDir, downloadJobId("chat", CHAT.id));
+    expect(job?.status).toBe("cancelled");
+    const dest = resolveModelFilePath(dataDir, CHAT.id, CHAT.filename);
+    expect(existsSync(dest)).toBe(false);
+    expect(readFileSync(resolvePartialPath(dest), "utf-8")).toBe("ab");
+  });
+
+  it("initialDownloadJob reports the partial already on disk instead of 0%", () => {
+    const dest = resolveModelFilePath(dataDir, CHAT.id, CHAT.filename);
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(resolvePartialPath(dest), Buffer.alloc(250));
+    writeFileSync(
+      resolvePartialMetaPath(dest),
+      JSON.stringify({ url: CHAT.huggingFaceUrl, total: 1000, etag: null, lastModified: null }),
+    );
+    const job = initialDownloadJob({
+      dataDir,
+      kind: "chat",
+      modelId: CHAT.id,
+      mode: "gguf-only",
+      pid: 4242,
+      now: new Date("2026-09-07T12:00:00.000Z"),
+    });
+    expect(job).toMatchObject({
+      id: downloadJobId("chat", CHAT.id),
+      pid: 4242,
+      status: "running",
+      phase: "gguf",
+      percent: 25,
+      transferredBytes: 250,
+      totalBytes: 1000,
+      startedAt: "2026-09-07T12:00:00.000Z",
+    });
+  });
+
+  it("initialDownloadJob sizes a fresh job from the catalog estimate", () => {
+    const job = initialDownloadJob({
+      dataDir,
+      kind: "embedding",
+      modelId: EMB.id,
+      mode: "gguf-only",
+      pid: 1,
+    });
+    expect(job.transferredBytes).toBe(0);
+    expect(job.totalBytes).toBe(Math.round(EMB.fileSizeGb * 1024 * 1024 * 1024));
+    expect(job.label).toBe(EMB.name);
+  });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("waitFor timed out");
+}

--- a/src/local-llm/download-worker.ts
+++ b/src/local-llm/download-worker.ts
@@ -1,0 +1,268 @@
+import { resolveModelFilePath, resolveMmprojFilePath } from "./backend-paths.js";
+import { readPartialDownload } from "./download-file.js";
+import {
+  downloadJobId,
+  writeDownloadJob,
+  type DownloadJob,
+  type DownloadJobKind,
+  type DownloadJobMode,
+} from "./download-jobs.js";
+import {
+  downloadEmbeddingModel,
+  downloadMmproj,
+  downloadModel,
+  isMmprojDownloaded,
+  isModelDownloaded,
+} from "./model-installer.js";
+import {
+  getEmbeddingModelDef,
+  getLocalModelDef,
+  type EmbeddingModelId,
+  type LocalModelId,
+} from "./models-catalog.js";
+
+/**
+ * The body of a background download: fetch the files for one job while
+ * keeping its record on disk current. Runs inside the detached worker
+ * process (`models pull-worker`), but takes everything as arguments so
+ * a test can drive it in-process against a mocked `fetch`.
+ */
+export interface DownloadWorkerInput {
+  dataDir: string;
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+  /** Cancels the download; the job is then recorded as `cancelled`. */
+  signal?: AbortSignal;
+  /** Worker log line sink. Defaults to stdout. */
+  log?: (line: string) => void;
+  /** Progress writes are throttled to this. Default 500ms. */
+  writeIntervalMs?: number;
+  /** Test seam. */
+  now?: () => Date;
+}
+
+export type DownloadWorkerOutcome = "done" | "failed" | "cancelled";
+
+const DEFAULT_WRITE_INTERVAL_MS = 500;
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Seed the record a spawner writes the instant the worker is launched,
+ * so `models downloads` lists the job before the worker has opened its
+ * first socket. The worker overwrites it with real numbers as soon as
+ * they exist. The partial already on disk (if any) is reported from
+ * the start, so a resumed job never shows 0% even for a moment.
+ */
+export function initialDownloadJob(input: {
+  dataDir: string;
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+  pid: number;
+  now?: Date;
+}): DownloadJob {
+  const now = (input.now ?? new Date()).toISOString();
+  const { label, dest, estTotal } = describeFirstPhase(input);
+  const partial = readPartialDownload(dest);
+  const transferred = partial?.transferred ?? 0;
+  const total = partial?.total || estTotal;
+  return {
+    version: 1,
+    id: downloadJobId(input.kind, input.modelId),
+    kind: input.kind,
+    modelId: input.modelId,
+    mode: input.mode,
+    pid: input.pid,
+    status: "running",
+    phase: input.kind === "chat" && input.mode === "mmproj-only" ? "mmproj" : "gguf",
+    label,
+    percent: total > 0 ? Math.round((transferred / total) * 100) : 0,
+    transferredBytes: transferred,
+    totalBytes: total,
+    error: null,
+    startedAt: now,
+    updatedAt: now,
+    finishedAt: null,
+  };
+}
+
+function describeFirstPhase(input: {
+  dataDir: string;
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+}): { label: string; dest: string; estTotal: number } {
+  const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
+  if (input.kind === "embedding") {
+    const def = getEmbeddingModelDef(input.modelId as EmbeddingModelId);
+    return {
+      label: def.name,
+      dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
+      estTotal: gb(def.fileSizeGb),
+    };
+  }
+  const def = getLocalModelDef(input.modelId as LocalModelId);
+  const ggufDone = isModelDownloaded(input.dataDir, def);
+  const mmprojPhase =
+    input.mode === "mmproj-only" || (input.mode === "with-mmproj" && ggufDone);
+  if (mmprojPhase && def.mmprojFilename) {
+    return {
+      label: `${def.name} (mmproj)`,
+      dest: resolveMmprojFilePath(input.dataDir, def.id, def.mmprojFilename),
+      estTotal: gb(def.mmprojFileSizeGb ?? 1),
+    };
+  }
+  return {
+    label: `${def.name} (gguf)`,
+    dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
+    estTotal: gb(def.fileSizeGb),
+  };
+}
+
+/**
+ * Run one job to completion. Never throws for a download failure — the
+ * outcome is the return value and the record on disk; the worker
+ * process maps it to an exit code. Throws only for a bad job spec (an
+ * unknown model id), which the spawner should have rejected already.
+ */
+export async function runDownloadWorker(
+  input: DownloadWorkerInput,
+): Promise<DownloadWorkerOutcome> {
+  const log = input.log ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const now = input.now ?? (() => new Date());
+  const writeIntervalMs = input.writeIntervalMs ?? DEFAULT_WRITE_INTERVAL_MS;
+  const stamp = (): string => now().toISOString();
+
+  let job = initialDownloadJob({
+    dataDir: input.dataDir,
+    kind: input.kind,
+    modelId: input.modelId,
+    mode: input.mode,
+    pid: process.pid,
+    now: now(),
+  });
+  let lastWriteAt = 0;
+  const persist = (patch: Partial<DownloadJob>, force = false): void => {
+    job = { ...job, ...patch, updatedAt: stamp() };
+    const t = Date.now();
+    if (!force && t - lastWriteAt < writeIntervalMs) return;
+    lastWriteAt = t;
+    writeDownloadJob(input.dataDir, job);
+  };
+  persist({}, true);
+  log(
+    `[${stamp()}] start ${job.id} (${job.label}), ${job.transferredBytes} bytes already on disk`,
+  );
+
+  const phaseOpts = (
+    label: string,
+    phase: DownloadJob["phase"],
+    dest: string,
+    estTotal: number,
+  ) => {
+    // A phase opens on what its partial already holds, never on 0%: a
+    // watcher that reads the record between this write and the first
+    // (throttled) progress write must not see a resumed download reset.
+    const partial = readPartialDownload(dest);
+    const transferred = partial?.transferred ?? 0;
+    const total = partial?.total || estTotal;
+    persist(
+      {
+        label,
+        phase,
+        percent: total > 0 ? Math.round((transferred / total) * 100) : 0,
+        transferredBytes: transferred,
+        totalBytes: total,
+      },
+      true,
+    );
+    let first = true;
+    return {
+      signal: input.signal,
+      onProgress: (percent: number, transferred: number, total: number) => {
+        persist(
+          {
+            percent,
+            transferredBytes: transferred,
+            totalBytes: total > 0 ? total : estTotal,
+          },
+          first,
+        );
+        first = false;
+      },
+      onRetry: (info: { attempt: number; maxRetries: number; delayMs: number; error: Error }) => {
+        log(
+          `[${stamp()}] interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s`,
+        );
+      },
+    };
+  };
+  const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
+
+  try {
+    if (input.kind === "embedding") {
+      const def = getEmbeddingModelDef(input.modelId as EmbeddingModelId);
+      await downloadEmbeddingModel(
+        input.dataDir,
+        def,
+        phaseOpts(
+          def.name,
+          "gguf",
+          resolveModelFilePath(input.dataDir, def.id, def.filename),
+          gb(def.fileSizeGb),
+        ),
+      );
+    } else {
+      const def = getLocalModelDef(input.modelId as LocalModelId);
+      const wantGguf = input.mode !== "mmproj-only";
+      const wantMmproj =
+        def.supportsVision && (input.mode === "with-mmproj" || input.mode === "mmproj-only");
+      if (wantGguf && !isModelDownloaded(input.dataDir, def)) {
+        await downloadModel(
+          input.dataDir,
+          def,
+          phaseOpts(
+            `${def.name} (gguf)`,
+            "gguf",
+            resolveModelFilePath(input.dataDir, def.id, def.filename),
+            gb(def.fileSizeGb),
+          ),
+        );
+        log(`[${stamp()}] gguf complete`);
+      }
+      if (wantMmproj && !isMmprojDownloaded(input.dataDir, def)) {
+        await downloadMmproj(
+          input.dataDir,
+          def,
+          phaseOpts(
+            `${def.name} (mmproj)`,
+            "mmproj",
+            resolveMmprojFilePath(input.dataDir, def.id, def.mmprojFilename ?? ""),
+            gb(def.mmprojFileSizeGb ?? 1),
+          ),
+        );
+        log(`[${stamp()}] mmproj complete`);
+      }
+    }
+    persist(
+      { status: "done", percent: 100, error: null, finishedAt: stamp() },
+      true,
+    );
+    log(`[${stamp()}] done`);
+    return "done";
+  } catch (err) {
+    if (isAbortError(err) || input.signal?.aborted) {
+      persist({ status: "cancelled", finishedAt: stamp() }, true);
+      log(`[${stamp()}] cancelled — partial kept for resume`);
+      return "cancelled";
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    persist({ status: "failed", error: message, finishedAt: stamp() }, true);
+    log(`[${stamp()}] failed: ${message}`);
+    return "failed";
+  }
+}

--- a/src/local-llm/index.ts
+++ b/src/local-llm/index.ts
@@ -63,6 +63,29 @@ export {
   type PartialDownloadMeta,
 } from "./download-file.js";
 export {
+  DOWNLOAD_JOB_VERSION,
+  downloadJobId,
+  isDownloadJobLive,
+  listDownloadJobs,
+  readDownloadJob,
+  reconcileDownloadJob,
+  removeDownloadJob,
+  resolveDownloadJobPath,
+  resolveDownloadLogPath,
+  resolveDownloadsDir,
+  writeDownloadJob,
+  type DownloadJob,
+  type DownloadJobKind,
+  type DownloadJobMode,
+  type DownloadJobStatus,
+} from "./download-jobs.js";
+export {
+  initialDownloadJob,
+  runDownloadWorker,
+  type DownloadWorkerInput,
+  type DownloadWorkerOutcome,
+} from "./download-worker.js";
+export {
   readBackendVersion,
   writeBackendVersion,
   type BackendVersionInfo,

--- a/src/local-llm/index.ts
+++ b/src/local-llm/index.ts
@@ -50,7 +50,18 @@ export {
   resolveEmbeddingLogFilePath,
 } from "./backend-paths.js";
 
-export { downloadFile, type DownloadProgressFn } from "./download-file.js";
+export {
+  downloadFile,
+  discardPartialDownload,
+  isRetryableDownloadError,
+  readPartialDownload,
+  resolvePartialMetaPath,
+  resolvePartialPath,
+  type DownloadFileOptions,
+  type DownloadProgressFn,
+  type DownloadRetryFn,
+  type PartialDownloadMeta,
+} from "./download-file.js";
 export {
   readBackendVersion,
   writeBackendVersion,
@@ -78,6 +89,7 @@ export {
   isEmbeddingModelDownloaded,
   downloadEmbeddingModel,
   removeEmbeddingModel,
+  type ModelDownloadOptions,
 } from "./model-installer.js";
 export { resolveChatTemplatePath } from "./chat-templates.js";
 export {

--- a/src/local-llm/model-installer.ts
+++ b/src/local-llm/model-installer.ts
@@ -13,7 +13,13 @@ import {
   resolveModelFilePath,
   resolveMmprojFilePath,
 } from "./backend-paths.js";
-import { downloadFile, type DownloadProgressFn } from "./download-file.js";
+import { downloadFile, type DownloadFileOptions } from "./download-file.js";
+
+/** What a model pull lets its caller steer: progress, retry notices, cancel. */
+export type ModelDownloadOptions = Pick<
+  DownloadFileOptions,
+  "onProgress" | "onRetry" | "signal"
+>;
 
 export function isModelDownloaded(dataDir: string, model: LocalModelDef): boolean {
   return existsSync(resolveModelFilePath(dataDir, model.id, model.filename));
@@ -44,7 +50,7 @@ export function isMmprojDownloaded(
 export async function downloadModel(
   dataDir: string,
   model: LocalModelDef,
-  opts?: { onProgress?: DownloadProgressFn; signal?: AbortSignal },
+  opts?: ModelDownloadOptions,
 ): Promise<void> {
   const dest = resolveModelFilePath(dataDir, model.id, model.filename);
   if (existsSync(dest)) return;
@@ -60,7 +66,7 @@ export async function downloadModel(
 export async function downloadMmproj(
   dataDir: string,
   model: LocalModelDef,
-  opts?: { onProgress?: DownloadProgressFn; signal?: AbortSignal },
+  opts?: ModelDownloadOptions,
 ): Promise<void> {
   if (!model.supportsVision || !model.mmprojUrl || !model.mmprojFilename) {
     throw new Error(
@@ -111,7 +117,7 @@ export function isEmbeddingModelDownloaded(
 export async function downloadEmbeddingModel(
   dataDir: string,
   model: EmbeddingModelDef,
-  opts?: { onProgress?: DownloadProgressFn; signal?: AbortSignal },
+  opts?: ModelDownloadOptions,
 ): Promise<void> {
   const dest = resolveModelFilePath(dataDir, model.id, model.filename);
   if (existsSync(dest)) return;

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -70,6 +70,7 @@ import {
 } from "../persist-embedding-hybrid-recall.js";
 import { persistUserLocalModelsConfig } from "../persist-user-local-models-config.js";
 import { ChatPullMirror, downloadProgressFor } from "../local-turn-gate.js";
+import type { DownloadRetryFn } from "../../local-llm/index.js";
 import type { TuiEventBus } from "../tui-app.js";
 
 /**
@@ -244,6 +245,22 @@ export class LocalModelsOrchestrator {
         await this.stopDaemonSilent();
       }
     }
+  }
+
+  /**
+   * A retrying download must say so: between attempts the bar stands
+   * still, and a still bar with no explanation reads as a hang. The
+   * partial stays on disk, so every retry resumes rather than restarts.
+   */
+  private downloadRetryNotice(label: string): DownloadRetryFn {
+    return (info) => {
+      this.bus.emit({
+        type: "runtime_info",
+        line:
+          `local-llm: ${label} download interrupted (${info.error.message}) — ` +
+          `retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s, resuming`,
+      });
+    };
   }
 
   async refresh(): Promise<void> {
@@ -573,6 +590,7 @@ export class LocalModelsOrchestrator {
     });
     await downloadModel(dataDir, def, {
       signal,
+      onRetry: this.downloadRetryNotice(`${def.name} (gguf)`),
       onProgress: (percent, transferred, total) => {
         this.bus.emit({
           type: "local_models_pull_progress",
@@ -612,6 +630,7 @@ export class LocalModelsOrchestrator {
     });
     await downloadMmproj(dataDir, def, {
       signal,
+      onRetry: this.downloadRetryNotice(`${def.name} (mmproj)`),
       onProgress: (percent, transferred, total) => {
         this.bus.emit({
           type: "local_models_pull_progress",
@@ -1572,6 +1591,7 @@ export class LocalModelsOrchestrator {
     try {
       await downloadEmbeddingModel(dataDir, def, {
         signal: controller.signal,
+        onRetry: this.downloadRetryNotice(def.name),
         onProgress: (percent, transferred, total) => {
           this.bus.emit({
             type: "local_models_pull_progress",


### PR DESCRIPTION
Stacked on #334 (resumable downloads). The diff includes that PR's commit until it merges; review the second commit.

## Problem

A 20 GB GGUF pull ties up a terminal for hours, and dies with it. With #334 the bytes survive an interruption, but the operator still has to keep a window open and re-run the pull after every hiccup.

## Change

**`atag models pull --background <id>`** (also `pull-embedding --background`) launches a detached copy of the CLI running the hidden `models pull-worker <kind> <id> <mode>`, sends its output to `<dataDir>/downloads/<job>.log`, seeds the job record and returns at once. The worker is in its own process group, holds no tty and ignores SIGHUP, so it keeps downloading after the terminal that started it closes. It is the same arrangement `startDaemon` uses for `llama-server`.

The worker keeps **`<dataDir>/downloads/<job>.json`** current (atomic tmp+rename, throttled to 500 ms): `pid`, `status`, `phase`, `label`, `percent`, bytes, `error`, timestamps. A `running` record whose pid is dead reads back as `interrupted`, and the partial file from #334 means any re-run of the same pull, with or without `--background`, resumes rather than restarts. A phase record opens on what its partial already holds, never on 0%.

New CLI surface:

- `models downloads` — list jobs (running / done / failed / cancelled / interrupted), newest first, with the log location.
- `models downloads cancel <id>` — SIGTERM (taskkill on Windows); the worker aborts, records `cancelled`, keeps the partial.
- `models downloads clear` — forget finished records.
- A foreground `models pull <id>` whose model has a live worker **follows** it instead of racing it for the same bytes; Ctrl+C there only detaches, and says so.
- `models pull --mmproj` fetches a vision model's projector too (foreground and background). The worker carries a `mode` (`gguf-only` / `with-mmproj` / `mmproj-only`) so the TUI can drive it next.

Internals: `local-llm/download-jobs.ts` (on-disk contract, reconciliation), `local-llm/download-worker.ts` (the job body, in-process testable), `cli/self-invocation.ts` (re-run this program: SEA binary vs `node dist/cli/index.js`, with `execArgv`), `cli/models-downloads.ts` (spawn / follow / list / cancel / worker entry). `node:sea` is loaded lazily as in the native loaders so the module stays importable under vitest. `renderPullProgress` / `renderPullRetry` move to `cli/pull-progress.ts`.

## Tests

- `download-jobs.test.ts` (7): paths and ids, atomic round-trip, malformed / foreign-version records, dead-pid → `interrupted` persisted, live pid stays `running`, reconciliation only touches running jobs, ordering and removal.
- `download-worker.test.ts` (5): embedding job to `done` with a current record, 404 → `failed` with message, abort → `cancelled` with the partial kept, initial record reports the partial instead of 0%, catalog estimate for a fresh job.
- `self-invocation.test.ts` (4): SEA, node script, `execArgv` loader flags, no script path.
- `models-downloads.test.ts` (10): spawn argv / detached / stdio / env and the seeded record, no second worker for a live one, `pull --background` output, `downloads` listing with an interrupted worker, `cancel` on a finished job, `clear`, `followDownloadJob` on done / failed / interrupted, a foreground pull does not follow a finished record, log path.

`npm run lint` clean; `npm test` 7169 passed, 1 failed (`sidecar/send-message-concurrency`, fails identically on clean `main`).

## Live check (macOS, slow link, `nomic-embed-text-v1.5`, 84 MB)

1. `models pull-embedding --background` from a subshell that exits → worker `ppid 1`, own session, `TTY ??`.
2. `models downloads` → `running (pid …) 5%  4 MB / 80 MB`.
3. Foreground `pull-embedding` followed it; SIGINT → `detached — the download continues in the background (pid …)`; worker still alive.
4. `kill -HUP <worker>` → alive, partial kept growing (7.3 MB → 12.5 MB over 5 s).
5. `models downloads cancel` → `stopped (cancelled); 13 MB kept on disk`; record `cancelled`, `.part` + sidecar present.
6. A worker killed outright showed as `interrupted 9 MB / 80 MB`; `pull-embedding --background` again printed `resuming … in the background` and its log says `10289498 bytes already on disk`.
7. Follow to completion → `done 80 MB / 80 MB`, no `.part` left, sha256 equals the LFS oid Hugging Face publishes (`d4e38889…95ac`).

## Follow-up

TUI pulls running through this worker (quit the TUI, the download continues; reopen, the chip resumes) come as the next PR.
