### PR TITLE
fix(tui): explain a dropped stream instead of a bare "terminated"

### DIFF
--- a/src/llm/reliability/index.ts
+++ b/src/llm/reliability/index.ts
@@ -12,9 +12,14 @@ export {
 } from "./llm-failures.js";
 export type { LlmFailureOptions } from "./llm-failures.js";
 export { classifyFailure } from "./classify-failure.js";
+// `looksLikeDroppedConnection` is deliberately NOT re-exported: it is the
+// classifier's own key, used inside `network-error.ts` by `isNetworkError`
+// and asserted directly by that module's test, with no consumer outside
+// the directory. Widening the barrel with it would advertise the broad
+// predicate next to the narrow one and invite a caller to reach for the
+// wrong half — the exact mix-up `network-error.ts` documents at length.
 export {
   isNetworkError,
-  looksLikeDroppedConnection,
   looksLikeMidStreamDrop,
   readNetworkErrorCode,
 } from "./network-error.js";

--- a/src/llm/reliability/index.ts
+++ b/src/llm/reliability/index.ts
@@ -15,6 +15,7 @@ export { classifyFailure } from "./classify-failure.js";
 export {
   isNetworkError,
   looksLikeDroppedConnection,
+  looksLikeMidStreamDrop,
   readNetworkErrorCode,
 } from "./network-error.js";
 export { detectModelFailure } from "./detect-model-failure.js";

--- a/src/llm/reliability/index.ts
+++ b/src/llm/reliability/index.ts
@@ -14,6 +14,7 @@ export type { LlmFailureOptions } from "./llm-failures.js";
 export { classifyFailure } from "./classify-failure.js";
 export {
   isNetworkError,
+  looksLikeDroppedConnection,
   readNetworkErrorCode,
 } from "./network-error.js";
 export { detectModelFailure } from "./detect-model-failure.js";

--- a/src/llm/reliability/network-error.test.ts
+++ b/src/llm/reliability/network-error.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   isNetworkError,
   looksLikeDroppedConnection,
+  looksLikeMidStreamDrop,
   readNetworkErrorCode,
 } from "./network-error.js";
 
@@ -117,5 +118,63 @@ describe("looksLikeDroppedConnection", () => {
         isNetworkError(new Error(message)),
       );
     }
+  });
+});
+
+describe("looksLikeMidStreamDrop", () => {
+  // The narrow key: only the messages that can ONLY come from a socket
+  // that was already carrying a request. This is what may be quoted back
+  // to a user as "your reply was cut off"; the broad predicate above is
+  // what drives classification and fallover.
+  it.each([
+    "terminated",
+    "  TERMINATED\n",
+    "socket hang up",
+    "read ECONNRESET: socket hang up",
+    "other side closed",
+  ])("recognises %j as a reply cut off", (message) => {
+    expect(looksLikeMidStreamDrop(message)).toBe(true);
+  });
+
+  it.each([
+    // undici's outer catch-all. Verified on Node 22.22.2: an
+    // unresolvable host (`ENOTFOUND`) and a closed port (`ECONNREFUSED`)
+    // BOTH throw `TypeError: fetch failed`, errno only on `cause`. So
+    // this message cannot support a claim that a reply was in flight,
+    // and `network-error.ts` / `classify-failure.ts` both document that
+    // MCP, embedding and vendor-SDK sockets arrive here bare.
+    "fetch failed",
+    // The TLS variant names a handshake that never completed — no
+    // request was ever sent.
+    "Client network socket disconnected before secure TLS connection was established",
+    "connection reset",
+    "terminated the request early",
+    "",
+  ])("does not claim %j", (message) => {
+    expect(looksLikeMidStreamDrop(message)).toBe(false);
+  });
+
+  it("is a strict subset of looksLikeDroppedConnection", () => {
+    // The classifier's list must stay the wider one: `isNetworkError`
+    // drives `shouldAdvance`/fallover, and narrowing IT would change
+    // which failures fall over to the next provider.
+    const family = [
+      "fetch failed",
+      "terminated",
+      "socket hang up",
+      "other side closed",
+      "Client network socket disconnected before secure TLS connection was established",
+      "network socket disconnected",
+      "x.map is not a function",
+    ];
+    for (const message of family) {
+      if (looksLikeMidStreamDrop(message)) {
+        expect(looksLikeDroppedConnection(message)).toBe(true);
+      }
+    }
+    // …and strictly smaller: at least one member of the broad family is
+    // deliberately not in the narrow one.
+    expect(looksLikeDroppedConnection("fetch failed")).toBe(true);
+    expect(looksLikeMidStreamDrop("fetch failed")).toBe(false);
   });
 });

--- a/src/llm/reliability/network-error.test.ts
+++ b/src/llm/reliability/network-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isNetworkError, readNetworkErrorCode } from "./network-error.js";
+import {
+  isNetworkError,
+  looksLikeDroppedConnection,
+  readNetworkErrorCode,
+} from "./network-error.js";
 
 /** The shape undici throws from `fetch` when the connection fails. */
 function fetchFailed(cause: unknown): TypeError {
@@ -74,5 +78,44 @@ describe("isNetworkError", () => {
     expect(isNetworkError(new TypeError("x.map is not a function"))).toBe(false);
     expect(isNetworkError(new Error("tool crashed"))).toBe(false);
     expect(isNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe("looksLikeDroppedConnection", () => {
+  // The message-only door into the same vocabulary `isNetworkError`
+  // uses, for consumers that only ever see the flattened text — the TUI
+  // chat formatter is the one in tree.
+  it.each([
+    "fetch failed",
+    "terminated",
+    "  terminated\n",
+    "TERMINATED",
+    "socket hang up",
+    "read ECONNRESET: socket hang up",
+    "other side closed",
+    "Client network socket disconnected before secure TLS connection was established",
+  ])("recognises %j", (message) => {
+    expect(looksLikeDroppedConnection(message)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "connection reset",
+    "terminated the request early",
+    "the fetch failed because the grammar was rejected",
+    "upstream HTTP 502",
+    "x.map is not a function",
+  ])("does not claim %j", (message) => {
+    expect(looksLikeDroppedConnection(message)).toBe(false);
+  });
+
+  it("agrees with isNetworkError on a bare message-only error", () => {
+    // Same list, one definition: if these ever disagree the predicate
+    // has grown a second copy of the vocabulary.
+    for (const message of ["terminated", "socket hang up", "tool crashed"]) {
+      expect(looksLikeDroppedConnection(message)).toBe(
+        isNetworkError(new Error(message)),
+      );
+    }
   });
 });

--- a/src/llm/reliability/network-error.ts
+++ b/src/llm/reliability/network-error.ts
@@ -102,6 +102,11 @@ const NETWORK_MESSAGES = [
  * died mid-body are the same verdict. Do not use it to say anything to a
  * user about what happened to their reply; use
  * `looksLikeMidStreamDrop` for that.
+ *
+ * Exported for this module's own test only, and kept out of
+ * `reliability/index.ts` for that reason: every consumer outside this
+ * directory wants the narrow predicate, and offering both at the barrel
+ * makes picking the wrong one a one-character mistake.
  */
 export function looksLikeDroppedConnection(message: string): boolean {
   const trimmed = message.trim();

--- a/src/llm/reliability/network-error.ts
+++ b/src/llm/reliability/network-error.ts
@@ -54,6 +54,17 @@ const NETWORK_MESSAGES = [
   /network socket disconnected/i,
 ];
 
+/**
+ * True when `message` is one of the stock "the connection is gone"
+ * strings above. Shared with `isNetworkError`'s message arm rather than
+ * copied, so the two can never drift apart: the classifier and any
+ * message-only consumer recognise exactly the same vocabulary.
+ */
+export function looksLikeDroppedConnection(message: string): boolean {
+  const trimmed = message.trim();
+  return NETWORK_MESSAGES.some((re) => re.test(trimmed));
+}
+
 /** Depth cap on the `cause` walk — a chain longer than this is a cycle. */
 const MAX_CAUSE_DEPTH = 5;
 
@@ -88,7 +99,7 @@ export function isNetworkError(err: unknown): boolean {
   for (const link of causeChain(err)) {
     const message = (link as { message?: unknown }).message;
     if (typeof message !== "string") continue;
-    if (NETWORK_MESSAGES.some((re) => re.test(message.trim()))) return true;
+    if (looksLikeDroppedConnection(message)) return true;
   }
   return false;
 }

--- a/src/llm/reliability/network-error.ts
+++ b/src/llm/reliability/network-error.ts
@@ -41,17 +41,54 @@ const NETWORK_ERROR_CODES = new Set([
 const UNDICI_CODE_PREFIX = "UND_ERR_";
 
 /**
- * Messages undici/Node produce for a dead connection when no errno
- * survives the wrapping. `fetch failed` is the generic outer message;
- * the rest are the inner ones seen in the wild.
+ * The subset of the messages below that can only be produced by a socket
+ * that was *established and carrying a request* when it died — i.e. the
+ * cases where it is true to tell an operator that a reply was cut off.
+ *
+ * Membership is argued per pattern, because the whole value of this list
+ * is that everything in it supports that claim:
+ *
+ * - `/^terminated$/i` — undici's word for the socket dying mid-body,
+ *   after the response has begun. The reported case (#339).
+ * - `/socket hang up/i` — Node core, emitted when the peer closes a
+ *   socket that already carries our request and no complete response has
+ *   arrived. The request was in flight by construction.
+ * - `/other side closed/i` — undici, the peer closing a connection we
+ *   were already using.
+ *
+ * Deliberately excluded, though both are network failures and both stay
+ * in `NETWORK_MESSAGES` below:
+ *
+ * - `/^fetch failed$/i` — undici's outer catch-all, which it *also*
+ *   throws for a connection that never opened. Verified on Node 22.22.2:
+ *   `ENOTFOUND` on an unresolvable host and `ECONNREFUSED` on a closed
+ *   port both surface as exactly `fetch failed`, the errno surviving only
+ *   on `cause`. Nothing was in flight, so "the reply was cut off" is
+ *   simply false for it.
+ * - `/network socket disconnected/i` — the TLS variant ("… before secure
+ *   TLS connection was established") names a handshake that never
+ *   completed, so no request was ever sent.
  */
-const NETWORK_MESSAGES = [
-  /^fetch failed$/i,
+const MID_STREAM_DROP_MESSAGES = [
   /^terminated$/i,
   /socket hang up/i,
   /other side closed/i,
-  /client network socket disconnected/i,
+];
+
+/**
+ * Messages undici/Node produce for a dead connection when no errno
+ * survives the wrapping. `fetch failed` is the generic outer message;
+ * the rest are the inner ones seen in the wild.
+ *
+ * `/client network socket disconnected/i` used to sit here next to the
+ * unanchored `/network socket disconnected/i`; it is a strict subset of
+ * it (every string matching the first matches the second) and matched
+ * nothing extra, so it is gone. No behaviour change.
+ */
+const NETWORK_MESSAGES = [
+  /^fetch failed$/i,
   /network socket disconnected/i,
+  ...MID_STREAM_DROP_MESSAGES,
 ];
 
 /**
@@ -59,10 +96,30 @@ const NETWORK_MESSAGES = [
  * strings above. Shared with `isNetworkError`'s message arm rather than
  * copied, so the two can never drift apart: the classifier and any
  * message-only consumer recognise exactly the same vocabulary.
+ *
+ * This is the CLASSIFIER's key — deliberately broad, because for
+ * `shouldAdvance` / fallover a connection that never opened and one that
+ * died mid-body are the same verdict. Do not use it to say anything to a
+ * user about what happened to their reply; use
+ * `looksLikeMidStreamDrop` for that.
  */
 export function looksLikeDroppedConnection(message: string): boolean {
   const trimmed = message.trim();
   return NETWORK_MESSAGES.some((re) => re.test(trimmed));
+}
+
+/**
+ * True when `message` names a connection that broke *while a reply was
+ * in flight* — the strict subset of `looksLikeDroppedConnection` above
+ * that justifies telling an operator their reply was cut off.
+ *
+ * Same file, same vocabulary, one list feeding the other, so a new
+ * pattern has to be classified as one or the other rather than silently
+ * joining both.
+ */
+export function looksLikeMidStreamDrop(message: string): boolean {
+  const trimmed = message.trim();
+  return MID_STREAM_DROP_MESSAGES.some((re) => re.test(trimmed));
 }
 
 /** Depth cap on the `cause` walk — a chain longer than this is a cycle. */

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -501,9 +501,14 @@ describe("reduceTuiState", () => {
     const errMsg = next.messages.find(
       (m) => m.role === "system" && m.variant === "warn",
     );
-    expect(errMsg?.text).toContain("Turn failed [transport]: fetch failed");
-    expect(errMsg?.text).not.toContain("llama-server is not reachable");
-    expect(errMsg?.text).not.toContain("atomic-agent models start");
+    // Exactly the base line and nothing else. `fetch failed` is undici's
+    // catch-all for a connection that never opened as much as for one
+    // that died (verified on Node 22.22.2: `ENOTFOUND` and `ECONNREFUSED`
+    // both surface as this bare string), so neither hint may fire — the
+    // llama one names the wrong server on a cloud route, and the drop one
+    // would assert a reply was cut off on a turn that may have completed
+    // zero steps.
+    expect(errMsg?.text).toBe("Turn failed [transport]: fetch failed");
   });
 
   it("explains a cloud route's mid-stream drop through the whole reducer", () => {

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -501,7 +501,41 @@ describe("reduceTuiState", () => {
     const errMsg = next.messages.find(
       (m) => m.role === "system" && m.variant === "warn",
     );
-    expect(errMsg?.text).toBe("Turn failed [transport]: fetch failed");
+    expect(errMsg?.text).toContain("Turn failed [transport]: fetch failed");
+    expect(errMsg?.text).not.toContain("llama-server is not reachable");
+    expect(errMsg?.text).not.toContain("atomic-agent models start");
+  });
+
+  it("explains a cloud route's mid-stream drop through the whole reducer", () => {
+    // The reported shape: a cloud provider's stream dies mid-body and
+    // undici's message is the single word `terminated`.
+    // Source: Discord #feedback-and-bugs, 2026-09-03.
+    const initial = createInitialTuiState(fakeSession());
+    const next = apply(initial, [
+      {
+        type: "providers_refresh",
+        rows: [providerRow({ id: "openrouter", kind: "openrouter", isActiveText: true })],
+      },
+      { type: "message_submitted" },
+      {
+        type: "agent_event",
+        event: {
+          type: "loop_failed",
+          error: new Error("terminated"),
+          category: "transport",
+        },
+      },
+    ]);
+    const errMsg = next.messages.find(
+      (m) => m.role === "system" && m.variant === "warn",
+    );
+    expect(errMsg?.text).toContain("Turn failed [transport]: terminated");
+    expect(errMsg?.text).toContain(
+      "the connection to the model dropped before the reply finished",
+    );
+    expect(errMsg?.text).toContain(
+      "the steps that already finished are kept in this session",
+    );
   });
 
   it("maps loop_completed reason failed to failed outcome", () => {

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -42,14 +42,20 @@ describe("formatAgentErrorForChat", () => {
     expect(text).toContain("atomic-agent models start");
   });
 
-  it("keeps the llama hint away from cloud providers — advice about the wrong server", () => {
-    const text = formatAgentErrorForChat("transport", "fetch failed", {
-      activeProviderIsLocal: false,
-      llamaUrl: "http://127.0.0.1:19091",
-    });
-    expect(text).toContain("Turn failed [transport]: fetch failed");
-    expect(text).not.toContain("llama-server is not reachable");
-    expect(text).not.toContain("atomic-agent models start");
+  it("keeps every hint away from a cloud `fetch failed` — nothing was in flight", () => {
+    // `fetch failed` is undici's outer catch-all and is ALSO what it
+    // throws when the connection never opened at all: verified on Node
+    // 22.22.2, both `ENOTFOUND` (unresolvable host) and `ECONNREFUSED`
+    // (closed port) produce exactly this message, with the errno only on
+    // `cause`. So neither hint may fire on it — not the llama one (wrong
+    // server on a cloud route) and not the drop one, whose first line
+    // claims a reply was cut off.
+    expect(
+      formatAgentErrorForChat("transport", "fetch failed", {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe("Turn failed [transport]: fetch failed");
   });
 
   it("keeps every hint away from a cloud transport failure that is not a drop", () => {
@@ -81,18 +87,8 @@ describe("formatAgentErrorForChat", () => {
     expect(text).toContain("re-sending the whole task starts it over");
   });
 
-  it("carries the drop hint with no provider context at all", () => {
-    // `chat-orchestrator.ts` calls the formatter without the local
-    // context for its own catch arm; a drop must still explain itself.
-    expect(formatAgentErrorForChat("transport", "socket hang up")).toContain(
-      "the connection to the model dropped before the reply finished",
-    );
-  });
-
   it.each([
-    "fetch failed",
     "terminated",
-    "Client network socket disconnected before secure TLS connection was established",
     "read ECONNRESET: socket hang up",
     "other side closed",
   ])("recognises the drop family: %s", (message) => {
@@ -109,6 +105,12 @@ describe("formatAgentErrorForChat", () => {
     "upstream HTTP 502 (bad gateway)",
     "request timed out after 120s",
     "terminated the request early",
+    // A network failure the classifier still files as `transport` (both
+    // are in `NETWORK_MESSAGES`), but where no reply was ever in flight:
+    // undici's catch-all for a connection that never opened, and a TLS
+    // handshake that never completed. The hint would be false.
+    "fetch failed",
+    "Client network socket disconnected before secure TLS connection was established",
   ])("leaves unrelated transport failures bare: %s", (message) => {
     expect(
       formatAgentErrorForChat("transport", message, {
@@ -118,11 +120,71 @@ describe("formatAgentErrorForChat", () => {
     ).toBe(`Turn failed [transport]: ${message}`);
   });
 
-  it("keeps the drop hint out of non-transport categories", () => {
-    expect(formatAgentErrorForChat("tool", "terminated")).toBe(
-      "Turn failed [tool]: terminated",
+  it("keys the hint off the raw message, not the truncated body", () => {
+    // The one behaviour that separates `looksLikeMidStreamDrop(message)`
+    // from `looksLikeMidStreamDrop(body)`: a drop phrase sitting past the
+    // 480-char body cap. Under 800 chars, so the wall does not fire and
+    // the only transformation is the truncation. Switch the predicate's
+    // argument to `body` and this test fails — that mutation used to
+    // survive the whole suite.
+    const long = `${"x".repeat(600)} socket hang up`;
+    const text = formatAgentErrorForChat("transport", long, {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    const [head, ...hint] = text.split("\n");
+    expect(head).not.toContain("socket hang up");
+    expect(hint.join("\n")).toBe(
+      [
+        "the connection to the model dropped before the reply finished",
+        "  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over",
+      ].join("\n"),
     );
   });
+
+  // When the wall substitution fires, `body` stops being the transport's
+  // words and becomes a rival diagnosis of the same failure. The two
+  // explanations are mutually exclusive — a page of HTML or a status line
+  // is a reply that ARRIVED, not one that was cut off — and emitting both
+  // told the operator two incompatible stories in three lines. The wall
+  // wins: it read the whole payload, the drop arm only matches a phrase.
+  it.each([
+    [
+      "over the 800-char wall with no status in it",
+      `socket hang up ${"x".repeat(900)}`,
+      "upstream returned HTML instead of JSON (check API URL and provider)",
+    ],
+    [
+      "over the 800-char wall with a status in it",
+      `socket hang up 502 ${"x".repeat(900)}`,
+      "upstream HTTP 502 (wrong API URL or provider config)",
+    ],
+    [
+      "an actual HTML wall that happens to contain a drop word",
+      "terminated <!DOCTYPE html><html><body>404 not found</body></html>",
+      "upstream HTTP 404 (wrong API URL or provider config)",
+    ],
+  ])("drops the hint when the body was replaced: %s", (_name, message, body) => {
+    expect(
+      formatAgentErrorForChat("transport", message, {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe(`Turn failed [transport]: ${body}`);
+  });
+
+  it.each(["tool", "runtime"])(
+    "keeps the drop hint out of the %s category",
+    (category) => {
+      // `runtime` is the only other shape production produces: the
+      // orchestrator's catch arm (`chat-orchestrator.ts`) calls
+      // `formatAgentErrorForChat("runtime", msg)` with no provider
+      // context, so it can never reach the transport branch at all.
+      expect(formatAgentErrorForChat(category, "terminated")).toBe(
+        `Turn failed [${category}]: terminated`,
+      );
+    },
+  );
 
   it("prefers the llama hint when a local provider drops mid-stream", () => {
     // Both arms match. The local one wins: "start llama-server" is a fix,

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -42,13 +42,125 @@ describe("formatAgentErrorForChat", () => {
     expect(text).toContain("atomic-agent models start");
   });
 
-  it("keeps the hint away from cloud providers — advice about the wrong server", () => {
+  it("keeps the llama hint away from cloud providers — advice about the wrong server", () => {
+    const text = formatAgentErrorForChat("transport", "fetch failed", {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    expect(text).toContain("Turn failed [transport]: fetch failed");
+    expect(text).not.toContain("llama-server is not reachable");
+    expect(text).not.toContain("atomic-agent models start");
+  });
+
+  it("keeps every hint away from a cloud transport failure that is not a drop", () => {
     expect(
-      formatAgentErrorForChat("transport", "fetch failed", {
+      formatAgentErrorForChat("transport", "upstream HTTP 503", {
         activeProviderIsLocal: false,
         llamaUrl: "http://127.0.0.1:19091",
       }),
-    ).toBe("Turn failed [transport]: fetch failed");
+    ).toBe("Turn failed [transport]: upstream HTTP 503");
+  });
+
+  // The reported failure: a multi-step research turn whose LLM call died
+  // mid-body on a cloud provider. undici's bare word for it is
+  // `terminated`, and that single word was the entire message the
+  // operator got — nothing about the connection, nothing about the six
+  // steps that had already succeeded.
+  // Source: Discord #feedback-and-bugs, 2026-09-03.
+  it("explains a mid-stream drop and where the finished steps went", () => {
+    const text = formatAgentErrorForChat("transport", "terminated", {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    expect(text).toContain("Turn failed [transport]: terminated");
+    expect(text).toContain(
+      "the connection to the model dropped before the reply finished",
+    );
+    expect(text).toContain("kept in this session");
+    expect(text).toContain("ask to continue from there");
+    expect(text).toContain("re-sending the whole task starts it over");
+  });
+
+  it("carries the drop hint with no provider context at all", () => {
+    // `chat-orchestrator.ts` calls the formatter without the local
+    // context for its own catch arm; a drop must still explain itself.
+    expect(formatAgentErrorForChat("transport", "socket hang up")).toContain(
+      "the connection to the model dropped before the reply finished",
+    );
+  });
+
+  it.each([
+    "fetch failed",
+    "terminated",
+    "Client network socket disconnected before secure TLS connection was established",
+    "read ECONNRESET: socket hang up",
+    "other side closed",
+  ])("recognises the drop family: %s", (message) => {
+    expect(
+      formatAgentErrorForChat("transport", message, {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toContain("the steps that already finished are kept in this session");
+  });
+
+  it.each([
+    "connection reset",
+    "upstream HTTP 502 (bad gateway)",
+    "request timed out after 120s",
+    "terminated the request early",
+  ])("leaves unrelated transport failures bare: %s", (message) => {
+    expect(
+      formatAgentErrorForChat("transport", message, {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe(`Turn failed [transport]: ${message}`);
+  });
+
+  it("keeps the drop hint out of non-transport categories", () => {
+    expect(formatAgentErrorForChat("tool", "terminated")).toBe(
+      "Turn failed [tool]: terminated",
+    );
+  });
+
+  it("prefers the llama hint when a local provider drops mid-stream", () => {
+    // Both arms match. The local one wins: "start llama-server" is a fix,
+    // the drop hint is only an explanation.
+    const text = formatAgentErrorForChat("transport", "terminated", {
+      activeProviderIsLocal: true,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    expect(text).toBe(
+      [
+        "Turn failed [transport]: terminated",
+        "llama-server is not reachable at http://127.0.0.1:19091",
+        "  start it with:       atomic-agent models start",
+        "  or point elsewhere:  atomic-agent config set localModels.url <url>",
+      ].join("\n"),
+    );
+  });
+
+  it("truncates the body, never the hint", () => {
+    // Under the 800-char HTML-wall threshold, over the 480-char body cap.
+    const long = `socket hang up ${"x".repeat(600)}`;
+    const text = formatAgentErrorForChat("transport", long, {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    const [head, ...hint] = text.split("\n");
+    expect(head!.startsWith("Turn failed [transport]: socket hang up")).toBe(
+      true,
+    );
+    expect(head!.endsWith("…")).toBe(true);
+    // 480-char body cap + the "Turn failed [transport]: " prefix + "…".
+    expect(head!.length).toBe("Turn failed [transport]: ".length + 480 + 1);
+    expect(hint.join("\n")).toBe(
+      [
+        "the connection to the model dropped before the reply finished",
+        "  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over",
+      ].join("\n"),
+    );
   });
 
   it("keeps the hint away from non-transport failures", () => {

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -168,7 +168,7 @@ describe("formatAgentErrorForChat", () => {
     [
       "a bulky markup fragment with no document marker",
       `socket hang up <center>502 Bad Gateway</center>${"x".repeat(900)}`,
-      "upstream HTTP 502 (wrong API URL or provider config)",
+      "upstream returned HTML instead of JSON (check API URL and provider)",
     ],
   ])("drops the hint when the body was replaced: %s", (_name, message, body) => {
     expect(
@@ -179,52 +179,230 @@ describe("formatAgentErrorForChat", () => {
     ).toBe(`Turn failed [transport]: ${body}`);
   });
 
-  // The regression this replaces. `mapCliFailure` in the subscription-CLI
-  // provider quotes a subprocess's stderr verbatim (up to 2048 chars), so
-  // a `claude`/`codex` run that dies on a Node `socket hang up` arrives
-  // here as an ~840-char crash dump — over the old length-only wall
-  // threshold, with no markup anywhere in it. The wall fired, scraped
-  // `/\b(\d{3})\b/`, and reported "upstream HTTP 720" — the line number
-  // out of `node:internal/errors:720:14`, for a local subprocess with no
-  // upstream URL at all — while the guard suppressed the true
-  // explanation. This is a behaviour change against `main`, which prints
-  // the same bogus status (just without the hint).
-  it("does not invent an HTTP status for a long message with no markup", () => {
-    const message = [
-      '"claude" exited with code 1: node:internal/errors:720',
-      "  const err = new Error(message);",
-      "              ^",
-      "",
-      "Error: socket hang up",
-      "    at connResetException (node:internal/errors:720:14)",
-      "    at Socket.socketOnEnd (node:_http_client:519:23)",
-      "    at Socket.emit (node:events:531:35)",
-      "    at endReadableNT (node:internal/streams/readable:1698:12)",
-      "    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)",
-      "    at async Object.request (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:284:19)",
-      "    at async Stream.fromSSEResponse (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:1902:24)",
-      "    at async streamQuery (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:9931:11)",
-      "    at async main (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:20233:7) {",
-      "  code: 'ECONNRESET'",
-      "}",
-      "",
-      "Node.js v22.22.2",
-    ].join("\n");
-    // Long enough to have tripped the old length-only wall.
-    expect(message.trim().replace(/\s+/g, " ").length).toBeGreaterThan(800);
-    const text = formatAgentErrorForChat("transport", message, {
+  // The regression this PR exists for. `mapCliFailure` in the
+  // subscription-CLI provider quotes a subprocess's stderr verbatim (up
+  // to 2048 chars), so a `claude`/`codex` run that dies on a Node
+  // `socket hang up` arrives here as a ~970-char crash dump — over the
+  // wall's length threshold. The wall fired, scraped `/\b(\d{3})\b/`,
+  // and reported an HTTP status made out of a source line number, for a
+  // local subprocess with no upstream URL at all, while the
+  // `!diagnosedAsWall` guard suppressed the true explanation.
+  //
+  // Captured verbatim from Node v22.22.2 by making a bundled CJS entry
+  // point throw at top level; only the install prefix is rewritten to
+  // `/opt/homebrew`. The `at Object.<anonymous>` frame is the part that
+  // matters: an earlier attempt at this fix demanded "real markup" and
+  // then accepted `<anonymous>` as a tag, so this exact payload was
+  // still walled — and *worse* than on `main`, because the hint went
+  // with it. Every callback-bearing Node stack carries one of these
+  // (`Object.`, `Socket.`, `Timeout.`, `new Promise (<anonymous>)`).
+  const NODE_CJS_DUMP = [
+    '"claude" exited with code 1: /opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8',
+    '  throw connResetException("socket hang up");',
+    "  ^",
+    "",
+    "Error: socket hang up",
+    "    at connResetException (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:3:15)",
+    "    at socketOnEnd (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:9)",
+    "    at fromSSEResponse (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:10:30)",
+    "    at streamQuery (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:11:26)",
+    "    at main (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:12:19)",
+    "    at Object.<anonymous> (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:13:1)",
+    "    at Module._compile (node:internal/modules/cjs/loader:1705:14)",
+    "    at Object..js (node:internal/modules/cjs/loader:1838:10)",
+    "    at Module.load (node:internal/modules/cjs/loader:1441:32)",
+    "    at Function._load (node:internal/modules/cjs/loader:1263:12) {",
+    "  code: 'ECONNRESET'",
+    "}",
+    "",
+    "Node.js v22.22.2",
+  ].join("\n");
+
+  it("keeps a real Node crash dump with an <anonymous> frame off the wall", () => {
+    // Long enough to reach the wall's length arm on its own — no padding.
+    expect(NODE_CJS_DUMP.trim().replace(/\s+/g, " ").length).toBeGreaterThan(
+      800,
+    );
+    expect(NODE_CJS_DUMP).toContain("at Object.<anonymous>");
+    const text = formatAgentErrorForChat("transport", NODE_CJS_DUMP, {
       activeProviderIsLocal: false,
       llamaUrl: "http://127.0.0.1:19091",
     });
     const [head, ...hint] = text.split("\n");
     expect(head).not.toContain("upstream HTTP");
+    expect(head).not.toContain("upstream returned HTML");
     expect(head).toContain('"claude" exited with code 1');
+    expect(head).toContain("socket hang up");
     expect(head!.endsWith("…")).toBe(true);
     expect(hint.join("\n")).toBe(
       [
         "the connection to the model dropped before the reply finished",
         "  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over",
       ].join("\n"),
+    );
+  });
+
+  it("keeps a Socket.<anonymous> dump off the wall, line numbers and all", () => {
+    // The other shape a bundled CLI prints, and the one that produced
+    // "upstream HTTP 519" — 519 being the column-bearing line number in
+    // `node:events:519:28`. The frames are verbatim Node v22.22.2; the
+    // trailing filler stands in for the rest of a real CLI's stderr,
+    // because this stack alone is ~310 chars and the length arm only
+    // looks at payloads over 800.
+    const message = [
+      '"codex" exited with code 1: /opt/homebrew/lib/node_modules/@openai/codex/cli.js:9',
+      "    throw e;",
+      "    ^",
+      "",
+      "Error: socket hang up",
+      "    at Socket.<anonymous> (/opt/homebrew/lib/node_modules/@openai/codex/cli.js:7:15)",
+      "    at Socket.emit (node:events:519:28)",
+      "    at TCP.<anonymous> (node:net:346:12) {",
+      "  code: 'ECONNRESET'",
+      "}",
+      "",
+      "Node.js v22.22.2",
+      "-".repeat(600),
+    ].join("\n");
+    expect(message.trim().replace(/\s+/g, " ").length).toBeGreaterThan(800);
+    const text = formatAgentErrorForChat("transport", message, {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    expect(text).not.toContain("upstream HTTP 519");
+    expect(text).not.toContain("upstream returned HTML");
+    expect(text.split("\n")[0]).toContain("socket hang up");
+    expect(text).toContain(
+      "the connection to the model dropped before the reply finished",
+    );
+  });
+
+  it.each([
+    [
+      "a JVM trace with a generic type argument and an <init> frame",
+      `boom: java.lang.IllegalStateException at com.example.Repo.load(List<String> ids)(Repo.java:100) at com.example.Svc.<init>(Svc.java:42)${"-".repeat(800)}`,
+    ],
+    [
+      "a TypeScript trace with Promise<void> in it",
+      `boom: TypeError at run (src/a.ts:200:3) returning Promise<void>${"-".repeat(800)}`,
+    ],
+    [
+      "a Java trace whose generic has a comma in it",
+      `boom at com.example.Cache.get(Map<String,Object> m)(Cache.java:100)${"-".repeat(800)}`,
+    ],
+    [
+      "a Python traceback with a <module> frame",
+      `boom Traceback (most recent call last): File "run.py", line 100, in <module>${"-".repeat(800)}`,
+    ],
+    [
+      "a bare generic parameter",
+      `boom: expected <T> but got <U> at Foo.run(Foo.java:100)${"-".repeat(800)}`,
+    ],
+    [
+      "a generic argument that happens to be spelled like an element",
+      `boom at com.example.Repo.find(Repo.java:100) returning List<Table>${"-".repeat(800)}`,
+    ],
+    [
+      "a TypeScript generic spelled like an element",
+      `boom at fetchJson (src/http.ts:100:9) returning Promise<Body>${"-".repeat(800)}`,
+    ],
+  ])("does not mistake a stack trace for a page: %s", (_name, message) => {
+    // `<anonymous>`, `<init>`, `<module>` and `<T>` all have the shape of
+    // a bare open tag, and `/i` made `[a-z]` accept `List<String>` and
+    // `Promise<void>` too. The last two cases are why the name allowlist
+    // is not enough on its own and the `(?<!\w)` guard has to be there:
+    // `Table` and `Body` really are element names, and only their
+    // position — glued to the end of a word — says they are not tags.
+    // Every one of these carries a three-digit run (a line number) that
+    // the wall used to report as an HTTP status.
+    expect(message.trim().replace(/\s+/g, " ").length).toBeGreaterThan(800);
+    const head = formatAgentErrorForChat("transport", message, {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    }).split("\n")[0]!;
+    expect(head).not.toContain("upstream HTTP");
+    expect(head).not.toContain("upstream returned HTML");
+    expect(head).toContain("boom");
+  });
+
+  it("never scrapes a status out of a bulky fragment, only out of a document", () => {
+    // Part of the same repair, and the half that holds even when the tag
+    // test is wrong: `/\b(\d{3})\b/` has no idea what it is reading, so
+    // it only gets to speak when a document marker proved this really is
+    // a page. Here the fragment is genuine markup and the `502` is
+    // genuinely the status — and we still decline to claim it, because
+    // the identical shape is a line number in a crash dump.
+    expect(
+      formatAgentErrorForChat(
+        "transport",
+        `<center>502 Bad Gateway</center><hr/>${"x".repeat(900)}`,
+        { activeProviderIsLocal: false, llamaUrl: "http://127.0.0.1:19091" },
+      ),
+    ).toBe(
+      "Turn failed [transport]: upstream returned HTML instead of JSON (check API URL and provider)",
+    );
+  });
+
+  it("walls an uppercase document with no lowercase markup in it", () => {
+    // The document arm used to be `body.includes("<!DOCTYPE") ||
+    // body.includes("<html")` — case-SENSITIVE — so an all-caps page got
+    // in through the tag arm instead, and only because `HTML_TAG` was
+    // `/i`. Nothing pinned that, and appliances really do emit this.
+    // Short enough that the length arm cannot fire.
+    const page =
+      "<HTML><HEAD><TITLE>504 Gateway Time-out</TITLE></HEAD><BODY><H1>504 Gateway Time-out</H1></BODY></HTML>";
+    expect(page.length).toBeLessThan(800);
+    expect(
+      formatAgentErrorForChat("transport", page, {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe(
+      "Turn failed [transport]: upstream HTTP 504 (wrong API URL or provider config)",
+    );
+  });
+
+  it.each([
+    [
+      "self-closing XHTML tags",
+      `502 Bad Gateway<br/><hr/>${"x".repeat(900)}`,
+    ],
+    [
+      "self-closing tags with a space before the slash",
+      `502 Bad Gateway<br /><hr />${"x".repeat(900)}`,
+    ],
+    [
+      "a namespaced SOAP body",
+      `<soapenv:Body><soapenv:Fault>502</soapenv:Fault></soapenv:Body>${"x".repeat(900)}`,
+    ],
+    [
+      "a hyphenated custom element",
+      `<my-widget>gateway down</my-widget>${"x".repeat(900)}`,
+    ],
+    [
+      "tags that only ever appear adjacent to each other",
+      `${"x".repeat(900)}</td><td>y`,
+    ],
+    [
+      "a page truncated so hard that only a closing tag survives",
+      `500 Internal Server Error ${"x".repeat(900)} </h1>`,
+    ],
+    [
+      "a fragment whose only tag is recognisable by its attributes",
+      `Error 1020 ${"x".repeat(900)} <section data-translate="error">`,
+    ],
+  ])("still walls markup shapes the tag test used to miss: %s", (_n, body) => {
+    // These are the appliance and middleware bodies the length arm was
+    // kept for. `<br/>` fails a `(?:\s[^<>]*)?>` tail because `/` is
+    // neither whitespace nor `>`; `<soapenv:Body>` and `<my-widget>` fail
+    // `[a-z][a-z0-9]*` on the `:` and the `-`.
+    expect(
+      formatAgentErrorForChat("transport", body, {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe(
+      "Turn failed [transport]: upstream returned HTML instead of JSON (check API URL and provider)",
     );
   });
 

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -143,11 +143,15 @@ describe("formatAgentErrorForChat", () => {
   });
 
   // When the wall substitution fires, `body` stops being the transport's
-  // words and becomes a rival diagnosis of the same failure. The two
-  // explanations are mutually exclusive — a page of HTML is a reply that
-  // ARRIVED, not one that was cut off — and emitting both told the
-  // operator two incompatible stories in three lines. The wall wins: it
-  // read the whole payload, the drop arm only matches a phrase.
+  // words and becomes a rival account of the same failure, and printing
+  // the drop hint underneath it tells the operator two incompatible
+  // stories in three lines. Exactly one can be true and this function
+  // cannot tell which, so it stays out of the argument.
+  //
+  // Note what this does NOT assume: that the wall is right. It is not,
+  // on plenty of payloads (see the pre-existing-defect note in the pull
+  // request) — but a wrong wall plus a contradicting hint is worse than
+  // a wrong wall alone, so the guard holds either way.
   //
   // Every case here uses an unanchored drop phrase (`socket hang up`),
   // so the drop arm genuinely matches and the `!diagnosedAsWall` guard is
@@ -166,9 +170,9 @@ describe("formatAgentErrorForChat", () => {
       "upstream returned HTML instead of JSON (check API URL and provider)",
     ],
     [
-      "a bulky markup fragment with no document marker",
+      "a payload walled by sheer bulk, with a status scraped out of it",
       `socket hang up <center>502 Bad Gateway</center>${"x".repeat(900)}`,
-      "upstream returned HTML instead of JSON (check API URL and provider)",
+      "upstream HTTP 502 (wrong API URL or provider config)",
     ],
   ])("drops the hint when the body was replaced: %s", (_name, message, body) => {
     expect(
@@ -179,269 +183,15 @@ describe("formatAgentErrorForChat", () => {
     ).toBe(`Turn failed [transport]: ${body}`);
   });
 
-  // The regression this PR exists for. `mapCliFailure` in the
-  // subscription-CLI provider quotes a subprocess's stderr verbatim (up
-  // to 2048 chars), so a `claude`/`codex` run that dies on a Node
-  // `socket hang up` arrives here as a ~970-char crash dump — over the
-  // wall's length threshold. The wall fired, scraped `/\b(\d{3})\b/`,
-  // and reported an HTTP status made out of a source line number, for a
-  // local subprocess with no upstream URL at all, while the
-  // `!diagnosedAsWall` guard suppressed the true explanation.
-  //
-  // Captured verbatim from Node v22.22.2 by making a bundled CJS entry
-  // point throw at top level; only the install prefix is rewritten to
-  // `/opt/homebrew`. The `at Object.<anonymous>` frame is the part that
-  // matters: an earlier attempt at this fix demanded "real markup" and
-  // then accepted `<anonymous>` as a tag, so this exact payload was
-  // still walled — and *worse* than on `main`, because the hint went
-  // with it. Every callback-bearing Node stack carries one of these
-  // (`Object.`, `Socket.`, `Timeout.`, `new Promise (<anonymous>)`).
-  const NODE_CJS_DUMP = [
-    '"claude" exited with code 1: /opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8',
-    '  throw connResetException("socket hang up");',
-    "  ^",
-    "",
-    "Error: socket hang up",
-    "    at connResetException (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:3:15)",
-    "    at socketOnEnd (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:8:9)",
-    "    at fromSSEResponse (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:10:30)",
-    "    at streamQuery (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:11:26)",
-    "    at main (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:12:19)",
-    "    at Object.<anonymous> (/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:13:1)",
-    "    at Module._compile (node:internal/modules/cjs/loader:1705:14)",
-    "    at Object..js (node:internal/modules/cjs/loader:1838:10)",
-    "    at Module.load (node:internal/modules/cjs/loader:1441:32)",
-    "    at Function._load (node:internal/modules/cjs/loader:1263:12) {",
-    "  code: 'ECONNRESET'",
-    "}",
-    "",
-    "Node.js v22.22.2",
-  ].join("\n");
-
-  it("keeps a real Node crash dump with an <anonymous> frame off the wall", () => {
-    // Long enough to reach the wall's length arm on its own — no padding.
-    expect(NODE_CJS_DUMP.trim().replace(/\s+/g, " ").length).toBeGreaterThan(
-      800,
-    );
-    expect(NODE_CJS_DUMP).toContain("at Object.<anonymous>");
-    const text = formatAgentErrorForChat("transport", NODE_CJS_DUMP, {
-      activeProviderIsLocal: false,
-      llamaUrl: "http://127.0.0.1:19091",
-    });
-    const [head, ...hint] = text.split("\n");
-    expect(head).not.toContain("upstream HTTP");
-    expect(head).not.toContain("upstream returned HTML");
-    expect(head).toContain('"claude" exited with code 1');
-    expect(head).toContain("socket hang up");
-    expect(head!.endsWith("…")).toBe(true);
-    expect(hint.join("\n")).toBe(
-      [
-        "the connection to the model dropped before the reply finished",
-        "  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over",
-      ].join("\n"),
-    );
-  });
-
-  it("keeps a Socket.<anonymous> dump off the wall, line numbers and all", () => {
-    // The other shape a bundled CLI prints, and the one that produced
-    // "upstream HTTP 519" — 519 being the column-bearing line number in
-    // `node:events:519:28`. The frames are verbatim Node v22.22.2; the
-    // trailing filler stands in for the rest of a real CLI's stderr,
-    // because this stack alone is ~310 chars and the length arm only
-    // looks at payloads over 800.
-    const message = [
-      '"codex" exited with code 1: /opt/homebrew/lib/node_modules/@openai/codex/cli.js:9',
-      "    throw e;",
-      "    ^",
-      "",
-      "Error: socket hang up",
-      "    at Socket.<anonymous> (/opt/homebrew/lib/node_modules/@openai/codex/cli.js:7:15)",
-      "    at Socket.emit (node:events:519:28)",
-      "    at TCP.<anonymous> (node:net:346:12) {",
-      "  code: 'ECONNRESET'",
-      "}",
-      "",
-      "Node.js v22.22.2",
-      "-".repeat(600),
-    ].join("\n");
-    expect(message.trim().replace(/\s+/g, " ").length).toBeGreaterThan(800);
-    const text = formatAgentErrorForChat("transport", message, {
-      activeProviderIsLocal: false,
-      llamaUrl: "http://127.0.0.1:19091",
-    });
-    expect(text).not.toContain("upstream HTTP 519");
-    expect(text).not.toContain("upstream returned HTML");
-    expect(text.split("\n")[0]).toContain("socket hang up");
-    expect(text).toContain(
-      "the connection to the model dropped before the reply finished",
-    );
-  });
-
-  it.each([
-    [
-      "a JVM trace with a generic type argument and an <init> frame",
-      `boom: java.lang.IllegalStateException at com.example.Repo.load(List<String> ids)(Repo.java:100) at com.example.Svc.<init>(Svc.java:42)${"-".repeat(800)}`,
-    ],
-    [
-      "a TypeScript trace with Promise<void> in it",
-      `boom: TypeError at run (src/a.ts:200:3) returning Promise<void>${"-".repeat(800)}`,
-    ],
-    [
-      "a Java trace whose generic has a comma in it",
-      `boom at com.example.Cache.get(Map<String,Object> m)(Cache.java:100)${"-".repeat(800)}`,
-    ],
-    [
-      "a Python traceback with a <module> frame",
-      `boom Traceback (most recent call last): File "run.py", line 100, in <module>${"-".repeat(800)}`,
-    ],
-    [
-      "a bare generic parameter",
-      `boom: expected <T> but got <U> at Foo.run(Foo.java:100)${"-".repeat(800)}`,
-    ],
-    [
-      "a generic argument that happens to be spelled like an element",
-      `boom at com.example.Repo.find(Repo.java:100) returning List<Table>${"-".repeat(800)}`,
-    ],
-    [
-      "a TypeScript generic spelled like an element",
-      `boom at fetchJson (src/http.ts:100:9) returning Promise<Body>${"-".repeat(800)}`,
-    ],
-  ])("does not mistake a stack trace for a page: %s", (_name, message) => {
-    // `<anonymous>`, `<init>`, `<module>` and `<T>` all have the shape of
-    // a bare open tag, and `/i` made `[a-z]` accept `List<String>` and
-    // `Promise<void>` too. The last two cases are why the name allowlist
-    // is not enough on its own and the `(?<!\w)` guard has to be there:
-    // `Table` and `Body` really are element names, and only their
-    // position — glued to the end of a word — says they are not tags.
-    // Every one of these carries a three-digit run (a line number) that
-    // the wall used to report as an HTTP status.
-    expect(message.trim().replace(/\s+/g, " ").length).toBeGreaterThan(800);
-    const head = formatAgentErrorForChat("transport", message, {
-      activeProviderIsLocal: false,
-      llamaUrl: "http://127.0.0.1:19091",
-    }).split("\n")[0]!;
-    expect(head).not.toContain("upstream HTTP");
-    expect(head).not.toContain("upstream returned HTML");
-    expect(head).toContain("boom");
-  });
-
-  it("never scrapes a status out of a bulky fragment, only out of a document", () => {
-    // Part of the same repair, and the half that holds even when the tag
-    // test is wrong: `/\b(\d{3})\b/` has no idea what it is reading, so
-    // it only gets to speak when a document marker proved this really is
-    // a page. Here the fragment is genuine markup and the `502` is
-    // genuinely the status — and we still decline to claim it, because
-    // the identical shape is a line number in a crash dump.
-    expect(
-      formatAgentErrorForChat(
-        "transport",
-        `<center>502 Bad Gateway</center><hr/>${"x".repeat(900)}`,
-        { activeProviderIsLocal: false, llamaUrl: "http://127.0.0.1:19091" },
-      ),
-    ).toBe(
-      "Turn failed [transport]: upstream returned HTML instead of JSON (check API URL and provider)",
-    );
-  });
-
-  it("walls an uppercase document with no lowercase markup in it", () => {
-    // The document arm used to be `body.includes("<!DOCTYPE") ||
-    // body.includes("<html")` — case-SENSITIVE — so an all-caps page got
-    // in through the tag arm instead, and only because `HTML_TAG` was
-    // `/i`. Nothing pinned that, and appliances really do emit this.
-    // Short enough that the length arm cannot fire.
-    const page =
-      "<HTML><HEAD><TITLE>504 Gateway Time-out</TITLE></HEAD><BODY><H1>504 Gateway Time-out</H1></BODY></HTML>";
-    expect(page.length).toBeLessThan(800);
-    expect(
-      formatAgentErrorForChat("transport", page, {
-        activeProviderIsLocal: false,
-        llamaUrl: "http://127.0.0.1:19091",
-      }),
-    ).toBe(
-      "Turn failed [transport]: upstream HTTP 504 (wrong API URL or provider config)",
-    );
-  });
-
-  it("walls an uppercase markup fragment with no document marker", () => {
-    // Pins the `/i` on `HTML_TAG` itself, which the test above no longer
-    // does now that the document arm is case-insensitive on its own.
-    expect(
-      formatAgentErrorForChat(
-        "transport",
-        `socket hang up <CENTER>Bad Gateway</CENTER>${"x".repeat(900)}`,
-        { activeProviderIsLocal: false, llamaUrl: "http://127.0.0.1:19091" },
-      ),
-    ).toBe(
-      "Turn failed [transport]: upstream returned HTML instead of JSON (check API URL and provider)",
-    );
-  });
-
-  it("walls a document marker that carries no tag at all", () => {
-    // The document arm has to stand on its own. Every other page fixture
-    // also carries a tag, so "require BOTH a marker and a tag" used to
-    // survive the whole suite. Under 800 chars, so the length arm is out.
-    const message = "socket hang up <!DOCTYPE html> 502 and nothing else";
-    expect(message.length).toBeLessThan(800);
-    expect(
-      formatAgentErrorForChat("transport", message, {
-        activeProviderIsLocal: false,
-        llamaUrl: "http://127.0.0.1:19091",
-      }),
-    ).toBe(
-      "Turn failed [transport]: upstream HTTP 502 (wrong API URL or provider config)",
-    );
-  });
-
-  it.each([
-    [
-      "self-closing XHTML tags",
-      `502 Bad Gateway<br/><hr/>${"x".repeat(900)}`,
-    ],
-    [
-      "self-closing tags with a space before the slash",
-      `502 Bad Gateway<br /><hr />${"x".repeat(900)}`,
-    ],
-    [
-      "a namespaced SOAP body",
-      `<soapenv:Body><soapenv:Fault>502</soapenv:Fault></soapenv:Body>${"x".repeat(900)}`,
-    ],
-    [
-      "a hyphenated custom element",
-      `<my-widget>gateway down</my-widget>${"x".repeat(900)}`,
-    ],
-    [
-      "tags that only ever appear adjacent to each other",
-      `${"x".repeat(900)}</td><td>y`,
-    ],
-    [
-      "a page truncated so hard that only a closing tag survives",
-      `500 Internal Server Error ${"x".repeat(900)} </h1>`,
-    ],
-    [
-      "a fragment whose only tag is recognisable by its attributes",
-      `Error 1020 ${"x".repeat(900)} <section data-translate="error">`,
-    ],
-  ])("still walls markup shapes the tag test used to miss: %s", (_n, body) => {
-    // These are the appliance and middleware bodies the length arm was
-    // kept for. `<br/>` fails a `(?:\s[^<>]*)?>` tail because `/` is
-    // neither whitespace nor `>`; `<soapenv:Body>` and `<my-widget>` fail
-    // `[a-z][a-z0-9]*` on the `:` and the `-`.
-    expect(
-      formatAgentErrorForChat("transport", body, {
-        activeProviderIsLocal: false,
-        llamaUrl: "http://127.0.0.1:19091",
-      }),
-    ).toBe(
-      "Turn failed [transport]: upstream returned HTML instead of JSON (check API URL and provider)",
-    );
-  });
-
-  // The wall's second entrance — bulk plus a tag — is a threshold, and a
+  // The wall's second entrance — sheer bulk — is a threshold, and a
   // threshold nobody tests drifts. Both sides pinned: `800 → 799` kills
-  // the first of these, `800 → 801` kills the second.
+  // the first of these, `800 → 801` kills the second. The point here is
+  // not that the threshold is well chosen (it is not — see the
+  // pre-existing-defect note in the pull request); it is that this
+  // change leaves it exactly where `main` had it.
   const WALL_EDGE = `socket hang up <div>${"x".repeat(780)}`;
 
-  it("leaves a markup fragment of exactly 800 chars to the drop arm", () => {
+  it("leaves a payload of exactly 800 chars to the drop arm", () => {
     expect(WALL_EDGE).toHaveLength(800);
     const text = formatAgentErrorForChat("transport", WALL_EDGE, {
       activeProviderIsLocal: false,
@@ -455,7 +205,7 @@ describe("formatAgentErrorForChat", () => {
     );
   });
 
-  it("treats a markup fragment of 801 chars as a wall", () => {
+  it("treats a payload of 801 chars as a wall", () => {
     const overEdge = `${WALL_EDGE}x`;
     expect(overEdge).toHaveLength(801);
     expect(

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -144,25 +144,31 @@ describe("formatAgentErrorForChat", () => {
 
   // When the wall substitution fires, `body` stops being the transport's
   // words and becomes a rival diagnosis of the same failure. The two
-  // explanations are mutually exclusive — a page of HTML or a status line
-  // is a reply that ARRIVED, not one that was cut off — and emitting both
-  // told the operator two incompatible stories in three lines. The wall
-  // wins: it read the whole payload, the drop arm only matches a phrase.
+  // explanations are mutually exclusive — a page of HTML is a reply that
+  // ARRIVED, not one that was cut off — and emitting both told the
+  // operator two incompatible stories in three lines. The wall wins: it
+  // read the whole payload, the drop arm only matches a phrase.
+  //
+  // Every case here uses an unanchored drop phrase (`socket hang up`),
+  // so the drop arm genuinely matches and the `!diagnosedAsWall` guard is
+  // the only thing suppressing the hint. A `terminated …` case would be
+  // vacuous: `/^terminated$/i` is anchored and never matches a string
+  // with a page glued to it, so it passed with the guard mutated away.
   it.each([
     [
-      "over the 800-char wall with no status in it",
-      `socket hang up ${"x".repeat(900)}`,
+      "a document-marker wall with a status in it",
+      "socket hang up <!DOCTYPE html><html><body>404 not found</body></html>",
+      "upstream HTTP 404 (wrong API URL or provider config)",
+    ],
+    [
+      "a document-marker wall with no status in it",
+      "socket hang up <html><body>gateway unavailable</body></html>",
       "upstream returned HTML instead of JSON (check API URL and provider)",
     ],
     [
-      "over the 800-char wall with a status in it",
-      `socket hang up 502 ${"x".repeat(900)}`,
+      "a bulky markup fragment with no document marker",
+      `socket hang up <center>502 Bad Gateway</center>${"x".repeat(900)}`,
       "upstream HTTP 502 (wrong API URL or provider config)",
-    ],
-    [
-      "an actual HTML wall that happens to contain a drop word",
-      "terminated <!DOCTYPE html><html><body>404 not found</body></html>",
-      "upstream HTTP 404 (wrong API URL or provider config)",
     ],
   ])("drops the hint when the body was replaced: %s", (_name, message, body) => {
     expect(
@@ -171,6 +177,107 @@ describe("formatAgentErrorForChat", () => {
         llamaUrl: "http://127.0.0.1:19091",
       }),
     ).toBe(`Turn failed [transport]: ${body}`);
+  });
+
+  // The regression this replaces. `mapCliFailure` in the subscription-CLI
+  // provider quotes a subprocess's stderr verbatim (up to 2048 chars), so
+  // a `claude`/`codex` run that dies on a Node `socket hang up` arrives
+  // here as an ~840-char crash dump — over the old length-only wall
+  // threshold, with no markup anywhere in it. The wall fired, scraped
+  // `/\b(\d{3})\b/`, and reported "upstream HTTP 720" — the line number
+  // out of `node:internal/errors:720:14`, for a local subprocess with no
+  // upstream URL at all — while the guard suppressed the true
+  // explanation. This is a behaviour change against `main`, which prints
+  // the same bogus status (just without the hint).
+  it("does not invent an HTTP status for a long message with no markup", () => {
+    const message = [
+      '"claude" exited with code 1: node:internal/errors:720',
+      "  const err = new Error(message);",
+      "              ^",
+      "",
+      "Error: socket hang up",
+      "    at connResetException (node:internal/errors:720:14)",
+      "    at Socket.socketOnEnd (node:_http_client:519:23)",
+      "    at Socket.emit (node:events:531:35)",
+      "    at endReadableNT (node:internal/streams/readable:1698:12)",
+      "    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)",
+      "    at async Object.request (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:284:19)",
+      "    at async Stream.fromSSEResponse (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:1902:24)",
+      "    at async streamQuery (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:9931:11)",
+      "    at async main (file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:20233:7) {",
+      "  code: 'ECONNRESET'",
+      "}",
+      "",
+      "Node.js v22.22.2",
+    ].join("\n");
+    // Long enough to have tripped the old length-only wall.
+    expect(message.trim().replace(/\s+/g, " ").length).toBeGreaterThan(800);
+    const text = formatAgentErrorForChat("transport", message, {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    const [head, ...hint] = text.split("\n");
+    expect(head).not.toContain("upstream HTTP");
+    expect(head).toContain('"claude" exited with code 1');
+    expect(head!.endsWith("…")).toBe(true);
+    expect(hint.join("\n")).toBe(
+      [
+        "the connection to the model dropped before the reply finished",
+        "  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over",
+      ].join("\n"),
+    );
+  });
+
+  // The wall's second entrance — bulk plus a tag — is a threshold, and a
+  // threshold nobody tests drifts. Both sides pinned: `800 → 799` kills
+  // the first of these, `800 → 801` kills the second.
+  const WALL_EDGE = `socket hang up <div>${"x".repeat(780)}`;
+
+  it("leaves a markup fragment of exactly 800 chars to the drop arm", () => {
+    expect(WALL_EDGE).toHaveLength(800);
+    const text = formatAgentErrorForChat("transport", WALL_EDGE, {
+      activeProviderIsLocal: false,
+      llamaUrl: "http://127.0.0.1:19091",
+    });
+    expect(text.split("\n")[0]).toBe(
+      `Turn failed [transport]: ${WALL_EDGE.slice(0, 480)}…`,
+    );
+    expect(text).toContain(
+      "the connection to the model dropped before the reply finished",
+    );
+  });
+
+  it("treats a markup fragment of 801 chars as a wall", () => {
+    const overEdge = `${WALL_EDGE}x`;
+    expect(overEdge).toHaveLength(801);
+    expect(
+      formatAgentErrorForChat("transport", overEdge, {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe(
+      "Turn failed [transport]: upstream returned HTML instead of JSON (check API URL and provider)",
+    );
+  });
+
+  it("reads the drop phrase through whitespace, exactly as the body does", () => {
+    // `body` is whitespace-collapsed; the predicate used to read the raw
+    // `message`, so a phrase broken across lines printed in the body and
+    // had its explanation withheld. One normalisation now feeds both.
+    // Not reachable from undici's own strings, but a subprocess's stderr
+    // reaches this formatter verbatim, newlines and all.
+    expect(
+      formatAgentErrorForChat("transport", "socket\nhang\nup", {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe(
+      [
+        "Turn failed [transport]: socket hang up",
+        "the connection to the model dropped before the reply finished",
+        "  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over",
+      ].join("\n"),
+    );
   });
 
   it.each(["tool", "runtime"])(

--- a/src/tui/format-agent-error-for-chat.test.ts
+++ b/src/tui/format-agent-error-for-chat.test.ts
@@ -362,6 +362,36 @@ describe("formatAgentErrorForChat", () => {
     );
   });
 
+  it("walls an uppercase markup fragment with no document marker", () => {
+    // Pins the `/i` on `HTML_TAG` itself, which the test above no longer
+    // does now that the document arm is case-insensitive on its own.
+    expect(
+      formatAgentErrorForChat(
+        "transport",
+        `socket hang up <CENTER>Bad Gateway</CENTER>${"x".repeat(900)}`,
+        { activeProviderIsLocal: false, llamaUrl: "http://127.0.0.1:19091" },
+      ),
+    ).toBe(
+      "Turn failed [transport]: upstream returned HTML instead of JSON (check API URL and provider)",
+    );
+  });
+
+  it("walls a document marker that carries no tag at all", () => {
+    // The document arm has to stand on its own. Every other page fixture
+    // also carries a tag, so "require BOTH a marker and a tag" used to
+    // survive the whole suite. Under 800 chars, so the length arm is out.
+    const message = "socket hang up <!DOCTYPE html> 502 and nothing else";
+    expect(message.length).toBeLessThan(800);
+    expect(
+      formatAgentErrorForChat("transport", message, {
+        activeProviderIsLocal: false,
+        llamaUrl: "http://127.0.0.1:19091",
+      }),
+    ).toBe(
+      "Turn failed [transport]: upstream HTTP 502 (wrong API URL or provider config)",
+    );
+  });
+
   it.each([
     [
       "self-closing XHTML tags",

--- a/src/tui/format-agent-error-for-chat.ts
+++ b/src/tui/format-agent-error-for-chat.ts
@@ -1,4 +1,5 @@
 import { formatLlamaUnreachableHint } from "../llm/llama-server-health.js";
+import { looksLikeDroppedConnection } from "../llm/reliability/network-error.js";
 
 const MAX_CHARS = 480;
 
@@ -14,6 +15,31 @@ export interface LocalProviderErrorContext {
   activeProviderIsLocal: boolean;
   llamaUrl: string;
 }
+
+/**
+ * What a dropped connection actually means, for an operator who
+ * otherwise reads `Turn failed [transport]: terminated` and concludes
+ * the whole task is gone.
+ *
+ * Both lines are things the code guarantees, not hopes. The turn's
+ * `tool_call` / `tool_result` rows are recorded into `SessionState.turns`
+ * by `step-executor.ts` as each step completes; the agent loop's `failed`
+ * branch RETURNS instead of throwing (agent-loop.ts, "Symmetric with the
+ * cancelled path above"), so `executeTurn` in `runtime/bootstrap.ts`
+ * reaches its `sessionStore.save(finished)`, and `chat-orchestrator.ts`
+ * keeps that same session as the active one. The next message in the
+ * session therefore renders those `tool_result` turns back into the
+ * prompt (`prompt/build-prompt-world-conversation.ts`).
+ *
+ * Deliberately NOT promised: automatic resumption. Nothing retries or
+ * replays the dead stream — `llm/fallback/prime-stream.ts` pins the
+ * invariant that a stream which already emitted output is never
+ * restarted — so the operator has to ask for the continuation.
+ */
+const DROPPED_CONNECTION_HINT = [
+  "the connection to the model dropped before the reply finished",
+  "  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over",
+].join("\n");
 
 /**
  * Compact, chat-safe agent failure text (strips HTML walls from bad URLs).
@@ -40,8 +66,25 @@ export function formatAgentErrorForChat(
     body = `${body.slice(0, MAX_CHARS)}…`;
   }
   const base = `Turn failed [${category}]: ${body}`;
-  if (category === "transport" && local?.activeProviderIsLocal) {
-    return `${base}\n${formatLlamaUnreachableHint(local.llamaUrl)}`;
+  if (category === "transport") {
+    // The local arm wins the overlap on purpose, and stays byte-identical
+    // to what it has always emitted. A socket that dies on a local route
+    // is nearly always llama-server itself going down or restarting, and
+    // "start it with: atomic-agent models start" is a FIX; the drop hint
+    // below is only an explanation. Stacking both would bury the fix
+    // under five lines. The `terminated` case that prompted this — a
+    // cloud provider dropping mid-stream — never reaches the local arm.
+    if (local?.activeProviderIsLocal) {
+      return `${base}\n${formatLlamaUnreachableHint(local.llamaUrl)}`;
+    }
+    // Matched on the raw message rather than `body`: `body` may have been
+    // truncated or swapped for the HTML placeholder above, and the hint
+    // must key off what the transport actually said. The formatter is
+    // handed `(category, message)` — see the note on the predicate in
+    // `llm/reliability/network-error.ts` for why the text is the signal.
+    if (looksLikeDroppedConnection(message)) {
+      return `${base}\n${DROPPED_CONNECTION_HINT}`;
+    }
   }
   return base;
 }

--- a/src/tui/format-agent-error-for-chat.ts
+++ b/src/tui/format-agent-error-for-chat.ts
@@ -1,5 +1,5 @@
 import { formatLlamaUnreachableHint } from "../llm/llama-server-health.js";
-import { looksLikeDroppedConnection } from "../llm/reliability/network-error.js";
+import { looksLikeMidStreamDrop } from "../llm/reliability/network-error.js";
 
 const MAX_CHARS = 480;
 
@@ -20,6 +20,12 @@ export interface LocalProviderErrorContext {
  * What a dropped connection actually means, for an operator who
  * otherwise reads `Turn failed [transport]: terminated` and concludes
  * the whole task is gone.
+ *
+ * Keyed off `looksLikeMidStreamDrop`, not the classifier's broader
+ * `looksLikeDroppedConnection`: line 1 asserts a reply was in flight,
+ * which is false for undici's catch-all `fetch failed` (a connection
+ * that never opened reads exactly the same). See the two lists in
+ * `llm/reliability/network-error.ts`.
  *
  * Both lines are things the code guarantees, not hopes. The turn's
  * `tool_call` / `tool_result` rows are recorded into `SessionState.turns`
@@ -50,6 +56,9 @@ export function formatAgentErrorForChat(
   local?: LocalProviderErrorContext,
 ): string {
   let body = message.trim().replace(/\s+/g, " ");
+  // Set when the wall below throws the transport's own words away and
+  // substitutes a diagnosis of its own.
+  let diagnosedAsWall = false;
   if (
     body.includes("<!DOCTYPE") ||
     body.includes("<html") ||
@@ -61,6 +70,7 @@ export function formatAgentErrorForChat(
       status != null
         ? `upstream HTTP ${status} (wrong API URL or provider config)`
         : "upstream returned HTML instead of JSON (check API URL and provider)";
+    diagnosedAsWall = true;
   }
   if (body.length > MAX_CHARS) {
     body = `${body.slice(0, MAX_CHARS)}…`;
@@ -77,12 +87,21 @@ export function formatAgentErrorForChat(
     if (local?.activeProviderIsLocal) {
       return `${base}\n${formatLlamaUnreachableHint(local.llamaUrl)}`;
     }
-    // Matched on the raw message rather than `body`: `body` may have been
-    // truncated or swapped for the HTML placeholder above, and the hint
-    // must key off what the transport actually said. The formatter is
-    // handed `(category, message)` — see the note on the predicate in
-    // `llm/reliability/network-error.ts` for why the text is the signal.
-    if (looksLikeDroppedConnection(message)) {
+    // Matched on the raw `message`, never on `body`: `body` has been
+    // capped at MAX_CHARS, so a drop phrase that sits past that cap
+    // survives in one and not the other, and the hint must key off what
+    // the transport actually said. Pinned by a test that fails if this
+    // is switched to `body`.
+    //
+    // Except when the wall above fired: then `body` is not a truncation
+    // of the transport's words but a *rival diagnosis* of the same
+    // failure ("upstream returned HTML instead of JSON", "upstream HTTP
+    // 502"), and the two explanations are mutually exclusive — a page of
+    // HTML or a status line is a reply that arrived, not a reply that was
+    // cut off. Printing both told the operator two incompatible stories
+    // at once. The wall wins: it is the arm that looked at the whole
+    // payload, where this one only pattern-matches a phrase inside it.
+    if (!diagnosedAsWall && looksLikeMidStreamDrop(message)) {
       return `${base}\n${DROPPED_CONNECTION_HINT}`;
     }
   }

--- a/src/tui/format-agent-error-for-chat.ts
+++ b/src/tui/format-agent-error-for-chat.ts
@@ -6,16 +6,81 @@ const MAX_CHARS = 480;
 /**
  * Length past which a payload that *also* carries markup is treated as a
  * page rather than a sentence. Only ever consulted together with
- * `HTML_TAG` — see `looksLikeHtmlWall`.
+ * `HTML_TAG` — see `classifyHtmlWall`.
  */
 const WALL_CHARS = 800;
 
 /**
- * A real tag: `<`, a name, optional attributes, `>`. Deliberately not a
- * bare `<`, which shows up in ordinary prose ("expected <=4 tools") and
- * in stack frames.
+ * The front matter of a real document. Case-insensitive on purpose:
+ * appliances and old proxies still emit `<HTML><HEAD><TITLE>504 Gateway
+ * Time-out</TITLE>`, and an uppercase page is every bit as much a page.
  */
-const HTML_TAG = /<\/?[a-z][a-z0-9]*(?:\s[^<>]*)?>/i;
+const HTML_DOCUMENT_MARKER = /<!doctype\b|<html\b/i;
+
+/** `div`, `soapenv:Body`, `my-widget` — optionally namespaced or hyphenated. */
+const TAG_NAME = String.raw`[a-z][a-z0-9]*(?:[:-][a-z0-9]+)*`;
+
+/** The same, but *required* to carry the `:` or the `-`. */
+const QUALIFIED_TAG_NAME = String.raw`[a-z][a-z0-9]*(?:[:-][a-z0-9]+)+`;
+
+/**
+ * Names that are actually HTML elements, so a bare `<name>` with no
+ * attributes and no slash can still be recognised as markup.
+ *
+ * The single-letter elements (`a`, `b`, `i`, `p`, `u`, `q`, `s`) are
+ * deliberately absent: a bare `<T>`, `<U>` or `<B>` is a generic type
+ * parameter far more often than it is markup, and the two are
+ * indistinguishable by shape. Losing them costs nothing realistic — a
+ * payload over 800 characters that carries markup carries more than one
+ * bare `<p>`, and if it somehow does not, the outcome is 480 characters
+ * of raw text rather than a fabricated diagnosis.
+ */
+const HTML_ELEMENT_NAME = [
+  "big", "blockquote", "body", "br", "center", "code", "dd", "div",
+  "dl", "dt", "em", "font", "footer", "form", "h1", "h2", "h3", "h4", "h5",
+  "h6", "head", "header", "hr", "html", "li", "main", "nav", "ol",
+  "pre", "script", "section", "small", "span", "strong", "style", "sub",
+  "sup", "table", "tbody", "td", "tfoot", "th", "thead", "title", "tr", "tt",
+  "ul",
+].join("|");
+
+/**
+ * A real markup tag. Four shapes, and the split between them is the
+ * whole point:
+ *
+ * - a closing tag (`</center>`),
+ * - a self-closing tag (`<br/>`, `<hr />`) — XHTML and appliance bodies
+ *   are full of these, and the older pattern rejected them because `/`
+ *   is neither whitespace nor `>`,
+ * - an open tag carrying attributes (`<meta http-equiv="refresh" …>`),
+ * - a *bare* open tag, but only when the name is either a genuine HTML
+ *   element or namespaced/hyphenated (`<soapenv:Body>`, `<my-widget>`).
+ *
+ * That last restriction is the fix. Every stack-trace pseudo-frame has
+ * exactly the shape of a bare open tag — `at Object.<anonymous>`,
+ * `at Socket.<anonymous>`, `at new Promise (<anonymous>)`, JVM
+ * `<init>`/`<clinit>`, Python `<module>` — and a pattern that accepts any
+ * name accepts all of them. A bundled CJS CLI (`claude`, `codex`) prints
+ * `at Object.<anonymous>` on any top-level throw, so the subscription-CLI
+ * provider's verbatim stderr was reliably mistaken for a web page.
+ *
+ * The leading `(?<!\w)` is the other half: it separates a tag from a
+ * generic type argument. `List<String>`, `Promise<void>`, `Array<number>`
+ * and `Vector<Body>` all sit immediately after a word character;
+ * `<body>`, `</td><td>` and `Gateway<br/><hr/>` do not (`>` is
+ * deliberately allowed before a tag, because adjacent tags are how real
+ * markup is written).
+ */
+const HTML_TAG = new RegExp(
+  String.raw`(?<!\w)(?:` +
+    String.raw`<\/${TAG_NAME}\s*>` +
+    String.raw`|<${TAG_NAME}(?:\s[^<>]*)?\/>` +
+    String.raw`|<${TAG_NAME}\s[^<>]*>` +
+    String.raw`|<(?:${HTML_ELEMENT_NAME})>` +
+    String.raw`|<${QUALIFIED_TAG_NAME}>` +
+    `)`,
+  "i",
+);
 
 /**
  * Where the failed turn was pointed, so a transport failure can say what
@@ -55,6 +120,11 @@ export interface LocalProviderErrorContext {
  * replays the dead stream — `llm/fallback/prime-stream.ts` pins the
  * invariant that a stream which already emitted output is never
  * restarted — so the operator has to ask for the continuation.
+ *
+ * Known imprecision, unchanged in kind from `main`: the predicate is
+ * unanchored, so a gateway that quotes its own upstream inside a JSON
+ * body (`{"error":{"message":"upstream: socket hang up"}}`) is a reply
+ * that DID arrive and still draws line 1. Line 2 stays true either way.
  */
 const DROPPED_CONNECTION_HINT = [
   "the connection to the model dropped before the reply finished",
@@ -62,34 +132,34 @@ const DROPPED_CONNECTION_HINT = [
 ].join("\n");
 
 /**
- * True when `body` is an error *page* rather than an error *sentence* —
- * the case the substitution below was written for: a misconfigured
- * `baseUrl` pointed at a web server, which answers a JSON POST with a
- * whole HTML document whose only useful content is its status code.
+ * How `body` failed to be an error *sentence*, or `null` when it is one.
  *
- * Two ways in, both of which require actual markup:
+ * The case the substitution was written for: a misconfigured `baseUrl`
+ * pointed at a web server, which answers a JSON POST with a whole HTML
+ * document whose only useful content is its status code.
  *
- * - the document markers, which every real error page carries near its
- *   front (`<!DOCTYPE html>`, `<html lang=…>`);
- * - failing those, sheer bulk *plus* at least one tag, for the
- *   fragments that arrive without a preamble (an nginx body that starts
- *   at `<center>`, a proxy that emits `<body>…` alone).
+ * Two ways in, and the caller treats them differently:
+ *
+ * - `"document"` — the front-matter markers every real error page
+ *   carries (`<!DOCTYPE html>`, `<html lang=…>`, `<HTML>`);
+ * - `"fragment"` — failing those, sheer bulk *plus* at least one real
+ *   tag, for the pages that arrive without a preamble (an nginx body
+ *   truncated to `<center>…`, an appliance that emits
+ *   `502 Bad Gateway<br/><hr/>…`).
  *
  * Length alone used to be enough, and that was the bug: a long message
  * with no markup in it is not a wall, and scraping `/\b(\d{3})\b/` out
  * of one invents an HTTP status that never existed. The case in tree is
  * the subscription-CLI provider, whose failures carry a subprocess's
- * verbatim stderr: a Node crash dump for `socket hang up` is ~840 chars
- * and its first three-digit run is the line number in
- * `node:internal/errors:720:14`, which was reported to the operator as
- * "upstream HTTP 720 (wrong API URL or provider config)" — for a local
- * subprocess with no upstream URL at all. Such a message now truncates
- * at `MAX_CHARS` like any other long message, which is both honest and
- * enough: the transport's own words are what the operator needs.
+ * verbatim stderr — see `HTML_TAG` for why a Node crash dump kept
+ * looking like markup even after that first repair.
  */
-function looksLikeHtmlWall(body: string): boolean {
-  if (body.includes("<!DOCTYPE") || body.includes("<html")) return true;
-  return body.length > WALL_CHARS && HTML_TAG.test(body);
+type HtmlWallKind = "document" | "fragment";
+
+function classifyHtmlWall(body: string): HtmlWallKind | null {
+  if (HTML_DOCUMENT_MARKER.test(body)) return "document";
+  if (body.length > WALL_CHARS && HTML_TAG.test(body)) return "fragment";
+  return null;
 }
 
 /**
@@ -113,9 +183,18 @@ export function formatAgentErrorForChat(
   // Set when the wall below throws the transport's own words away and
   // substitutes a diagnosis of its own.
   let diagnosedAsWall = false;
-  if (looksLikeHtmlWall(body)) {
-    const statusMatch = /\b(\d{3})\b/.exec(body);
-    const status = statusMatch?.[1];
+  const wall = classifyHtmlWall(body);
+  if (wall != null) {
+    // The status is only scraped out of a *document*. `/\b(\d{3})\b/`
+    // has no idea what it is reading — inside a document it is almost
+    // always the status line, but inside a bulky fragment the first
+    // three-digit run is as likely to be a source line number, a port
+    // or a byte count, and "upstream HTTP 519 (wrong API URL or
+    // provider config)" is a confident lie built out of
+    // `node:events:519:28`. When we are only guessing from bulk plus a
+    // tag, say what we actually know instead.
+    const status =
+      wall === "document" ? /\b(\d{3})\b/.exec(body)?.[1] : undefined;
     body =
       status != null
         ? `upstream HTTP ${status} (wrong API URL or provider config)`
@@ -150,9 +229,11 @@ export function formatAgentErrorForChat(
     // HTML is a reply that arrived, not a reply that was cut off.
     // Printing both told the operator two incompatible stories at once.
     // The wall wins: it is the arm that looked at the whole payload,
-    // where this one only pattern-matches a phrase inside it. Since
-    // `looksLikeHtmlWall` now demands real markup, the only bodies this
-    // suppresses are ones that genuinely carry a page.
+    // where this one only pattern-matches a phrase inside it. This
+    // suppression is only safe to the extent `classifyHtmlWall` is
+    // right, which is why `HTML_TAG` has to reject stack frames: a
+    // crash dump walled by mistake would lose its own stderr AND this
+    // explanation at once.
     if (!diagnosedAsWall && looksLikeMidStreamDrop(collapsed)) {
       return `${base}\n${DROPPED_CONNECTION_HINT}`;
     }

--- a/src/tui/format-agent-error-for-chat.ts
+++ b/src/tui/format-agent-error-for-chat.ts
@@ -4,85 +4,6 @@ import { looksLikeMidStreamDrop } from "../llm/reliability/index.js";
 const MAX_CHARS = 480;
 
 /**
- * Length past which a payload that *also* carries markup is treated as a
- * page rather than a sentence. Only ever consulted together with
- * `HTML_TAG` — see `classifyHtmlWall`.
- */
-const WALL_CHARS = 800;
-
-/**
- * The front matter of a real document. Case-insensitive on purpose:
- * appliances and old proxies still emit `<HTML><HEAD><TITLE>504 Gateway
- * Time-out</TITLE>`, and an uppercase page is every bit as much a page.
- */
-const HTML_DOCUMENT_MARKER = /<!doctype\b|<html\b/i;
-
-/** `div`, `soapenv:Body`, `my-widget` — optionally namespaced or hyphenated. */
-const TAG_NAME = String.raw`[a-z][a-z0-9]*(?:[:-][a-z0-9]+)*`;
-
-/** The same, but *required* to carry the `:` or the `-`. */
-const QUALIFIED_TAG_NAME = String.raw`[a-z][a-z0-9]*(?:[:-][a-z0-9]+)+`;
-
-/**
- * Names that are actually HTML elements, so a bare `<name>` with no
- * attributes and no slash can still be recognised as markup.
- *
- * The single-letter elements (`a`, `b`, `i`, `p`, `u`, `q`, `s`) are
- * deliberately absent: a bare `<T>`, `<U>` or `<B>` is a generic type
- * parameter far more often than it is markup, and the two are
- * indistinguishable by shape. Losing them costs nothing realistic — a
- * payload over 800 characters that carries markup carries more than one
- * bare `<p>`, and if it somehow does not, the outcome is 480 characters
- * of raw text rather than a fabricated diagnosis.
- */
-const HTML_ELEMENT_NAME = [
-  "big", "blockquote", "body", "br", "center", "code", "dd", "div",
-  "dl", "dt", "em", "font", "footer", "form", "h1", "h2", "h3", "h4", "h5",
-  "h6", "head", "header", "hr", "html", "li", "main", "nav", "ol",
-  "pre", "script", "section", "small", "span", "strong", "style", "sub",
-  "sup", "table", "tbody", "td", "tfoot", "th", "thead", "title", "tr", "tt",
-  "ul",
-].join("|");
-
-/**
- * A real markup tag. Four shapes, and the split between them is the
- * whole point:
- *
- * - a closing tag (`</center>`),
- * - a self-closing tag (`<br/>`, `<hr />`) — XHTML and appliance bodies
- *   are full of these, and the older pattern rejected them because `/`
- *   is neither whitespace nor `>`,
- * - an open tag carrying attributes (`<meta http-equiv="refresh" …>`),
- * - a *bare* open tag, but only when the name is either a genuine HTML
- *   element or namespaced/hyphenated (`<soapenv:Body>`, `<my-widget>`).
- *
- * That last restriction is the fix. Every stack-trace pseudo-frame has
- * exactly the shape of a bare open tag — `at Object.<anonymous>`,
- * `at Socket.<anonymous>`, `at new Promise (<anonymous>)`, JVM
- * `<init>`/`<clinit>`, Python `<module>` — and a pattern that accepts any
- * name accepts all of them. A bundled CJS CLI (`claude`, `codex`) prints
- * `at Object.<anonymous>` on any top-level throw, so the subscription-CLI
- * provider's verbatim stderr was reliably mistaken for a web page.
- *
- * The leading `(?<!\w)` is the other half: it separates a tag from a
- * generic type argument. `List<String>`, `Promise<void>`, `Array<number>`
- * and `Vector<Body>` all sit immediately after a word character;
- * `<body>`, `</td><td>` and `Gateway<br/><hr/>` do not (`>` is
- * deliberately allowed before a tag, because adjacent tags are how real
- * markup is written).
- */
-const HTML_TAG = new RegExp(
-  String.raw`(?<!\w)(?:` +
-    String.raw`<\/${TAG_NAME}\s*>` +
-    String.raw`|<${TAG_NAME}(?:\s[^<>]*)?\/>` +
-    String.raw`|<${TAG_NAME}\s[^<>]*>` +
-    String.raw`|<(?:${HTML_ELEMENT_NAME})>` +
-    String.raw`|<${QUALIFIED_TAG_NAME}>` +
-    `)`,
-  "i",
-);
-
-/**
  * Where the failed turn was pointed, so a transport failure can say what
  * to actually do about it. The CLI has printed
  * `formatLlamaUnreachableHint` for years; the TUI dropped the same
@@ -132,38 +53,17 @@ const DROPPED_CONNECTION_HINT = [
 ].join("\n");
 
 /**
- * How `body` failed to be an error *sentence*, or `null` when it is one.
- *
- * The case the substitution was written for: a misconfigured `baseUrl`
- * pointed at a web server, which answers a JSON POST with a whole HTML
- * document whose only useful content is its status code.
- *
- * Two ways in, and the caller treats them differently:
- *
- * - `"document"` — the front-matter markers every real error page
- *   carries (`<!DOCTYPE html>`, `<html lang=…>`, `<HTML>`);
- * - `"fragment"` — failing those, sheer bulk *plus* at least one real
- *   tag, for the pages that arrive without a preamble (an nginx body
- *   truncated to `<center>…`, an appliance that emits
- *   `502 Bad Gateway<br/><hr/>…`).
- *
- * Length alone used to be enough, and that was the bug: a long message
- * with no markup in it is not a wall, and scraping `/\b(\d{3})\b/` out
- * of one invents an HTTP status that never existed. The case in tree is
- * the subscription-CLI provider, whose failures carry a subprocess's
- * verbatim stderr — see `HTML_TAG` for why a Node crash dump kept
- * looking like markup even after that first repair.
- */
-type HtmlWallKind = "document" | "fragment";
-
-function classifyHtmlWall(body: string): HtmlWallKind | null {
-  if (HTML_DOCUMENT_MARKER.test(body)) return "document";
-  if (body.length > WALL_CHARS && HTML_TAG.test(body)) return "fragment";
-  return null;
-}
-
-/**
  * Compact, chat-safe agent failure text (strips HTML walls from bad URLs).
+ *
+ * The HTML-wall block below is `main`'s heuristic, character for
+ * character, on purpose. It is known to be wrong on several shapes — it
+ * walls any payload over 800 characters whether or not there is markup
+ * in it, and scrapes `/\b(\d{3})\b/` out of the result as an "upstream
+ * HTTP status" that may well be a line number — but that is a
+ * pre-existing defect with its own blast radius, unrelated to the
+ * dropped-stream message this change exists for. It is written up in the
+ * pull request so it can be fixed on its own terms; do not repair it
+ * here.
  */
 export function formatAgentErrorForChat(
   category: string,
@@ -183,18 +83,13 @@ export function formatAgentErrorForChat(
   // Set when the wall below throws the transport's own words away and
   // substitutes a diagnosis of its own.
   let diagnosedAsWall = false;
-  const wall = classifyHtmlWall(body);
-  if (wall != null) {
-    // The status is only scraped out of a *document*. `/\b(\d{3})\b/`
-    // has no idea what it is reading — inside a document it is almost
-    // always the status line, but inside a bulky fragment the first
-    // three-digit run is as likely to be a source line number, a port
-    // or a byte count, and "upstream HTTP 519 (wrong API URL or
-    // provider config)" is a confident lie built out of
-    // `node:events:519:28`. When we are only guessing from bulk plus a
-    // tag, say what we actually know instead.
-    const status =
-      wall === "document" ? /\b(\d{3})\b/.exec(body)?.[1] : undefined;
+  if (
+    body.includes("<!DOCTYPE") ||
+    body.includes("<html") ||
+    body.length > 800
+  ) {
+    const statusMatch = /\b(\d{3})\b/.exec(body);
+    const status = statusMatch?.[1];
     body =
       status != null
         ? `upstream HTTP ${status} (wrong API URL or provider config)`
@@ -222,18 +117,19 @@ export function formatAgentErrorForChat(
     // transport actually said. Pinned by a test that fails if this is
     // switched to `body`.
     //
-    // Except when the wall above fired: then `body` is not a truncation
-    // of the transport's words but a *rival diagnosis* of the same
-    // failure ("upstream returned HTML instead of JSON", "upstream HTTP
-    // 502"), and the two explanations are mutually exclusive — a page of
-    // HTML is a reply that arrived, not a reply that was cut off.
-    // Printing both told the operator two incompatible stories at once.
-    // The wall wins: it is the arm that looked at the whole payload,
-    // where this one only pattern-matches a phrase inside it. This
-    // suppression is only safe to the extent `classifyHtmlWall` is
-    // right, which is why `HTML_TAG` has to reject stack frames: a
-    // crash dump walled by mistake would lose its own stderr AND this
-    // explanation at once.
+    // Except when the wall above fired. This guard makes no claim about
+    // the wall being right — it is about not printing two diagnoses of
+    // one failure. Once the wall has spoken, `body` is no longer a
+    // truncation of the transport's words but a rival account of the
+    // same failure ("upstream returned HTML instead of JSON", "upstream
+    // HTTP 502"), and appending "the connection dropped before the reply
+    // finished" underneath it tells the operator two incompatible
+    // stories in three lines. Exactly one of them can be true, and this
+    // function has no way to tell which, so it adds nothing to what the
+    // wall already decided. The cost is real and accepted: on a payload
+    // the wall walls by mistake, this explanation is lost along with the
+    // transport's own words — see the pre-existing-defect note in the
+    // pull request.
     if (!diagnosedAsWall && looksLikeMidStreamDrop(collapsed)) {
       return `${base}\n${DROPPED_CONNECTION_HINT}`;
     }

--- a/src/tui/format-agent-error-for-chat.ts
+++ b/src/tui/format-agent-error-for-chat.ts
@@ -1,5 +1,5 @@
 import { formatLlamaUnreachableHint } from "../llm/llama-server-health.js";
-import { looksLikeMidStreamDrop } from "../llm/reliability/network-error.js";
+import { looksLikeMidStreamDrop } from "../llm/reliability/index.js";
 
 const MAX_CHARS = 480;
 

--- a/src/tui/format-agent-error-for-chat.ts
+++ b/src/tui/format-agent-error-for-chat.ts
@@ -4,6 +4,20 @@ import { looksLikeMidStreamDrop } from "../llm/reliability/index.js";
 const MAX_CHARS = 480;
 
 /**
+ * Length past which a payload that *also* carries markup is treated as a
+ * page rather than a sentence. Only ever consulted together with
+ * `HTML_TAG` — see `looksLikeHtmlWall`.
+ */
+const WALL_CHARS = 800;
+
+/**
+ * A real tag: `<`, a name, optional attributes, `>`. Deliberately not a
+ * bare `<`, which shows up in ordinary prose ("expected <=4 tools") and
+ * in stack frames.
+ */
+const HTML_TAG = /<\/?[a-z][a-z0-9]*(?:\s[^<>]*)?>/i;
+
+/**
  * Where the failed turn was pointed, so a transport failure can say what
  * to actually do about it. The CLI has printed
  * `formatLlamaUnreachableHint` for years; the TUI dropped the same
@@ -48,6 +62,37 @@ const DROPPED_CONNECTION_HINT = [
 ].join("\n");
 
 /**
+ * True when `body` is an error *page* rather than an error *sentence* —
+ * the case the substitution below was written for: a misconfigured
+ * `baseUrl` pointed at a web server, which answers a JSON POST with a
+ * whole HTML document whose only useful content is its status code.
+ *
+ * Two ways in, both of which require actual markup:
+ *
+ * - the document markers, which every real error page carries near its
+ *   front (`<!DOCTYPE html>`, `<html lang=…>`);
+ * - failing those, sheer bulk *plus* at least one tag, for the
+ *   fragments that arrive without a preamble (an nginx body that starts
+ *   at `<center>`, a proxy that emits `<body>…` alone).
+ *
+ * Length alone used to be enough, and that was the bug: a long message
+ * with no markup in it is not a wall, and scraping `/\b(\d{3})\b/` out
+ * of one invents an HTTP status that never existed. The case in tree is
+ * the subscription-CLI provider, whose failures carry a subprocess's
+ * verbatim stderr: a Node crash dump for `socket hang up` is ~840 chars
+ * and its first three-digit run is the line number in
+ * `node:internal/errors:720:14`, which was reported to the operator as
+ * "upstream HTTP 720 (wrong API URL or provider config)" — for a local
+ * subprocess with no upstream URL at all. Such a message now truncates
+ * at `MAX_CHARS` like any other long message, which is both honest and
+ * enough: the transport's own words are what the operator needs.
+ */
+function looksLikeHtmlWall(body: string): boolean {
+  if (body.includes("<!DOCTYPE") || body.includes("<html")) return true;
+  return body.length > WALL_CHARS && HTML_TAG.test(body);
+}
+
+/**
  * Compact, chat-safe agent failure text (strips HTML walls from bad URLs).
  */
 export function formatAgentErrorForChat(
@@ -55,15 +100,20 @@ export function formatAgentErrorForChat(
   message: string,
   local?: LocalProviderErrorContext,
 ): string {
-  let body = message.trim().replace(/\s+/g, " ");
+  // One normalisation, used for both the body and the drop predicate, so
+  // the two can never disagree about what the transport said. Before,
+  // the predicate read the raw `message` while the body read this
+  // collapsed form, which meant `"socket\nhang\nup"` printed the drop
+  // phrase and withheld its explanation. Collapsing cannot widen the
+  // anchored pattern (`/^terminated$/i` already sees a trimmed string)
+  // and can only help the unanchored ones find a phrase a line break
+  // had split.
+  const collapsed = message.trim().replace(/\s+/g, " ");
+  let body = collapsed;
   // Set when the wall below throws the transport's own words away and
   // substitutes a diagnosis of its own.
   let diagnosedAsWall = false;
-  if (
-    body.includes("<!DOCTYPE") ||
-    body.includes("<html") ||
-    body.length > 800
-  ) {
+  if (looksLikeHtmlWall(body)) {
     const statusMatch = /\b(\d{3})\b/.exec(body);
     const status = statusMatch?.[1];
     body =
@@ -87,21 +137,23 @@ export function formatAgentErrorForChat(
     if (local?.activeProviderIsLocal) {
       return `${base}\n${formatLlamaUnreachableHint(local.llamaUrl)}`;
     }
-    // Matched on the raw `message`, never on `body`: `body` has been
-    // capped at MAX_CHARS, so a drop phrase that sits past that cap
-    // survives in one and not the other, and the hint must key off what
-    // the transport actually said. Pinned by a test that fails if this
-    // is switched to `body`.
+    // Matched on `collapsed`, never on `body`: `body` has been capped at
+    // MAX_CHARS, so a drop phrase that sits past that cap survives in
+    // one and not the other, and the hint must key off what the
+    // transport actually said. Pinned by a test that fails if this is
+    // switched to `body`.
     //
     // Except when the wall above fired: then `body` is not a truncation
     // of the transport's words but a *rival diagnosis* of the same
     // failure ("upstream returned HTML instead of JSON", "upstream HTTP
     // 502"), and the two explanations are mutually exclusive — a page of
-    // HTML or a status line is a reply that arrived, not a reply that was
-    // cut off. Printing both told the operator two incompatible stories
-    // at once. The wall wins: it is the arm that looked at the whole
-    // payload, where this one only pattern-matches a phrase inside it.
-    if (!diagnosedAsWall && looksLikeMidStreamDrop(message)) {
+    // HTML is a reply that arrived, not a reply that was cut off.
+    // Printing both told the operator two incompatible stories at once.
+    // The wall wins: it is the arm that looked at the whole payload,
+    // where this one only pattern-matches a phrase inside it. Since
+    // `looksLikeHtmlWall` now demands real markup, the only bodies this
+    // suppresses are ones that genuinely carry a page.
+    if (!diagnosedAsWall && looksLikeMidStreamDrop(collapsed)) {
       return `${base}\n${DROPPED_CONNECTION_HINT}`;
     }
   }


### PR DESCRIPTION
## What

A cloud provider whose stream dies mid-body reaches the TUI as undici's one-word `terminated`, and that is all the operator sees:

```
Turn failed [transport]: terminated
```

This adds a second hint arm to the transport branch of `src/tui/format-agent-error-for-chat.ts` so a genuine mid-stream drop renders as:

```
Turn failed [transport]: terminated
the connection to the model dropped before the reply finished
  the steps that already finished are kept in this session — ask to continue from there; re-sending the whole task starts it over
```

That is the whole change. **Scope note:** earlier revisions of this branch also rewrote the formatter's HTML-wall heuristic. That rewrite has been reverted — the wall is now byte-for-byte `main`'s again. The reasons, and a full write-up of the pre-existing defect it was chasing, are in [Not fixed here](#not-fixed-here-the-html-wall) below.

## Why

Source: Discord #feedback-and-bugs, 2026-09-03 — https://discord.com/channels/1515649306781155428/1515650562430079048/1545176977819050054

The reporter had ~6 research steps already completed when the next LLM call died mid-stream, got only `Turn failed [transport]: terminated`, and re-sent the whole task — which started it over.

The second half of that is avoidable. The work is **not** lost:

- `src/agent/step-executor.ts` records `tool_call` / `tool_result` turns into `SessionState.turns` as each step completes.
- The agent loop's `failed` branch **returns** rather than throwing (`src/agent/agent-loop.ts`, the "Symmetric with the cancelled path above" comment), so `executeTurn` in `src/runtime/bootstrap.ts` reaches its `sessionStore.save(finished)`.
- `src/tui/chat-orchestrator.ts` keeps `result.session` as the active session on a failed turn (`if (attached) this.session = result.session;`).
- `src/prompt/build-prompt-world-conversation.ts` renders those earlier `tool_result` turns back into the next prompt.

So a follow-up message in the same session does see the completed steps. The user just had no way to know that.

## How it is keyed

`src/llm/reliability/network-error.ts` already owns the vocabulary for this failure family in `NETWORK_MESSAGES`. It now exposes that vocabulary as **two** predicates, built from one list so they cannot drift:

```ts
/** The classifier's key: any dead connection. Unchanged behaviour. */
export function looksLikeDroppedConnection(message: string): boolean

/** Strictly smaller: only a socket that was already carrying a request. */
export function looksLikeMidStreamDrop(message: string): boolean
```

`isNetworkError`'s message arm keeps the **broad** one and keeps its exact current membership — it drives `shouldAdvance` and provider fallover, where a connection that never opened and one that died mid-body are the same verdict, and narrowing it would change which failures fall over.

The **hint** is keyed on the narrow one, because its first line asserts that a reply was in flight:

| message | classifier (`transport`) | hint |
| --- | --- | --- |
| `terminated` | yes | **yes** — undici's word for the socket dying mid-body |
| `socket hang up` | yes | **yes** — peer closed a socket already carrying our request |
| `other side closed` | yes | **yes** — peer closed a connection we were already using |
| `fetch failed` | yes | no |
| `… network socket disconnected …` (TLS) | yes | no |

`fetch failed` is excluded because it is undici's outer catch-all for a connection that **never opened**. Verified on Node 22.22.2:

```
http://no-such-host-zzz.invalid/x  → TypeError: fetch failed   (cause.code ENOTFOUND)
http://127.0.0.1:45999/x           → TypeError: fetch failed   (cause.code ECONNREFUSED)
```

`network-error.ts` and `classify-failure.ts` both document that MCP streamable-http transports, embedding calls and vendor SDKs reach the classifier as exactly that bare string, so the hint could have claimed a cut-off reply on a turn with zero completed steps. The TLS variant is excluded for the same reason: a handshake that never completed means no request was ever sent.

`/client network socket disconnected/i` was also removed from the runtime list — it is a strict subset of the unanchored `/network socket disconnected/i` next to it and matched nothing extra. No behaviour change, and that is asserted rather than merely claimed: `network-error.test.ts` pins `looksLikeDroppedConnection("Client network socket disconnected before secure TLS connection was established") === true`, and pins that the predicate and `isNetworkError` agree message-for-message.

Only the narrow predicate is re-exported from `src/llm/reliability/index.ts`. `looksLikeDroppedConnection` had no consumer outside the directory and is not offered there, because the two names differ by one word and mean opposite things to a caller; it stays exported from `network-error.ts` for `isNetworkError` and that module's own test.

The TUI's import was moved to the barrel to match, and that half is a genuine trade rather than a clear win: it follows the directory's convention, but it also pulls ~36 modules into the import graph of a pure string formatter that previously reached exactly one. Nothing measurable depends on it either way, and a reviewer who prefers the direct `network-error.js` path should say so — the barrel narrowing stands on its own regardless.

## One normalisation for the body and the predicate

The formatter matches the transport's own words, not the `body` it prints, because `body` is capped at `MAX_CHARS` and a drop phrase past that cap survives in one and not the other. That is a real decision and it is pinned by a test that fails if the argument is switched to `body`.

But `body` is also whitespace-collapsed, so matching the raw `message` had the mirror-image bug: `"socket\nhang\nup"` printed the drop phrase in the body and withheld its explanation. Both now read one `collapsed` string, computed before truncation. Collapsing cannot widen the anchored `/^terminated$/i` (it already sees a trimmed string) and only lets the unanchored patterns find a phrase a line break had split. Not reachable from undici's own strings — but a subprocess's stderr reaches this formatter verbatim, newlines and all.

## The one guard the wall gets: `diagnosedAsWall`

When the existing HTML-wall substitution fires, `body` stops being a truncation of the transport's words and becomes a **rival account of the same failure** — `upstream HTTP 502`, or `upstream returned HTML instead of JSON`. Appending "the connection dropped before the reply finished" underneath that prints two mutually exclusive stories in three lines: a page of HTML is a reply that *arrived*, not one that was cut off. Exactly one of them can be true and this function cannot tell which, so when the wall has spoken the hint stays out of the argument.

Note what that guard does **not** assume: that the wall is right. It usually is not (below). But a wrong wall plus a contradicting hint is strictly worse than a wrong wall alone, so the guard holds either way — which is why it survives the revert while everything else about the wall goes back to `main`.

The cost is named plainly: on a payload the wall walls by mistake, this explanation is lost along with the transport's own words. Fixing the wall would recover the hint there too. This PR does not do that, for the reasons below.

## Was a richer signal available? Yes, and it was not used

The formatter's signature is `(category, message, local?)`, but `src/tui/agent-event-reducer.ts` handles `loop_failed { error: Error; category }` and could pass the whole `Error` with its `cause` chain.

Being honest about the call sites, since an earlier draft of this section was not:

1. There are two production callers, and only one can reach this arm. `chat-orchestrator.ts:1105` passes category `"runtime"`, which never enters the `transport` branch at all — so `agent-event-reducer.ts:500` is the *only* caller that can reach the drop hint, and it **does** hold the `Error` with its full cause chain. "The other call site only has a string" is not a reason.
2. Passing the error object would not have made the hint more accurate on its own. `isNetworkError(err)` is *broader*, not narrower: on top of the same message list it returns true for any `NETWORK_ERROR_CODES` / `UND_ERR_*` errno anywhere in the chain, which mixes mid-stream drops (`UND_ERR_SOCKET`) with connections that never opened (`ECONNREFUSED`, `ENOTFOUND`). The accuracy problem was never message-vs-object; it was that one vocabulary was being used for two different claims. Splitting the predicate is what fixes it, and the split works on text.
3. The reported case is a bare `terminated`, which the message arm matches exactly.

If a maintainer would rather thread the error object through later, `looksLikeMidStreamDrop` is the seam to do it against — an errno arm for it would have to name the mid-stream codes only.

## Which hint wins on a local route

Both arms can match at once (local provider + a dropped socket). The local-llama arm wins and is byte-identical to today's behaviour — a socket dying on a local route is nearly always llama-server going down or restarting, and `atomic-agent models start` is a *fix* where the drop hint is only an *explanation*. Stacking both would bury the fix under five lines. Justified in a comment at the branch, and covered by a test.

<a name="not-fixed-here-the-html-wall"></a>
## Not fixed here: the HTML wall (pre-existing defect, evidence for whoever takes it)

`formatAgentErrorForChat` has, long before this PR, replaced the whole error body with a canned diagnosis whenever:

```ts
body.includes("<!DOCTYPE") || body.includes("<html") || body.length > 800
```

…and then scraped `/\b(\d{3})\b/` out of whatever it got and printed it as `upstream HTTP <n> (wrong API URL or provider config)`.

This branch spent three commits rewriting that predicate, and **every version was falsified by the next review round**. It has therefore been reverted to `main` in full. What follows is what those rounds established, so a maintainer can fix it once, on its own terms, rather than in a message-wording PR.

### The defect, reproduced on this HEAD

All four of these are current behaviour, measured on Node v22.22.2 by calling `formatAgentErrorForChat("transport", …, { activeProviderIsLocal: false, … })`:

| input | output |
| --- | --- |
| a real 944-char Node CJS crash dump, **zero markup in it**, whose first three-digit run is the line number in `at connResetException (node:_http_client:720:15)` | `Turn failed [transport]: upstream HTTP 720 (wrong API URL or provider config)` |
| an 849-char Python traceback, zero markup, first run is `line 214, in <module>` | `upstream HTTP 214 (wrong API URL or provider config)` |
| a **99-char** tool error: `read_file failed: /work/site/index.html starts with <!DOCTYPE html> and is 903 bytes; expected JSON` | `upstream HTTP 903 (wrong API URL or provider config)` — 903 is a byte count |
| a **69-char** lint error: `lint failed: index.html:402:1: unexpected <html lang="en"> after body` | `upstream HTTP 402 (wrong API URL or provider config)` — 402 is a column-bearing line number |

Two separate faults are visible there:

1. **The length arm has nothing to do with HTML.** Any payload over 800 chars is declared a page. The subscription-CLI provider walks straight into this: `mapCliFailure` (`src/llm/provider/subscription-cli/subscription-cli-errors.ts`) quotes a subprocess's stderr verbatim up to 2048 chars, so a `claude`/`codex` run that dies on a Node `socket hang up` arrives as a ~1000-char crash dump and is reported as an HTTP status from an upstream URL that does not exist — it is a local subprocess.
2. **The document arm is unanchored and ungated.** `<!DOCTYPE` or `<html` *anywhere* in a payload of *any* length replaces the whole message. A 69-char lint error mentioning a tag is enough.

In both cases the drop hint is suppressed by the `diagnosedAsWall` guard, so fixing the wall would also recover the explanation on these payloads.

### Why the three rewrite attempts were abandoned

Each attempt narrowed the predicate to "long **and** carries markup", and each was defeated by real generated output:

- **Attempt 1** (`/<\/?[a-z][a-z0-9]*(?:\s[^<>]*)?>/i`) matched `<anonymous>` — the commonest token in a Node stack trace, printed by every bundled CJS CLI on a top-level throw — plus `Promise<void>` and `List<String>`, because `/i` makes `[a-z]` accept uppercase. Real dumps still walled, now *worse* than `main`, since the new guard also swallowed the hint.
- **Attempt 2** added an element-name allowlist and a `(?<!\w)` guard. Review then produced the successors from real output on this machine: Node 22 `util.inspect` prints `<ref *1>` and `<Buffer 7b … 79 more bytes>`; Python 3.13 prints `<class '…'>` and `<built-in function print>`; every Ruby backtrace carries `<main>`, and `"main"` was in the allowlist with the pattern still `/i`; .NET prints `<Main>$`.
- **Attempt 3** additionally made the document arm case-insensitive, which **newly walled payloads `main` leaves alone** — a 184-char tool error quoting `<!doctype html>` rendered as `upstream HTTP 903`, and `index.html:402:1: error: Stray start tag <HTML>.` as `upstream HTTP 402`. Measured 53,526 attempt-3-only walls across a 200,000-case differential, every one of them also fabricating a status.

There is no reason to think a fourth guess would fare better inside this PR's diff, and each attempt shipped a new variant of the same class of bug. Hence the revert.

### Three repairs the review converged on, for whoever picks this up

1. **Anchor or gate the document arm.** Require `<!DOCTYPE` / `<html` to sit near the start of the payload, or put a length floor under it. Either kills the 69-char and 99-char cases above without touching real error pages, which begin with their doctype.
2. **Drop `"main"` from any element allowlist**, for exactly the reason `a b i p u q s` are already excluded: `<main>` appears in every Ruby backtrace, and a bare one-word tag is a stack frame far more often than it is markup.
3. **Require ≥2 distinct tag matches to call a fragment markup.** This alone kills `<ref *1>`, `<class '…'>`, `<built-in function …>` and the whole `<placeholder>` family, while every real markup fragment — an nginx `<center>…</center><hr/>` body, a truncated appliance page — carries many.

A fix that does (1)–(3) *and* keeps the status scrape to documents only would be a good change. It is just not this change.

## Tests

Every test was checked against the mutation it exists to kill, by applying the mutation to a file copy and restoring from that copy. Run over `src/tui/format-agent-error-for-chat.test.ts src/tui/agent-event-reducer.test.ts src/llm/reliability` (155 tests green at baseline):

| mutation | result |
| --- | --- |
| drop the `!diagnosedAsWall` guard | 4 failed |
| `800 → 801` in the wall predicate | 1 failed |
| `800 → 799` in the wall predicate | 1 failed |
| match the raw `message` instead of `collapsed` | 1 failed |
| `looksLikeMidStreamDrop(collapsed)` → `(body)` | 1 failed |
| narrow predicate → `looksLikeDroppedConnection` | 4 failed |
| add `/^fetch failed$/i` to `MID_STREAM_DROP_MESSAGES` | 5 failed |
| stop collapsing whitespace | 1 failed |

The tests that existed only to pin the reverted wall rewrite are gone with it. The 800-char threshold is still pinned on both sides — but now as a characterisation of `main`'s behaviour, so that a future wall fix has to move it deliberately rather than by accident.

Coverage: the drop family gets the hint; `fetch failed` and the TLS variant explicitly do not; unrelated transport messages stay bare; non-transport categories stay bare, including `runtime`, which is the shape the orchestrator's catch arm actually produces; the local-llama arm is asserted byte-for-byte and wins the overlap; the body cap applies to the body and never to the hint; a drop phrase past the body cap still fires the hint; `"socket\nhang\nup"` gets the hint; the hint is suppressed on all three shapes of walled body; and one end-to-end case drives a `terminated` `loop_failed` through `agent-event-reducer` to the chat message.

```
$ npm run lint
> tsc -p tsconfig.json --noEmit     # clean

$ npx vitest run src/tui/format-agent-error-for-chat.test.ts src/tui/agent-event-reducer.test.ts src/llm/reliability
Test Files  6 passed (6)
     Tests  155 passed (155)

$ npx vitest run src/tui src/llm/reliability
Test Files  253 passed (253)
     Tests  2809 passed (2809)
```

That last run also reports one unhandled error — `spawn …/models/backend/llama-server EACCES` out of `src/tui/local-models/local-models-orchestrator-auto-update.test.ts`. It is environmental (the sandbox will not exec the stub binary), pre-existing, and untouched by this branch; every test still passes.

## Behavioural delta vs `main`

Exactly three things:

1. A cloud-route transport failure whose message names a **mid-stream** drop (`terminated`, `socket hang up`, `other side closed`) gains the two-line hint. Nothing else gains it.
2. The drop predicate reads the same whitespace-collapsed string the body is built from, so a phrase split across newlines is recognised.
3. `src/llm/reliability/index.ts` re-exports `looksLikeMidStreamDrop` (and deliberately not `looksLikeDroppedConnection`); `network-error.ts` factors its message list into two, with `isNetworkError`'s membership unchanged.

The HTML-wall predicate, its status scrape, the 800-char threshold, the `MAX_CHARS` truncation and the local-llama arm are all unchanged from `main`.

## Out of scope / for maintainers

**(a) The HTML wall.** See [above](#not-fixed-here-the-html-wall) — deliberately left at `main`'s behaviour, written up with reproductions and three suggested repairs.

**(b) Mid-stream retry or resume.** Not attempted. `src/llm/fallback/prime-stream.ts` documents the invariant that a failure to *open* a stream is fallover-worthy while "a stream that has already emitted output is never restarted", and the whole fallback seam is built on it. Making a dead mid-body stream resumable is a design change to that invariant, not a triage fix — hence the hint promises an explanation and a manual continuation, never automatic resumption.

**(c) The macro-turn history footprint — checked, and it does *not* currently apply to a failed turn.** The concern was that a failed turn's `tool_result`s would be treated as ordinary already-replied history by `findCurrentMacroTurnStart` and so lose their full body on the next turn, giving the model a second reason to start over. On this HEAD that does not happen: `findCurrentMacroTurnStart` (`src/session/conversation-turn.ts:206`) returns the slice after the most recent `assistant_reply` turn, and a transport-failed turn appends no `assistant_reply` — those turns are only recorded on a successful `reply`/`finish` (`step-executor.ts:2303`, `agent-loop.ts:818`) or the breaker's synthetic reply (`agent-loop.ts:1050`). So the failed turn's rows stay inside the current macro-turn and keep their fresh footprint, and the follow-up user message joins the same macro-turn.

Two things a maintainer may still want to weigh:

- The reduced-footprint path only ever applied to `TOOLS_FULL_BODY_WHEN_FRESH` (today: `os.http.request`) and the fresh-`gog` shell case, not to `tool_result`s generally — so even once a reply does land, most step output is capped by `TOOL_RESULT_RENDER_CAP_CHARS` either way.
- The flip side: because the failed turn never closes a macro-turn, it and the next user message merge into one, which is benign today but is the thing to re-check if `findCurrentMacroTurnStart` ever learns about failed turns.

Either way it is a token-cost policy question, not part of this fix.

**(d) The hint's second line is still unconditional.** "the steps that already finished are kept in this session" is true whatever the count, but on a turn that completed zero steps it is merely vacuous rather than useful. Making it conditional needs a step count the formatter is not given; the narrowing above removes the case where it was actively misleading.

**(e) The local-llama arm has the same "two incompatible diagnoses" shape, and is left alone.** It returns early, so on a local route a genuine mid-stream drop gets `atomic-agent models start` and never the explanation — the same collision the `diagnosedAsWall` guard resolves, decided the other way and for a good reason (a fix beats an explanation). But that early return is unchanged from `main`, so re-litigating it here would widen a triage fix into a behaviour change on the local path. Worth a follow-up if anyone wants the two stacked on that route.

**(f) `looksLikeMidStreamDrop` is unanchored on the substring patterns.** A gateway that quotes its own upstream inside a JSON body — `{"error":{"message":"upstream: socket hang up"}}` — is a reply that *did* arrive, and it draws "the connection dropped before the reply finished". This is new relative to `main` (which had no hint at all) and low impact: the body is short, so no wall fires, the operator still sees the gateway's own words, and the hint's second line stays true. Anchoring it would need to know whether the string is a transport message or a payload, which the formatter is not told.
