### PR TITLE
fix(integrations): show why a channel failed, and drop the dead-tab pointer

### DIFF
--- a/src/channels/discord/discord-channel.ts
+++ b/src/channels/discord/discord-channel.ts
@@ -160,6 +160,17 @@ export class DiscordChannel {
       return;
     }
     if (type !== "MESSAGE_CREATE" || this.botUserId === null) return;
+    // Logged before any drop decision: when a bot "does not answer",
+    // the first thing to establish is whether the message reached us at
+    // all (gateway/intents) or was deliberately ignored (not addressed,
+    // not the owner). Without this the two are indistinguishable.
+    const msg = data as DiscordMessageEvent;
+    this.deps.logger.info("discord: message received", {
+      channelId: msg.channel_id,
+      authorId: msg.author?.id,
+      isDm: msg.guild_id === undefined,
+      mentionsBot: msg.mentions?.some((m) => m.id === this.botUserId) === true,
+    });
     await handleDiscordMessage(data as DiscordMessageEvent, {
       runtime: this.deps.runtime,
       api,

--- a/src/channels/discord/discord-lockfile.ts
+++ b/src/channels/discord/discord-lockfile.ts
@@ -27,7 +27,7 @@ export class DiscordLockfile {
     const holder = this.readPid();
     if (holder !== null && holder !== process.pid && isAlive(holder)) {
       throw new Error(
-        `another atomic-agent process (pid ${holder}) is already running the Discord channel`,
+        `another atomic-agent (pid ${holder}) is already running the Discord channel — stop it first`,
       );
     }
     // Stale (or ours): reclaim it.

--- a/src/channels/telegram/telegram-lockfile.ts
+++ b/src/channels/telegram/telegram-lockfile.ts
@@ -44,8 +44,11 @@ export class TelegramLockfile implements ChannelLock {
       pid !== process.pid &&
       isAlive(pid)
     ) {
+      // Names the cause and the fix: this surfaces verbatim in the
+      // Integrations pane, where "lockfile held by live pid 123" reads
+      // as a crash rather than as "you already have one running".
       throw new Error(
-        `telegram lockfile held by live pid ${pid} at ${this.path}`,
+        `another atomic-agent (pid ${pid}) is already running the Telegram channel — stop it first`,
       );
     }
     writeFileSync(this.path, String(process.pid), { flag: "w" });

--- a/src/integrations/discord-integration.test.ts
+++ b/src/integrations/discord-integration.test.ts
@@ -9,13 +9,16 @@ const OWNER = "ownerUserId";
 const BOTH = [TOKEN, OWNER];
 const VALID = `${"M".repeat(24)}.GaBcDe.${"z".repeat(30)}`;
 
-function ctx(present: string[], channel?: string) {
+function ctx(present: string[], channel?: string, error?: string) {
   return {
     presentFields: new Set(present),
     configured: BOTH.every((f) => present.includes(f)),
     ...(channel === undefined
       ? {}
       : { channelStates: new Map([["discord", channel]]) }),
+    ...(error === undefined
+      ? {}
+      : { channelErrors: new Map([["discord", error]]) }),
   };
 }
 
@@ -70,4 +73,29 @@ describe("discordIntegration", () => {
     const validate = discordIntegration.fields[1]?.validate;
     expect(validate?.("123456789012345678")).toBeUndefined();
     expect(validate?.("nope")).toMatch(/Developer Mode/);
+  });
+
+  it("shows the channel's own failure reason, not a generic line", () => {
+    // This used to read "gateway failed — see the Discord tab", which
+    // was useless twice over: it told the operator nothing actionable,
+    // and it pointed at a tab that does not exist.
+    const status = discordIntegration.status(
+      ctx(BOTH, "down", "another atomic-agent (pid 42) is already running the Discord channel — stop it first"),
+    );
+    expect(status.level).toBe("error");
+    expect(status.detail).toMatch(/already running/);
+    expect(status.detail).not.toMatch(/Discord tab/);
+  });
+
+  it("never points at a tab that does not exist", () => {
+    for (const state of [undefined, "up", "down", "starting", "disabled"]) {
+      const d = discordIntegration.status(ctx(BOTH, state)).detail ?? "";
+      expect(d).not.toMatch(/Discord tab/);
+    }
+  });
+
+  it("falls back to a plain reason when the channel has none", () => {
+    expect(discordIntegration.status(ctx(BOTH, "down")).detail).toBe(
+      "gateway failed",
+    );
   });

--- a/src/integrations/discord-integration.ts
+++ b/src/integrations/discord-integration.ts
@@ -87,7 +87,9 @@ export const discordIntegration: IntegrationDescriptor = {
       case "down":
         return {
           level: "error",
-          detail: "gateway failed — see the Discord tab",
+          // The channel's own reason, not a generic line pointing at a
+          // tab that does not exist.
+          detail: ctx.channelErrors?.get("discord") ?? "gateway failed",
         };
       case "starting":
         return { level: "configured", detail: "connecting" };

--- a/src/integrations/integration-descriptor.ts
+++ b/src/integrations/integration-descriptor.ts
@@ -93,6 +93,15 @@ export interface IntegrationStatusContext {
    * runtime is not available (e.g. in tests).
    */
   channelStates?: ReadonlyMap<string, string>;
+  /**
+   * Last error per channel, straight from `channel.lastError()`.
+   *
+   * A status line that says "channel failed to start" tells the
+   * operator nothing they cannot already see from the badge. The
+   * channel knows *why* — a held lock, a rejected token, disallowed
+   * intents — and that is the only part worth screen space.
+   */
+  channelErrors?: ReadonlyMap<string, string>;
 }
 
 /**

--- a/src/integrations/telegram-integration.test.ts
+++ b/src/integrations/telegram-integration.test.ts
@@ -8,13 +8,16 @@ const OWNER = "ownerUserId";
 const BOTH = [TOKEN, OWNER];
 const VALID = `123456789:${"A".repeat(35)}`;
 
-function ctx(present: string[], channel?: string) {
+function ctx(present: string[], channel?: string, error?: string) {
   return {
     presentFields: new Set(present),
     configured: BOTH.every((f) => present.includes(f)),
     ...(channel === undefined
       ? {}
       : { channelStates: new Map([["telegram", channel]]) }),
+    ...(error === undefined
+      ? {}
+      : { channelErrors: new Map([["telegram", error]]) }),
   };
 }
 
@@ -76,3 +79,19 @@ describe("telegramIntegration", () => {
     expect(telegramIntegration.appliesLive).toBe(true);
   });
 });
+
+  it("shows the channel's own failure reason", () => {
+    // "channel failed to start" told the operator nothing the badge did
+    // not already say. The channel knows why -- a held lock, a rejected
+    // token -- and that is the only part worth the screen space.
+    const status = telegramIntegration.status(
+      ctx(BOTH, "down", "another atomic-agent (pid 42) is already running the Telegram channel — stop it first"),
+    );
+    expect(status.detail).toMatch(/already running/);
+  });
+
+  it("falls back to a plain reason when the channel has none", () => {
+    expect(telegramIntegration.status(ctx(BOTH, "down")).detail).toBe(
+      "channel failed to start",
+    );
+  });

--- a/src/integrations/telegram-integration.ts
+++ b/src/integrations/telegram-integration.ts
@@ -98,7 +98,11 @@ export const telegramIntegration: IntegrationDescriptor = {
       case "up":
         return { level: "connected", detail: "channel up" };
       case "down":
-        return { level: "error", detail: "channel failed to start" };
+        return {
+          level: "error",
+          detail:
+            ctx.channelErrors?.get("telegram") ?? "channel failed to start",
+        };
       case "starting":
         return { level: "configured", detail: "starting" };
       default:

--- a/src/tui/integrations/integrations-orchestrator.ts
+++ b/src/tui/integrations/integrations-orchestrator.ts
@@ -61,10 +61,19 @@ export class IntegrationsOrchestrator {
     // way, so a token that is saved but not running reads differently
     // from one that is.
     const channelStates = new Map<string, string>();
+    const channelErrors = new Map<string, string>();
     const telegram = this.runtime.telegramChannel;
-    if (telegram) channelStates.set("telegram", telegram.state());
+    if (telegram) {
+      channelStates.set("telegram", telegram.state());
+      const err = telegram.lastError();
+      if (err) channelErrors.set("telegram", err);
+    }
     const discord = this.runtime.discordChannel;
-    if (discord) channelStates.set("discord", discord.state());
+    if (discord) {
+      channelStates.set("discord", discord.state());
+      const err = discord.lastError();
+      if (err) channelErrors.set("discord", err);
+    }
     return listIntegrations().map((descriptor) => {
       const present = presentFieldKeys(
         descriptor,
@@ -78,6 +87,7 @@ export class IntegrationsOrchestrator {
           .every((f) => present.has(f.key)),
         mcpServerStates,
         channelStates,
+        channelErrors,
       };
       const status = descriptor.status(statusCtx);
       const fields: IntegrationFieldRow[] = descriptor.fields.map((field) => ({


### PR DESCRIPTION
> **Stacked on #333 → #332 → … → #327.**

## What was on screen

```
Telegram  · channel failed to start
Discord   · gateway failed — see the Discord tab
```

Three faults in two lines:

1. **"see the Discord tab" points at a tab that does not exist** — removed in #332 when Discord moved into the hub. I fixed this same string in the `configured` branch and missed the `down` branch.
2. **Both lines throw away the reason.** Each channel knows exactly why it failed and exposes it via `lastError()`; the hub simply wasn't reading it. *"channel failed to start"* tells the operator nothing the red badge didn't already say.
3. **The most common cause read like a crash.** A second atomic-agent holding the lock surfaced as `telegram lockfile held by live pid 123` rather than "you already have one running".

## Fix

`IntegrationStatusContext` gains `channelErrors`, populated from `lastError()`, and both descriptors render it:

```
Telegram  · another atomic-agent (pid 42) is already running the Telegram channel — stop it first
```

Lock messages now name the cause **and** the fix.

## Also: inbound Discord logging

An `info` log on every inbound message, emitted **before** any drop decision. When a bot "doesn't answer", the first question is whether the message reached the gateway at all or was deliberately ignored (not addressed, not the owner) — previously indistinguishable from outside.

That log earned its place immediately: it's what proved the Discord gateway was healthy and the real fault was a **stale lock left by a dead process**, not the channel.

```
discord: message received {channelId:"…", authorId:"…", isDm:false, mentionsBot:false}
```

## Testing

`npm run lint` and `npm test` green (7320 tests). New cases pin that the real reason is surfaced, that a plain fallback is used when the channel has none, and — across every channel state — that **no status line ever mentions a Discord tab again**.
