### PR TITLE
feat(error-reporting): tag model failures with the effective tool-call transport

### DIFF
--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -18,6 +18,10 @@ import type {
   CapabilitiesSummary,
   SkillCatalogEntry,
 } from "../prompt/stable-prefix.js";
+import type {
+  CompletionResult,
+  ToolCallTransport,
+} from "../llm/provider/completion-types.js";
 
 const CAPS: CapabilitiesSummary = {
   platform: "darwin",
@@ -2598,5 +2602,125 @@ describe("executeStep ModelError transport tag", () => {
       reason: "empty",
       transport: "native_tools",
     });
+  });
+});
+
+describe("executeStep ModelError failure-stage tag", () => {
+  const grammarsDir = join(process.cwd(), "grammars");
+
+  /**
+   * Runs one step over a scripted list of completions (index 0 is the
+   * initial call, index 1 the one-shot repair) and reports how many LLM
+   * calls actually happened, so a test can prove *which* throw site
+   * fired rather than only what it threw.
+   */
+  async function runScriptedStep(opts: {
+    toolTransport: ToolCallTransport;
+    completions: Array<Partial<CompletionResult>>;
+  }) {
+    const registry = new ToolRegistry();
+    registry.register(replyTool);
+    const grammar = await buildGrammar(PLAIN_INSTRUCT_PROFILE, grammarsDir);
+    let calls = 0;
+    const run = executeStep(
+      {
+        session: createEmptySessionState({
+          id: "s-failure-stage",
+          workingDir: "/w",
+        }),
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "hi",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async (): Promise<CompletionResult> => {
+          const scripted = opts.completions[calls] ?? { content: "" };
+          calls += 1;
+          return {
+            content: "",
+            reasoningContent: "",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: 1,
+            },
+            cacheHitTokens: 0,
+            slotId: 0,
+            modelId: "mock",
+            ...scripted,
+          };
+        },
+        grammar,
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: opts.toolTransport,
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      },
+    );
+    return { run, calls: () => calls };
+  }
+
+  it("tags the first-attempt throw with stage=initial", async () => {
+    // native_tools, nothing in any channel: the by-design route, and the
+    // step ends on the first completion (no repair round-trip).
+    const { run, calls } = await runScriptedStep({
+      toolTransport: "native_tools",
+      completions: [{ content: "", reasoningContent: "" }],
+    });
+    await expect(run).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+      transport: "native_tools",
+      stage: "initial",
+    });
+    expect(calls()).toBe(1);
+  });
+
+  it("tags the post-repair throw with stage=repair on the SAME reason+transport pair", async () => {
+    // The counterexample to "native_tools + reason=empty means the
+    // by-design route": `content` empty but `reasoning_content` present
+    // satisfies `isNativeToolsEmptyCompletionHandledByParser`, so the
+    // first throw site does NOT fire. The parse then fails, the one-shot
+    // repair runs, the repair comes back with nothing in any channel,
+    // and the SECOND site throws the identical
+    // reason=empty + transport=native_tools pair. `stage` is the only
+    // field that separates them — the Sentry fingerprint cannot, because
+    // it keys off a frame basename and the shipped build is one file.
+    const { run, calls } = await runScriptedStep({
+      toolTransport: "native_tools",
+      completions: [
+        { content: "", reasoningContent: "Hmm, let me consider the options." },
+        { content: "", reasoningContent: "" },
+      ],
+    });
+    await expect(run).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+      transport: "native_tools",
+      stage: "repair",
+    });
+    expect(calls()).toBe(2);
+  });
+
+  it("tags a twice-empty grammar step with stage=repair", async () => {
+    const { run, calls } = await runScriptedStep({
+      toolTransport: "grammar",
+      completions: [{ content: "" }, { content: "" }],
+    });
+    await expect(run).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+      transport: "grammar",
+      stage: "repair",
+    });
+    expect(calls()).toBe(2);
   });
 });

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -2487,3 +2487,116 @@ describe("executeStep empty-completion repair", () => {
     });
   });
 });
+
+describe("executeStep ModelError transport tag", () => {
+  const grammarsDir = join(process.cwd(), "grammars");
+
+  /**
+   * Runs one step whose completions are ALL empty, so the model-failure
+   * path is the only exit, and returns the rejection for inspection.
+   *
+   * `servedTransport` stamps the completion the way the fallback chain
+   * wrapper does on a cross-transport fallover, so the configured
+   * transport and the effective one disagree.
+   */
+  async function runEmptyStep(opts: {
+    toolTransport: "grammar" | "native_tools";
+    servedTransport?: "grammar" | "native_tools";
+  }) {
+    const registry = new ToolRegistry();
+    registry.register(replyTool);
+    const grammar = await buildGrammar(PLAIN_INSTRUCT_PROFILE, grammarsDir);
+    return executeStep(
+      {
+        session: createEmptySessionState({
+          id: "s-transport-tag",
+          workingDir: "/w",
+        }),
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "hi",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async () => ({
+          content: "",
+          reasoningContent: "",
+          stop: true,
+          truncated: false,
+          timing: {
+            promptMs: 1,
+            predictedMs: 1,
+            promptTokens: 20,
+            predictedTokens: 0,
+          },
+          cacheHitTokens: 0,
+          slotId: 0,
+          modelId: "mock",
+          ...(opts.servedTransport === undefined
+            ? {}
+            : { servedTransport: opts.servedTransport }),
+        }),
+        grammar,
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: opts.toolTransport,
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      },
+    );
+  }
+
+  it("tags a native_tools empty completion with transport=native_tools", async () => {
+    // Sentry CLI-BA: `reason=empty` on native_tools is the by-design
+    // route (nothing in any channel), so the tag has to say so.
+    await expect(
+      runEmptyStep({ toolTransport: "native_tools" }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+      transport: "native_tools",
+    });
+  });
+
+  it("tags a twice-empty grammar completion with transport=grammar", async () => {
+    // Same `reason=empty`, materially different story: the one-shot
+    // repair ran and came back empty too.
+    await expect(
+      runEmptyStep({ toolTransport: "grammar" }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+      transport: "grammar",
+    });
+  });
+
+  it("reports the SERVED transport, not the configured one, on a cross-transport fallover", async () => {
+    // Configured native_tools, served by a grammar link: the response is
+    // parsed as grammar, so the tag must read grammar.
+    await expect(
+      runEmptyStep({
+        toolTransport: "native_tools",
+        servedTransport: "grammar",
+      }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+      transport: "grammar",
+    });
+
+    // And the mirror image: configured grammar, served by a native link.
+    await expect(
+      runEmptyStep({
+        toolTransport: "grammar",
+        servedTransport: "native_tools",
+      }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "empty",
+      transport: "native_tools",
+    });
+  });
+});

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -2724,3 +2724,100 @@ describe("executeStep ModelError failure-stage tag", () => {
     expect(calls()).toBe(2);
   });
 });
+
+describe("executeStep repair parse transport", () => {
+  const grammarsDir = join(process.cwd(), "grammars");
+
+  it("parses the REPAIR completion under the served transport, not the configured one", async () => {
+    // Guards the `retryParseDeps` hoist at the repair-path parse: passing
+    // the configured `deps` there instead makes the retry parse lose
+    // served-transport awareness, which no other test notices.
+    //
+    // Configured grammar, served by a native link. The repair answers the
+    // way a native link does — empty `content`, the call in `tool_calls`
+    // — so a grammar-shaped parse sees an empty body and the step dies
+    // with a GrammarError instead of replying.
+    const registry = new ToolRegistry();
+    registry.register(replyTool);
+    const grammar = await buildGrammar(PLAIN_INSTRUCT_PROFILE, grammarsDir);
+    let calls = 0;
+    const outcome = await executeStep(
+      {
+        session: createEmptySessionState({
+          id: "s-repair-served-transport",
+          workingDir: "/w",
+        }),
+        toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        stepIndex: 0,
+        signal: new AbortController().signal,
+        userMessage: "hi",
+      },
+      {
+        registry,
+        slotManager: new SlotManager(2),
+        llmComplete: async (): Promise<CompletionResult> => {
+          calls += 1;
+          if (calls === 1) {
+            // Reasoning-only: survives the first-attempt ModelError check
+            // (native rules), fails the parse, routes into the repair.
+            return {
+              content: "",
+              reasoningContent: "I should answer, but I forgot the call.",
+              stop: true,
+              truncated: false,
+              timing: {
+                promptMs: 1,
+                predictedMs: 1,
+                promptTokens: 20,
+                predictedTokens: 5,
+              },
+              cacheHitTokens: 0,
+              slotId: 0,
+              modelId: "mock",
+              servedTransport: "native_tools",
+            };
+          }
+          return {
+            content: "",
+            reasoningContent: "",
+            stop: true,
+            truncated: false,
+            timing: {
+              promptMs: 1,
+              predictedMs: 1,
+              promptTokens: 20,
+              predictedTokens: 5,
+            },
+            cacheHitTokens: 0,
+            slotId: 0,
+            modelId: "mock",
+            servedTransport: "native_tools",
+            toolCalls: [
+              {
+                id: "call-repair",
+                type: "function",
+                function: {
+                  name: "reply",
+                  arguments: JSON.stringify({ text: "served-native" }),
+                },
+              },
+            ],
+          };
+        },
+        grammar,
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "grammar",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      },
+    );
+
+    expect(calls).toBe(2);
+    expect(outcome.toolCalls).toHaveLength(1);
+    expect(outcome.toolCalls[0]!.tool).toBe("reply");
+    expect(outcome.toolCalls[0]!.args).toEqual({ text: "served-native" });
+    expect(outcome.toolResults[0]!.status).toBe("ok");
+  });
+});

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -529,6 +529,10 @@ async function executeStepInner(
       throw new ModelError(
         initialModelFailure.reason,
         initialModelFailure.message,
+        // Effective transport, not `deps.toolTransport`: on a
+        // cross-transport fallover the served link is the one whose
+        // rules decided this completion is terminal.
+        { transport: initialParseDeps.toolTransport },
       );
     }
     if (repairable) {
@@ -827,10 +831,11 @@ async function executeStepInner(
     // failure, not a grammar one — no point emitting `GrammarError` for
     // an empty body.
     const retryModelFailure = detectModelFailure(completion);
+    const retryParseDeps = parseDepsFor(completion, deps);
     if (
       retryModelFailure !== null &&
       !isNativeToolsEmptyCompletionHandledByParser(
-        parseDepsFor(completion, deps),
+        retryParseDeps,
         retryModelFailure.reason,
         completion,
       )
@@ -843,14 +848,13 @@ async function executeStepInner(
       throw new ModelError(
         retryModelFailure.reason,
         retryModelFailure.message,
+        // Same rule as the first-attempt throw: report the transport that
+        // served this completion, not the configured one.
+        { transport: retryParseDeps.toolTransport },
       );
     }
 
-    parsed = tryParseToolCalls(
-      completion,
-      deps.profile,
-      parseDepsFor(completion, deps),
-    );
+    parsed = tryParseToolCalls(completion, deps.profile, retryParseDeps);
     if (ctx.terminalOnly && parsed.ok) {
       const nonTerminal = parsed.batch.calls.find(
         ({ tool }) => tool !== "reply" && tool !== "finish",

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -532,7 +532,11 @@ async function executeStepInner(
         // Effective transport, not `deps.toolTransport`: on a
         // cross-transport fallover the served link is the one whose
         // rules decided this completion is terminal.
-        { transport: initialParseDeps.toolTransport },
+        //
+        // `stage: "initial"` is the other half of the split: the same
+        // `reason` + `transport` pair is also raised after the one-shot
+        // repair below, and only this field tells the two apart.
+        { transport: initialParseDeps.toolTransport, stage: "initial" },
       );
     }
     if (repairable) {
@@ -850,7 +854,14 @@ async function executeStepInner(
         retryModelFailure.message,
         // Same rule as the first-attempt throw: report the transport that
         // served this completion, not the configured one.
-        { transport: retryParseDeps.toolTransport },
+        //
+        // `stage: "repair"` — reached only after the one-shot repair ran,
+        // including the `native_tools` case where the first attempt was
+        // `content`-empty but carried `reasoning_content` (so the
+        // first-attempt throw was skipped) and the repair came back with
+        // nothing in any channel. Same `reason=empty`, same
+        // `transport=native_tools`, different story.
+        { transport: retryParseDeps.toolTransport, stage: "repair" },
       );
     }
 

--- a/src/error-reporting/error-scrubber.test.ts
+++ b/src/error-reporting/error-scrubber.test.ts
@@ -4,6 +4,7 @@ import {
   extractSafeCode,
   extractSafeReason,
   extractSafeTool,
+  extractSafeFailureStage,
   extractSafeToolTransport,
   extractSafeTransportHost,
   sanitizeStack,
@@ -132,6 +133,23 @@ describe("extractSafeToolTransport", () => {
   });
 });
 
+describe("extractSafeFailureStage", () => {
+  it("allows the known ModelFailureStage enum values", () => {
+    expect(extractSafeFailureStage({ stage: "initial" })).toBe("initial");
+    expect(extractSafeFailureStage({ stage: "repair" })).toBe("repair");
+  });
+
+  it("drops an unrecognised stage (could be freeform text)", () => {
+    expect(
+      extractSafeFailureStage({ stage: "repair of /Users/alex/x.txt" }),
+    ).toBeUndefined();
+    expect(extractSafeFailureStage({ stage: "" })).toBeUndefined();
+    expect(extractSafeFailureStage({ stage: 2 })).toBeUndefined();
+    expect(extractSafeFailureStage({})).toBeUndefined();
+    expect(extractSafeFailureStage(null)).toBeUndefined();
+  });
+});
+
 describe("extractSafeTool", () => {
   it("allows a bounded registry-style tool identifier", () => {
     expect(extractSafeTool({ tool: "os.fs.read" })).toBe("os.fs.read");
@@ -217,6 +235,34 @@ describe("scrubError", () => {
     const ev = scrubError(err, { source: "llm_failure" });
     expect(ev.reason).toBe("empty");
     expect(ev.toolTransport).toBeUndefined();
+  });
+
+  it("carries ModelError.stage through when it is a known enum value", () => {
+    // The axis `transport` does not cover: the same reason=empty +
+    // transport=native_tools pair is raised both by the by-design
+    // first-attempt route and after a repair that came back empty.
+    const err = Object.assign(new Error("empty completion"), {
+      name: "ModelError",
+      category: "model",
+      reason: "empty",
+      transport: "native_tools",
+      stage: "repair",
+    });
+    const ev = scrubError(err, { source: "llm_failure" });
+    expect(ev.toolTransport).toBe("native_tools");
+    expect(ev.failureStage).toBe("repair");
+  });
+
+  it("drops a bogus ModelError.stage rather than reporting it", () => {
+    const err = Object.assign(new Error("empty completion"), {
+      name: "ModelError",
+      category: "model",
+      reason: "empty",
+      stage: "stage 3 of /Users/alex/session.json",
+    });
+    const ev = scrubError(err, { source: "llm_failure" });
+    expect(ev.reason).toBe("empty");
+    expect(ev.failureStage).toBeUndefined();
   });
 
   it("carries ToolExecutionError.tool through when it is a bounded identifier", () => {

--- a/src/error-reporting/error-scrubber.test.ts
+++ b/src/error-reporting/error-scrubber.test.ts
@@ -4,6 +4,7 @@ import {
   extractSafeCode,
   extractSafeReason,
   extractSafeTool,
+  extractSafeToolTransport,
   extractSafeTransportHost,
   sanitizeStack,
   scrubError,
@@ -112,6 +113,25 @@ describe("extractSafeReason", () => {
   });
 });
 
+describe("extractSafeToolTransport", () => {
+  it("allows the known ToolCallTransport enum values", () => {
+    expect(extractSafeToolTransport({ transport: "grammar" })).toBe("grammar");
+    expect(extractSafeToolTransport({ transport: "native_tools" })).toBe(
+      "native_tools",
+    );
+  });
+
+  it("drops an unrecognised transport (could be freeform text)", () => {
+    expect(
+      extractSafeToolTransport({ transport: "grammar for /Users/alex/x.txt" }),
+    ).toBeUndefined();
+    expect(extractSafeToolTransport({ transport: "" })).toBeUndefined();
+    expect(extractSafeToolTransport({ transport: 7 })).toBeUndefined();
+    expect(extractSafeToolTransport({})).toBeUndefined();
+    expect(extractSafeToolTransport(null)).toBeUndefined();
+  });
+});
+
 describe("extractSafeTool", () => {
   it("allows a bounded registry-style tool identifier", () => {
     expect(extractSafeTool({ tool: "os.fs.read" })).toBe("os.fs.read");
@@ -173,6 +193,30 @@ describe("scrubError", () => {
     });
     const ev = scrubError(err, { source: "llm_failure" });
     expect(ev.reason).toBe("truncated");
+  });
+
+  it("carries ModelError.transport through when it is a known enum value", () => {
+    const err = Object.assign(new Error("empty completion"), {
+      name: "ModelError",
+      category: "model",
+      reason: "empty",
+      transport: "native_tools",
+    });
+    const ev = scrubError(err, { source: "llm_failure" });
+    expect(ev.reason).toBe("empty");
+    expect(ev.toolTransport).toBe("native_tools");
+  });
+
+  it("drops a bogus ModelError.transport rather than reporting it", () => {
+    const err = Object.assign(new Error("empty completion"), {
+      name: "ModelError",
+      category: "model",
+      reason: "empty",
+      transport: "totally made up /Users/alex",
+    });
+    const ev = scrubError(err, { source: "llm_failure" });
+    expect(ev.reason).toBe("empty");
+    expect(ev.toolTransport).toBeUndefined();
   });
 
   it("carries ToolExecutionError.tool through when it is a bounded identifier", () => {

--- a/src/error-reporting/error-scrubber.ts
+++ b/src/error-reporting/error-scrubber.ts
@@ -47,6 +47,18 @@ export interface ScrubbedErrorEvent {
    */
   toolTransport?: string;
   /**
+   * `ModelError.stage` when present — which attempt inside the step
+   * raised the defect. Restricted to the fixed 2-value
+   * `ModelFailureStage` enum (`initial | repair`) — an internal
+   * build-time constant, never freeform and never user-originated.
+   * `reason` + `toolTransport` do not cover this axis: within
+   * `native_tools`, `reason: "empty"` is raised both by the by-design
+   * first-attempt route and by "the one-shot repair came back empty
+   * too", and the Sentry fingerprint cannot split them either (it keys
+   * off a frame basename, and the shipped build is one bundled file).
+   */
+  failureStage?: string;
+  /**
    * `ToolExecutionError.tool` when present. Restricted to a bounded
    * identifier shape (registry tool names such as `os.fs.read`) — never
    * freeform text, since a hallucinated tool name could in theory echo
@@ -93,6 +105,9 @@ const KNOWN_MODEL_FAILURE_REASONS = new Set(["truncated", "empty", "no_stop"]);
 
 /** Mirror of `ToolCallTransport` in `src/llm/provider/completion-types.ts` — a fixed 2-value enum, safe to allowlist verbatim. */
 const KNOWN_TOOL_CALL_TRANSPORTS = new Set(["grammar", "native_tools"]);
+
+/** Mirror of `ModelFailureStage` in `src/llm/reliability/failure-category.ts` — a fixed 2-value enum, safe to allowlist verbatim. */
+const KNOWN_MODEL_FAILURE_STAGES = new Set(["initial", "repair"]);
 
 /**
  * Bounded identifier pattern for tool names (mirrors `MCP_TOOL_NAME_RE` in
@@ -228,6 +243,18 @@ export function extractSafeToolTransport(err: unknown): string | undefined {
 }
 
 /**
+ * Read `ModelError.stage` off an error, restricted to the known
+ * `ModelFailureStage` enum. Anything else is dropped rather than sent.
+ */
+export function extractSafeFailureStage(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const stage = (err as { stage?: unknown }).stage;
+  return typeof stage === "string" && KNOWN_MODEL_FAILURE_STAGES.has(stage)
+    ? stage
+    : undefined;
+}
+
+/**
  * Read `ToolExecutionError.tool` off an error, restricted to a bounded
  * identifier shape so freeform / hallucinated text is never sent.
  */
@@ -315,6 +342,7 @@ export function scrubError(
   const { httpStatus, code } = extractSafeCode(err);
   const reason = extractSafeReason(err);
   const toolTransport = extractSafeToolTransport(err);
+  const failureStage = extractSafeFailureStage(err);
   const tool = extractSafeTool(err);
   const transportHost = extractSafeTransportHost(err);
   const causeError = readCauseError(err);
@@ -335,6 +363,7 @@ export function scrubError(
   if (code !== undefined) event.code = code;
   if (reason !== undefined) event.reason = reason;
   if (toolTransport !== undefined) event.toolTransport = toolTransport;
+  if (failureStage !== undefined) event.failureStage = failureStage;
   if (tool !== undefined) event.tool = tool;
   if (transportHost !== undefined) event.transportHost = transportHost;
   return event;

--- a/src/error-reporting/error-scrubber.ts
+++ b/src/error-reporting/error-scrubber.ts
@@ -36,6 +36,17 @@ export interface ScrubbedErrorEvent {
    */
   reason?: string;
   /**
+   * `ModelError.transport` when present — the effective tool-call
+   * transport the defective completion was parsed under. Restricted to
+   * the fixed 2-value `ToolCallTransport` enum
+   * (`grammar | native_tools`) — an internal build-time constant, never
+   * freeform and never user-originated. Without it `reason: "empty"` is
+   * undiagnosable: on `native_tools` it is the by-design route for a
+   * completion with nothing in any channel, while on grammar it means
+   * the one-shot repair came back empty too.
+   */
+  toolTransport?: string;
+  /**
    * `ToolExecutionError.tool` when present. Restricted to a bounded
    * identifier shape (registry tool names such as `os.fs.read`) — never
    * freeform text, since a hallucinated tool name could in theory echo
@@ -79,6 +90,9 @@ export const STATIC_MESSAGE_ERRORS = new Set<string>([]);
 
 /** Mirror of `ModelFailureReason` in `src/llm/reliability/failure-category.ts` — a fixed 3-value enum, safe to allowlist verbatim. */
 const KNOWN_MODEL_FAILURE_REASONS = new Set(["truncated", "empty", "no_stop"]);
+
+/** Mirror of `ToolCallTransport` in `src/llm/provider/completion-types.ts` — a fixed 2-value enum, safe to allowlist verbatim. */
+const KNOWN_TOOL_CALL_TRANSPORTS = new Set(["grammar", "native_tools"]);
 
 /**
  * Bounded identifier pattern for tool names (mirrors `MCP_TOOL_NAME_RE` in
@@ -201,6 +215,19 @@ export function extractSafeReason(err: unknown): string | undefined {
 }
 
 /**
+ * Read `ModelError.transport` off an error, restricted to the known
+ * `ToolCallTransport` enum. Anything else is dropped rather than sent.
+ */
+export function extractSafeToolTransport(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null) return undefined;
+  const transport = (err as { transport?: unknown }).transport;
+  return typeof transport === "string" &&
+    KNOWN_TOOL_CALL_TRANSPORTS.has(transport)
+    ? transport
+    : undefined;
+}
+
+/**
  * Read `ToolExecutionError.tool` off an error, restricted to a bounded
  * identifier shape so freeform / hallucinated text is never sent.
  */
@@ -287,6 +314,7 @@ export function scrubError(
       : undefined) ?? readKnownCategory(err);
   const { httpStatus, code } = extractSafeCode(err);
   const reason = extractSafeReason(err);
+  const toolTransport = extractSafeToolTransport(err);
   const tool = extractSafeTool(err);
   const transportHost = extractSafeTransportHost(err);
   const causeError = readCauseError(err);
@@ -306,6 +334,7 @@ export function scrubError(
   if (httpStatus !== undefined) event.httpStatus = httpStatus;
   if (code !== undefined) event.code = code;
   if (reason !== undefined) event.reason = reason;
+  if (toolTransport !== undefined) event.toolTransport = toolTransport;
   if (tool !== undefined) event.tool = tool;
   if (transportHost !== undefined) event.transportHost = transportHost;
   return event;

--- a/src/error-reporting/sentry-envelope.test.ts
+++ b/src/error-reporting/sentry-envelope.test.ts
@@ -39,6 +39,40 @@ describe("buildEnvelope", () => {
     expect(payload.tags.cause_type).toBe("RangeError");
   });
 
+  it("stamps a tool_transport tag that splits ModelError reason=empty by transport", () => {
+    const base = {
+      errorType: "ModelError",
+      source: "llm_failure",
+      category: "model",
+      reason: "empty",
+      frames: [],
+    } as const;
+    const nativePayload = parseEventPayload(
+      buildEnvelope(DSN, { ...base, toolTransport: "native_tools" }, META).body,
+    );
+    const grammarPayload = parseEventPayload(
+      buildEnvelope(DSN, { ...base, toolTransport: "grammar" }, META).body,
+    );
+    expect(nativePayload.tags.tool_transport).toBe("native_tools");
+    expect(grammarPayload.tags.tool_transport).toBe("grammar");
+    expect(nativePayload.tags.reason).toBe(grammarPayload.tags.reason);
+    expect(nativePayload.tags.tool_transport).not.toBe(
+      grammarPayload.tags.tool_transport,
+    );
+  });
+
+  it("omits tool_transport when the scrubbed event has none", () => {
+    const ev: ScrubbedErrorEvent = {
+      errorType: "ModelError",
+      source: "llm_failure",
+      category: "model",
+      reason: "empty",
+      frames: [],
+    };
+    const { body } = buildEnvelope(DSN, ev, META);
+    expect(parseEventPayload(body).tags.tool_transport).toBeUndefined();
+  });
+
   it("omits cause_type when the scrubbed event has none", () => {
     const ev: ScrubbedErrorEvent = {
       errorType: "TransportError",

--- a/src/error-reporting/sentry-envelope.test.ts
+++ b/src/error-reporting/sentry-envelope.test.ts
@@ -73,6 +73,45 @@ describe("buildEnvelope", () => {
     expect(parseEventPayload(body).tags.tool_transport).toBeUndefined();
   });
 
+  it("stamps a failure_stage tag that splits an otherwise identical native_tools reason=empty", () => {
+    // The pair the transport tag alone cannot split: same errorType,
+    // same category, same reason, same transport — only the stage
+    // differs, and the Sentry fingerprint (a frame basename, in a
+    // single-file bundle) groups both into one issue.
+    const base = {
+      errorType: "ModelError",
+      source: "llm_failure",
+      category: "model",
+      reason: "empty",
+      toolTransport: "native_tools",
+      frames: [],
+    } as const;
+    const initialPayload = parseEventPayload(
+      buildEnvelope(DSN, { ...base, failureStage: "initial" }, META).body,
+    );
+    const repairPayload = parseEventPayload(
+      buildEnvelope(DSN, { ...base, failureStage: "repair" }, META).body,
+    );
+    expect(initialPayload.tags.failure_stage).toBe("initial");
+    expect(repairPayload.tags.failure_stage).toBe("repair");
+    expect(initialPayload.tags.reason).toBe(repairPayload.tags.reason);
+    expect(initialPayload.tags.tool_transport).toBe(
+      repairPayload.tags.tool_transport,
+    );
+  });
+
+  it("omits failure_stage when the scrubbed event has none", () => {
+    const ev: ScrubbedErrorEvent = {
+      errorType: "ModelError",
+      source: "llm_failure",
+      category: "model",
+      reason: "empty",
+      frames: [],
+    };
+    const { body } = buildEnvelope(DSN, ev, META);
+    expect(parseEventPayload(body).tags.failure_stage).toBeUndefined();
+  });
+
   it("omits cause_type when the scrubbed event has none", () => {
     const ev: ScrubbedErrorEvent = {
       errorType: "TransportError",

--- a/src/error-reporting/sentry-envelope.ts
+++ b/src/error-reporting/sentry-envelope.ts
@@ -54,6 +54,7 @@ export function buildEnvelope(
   if (ev.httpStatus !== undefined) tags.http_status = String(ev.httpStatus);
   if (ev.reason) tags.reason = ev.reason;
   if (ev.toolTransport) tags.tool_transport = ev.toolTransport;
+  if (ev.failureStage) tags.failure_stage = ev.failureStage;
   if (ev.tool) tags.tool = ev.tool;
   if (ev.transportHost) tags.transport_host = ev.transportHost;
 

--- a/src/error-reporting/sentry-envelope.ts
+++ b/src/error-reporting/sentry-envelope.ts
@@ -53,6 +53,7 @@ export function buildEnvelope(
   if (ev.code) tags.code = ev.code;
   if (ev.httpStatus !== undefined) tags.http_status = String(ev.httpStatus);
   if (ev.reason) tags.reason = ev.reason;
+  if (ev.toolTransport) tags.tool_transport = ev.toolTransport;
   if (ev.tool) tags.tool = ev.tool;
   if (ev.transportHost) tags.transport_host = ev.transportHost;
 

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -51,7 +51,9 @@ export type {
   DetectedModelFailure,
   LlmFailureCategory,
   LlmFailureOptions,
+  ModelErrorOptions,
   ModelFailureReason,
+  ModelFailureStage,
 } from "./reliability/index.js";
 export {
   LlamaServerProvider,

--- a/src/llm/reliability/failure-category.ts
+++ b/src/llm/reliability/failure-category.ts
@@ -36,3 +36,26 @@ export type LlmFailureCategory =
  * response.
  */
 export type ModelFailureReason = "truncated" | "empty" | "no_stop";
+
+/**
+ * Which attempt inside a single step raised the model-side defect. A
+ * fixed 2-value enum, mirrored verbatim by the error scrubber's
+ * allowlist.
+ *
+ *  - `initial`: the first completion of the step was defective and no
+ *               salvage path applied, so the step ended there.
+ *  - `repair`:  the first completion was salvageable-looking (or merely
+ *               unparseable), the one-shot repair ran, and the repair
+ *               completion was defective too.
+ *
+ * `reason` and `transport` alone cannot recover this split: on
+ * `native_tools` an `empty` body with nothing in any channel ends the
+ * step at `initial` by design, but a `content`-empty completion that
+ * still carries `reasoning_content` is handed to the parser, fails it,
+ * routes through the repair, and — when the repair comes back fully
+ * empty — raises the identical `reason=empty` + `transport=native_tools`
+ * pair at `repair`. Two different stories, one bucket, and the Sentry
+ * fingerprint cannot separate them either (it discriminates on a frame
+ * *basename*, and the shipped build is a single bundled file).
+ */
+export type ModelFailureStage = "initial" | "repair";

--- a/src/llm/reliability/index.ts
+++ b/src/llm/reliability/index.ts
@@ -1,6 +1,7 @@
 export type {
   LlmFailureCategory,
   ModelFailureReason,
+  ModelFailureStage,
 } from "./failure-category.js";
 export {
   CancelledError,

--- a/src/llm/reliability/index.ts
+++ b/src/llm/reliability/index.ts
@@ -10,7 +10,10 @@ export {
   ToolExecutionError,
   TransportError,
 } from "./llm-failures.js";
-export type { LlmFailureOptions } from "./llm-failures.js";
+export type {
+  LlmFailureOptions,
+  ModelErrorOptions,
+} from "./llm-failures.js";
 export { classifyFailure } from "./classify-failure.js";
 export {
   isNetworkError,

--- a/src/llm/reliability/llm-failures.ts
+++ b/src/llm/reliability/llm-failures.ts
@@ -1,3 +1,4 @@
+import type { ToolCallTransport } from "../provider/completion-types.js";
 import type {
   LlmFailureCategory,
   ModelFailureReason,
@@ -5,6 +6,16 @@ import type {
 
 export interface LlmFailureOptions {
   cause?: unknown;
+}
+
+/**
+ * `ModelError` extras. `transport` is the *effective* tool-call transport
+ * that the defective completion was parsed under — the transport of the
+ * link that actually served it, not necessarily the configured one (see
+ * `parseDepsFor` in `src/agent/step-executor.ts`).
+ */
+export interface ModelErrorOptions extends LlmFailureOptions {
+  transport?: ToolCallTransport;
 }
 
 /**
@@ -71,17 +82,33 @@ export class GrammarError extends LlmFailure {
  * missing stop token). These are never retried in-place because the
  * model already consumed its budget on this prompt — a second pass over
  * the same prefix would almost certainly hit the same wall.
+ *
+ * `transport` records which tool-call transport the completion was
+ * parsed under, because `reason` alone is ambiguous for the largest of
+ * these buckets: an `empty` body routes through `ModelError` **by
+ * design** on `native_tools` (nothing in any channel — see
+ * `isNativeToolsEmptyCompletionHandledByParser`), whereas on the grammar
+ * transports the same `reason` means the one-shot repair
+ * (`isGrammarEmptyCompletionWorthRepairing`) also came back empty, which
+ * is a different and more suspicious story. Diagnostic only — nothing
+ * branches on it.
  */
 export class ModelError extends LlmFailure {
   readonly category = "model" as const;
 
+  /** Effective transport the defective completion was parsed under. */
+  readonly transport?: ToolCallTransport;
+
   constructor(
     readonly reason: ModelFailureReason,
     message: string,
-    options?: LlmFailureOptions,
+    options?: ModelErrorOptions,
   ) {
     super(message, options);
     this.name = "ModelError";
+    if (options?.transport !== undefined) {
+      this.transport = options.transport;
+    }
   }
 }
 

--- a/src/llm/reliability/llm-failures.ts
+++ b/src/llm/reliability/llm-failures.ts
@@ -2,6 +2,7 @@ import type { ToolCallTransport } from "../provider/completion-types.js";
 import type {
   LlmFailureCategory,
   ModelFailureReason,
+  ModelFailureStage,
 } from "./failure-category.js";
 
 export interface LlmFailureOptions {
@@ -9,13 +10,21 @@ export interface LlmFailureOptions {
 }
 
 /**
- * `ModelError` extras. `transport` is the *effective* tool-call transport
- * that the defective completion was parsed under — the transport of the
- * link that actually served it, not necessarily the configured one (see
- * `parseDepsFor` in `src/agent/step-executor.ts`).
+ * `ModelError` extras.
+ *
+ * `transport` is the *effective* tool-call transport that the defective
+ * completion was parsed under — the transport of the link that actually
+ * served it, not necessarily the configured one (see `parseDepsFor` in
+ * `src/agent/step-executor.ts`).
+ *
+ * `stage` says which attempt inside the step raised the defect, which is
+ * the axis `transport` does **not** cover: within one transport the
+ * first-attempt throw and the repair-also-came-back-empty throw are
+ * otherwise indistinguishable.
  */
 export interface ModelErrorOptions extends LlmFailureOptions {
   transport?: ToolCallTransport;
+  stage?: ModelFailureStage;
 }
 
 /**
@@ -83,21 +92,32 @@ export class GrammarError extends LlmFailure {
  * model already consumed its budget on this prompt — a second pass over
  * the same prefix would almost certainly hit the same wall.
  *
- * `transport` records which tool-call transport the completion was
- * parsed under, because `reason` alone is ambiguous for the largest of
- * these buckets: an `empty` body routes through `ModelError` **by
- * design** on `native_tools` (nothing in any channel — see
- * `isNativeToolsEmptyCompletionHandledByParser`), whereas on the grammar
- * transports the same `reason` means the one-shot repair
- * (`isGrammarEmptyCompletionWorthRepairing`) also came back empty, which
- * is a different and more suspicious story. Diagnostic only — nothing
- * branches on it.
+ * `reason` alone is ambiguous for the largest of these buckets, and two
+ * orthogonal facts are needed to disambiguate it:
+ *
+ *  - `transport` — which tool-call transport the completion was parsed
+ *    under. `empty` on `native_tools` and `empty` on a grammar link are
+ *    produced by different rule sets
+ *    (`isNativeToolsEmptyCompletionHandledByParser` vs
+ *    `isGrammarEmptyCompletionWorthRepairing`).
+ *  - `stage` — which attempt raised it. On `native_tools` an `empty`
+ *    completion with nothing in any channel ends the step at `initial`
+ *    by design, while a `content`-empty completion that still carries
+ *    `reasoning_content` survives that check, fails the parse, goes
+ *    through the one-shot repair, and raises the *same*
+ *    `reason=empty` + `transport=native_tools` pair at `repair` when the
+ *    repair is empty too. Without `stage` those two are one bucket.
+ *
+ * Both are diagnostic only — nothing branches on either.
  */
 export class ModelError extends LlmFailure {
   readonly category = "model" as const;
 
   /** Effective transport the defective completion was parsed under. */
   readonly transport?: ToolCallTransport;
+
+  /** Which attempt inside the step raised this defect. */
+  readonly stage?: ModelFailureStage;
 
   constructor(
     readonly reason: ModelFailureReason,
@@ -108,6 +128,9 @@ export class ModelError extends LlmFailure {
     this.name = "ModelError";
     if (options?.transport !== undefined) {
       this.transport = options.transport;
+    }
+    if (options?.stage !== undefined) {
+      this.stage = options.stage;
     }
   }
 }


### PR DESCRIPTION
## Why

Sentry cluster **CLI-BA** is the largest *new* user-facing model-failure cluster: **61 events / 31 users in 14d**, **53 of them on 0.5.5**, and it is **win32-exclusive**. Tags: `error_type=ModelError`, `category=model`, `reason=empty`, `source=llm_failure`, `os=win32`. Culprit `executeStepInner`. Siblings **CLI-BR** (6 events / 2 users, 5 on win32) and **CLI-C0** (5 events / 1 user) have the same shape.

Today that cluster **cannot be diagnosed at all**, because the outcome hinges on two facts that never leave the machine: which tool-call transport served the completion, and which of the two throw sites in `executeStepInner` fired. Error messages are scrubbed by design (`src/error-reporting/error-scrubber.ts` is a strict allowlist, `STATIC_MESSAGE_ERRORS` is empty), so the only way to recover either is a new allowlisted enum field.

Both axes are needed, because neither one alone splits the bucket:

- **Transport.** `reason=empty` on `native_tools` and on a grammar link are produced by different rule sets — `isNativeToolsEmptyCompletionHandledByParser` vs `isGrammarEmptyCompletionWorthRepairing`.
- **Stage.** Within `native_tools`, `reason=empty` is raised by *both* throw sites, and they mean opposite things. A completion with nothing in any channel ends the step at the **first** site (`step-executor.ts:529`) — that is the by-design route. But a completion whose `content` is empty while `reasoning_content` is not satisfies `isNativeToolsEmptyCompletionHandledByParser` (`step-executor.ts:1271`), so the first site does **not** fire: the parse fails, the one-shot repair runs, and if the repair comes back fully empty the **second** site (`step-executor.ts:852`) throws the identical `reason=empty` + `tool_transport=native_tools` pair. Sentry cannot separate those either — the fingerprint (`sentry-envelope.ts:65` + `:86-92`) discriminates on `ev.frames[0].filename`, which is a **basename**, and the shipped build is a single bundled file (see the module comment at `sentry-envelope.ts:142`), so both sites hash into one issue.

So `tool_transport` alone delivers *grammar vs native*, and nothing more; `failure_stage` delivers the rest. Both are shipped here.

## What changed

1. `src/llm/reliability/llm-failures.ts` — `ModelError` gains an optional `transport` (the existing `ToolCallTransport` union, `grammar | native_tools`, from `src/llm/provider/completion-types.ts`) and an optional `stage`, both via a new `ModelErrorOptions`. Type-only imports.
2. `src/llm/reliability/failure-category.ts` — new `ModelFailureStage = "initial" | "repair"`, sitting next to `ModelFailureReason` as a fixed build-time enum.
3. `src/agent/step-executor.ts` — both model-failure throw sites populate `transport` from `parseDepsFor(completion, deps).toolTransport`, i.e. the **effective** transport (prefers `completion.servedTransport` over `deps.toolTransport`). On a cross-transport fallover the configured transport is not the one whose rules decided the completion is terminal, so tagging the configured one would make the field lie on exactly the case that matters most. The first site stamps `stage: "initial"`, the post-repair site `stage: "repair"`. The retry-path `parseDepsFor(...)` call is hoisted into a local and reused (it was already being computed twice).
4. `src/error-reporting/error-scrubber.ts` — `toolTransport` and `failureStage` on `ScrubbedErrorEvent`, filled by `extractSafeToolTransport` / `extractSafeFailureStage`, allowlisted exactly like `reason`: fixed enum membership against `KNOWN_TOOL_CALL_TRANSPORTS` / `KNOWN_MODEL_FAILURE_STAGES`, value dropped if it does not match. Both are two-value internal build-time constants, never freeform and never user-originated.
5. `src/error-reporting/sentry-envelope.ts` — stamps them as `tool_transport` and `failure_stage` tags, matching the existing `error_type` / `cause_type` / `http_status` / `transport_host` naming.
6. `src/llm/index.ts` — re-exports `ModelErrorOptions` and `ModelFailureStage`, aligning with the `LlmFailureOptions` that barrel already exported (`src/llm/reliability/index.ts` exported `ModelErrorOptions` but the top-level barrel did not).

The fingerprint is deliberately left untouched, so existing issues are not re-grouped; the two new tags are enough to split and filter CLI-BA in the UI.

### What the tags do and do not tell you

- `tool_transport` separates grammar from native. That is all it separates.
- `failure_stage` separates the by-design first-site throw from the "the repair came back empty too" second-site throw — the split `tool_transport` cannot make within one transport, and the fingerprint cannot make at all.
- One seam remains, pre-existing and deliberate: on a **cross-transport fallover** the repair prompt is still built from the **configured** `deps.toolTransport` (`step-executor.ts:758`, per the comment at `:367-370`) while the tag reports the **served** one. So "`tool_transport=grammar` + `failure_stage=repair` means a grammar-shaped repair also came back empty" is exactly true only when configured == served; on a fallover the repair was shaped for the configured transport. That is existing behaviour, unchanged here.

## Behaviour

No behaviour change where it matters: repair, fallover and classification are untouched. The two `isNative…` / `isGrammar…` predicates, the repair path, `detectModelFailure` and `parseDepsFor` all behave exactly as before, and the new values are written to fields nothing branches on. These are diagnosis-enabling fields only.

Not literally zero, though, in one inert respect: `tsconfig.json` targets ES2022 without `useDefineForClassFields`, which therefore defaults to **true**, so the `transport;` / `stage;` declarations are emitted as class fields and every `ModelError` now owns two extra enumerable keys even when constructed with no options — own keys go from `["category","reason","name"]` to `["category","transport","stage","reason","name"]`. Nothing in `src/` enumerates error own-properties and `JSON.stringify` drops `undefined`, so the observable impact is nil; noted rather than claimed away.

## Tests

New coverage, each verified to fail when the corresponding src change is reverted:

- `extractSafeToolTransport` / `extractSafeFailureStage` accept their enum values and **drop** a bogus one; `scrubError` carries valid ones and drops bogus ones (each fails with the allowlist replaced by a pass-through, or with the `scrubError` wiring removed).
- `buildEnvelope` emits `tool_transport` and `failure_stage`; two events with identical `reason=empty` tag differently by transport, and two events with identical `reason=empty` **and** identical `tool_transport=native_tools` tag differently by stage; both omitted when absent.
- `executeStep` transport tag: a `native_tools` empty completion throws `ModelError{reason:"empty", transport:"native_tools"}`; a twice-empty grammar step throws `transport:"grammar"`; and on a cross-transport fallover (`servedTransport` stamped, both directions) the thrown error reports the **served** transport, not the configured one.
- `executeStep` stage tag: the by-design first-site throw is `stage:"initial"` after exactly **1** LLM call; the counterexample above (`content` empty + `reasoning_content` present, then a fully empty repair) is `stage:"repair"` after **2** calls with the *same* `reason` and `transport`; a twice-empty grammar step is `stage:"repair"`.
- `executeStep` repair-parse transport: the repair/retry parse must run under the **served** transport. Configured `grammar`, served by a native link, repair answers native-shaped (empty `content`, the call in `tool_calls`) — parsed under the served transport the step replies, parsed under the configured one it dies with `GrammarError: tool-call body is empty`. This closes a pre-existing coverage gap on the one line this PR moved: swapping `tryParseToolCalls(completion, deps.profile, retryParseDeps)` back to `deps` previously survived the entire suite.

```
npm run lint                                            # tsc --noEmit, clean
npx vitest run src/error-reporting src/llm/reliability src/agent/step-executor.test.ts
#   Test Files  11 passed (11)
#        Tests  175 passed (175)
```
