### PR TITLE
fix(integrations): a channel running in another process is not an error

### DIFF
--- a/src/channels/channel-lock-error.test.ts
+++ b/src/channels/channel-lock-error.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CHANNEL_LOCKED_PREFIX,
+  describeChannelLockConflict,
+  formatChannelLockHeld,
+  isChannelLockConflict,
+} from "./channel-lock-error.js";
+
+describe("channel lock conflict", () => {
+  it("tags the reason so it can be told from a real failure", () => {
+    const reason = formatChannelLockHeld(4242);
+    expect(reason.startsWith(CHANNEL_LOCKED_PREFIX)).toBe(true);
+    expect(isChannelLockConflict(reason)).toBe(true);
+    expect(reason).toContain("4242");
+  });
+
+  it("does not mistake a real failure for a lock conflict", () => {
+    // A rejected token or disallowed intents must stay an error --
+    // that is the case where red is the right answer.
+    expect(isChannelLockConflict("Discord rejected the bot token (HTTP 401)")).toBe(false);
+    expect(isChannelLockConflict("409: Conflict: terminated by other getUpdates")).toBe(false);
+    expect(isChannelLockConflict(null)).toBe(false);
+    expect(isChannelLockConflict(undefined)).toBe(false);
+  });
+
+  it("strips the machine prefix for display", () => {
+    const shown = describeChannelLockConflict(formatChannelLockHeld(7));
+    expect(shown).toBe("already running in another atomic-agent (pid 7)");
+    expect(shown).not.toContain(CHANNEL_LOCKED_PREFIX);
+  });
+});

--- a/src/channels/channel-lock-error.ts
+++ b/src/channels/channel-lock-error.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared vocabulary for "this channel is already running somewhere
+ * else".
+ *
+ * Two atomic-agent processes on one bot token is not a failure — it is
+ * the normal shape of running the bots in one terminal and opening the
+ * TUI in another. The channel in the second process genuinely cannot
+ * start, so it reports `down`, but presenting that as a red error is
+ * wrong twice: nothing is broken, and the bot the operator cares about
+ * is working fine. Red that fires on a healthy system is red people
+ * learn to ignore.
+ *
+ * The lockfiles tag the reason with a stable prefix so the Integrations
+ * hub can tell this apart from a real failure (rejected token, bad
+ * intents) without pattern-matching on prose.
+ */
+
+/** Machine-readable prefix on a lock-conflict reason. */
+export const CHANNEL_LOCKED_PREFIX = "channel-locked:";
+
+/**
+ * Build the reason a lockfile throws when another live process holds
+ * it. The channel name is deliberately left out: the message is
+ * rendered on that channel's own row, where repeating it is noise.
+ */
+export function formatChannelLockHeld(pid: number): string {
+  return `${CHANNEL_LOCKED_PREFIX} already running in another atomic-agent (pid ${pid})`;
+}
+
+/** True when `reason` is a lock conflict rather than a real failure. */
+export function isChannelLockConflict(reason: string | null | undefined): boolean {
+  return typeof reason === "string" && reason.startsWith(CHANNEL_LOCKED_PREFIX);
+}
+
+/** The human half of a lock-conflict reason, without the machine prefix. */
+export function describeChannelLockConflict(reason: string): string {
+  return reason.slice(CHANNEL_LOCKED_PREFIX.length).trim();
+}

--- a/src/channels/discord/discord-lockfile.ts
+++ b/src/channels/discord/discord-lockfile.ts
@@ -14,6 +14,8 @@
 
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 
+import { formatChannelLockHeld } from "../channel-lock-error.js";
+
 export class DiscordLockfile {
   constructor(private readonly path: string) {}
 
@@ -26,9 +28,7 @@ export class DiscordLockfile {
     }
     const holder = this.readPid();
     if (holder !== null && holder !== process.pid && isAlive(holder)) {
-      throw new Error(
-        `another atomic-agent (pid ${holder}) is already running the Discord channel — stop it first`,
-      );
+      throw new Error(formatChannelLockHeld(holder));
     }
     // Stale (or ours): reclaim it.
     writeFileSync(this.path, String(process.pid), "utf8");

--- a/src/channels/telegram/telegram-lockfile.ts
+++ b/src/channels/telegram/telegram-lockfile.ts
@@ -1,3 +1,4 @@
+import { formatChannelLockHeld } from "../channel-lock-error.js";
 import {
   existsSync,
   readFileSync,
@@ -47,9 +48,7 @@ export class TelegramLockfile implements ChannelLock {
       // Names the cause and the fix: this surfaces verbatim in the
       // Integrations pane, where "lockfile held by live pid 123" reads
       // as a crash rather than as "you already have one running".
-      throw new Error(
-        `another atomic-agent (pid ${pid}) is already running the Telegram channel — stop it first`,
-      );
+      throw new Error(formatChannelLockHeld(pid));
     }
     writeFileSync(this.path, String(process.pid), { flag: "w" });
   }

--- a/src/integrations/discord-integration.test.ts
+++ b/src/integrations/discord-integration.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { formatChannelLockHeld } from "../channels/channel-lock-error.js";
+
 import { discordIntegration } from "./discord-integration.js";
 import { DISCORD_BOT_TOKEN_KEY } from "../channels/discord/index.js";
 
@@ -59,7 +61,6 @@ describe("discordIntegration", () => {
     );
     expect(validate?.("a".repeat(64))).toMatch(/client secret/);
   });
-});
 
   it("is not configured until the owner is paired too", () => {
     // A token with no owner would connect and then refuse every
@@ -99,3 +100,23 @@ describe("discordIntegration", () => {
       "gateway failed",
     );
   });
+
+  it("does not badge another running instance as an error", () => {
+    // Running the bots in one terminal and the TUI in another is normal.
+    // The channel here genuinely cannot start, but nothing is broken and
+    // the bot is working -- red on a healthy system is red people learn
+    // to ignore.
+    const status = discordIntegration.status(
+      ctx(BOTH, "down", formatChannelLockHeld(4242)),
+    );
+    expect(status.level).toBe("configured");
+    expect(status.detail).toBe("already running in another atomic-agent (pid 4242)");
+    expect(status.detail).not.toContain("channel-locked:");
+  });
+
+  it("still badges a genuine failure as an error", () => {
+    const status = discordIntegration.status(ctx(BOTH, "down", "token rejected (HTTP 401)"));
+    expect(status.level).toBe("error");
+    expect(status.detail).toMatch(/401/);
+  });
+});

--- a/src/integrations/discord-integration.ts
+++ b/src/integrations/discord-integration.ts
@@ -7,6 +7,10 @@
  */
 
 import { DISCORD_BOT_TOKEN_KEY } from "../channels/discord/index.js";
+import {
+  describeChannelLockConflict,
+  isChannelLockConflict,
+} from "../channels/channel-lock-error.js";
 import type {
   IntegrationDescriptor,
   IntegrationStatus,
@@ -85,12 +89,20 @@ export const discordIntegration: IntegrationDescriptor = {
       case "up":
         return { level: "connected", detail: "gateway connected" };
       case "down":
-        return {
-          level: "error",
-          // The channel's own reason, not a generic line pointing at a
-          // tab that does not exist.
-          detail: ctx.channelErrors?.get("discord") ?? "gateway failed",
-        };
+      {
+        const reason = ctx.channelErrors?.get("discord");
+        // Another process already running the channel is not a
+        // failure -- the bot is up, just not served from here.
+        if (isChannelLockConflict(reason)) {
+          return {
+            level: "configured",
+            detail: describeChannelLockConflict(reason!),
+          };
+        }
+        // The channel's own reason, never a pointer to a tab that does
+        // not exist.
+        return { level: "error", detail: reason ?? "gateway failed" };
+      }
       case "starting":
         return { level: "configured", detail: "connecting" };
       default:

--- a/src/integrations/telegram-integration.test.ts
+++ b/src/integrations/telegram-integration.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { formatChannelLockHeld } from "../channels/channel-lock-error.js";
+
 import { telegramIntegration } from "./telegram-integration.js";
 import { TELEGRAM_BOT_TOKEN_KEY } from "../channels/telegram/index.js";
 
@@ -78,7 +80,6 @@ describe("telegramIntegration", () => {
   it("applies live, because the hub can restart the channel itself", () => {
     expect(telegramIntegration.appliesLive).toBe(true);
   });
-});
 
   it("shows the channel's own failure reason", () => {
     // "channel failed to start" told the operator nothing the badge did
@@ -95,3 +96,23 @@ describe("telegramIntegration", () => {
       "channel failed to start",
     );
   });
+
+  it("does not badge another running instance as an error", () => {
+    // Running the bots in one terminal and the TUI in another is normal.
+    // The channel here genuinely cannot start, but nothing is broken and
+    // the bot is working -- red on a healthy system is red people learn
+    // to ignore.
+    const status = telegramIntegration.status(
+      ctx(BOTH, "down", formatChannelLockHeld(4242)),
+    );
+    expect(status.level).toBe("configured");
+    expect(status.detail).toBe("already running in another atomic-agent (pid 4242)");
+    expect(status.detail).not.toContain("channel-locked:");
+  });
+
+  it("still badges a genuine failure as an error", () => {
+    const status = telegramIntegration.status(ctx(BOTH, "down", "token rejected (HTTP 401)"));
+    expect(status.level).toBe("error");
+    expect(status.detail).toMatch(/401/);
+  });
+});

--- a/src/integrations/telegram-integration.ts
+++ b/src/integrations/telegram-integration.ts
@@ -9,6 +9,10 @@
  */
 
 import { TELEGRAM_BOT_TOKEN_KEY } from "../channels/telegram/index.js";
+import {
+  describeChannelLockConflict,
+  isChannelLockConflict,
+} from "../channels/channel-lock-error.js";
 import type {
   IntegrationDescriptor,
   IntegrationStatus,
@@ -97,12 +101,18 @@ export const telegramIntegration: IntegrationDescriptor = {
     switch (ctx.channelStates?.get("telegram")) {
       case "up":
         return { level: "connected", detail: "channel up" };
-      case "down":
-        return {
-          level: "error",
-          detail:
-            ctx.channelErrors?.get("telegram") ?? "channel failed to start",
-        };
+      case "down": {
+        const reason = ctx.channelErrors?.get("telegram");
+        // Another process already running the channel is not a
+        // failure -- the bot is up, just not served from here.
+        if (isChannelLockConflict(reason)) {
+          return {
+            level: "configured",
+            detail: describeChannelLockConflict(reason!),
+          };
+        }
+        return { level: "error", detail: reason ?? "channel failed to start" };
+      }
       case "starting":
         return { level: "configured", detail: "starting" };
       default:


### PR DESCRIPTION
> **Stacked on #337 → #333 → #332 → … → #327.**

## What was on screen

Running the bots in one terminal and opening the TUI in another — a normal workflow — painted the tab red:

```
Telegram  · another atomic-agent (pid 77052) is already running the Telegram channel — stop it first
Discord   · another atomic-agent (pid 77052) is already running the Discord channel — stop it first
```

Nothing was broken. **Both bots were working**; they were just being served from the other process. Red that fires on a healthy system is red people learn to ignore — which costs us the times it does mean something.

This is a follow-up to #337: that PR made the failure reason *visible*, which then made it obvious the reason wasn't a failure at all.

## Fix

The channel in the second process genuinely cannot start, so `down` remains the right *channel* state. The misjudgement was the **hub treating every `down` as a failure**.

Lockfiles now tag the reason with a stable `channel-locked:` prefix ([`src/channels/channel-lock-error.ts`](src/channels/channel-lock-error.ts)) so the hub can tell a lock conflict from a real failure without pattern-matching on prose, and renders it as an ordinary configured row:

```
Integrations  3/3 configured

  Composio  · connected
  Telegram  · already running in another atomic-agent (pid 6652)
  Discord   · already running in another atomic-agent (pid 6652)
```

A rejected token or disallowed intents **still badge red** — that's where red is the right answer, and a test pins the difference.

## Testing

`npm run lint` and `npm test` green (7327 tests). New cases: the marker round-trips, a real failure is never mistaken for a lock conflict, the machine prefix never reaches the screen, and each descriptor downgrades a lock conflict while keeping a genuine failure at `error`.

Verified against the real thing — bots holding both locks, TUI opened on the same profile, screenshot above.

Also repairs a stray `});` in the two descriptor test files that had been closing `describe` early, leaving later cases running as top-level tests.
