### PR TITLE
fix(llm): run the subscription CLIs through cmd.exe on Windows

### DIFF
--- a/src/llm/provider/subscription-cli/host-environment.test.ts
+++ b/src/llm/provider/subscription-cli/host-environment.test.ts
@@ -1,0 +1,139 @@
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { hostFileStatus, readShimHead } from "./host-environment.js";
+
+/**
+ * The two host facts the Windows shim cannot guess, tested against real
+ * files because that is where both bugs were: a `false` that meant
+ * "could not tell", and a partial read reported as a whole one.
+ *
+ * The same `%*` detector the shim uses, so a head that "contains the
+ * token" here means what it means there.
+ */
+const ARG_SUBSTITUTION = /%(?:\*|~[a-zA-Z$:]*[0-9]|[0-9])/;
+
+let dir = "";
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "shim-probe-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true, maxRetries: 3 });
+});
+
+function write(name: string, body: Buffer | string): string {
+  const path = join(dir, name);
+  writeFileSync(path, body);
+  return path;
+}
+
+describe("readShimHead", () => {
+  it("returns the head of an ordinary shim", () => {
+    const path = write(
+      "claude.cmd",
+      '@ECHO off\r\nendLocal & "%_prog%" "%dp0%\\cli.js" %*\r\n',
+    );
+    const head = readShimHead(path);
+    expect(head).not.toBeNull();
+    expect(ARG_SUBSTITUTION.test(head ?? "")).toBe(true);
+  });
+
+  it("refuses to answer for a file bigger than the probe window", () => {
+    // The dangerous shape: `%*` past the cap. A head truncated at 8 KiB
+    // contains no substitution token, so returning it says "this shim
+    // does not re-substitute" — and the caller picks the *single*
+    // escaping, which is the one an argument can break out of. There is
+    // no honest answer here short of reading more, so there is no
+    // answer at all.
+    const filler = `REM ${"x".repeat(9_000)}\r\n`;
+    const path = write("big.cmd", `${filler}@node cli.js %*\r\n`);
+    expect(readShimHead(path)).toBeNull();
+    // …and the truncated read really would have said "no": this is the
+    // case, not a rewording of the unreadable one.
+    const truncated = filler.slice(0, 8 * 1024);
+    expect(ARG_SUBSTITUTION.test(truncated)).toBe(false);
+  });
+
+  it("reads a shim that only just fits", () => {
+    const body = `@node cli.js %*\r\nREM ${"x".repeat(8_000)}`;
+    expect(body.length).toBeLessThan(8 * 1024);
+    expect(readShimHead(write("snug.cmd", body))).toContain("%*");
+  });
+
+  it("sees through a UTF-16LE BOM, where the token reads as %\\0*\\0", () => {
+    const path = write(
+      "utf16.cmd",
+      Buffer.concat([
+        Buffer.from([0xff, 0xfe]),
+        Buffer.from('@node cli.js %*\r\n', "utf16le"),
+      ]),
+    );
+    expect(ARG_SUBSTITUTION.test(readShimHead(path) ?? "")).toBe(true);
+  });
+
+  it("is not fooled by a UTF-8 BOM either", () => {
+    const path = write(
+      "bom.cmd",
+      Buffer.concat([
+        Buffer.from([0xef, 0xbb, 0xbf]),
+        Buffer.from("@node cli.js %*\r\n", "utf8"),
+      ]),
+    );
+    expect(ARG_SUBSTITUTION.test(readShimHead(path) ?? "")).toBe(true);
+  });
+
+  it("declines UTF-16BE rather than guessing at it", () => {
+    const le = Buffer.from("@node cli.js %*", "utf16le");
+    le.swap16();
+    const path = write(
+      "be.cmd",
+      Buffer.concat([Buffer.from([0xfe, 0xff]), le]),
+    );
+    expect(readShimHead(path)).toBeNull();
+  });
+
+  it("returns null for what it cannot open", () => {
+    expect(readShimHead(join(dir, "nope.cmd"))).toBeNull();
+    mkdirSync(join(dir, "adir.cmd"));
+    expect(readShimHead(join(dir, "adir.cmd"))).toBeNull();
+  });
+
+  it("re-reads a shim npm has replaced", () => {
+    const path = write("upgraded.cmd", "@node cli.js\r\n");
+    expect(ARG_SUBSTITUTION.test(readShimHead(path) ?? "")).toBe(false);
+    writeFileSync(path, "@node cli.js %* REM upgraded\r\n");
+    expect(ARG_SUBSTITUTION.test(readShimHead(path) ?? "")).toBe(true);
+  });
+});
+
+describe("hostFileStatus", () => {
+  it("tells present from absent", () => {
+    expect(hostFileStatus(write("claude.cmd", "@echo off"))).toBe("present");
+    expect(hostFileStatus(join(dir, "gone.cmd"))).toBe("absent");
+    // A file *under* a file: ENOTDIR, and just as absent.
+    expect(hostFileStatus(join(dir, "claude.cmd", "deeper.cmd"))).toBe(
+      "absent",
+    );
+  });
+
+  it("reports a path it may not stat as unknown, not as missing", () => {
+    // The bug `existsSync` cannot express: EACCES came back as `false`,
+    // and a real install under a restricted directory was reported as
+    // "was not found on PATH".
+    if (process.getuid?.() === 0) return; // root is not denied anything
+    const locked = join(dir, "locked");
+    mkdirSync(locked);
+    const path = join(locked, "claude.cmd");
+    writeFileSync(path, "@echo off");
+    chmodSync(locked, 0o000);
+    try {
+      expect(hostFileStatus(path)).toBe("unknown");
+    } finally {
+      chmodSync(locked, 0o700);
+    }
+  });
+});

--- a/src/llm/provider/subscription-cli/host-environment.ts
+++ b/src/llm/provider/subscription-cli/host-environment.ts
@@ -27,12 +27,20 @@ export function hostEnv(): NodeJS.ProcessEnv {
  * `existsSync` collapses "this path is not there" and "I was not allowed
  * to look" into the same `false`, and the second happens for real: a
  * `binPath` under a directory the user may traverse but not stat
- * (EACCES/EPERM), or on a UNC share that is momentarily unavailable
- * (ENETUNREACH, ETIMEDOUT, EBUSY). Reporting those as "not installed"
- * turns a working install into "was not found on PATH". Only ENOENT and
- * ENOTDIR — the path, or a directory along it, genuinely is not there —
- * are `absent`; everything else is `unknown` and the caller hands the
- * target to cmd.exe, which can answer for itself.
+ * (EACCES/EPERM), or on a UNC path whose host does not answer — which
+ * arrives as the code `UNKNOWN`, not one of the network errnos: libuv
+ * has no mapping for `ERROR_BAD_NETPATH` / `ERROR_BAD_NET_NAME`, so
+ * `err.code` is the literal string `"UNKNOWN"` with the Win32 status in
+ * `err.errno`. Reporting those as "not installed" turns a working
+ * install into "was not found on PATH". Only ENOENT and ENOTDIR — the
+ * path, or a directory along it, genuinely is not there — are `absent`;
+ * everything else is `unknown` and the caller hands the target to
+ * cmd.exe, which can answer for itself.
+ *
+ * One network case this does *not* rescue: a mapped drive whose
+ * connection has dropped stats as ENOENT, so `Z:\tools\claude.cmd` is
+ * `absent` and still reports as not installed. It is indistinguishable
+ * here from a path that really is gone.
  */
 export type FileStatus = "present" | "absent" | "unknown";
 

--- a/src/llm/provider/subscription-cli/host-environment.ts
+++ b/src/llm/provider/subscription-cli/host-environment.ts
@@ -1,4 +1,4 @@
-import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
+import { closeSync, openSync, readSync, statSync } from "node:fs";
 
 /**
  * Every fact about the host the Windows shim depends on, behind one
@@ -6,7 +6,7 @@ import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
  *
  * The point is testability: nobody working on this has a Windows box, so
  * the win32 branch has to be reachable from a macOS/Linux run. Passing
- * `platform` / `env` / `fileExists` explicitly covers the shim's own
+ * `platform` / `env` / `fileStatus` explicitly covers the shim's own
  * unit tests, and mocking this module (`vi.mock("./host-environment.js")`)
  * covers the wiring — `streamCliCommand` and `runCliCommand` calling the
  * shim at all, which is otherwise invisible off Windows because the shim
@@ -21,8 +21,29 @@ export function hostEnv(): NodeJS.ProcessEnv {
   return process.env;
 }
 
-export function hostFileExists(path: string): boolean {
-  return existsSync(path);
+/**
+ * Three answers, not two.
+ *
+ * `existsSync` collapses "this path is not there" and "I was not allowed
+ * to look" into the same `false`, and the second happens for real: a
+ * `binPath` under a directory the user may traverse but not stat
+ * (EACCES/EPERM), or on a UNC share that is momentarily unavailable
+ * (ENETUNREACH, ETIMEDOUT, EBUSY). Reporting those as "not installed"
+ * turns a working install into "was not found on PATH". Only ENOENT and
+ * ENOTDIR — the path, or a directory along it, genuinely is not there —
+ * are `absent`; everything else is `unknown` and the caller hands the
+ * target to cmd.exe, which can answer for itself.
+ */
+export type FileStatus = "present" | "absent" | "unknown";
+
+export function hostFileStatus(path: string): FileStatus {
+  try {
+    statSync(path);
+    return "present";
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code === "ENOENT" || code === "ENOTDIR" ? "absent" : "unknown";
+  }
 }
 
 /**
@@ -42,6 +63,13 @@ const probeCache = new Map<string, string | null>();
  * `null` is a real answer, not an error: the caller has a conservative
  * default for "cannot tell", and a shim we may not read is not a reason
  * to fail a turn.
+ *
+ * "Cannot tell" includes *reading only part of the file*. A file that
+ * fills the probe window may well substitute its arguments past the end
+ * of what we looked at, and answering "no `%*` in the first 8 KiB" with
+ * a confident `false` picks the weaker escaping for the one case we know
+ * nothing about — the exact injection the gate exists to close. A
+ * truncated read is therefore no answer at all.
  */
 export function readShimHead(path: string): string | null {
   let key = path;
@@ -65,7 +93,10 @@ function readHead(path: string): string | null {
     fd = openSync(path, "r");
     const buffer = Buffer.alloc(SHIM_PROBE_BYTES);
     const read = readSync(fd, buffer, 0, SHIM_PROBE_BYTES, 0);
-    return buffer.subarray(0, read).toString("latin1");
+    // Filled the window: there is more file than we read, so anything we
+    // did not see is unknown rather than absent.
+    if (read >= SHIM_PROBE_BYTES) return null;
+    return decodeShim(buffer.subarray(0, read));
   } catch {
     return null;
   } finally {
@@ -77,4 +108,28 @@ function readHead(path: string): string | null {
       }
     }
   }
+}
+
+/**
+ * Batch files are bytes, not text, and cmd reads them in the console
+ * codepage — so `latin1` (a byte-for-byte mapping that never fails) is
+ * the right default: it cannot mangle the ASCII `%*` / `%1` we are
+ * looking for, and a UTF-8 BOM is just three bytes of noise in front of
+ * it.
+ *
+ * UTF-16 is the one encoding that would hide the token, since `%*`
+ * becomes `%\0*\0`. cmd cannot reliably run a UTF-16LE batch file at all
+ * (it reads the NULs as command text), so this is close to unreachable —
+ * but decoding it costs one branch and removes the question. UTF-16BE
+ * has no decoder here and no plausible reader either, so it is simply
+ * "cannot tell".
+ */
+function decodeShim(bytes: Buffer): string | null {
+  if (bytes.length >= 2) {
+    if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+      return bytes.subarray(2).toString("utf16le");
+    }
+    if (bytes[0] === 0xfe && bytes[1] === 0xff) return null;
+  }
+  return bytes.toString("latin1");
 }

--- a/src/llm/provider/subscription-cli/host-environment.ts
+++ b/src/llm/provider/subscription-cli/host-environment.ts
@@ -1,0 +1,80 @@
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
+
+/**
+ * Every fact about the host the Windows shim depends on, behind one
+ * seam.
+ *
+ * The point is testability: nobody working on this has a Windows box, so
+ * the win32 branch has to be reachable from a macOS/Linux run. Passing
+ * `platform` / `env` / `fileExists` explicitly covers the shim's own
+ * unit tests, and mocking this module (`vi.mock("./host-environment.js")`)
+ * covers the wiring — `streamCliCommand` and `runCliCommand` calling the
+ * shim at all, which is otherwise invisible off Windows because the shim
+ * is a passthrough everywhere else.
+ */
+
+export function hostPlatform(): NodeJS.Platform {
+  return process.platform;
+}
+
+export function hostEnv(): NodeJS.ProcessEnv {
+  return process.env;
+}
+
+export function hostFileExists(path: string): boolean {
+  return existsSync(path);
+}
+
+/**
+ * How much of a `.cmd`/`.bat` we are willing to read to decide how to
+ * escape. npm's cmd-shim template is ~400 bytes and every generator in
+ * the wild is in the same range; the cap is there so a `.cmd` that is
+ * really a multi-megabyte blob cannot stall a turn.
+ */
+const SHIM_PROBE_BYTES = 8 * 1024;
+
+/** Keyed on identity *and* mtime/size, so an npm update is not missed. */
+const probeCache = new Map<string, string | null>();
+
+/**
+ * The first few KiB of a batch shim, or `null` when it cannot be read.
+ *
+ * `null` is a real answer, not an error: the caller has a conservative
+ * default for "cannot tell", and a shim we may not read is not a reason
+ * to fail a turn.
+ */
+export function readShimHead(path: string): string | null {
+  let key = path;
+  try {
+    const stat = statSync(path);
+    key = `${path}|${stat.size}|${stat.mtimeMs}`;
+  } catch {
+    return null;
+  }
+  const cached = probeCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const text = readHead(path);
+  probeCache.set(key, text);
+  return text;
+}
+
+function readHead(path: string): string | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, "r");
+    const buffer = Buffer.alloc(SHIM_PROBE_BYTES);
+    const read = readSync(fd, buffer, 0, SHIM_PROBE_BYTES, 0);
+    return buffer.subarray(0, read).toString("latin1");
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // nothing useful to do with a failing close here
+      }
+    }
+  }
+}

--- a/src/llm/provider/subscription-cli/index.ts
+++ b/src/llm/provider/subscription-cli/index.ts
@@ -36,11 +36,13 @@ export {
 } from "./subscription-cli-provider.js";
 export {
   SubscriptionCliAuthError,
+  SubscriptionCliCommandLineError,
   SubscriptionCliInvocationError,
   SubscriptionCliNotInstalledError,
   SubscriptionCliSpawnError,
 } from "./subscription-cli-errors.js";
 export {
+  MAX_CMD_COMMAND_LINE,
   resolveWindowsCliInvocation,
   type CliInvocation,
 } from "./windows-cli-shim.js";

--- a/src/llm/provider/subscription-cli/index.ts
+++ b/src/llm/provider/subscription-cli/index.ts
@@ -38,4 +38,9 @@ export {
   SubscriptionCliAuthError,
   SubscriptionCliInvocationError,
   SubscriptionCliNotInstalledError,
+  SubscriptionCliSpawnError,
 } from "./subscription-cli-errors.js";
+export {
+  resolveWindowsCliInvocation,
+  type CliInvocation,
+} from "./windows-cli-shim.js";

--- a/src/llm/provider/subscription-cli/run-cli-completion.ts
+++ b/src/llm/provider/subscription-cli/run-cli-completion.ts
@@ -47,6 +47,7 @@ export const runCliCommand: CliRunner = async (options) => {
   const invocation = resolveWindowsCliInvocation({
     binary: options.binary,
     args: options.args,
+    installHint: options.installHint,
   });
   let result;
   try {

--- a/src/llm/provider/subscription-cli/run-cli-completion.ts
+++ b/src/llm/provider/subscription-cli/run-cli-completion.ts
@@ -1,9 +1,12 @@
 import { runCommand } from "../../../sandbox/command-runner.js";
 import {
   isEnoent,
+  isSpawnEinval,
   mapCliFailure,
   SubscriptionCliNotInstalledError,
+  SubscriptionCliSpawnError,
 } from "./subscription-cli-errors.js";
+import { resolveWindowsCliInvocation } from "./windows-cli-shim.js";
 
 export interface CliRunOptions {
   binary: string;
@@ -39,9 +42,15 @@ export type CliRunner = (options: CliRunOptions) => Promise<CliRunOutcome>;
  * `git-runner.ts` wraps it for git.
  */
 export const runCliCommand: CliRunner = async (options) => {
+  // On Windows the vendor CLIs are `.cmd` shims, which spawn refuses to
+  // start without a shell; elsewhere this hands the pair straight back.
+  const invocation = resolveWindowsCliInvocation({
+    binary: options.binary,
+    args: options.args,
+  });
   let result;
   try {
-    result = await runCommand(options.binary, [...options.args], {
+    result = await runCommand(invocation.command, invocation.args, {
       cwd: options.cwd,
       timeoutMs: options.timeoutMs,
       maxOutputBytes: options.maxOutputBytes,
@@ -52,8 +61,16 @@ export const runCliCommand: CliRunner = async (options) => {
       // exactly that.
       ...(options.input === undefined ? {} : { input: options.input }),
       ...(options.signal ? { signal: options.signal } : {}),
+      ...(invocation.windowsVerbatimArguments
+        ? { windowsVerbatimArguments: true }
+        : {}),
     });
   } catch (err) {
+    // EINVAL is thrown, not emitted, so it reaches us through the
+    // promise rejection rather than the child's `error` event.
+    if (isSpawnEinval(err)) {
+      throw new SubscriptionCliSpawnError(options.binary, options.installHint);
+    }
     if (isEnoent(err)) {
       throw new SubscriptionCliNotInstalledError(
         options.binary,

--- a/src/llm/provider/subscription-cli/spawn-einval.test.ts
+++ b/src/llm/provider/subscription-cli/spawn-einval.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * The Windows failure both CLI paths have to survive, reproduced on any
+ * host: Node hands EACCES/EAGAIN/EMFILE/ENFILE/ENOENT to the child's
+ * `error` event and *throws* every other errno straight out of
+ * `ChildProcess.prototype.spawn`. A `.cmd`/`.bat` target spawned without
+ * a shell has failed with EINVAL since the CVE-2024-27980 fix, so the
+ * throw is what production actually sees — and mocking `spawn` is the
+ * only way to produce it off Windows.
+ */
+const SHIM = "C:\\npm\\claude.cmd";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (file: string, ...rest: unknown[]) => {
+      if (file === SHIM) {
+        throw Object.assign(new Error("spawn EINVAL"), {
+          code: "EINVAL",
+          errno: -22,
+          syscall: "spawn",
+          path: file,
+        });
+      }
+      return (actual.spawn as (...a: unknown[]) => unknown)(file, ...rest);
+    },
+  };
+});
+
+const { runCliCommand } = await import("./run-cli-completion.js");
+const { streamCliCommand } = await import("./stream-cli-completion.js");
+const { SubscriptionCliSpawnError } = await import(
+  "./subscription-cli-errors.js"
+);
+
+const options = {
+  binary: SHIM,
+  args: ["--print"],
+  cwd: process.cwd(),
+  timeoutMs: 5_000,
+  maxOutputBytes: 4096,
+  installHint: "Install Claude Code.",
+  authHint: "Run `claude` and complete /login.",
+};
+
+describe("a spawn that throws EINVAL", () => {
+  it("becomes a typed error on the buffered path", async () => {
+    await expect(runCliCommand(options)).rejects.toBeInstanceOf(
+      SubscriptionCliSpawnError,
+    );
+    await expect(runCliCommand(options)).rejects.toThrow(
+      /could not be started[\s\S]*Install Claude Code\./,
+    );
+  });
+
+  it("becomes a typed error on the streaming path", async () => {
+    // `spawn` is the generator's first statement, so nothing catches
+    // this unless the call itself is guarded.
+    await expect(streamCliCommand(options).next()).rejects.toBeInstanceOf(
+      SubscriptionCliSpawnError,
+    );
+  });
+
+  it("still reports a genuinely missing binary as not installed", async () => {
+    const missing = { ...options, binary: "definitely-not-a-real-binary-xyz" };
+    await expect(runCliCommand(missing)).rejects.toThrow(/was not found on PATH/);
+    await expect(streamCliCommand(missing).next()).rejects.toThrow(
+      /was not found on PATH/,
+    );
+  });
+});

--- a/src/llm/provider/subscription-cli/stream-cli-completion.ts
+++ b/src/llm/provider/subscription-cli/stream-cli-completion.ts
@@ -36,6 +36,7 @@ export const streamCliCommand: CliStreamRunner = async function* (options) {
   const invocation = resolveWindowsCliInvocation({
     binary: options.binary,
     args: options.args,
+    installHint: options.installHint,
   });
   let child;
   try {

--- a/src/llm/provider/subscription-cli/stream-cli-completion.ts
+++ b/src/llm/provider/subscription-cli/stream-cli-completion.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 import { isBrokenPipe } from "../../../sandbox/index.js";
+import { killProcessTree } from "../../../sandbox/kill-process-tree.js";
+import { hostPlatform } from "./host-environment.js";
 import type { CliRunOptions } from "./run-cli-completion.js";
 import {
   isEnoent,
@@ -24,8 +26,9 @@ export type CliStreamRunner = (
  *
  * Separate from `runCliCommand` because the buffered runner resolves
  * only once the process exits, which is exactly what streaming must
- * avoid. The generator's `finally` always kills the child, so a consumer
- * that abandons the iterator cannot leak a process.
+ * avoid. The generator's `finally` always kills the child — the whole
+ * process tree on Windows, where the child is a `cmd.exe` wrapper — so a
+ * consumer that abandons the iterator cannot leak a process.
  */
 export const streamCliCommand: CliStreamRunner = async function* (options) {
   // On Windows the vendor CLIs are `.cmd` shims, which spawn refuses to
@@ -72,21 +75,19 @@ export const streamCliCommand: CliStreamRunner = async function* (options) {
   const stop = (reason: "timeout" | "abort" | "done") => {
     if (settled) return;
     if (reason === "timeout") timedOut = true;
-    try {
-      child.kill("SIGTERM");
-    } catch {
-      // already gone
-    }
+    // Not `child.kill`: on Windows the direct child is `cmd.exe` and the
+    // real CLI is a grandchild, so `TerminateProcess` on this pid alone
+    // would leave it running — one orphan for every aborted turn, and
+    // Ctrl+C is the most routine thing in the TUI. `killProcessTree`
+    // walks the tree with `taskkill /T` there and is a plain
+    // `child.kill` everywhere else.
+    killProcessTree(child, { platform: hostPlatform() });
     // Escalate only if SIGTERM was not enough. A second `stop` (abort
     // followed by the generator's own cleanup) must not re-arm it, or
     // the first timer is orphaned and fires at a pid we no longer track.
     if (killTimer) return;
     killTimer = setTimeout(() => {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        // already gone
-      }
+      killProcessTree(child, { force: true, platform: hostPlatform() });
     }, SIGKILL_DELAY_MS);
     killTimer.unref?.();
   };

--- a/src/llm/provider/subscription-cli/stream-cli-completion.ts
+++ b/src/llm/provider/subscription-cli/stream-cli-completion.ts
@@ -3,9 +3,12 @@ import { isBrokenPipe } from "../../../sandbox/index.js";
 import type { CliRunOptions } from "./run-cli-completion.js";
 import {
   isEnoent,
+  isSpawnEinval,
   mapCliFailure,
   SubscriptionCliNotInstalledError,
+  SubscriptionCliSpawnError,
 } from "./subscription-cli-errors.js";
+import { resolveWindowsCliInvocation } from "./windows-cli-shim.js";
 
 /** Grace period between asking a child to stop and killing it. */
 const SIGKILL_DELAY_MS = 2_000;
@@ -25,13 +28,39 @@ export type CliStreamRunner = (
  * that abandons the iterator cannot leak a process.
  */
 export const streamCliCommand: CliStreamRunner = async function* (options) {
-  const child = spawn(options.binary, [...options.args], {
-    cwd: options.cwd,
-    env: process.env,
-    shell: false,
-    stdio: ["pipe", "pipe", "pipe"],
-    ...(process.platform === "win32" ? { windowsHide: true } : {}),
+  // On Windows the vendor CLIs are `.cmd` shims, which spawn refuses to
+  // start without a shell; elsewhere this hands the pair straight back.
+  const invocation = resolveWindowsCliInvocation({
+    binary: options.binary,
+    args: options.args,
   });
+  let child;
+  try {
+    child = spawn(invocation.command, invocation.args, {
+      cwd: options.cwd,
+      env: process.env,
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      ...(process.platform === "win32" ? { windowsHide: true } : {}),
+      ...(invocation.windowsVerbatimArguments
+        ? { windowsVerbatimArguments: true }
+        : {}),
+    });
+  } catch (err) {
+    // Only ENOENT-class errnos reach the `error` event below; everything
+    // else — EINVAL for a batch shim among them — is thrown right here,
+    // out of `ChildProcess.prototype.spawn`, before any handler exists.
+    if (isSpawnEinval(err)) {
+      throw new SubscriptionCliSpawnError(options.binary, options.installHint);
+    }
+    if (isEnoent(err)) {
+      throw new SubscriptionCliNotInstalledError(
+        options.binary,
+        options.installHint,
+      );
+    }
+    throw err;
+  }
 
   let stderr = "";
   let timedOut = false;

--- a/src/llm/provider/subscription-cli/stream-cli-completion.ts
+++ b/src/llm/provider/subscription-cli/stream-cli-completion.ts
@@ -45,7 +45,10 @@ export const streamCliCommand: CliStreamRunner = async function* (options) {
       env: process.env,
       shell: false,
       stdio: ["pipe", "pipe", "pipe"],
-      ...(process.platform === "win32" ? { windowsHide: true } : {}),
+      // `hostPlatform()`, not `process.platform`: the same seam the shim
+      // reads, so a faked win32 host produces the spawn options
+      // production would and a change to this line is visible to a test.
+      ...(hostPlatform() === "win32" ? { windowsHide: true } : {}),
       ...(invocation.windowsVerbatimArguments
         ? { windowsVerbatimArguments: true }
         : {}),
@@ -72,6 +75,10 @@ export const streamCliCommand: CliStreamRunner = async function* (options) {
   let stdinError: Error | null = null;
   let killTimer: NodeJS.Timeout | null = null;
   let settled = false;
+  // Set only when the tree-kill reports that the stop reached the
+  // descendants too. On Windows the direct child is `cmd.exe`, so its
+  // `close` says nothing about the CLI underneath it — this does.
+  let treeKilled = false;
 
   const stop = (reason: "timeout" | "abort" | "done") => {
     if (settled) return;
@@ -82,12 +89,23 @@ export const streamCliCommand: CliStreamRunner = async function* (options) {
     // Ctrl+C is the most routine thing in the TUI. `killProcessTree`
     // walks the tree with `taskkill /T` there and is a plain
     // `child.kill` everywhere else.
-    killProcessTree(child, { platform: hostPlatform() });
+    killProcessTree(child, {
+      platform: hostPlatform(),
+      onTreeKilled: (killed) => {
+        treeKilled = killed;
+      },
+    });
     // Escalate only if SIGTERM was not enough. A second `stop` (abort
     // followed by the generator's own cleanup) must not re-arm it, or
     // the first timer is orphaned and fires at a pid we no longer track.
     if (killTimer) return;
     killTimer = setTimeout(() => {
+      // Nothing left to force if the child is gone *and* the stop
+      // reached its descendants — the polite pass can report that late,
+      // since taskkill is a process of its own, and firing anyway would
+      // aim `/F` at a pid Windows may already have handed to somebody
+      // else. A child that merely ignored SIGTERM is still `!settled`.
+      if (settled && treeKilled) return;
       killProcessTree(child, { force: true, platform: hostPlatform() });
     }, SIGKILL_DELAY_MS);
     killTimer.unref?.();
@@ -198,7 +216,14 @@ export const streamCliCommand: CliStreamRunner = async function* (options) {
     // exit instead.
     if (killTimer) {
       const armed = killTimer;
-      const disarm = () => clearTimeout(armed);
+      // …and only once it is gone *with its descendants*. On Windows a
+      // polite pass that fell back to `child.kill` terminated the
+      // `cmd.exe` wrapper alone: `close` fires immediately, the CLI
+      // underneath is orphaned, and disarming here would be the last
+      // chance to reap it thrown away. `treeKilled` is the difference.
+      const disarm = () => {
+        if (treeKilled) clearTimeout(armed);
+      };
       // `.then(f, f)` rather than `.finally`: the latter returns a
       // promise that re-throws, and nobody is left to await it here.
       if (settled) disarm();

--- a/src/llm/provider/subscription-cli/subscription-cli-errors.test.ts
+++ b/src/llm/provider/subscription-cli/subscription-cli-errors.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   isEnoent,
+  isSpawnEinval,
   looksLikeAuthFailure,
   mapCliFailure,
   SubscriptionCliAuthError,
   SubscriptionCliInvocationError,
   SubscriptionCliNotInstalledError,
+  SubscriptionCliSpawnError,
 } from "./subscription-cli-errors.js";
 
 const base = {
@@ -27,6 +29,42 @@ describe("isEnoent", () => {
     expect(isEnoent(Object.assign(new Error("x"), { code: "ENOENT" }))).toBe(true);
     expect(isEnoent(new Error("x"))).toBe(false);
     expect(isEnoent(null)).toBe(false);
+  });
+});
+
+describe("isSpawnEinval", () => {
+  it("detects the thrown spawn error for a batch shim", () => {
+    const err = Object.assign(new Error("spawn EINVAL"), {
+      code: "EINVAL",
+      errno: -22,
+      syscall: "spawn",
+    });
+    expect(isSpawnEinval(err)).toBe(true);
+    expect(isSpawnEinval(Object.assign(new Error("x"), { code: "EINVAL" }))).toBe(
+      true,
+    );
+  });
+
+  it("ignores anything else", () => {
+    expect(isSpawnEinval(Object.assign(new Error("x"), { code: "ENOENT" }))).toBe(
+      false,
+    );
+    expect(
+      isSpawnEinval(
+        Object.assign(new Error("x"), { code: "EINVAL", syscall: "read" }),
+      ),
+    ).toBe(false);
+    expect(isSpawnEinval(new Error("x"))).toBe(false);
+    expect(isSpawnEinval(null)).toBe(false);
+  });
+});
+
+describe("SubscriptionCliSpawnError", () => {
+  it("keeps the install hint and stays apart from not-installed", () => {
+    const err = new SubscriptionCliSpawnError("claude", "Install Claude Code.");
+    expect(err.message).toContain("Install Claude Code.");
+    expect(err.message).toContain("EINVAL");
+    expect(err).not.toBeInstanceOf(SubscriptionCliNotInstalledError);
   });
 });
 

--- a/src/llm/provider/subscription-cli/subscription-cli-errors.ts
+++ b/src/llm/provider/subscription-cli/subscription-cli-errors.ts
@@ -11,6 +11,20 @@ export class SubscriptionCliNotInstalledError extends Error {
   }
 }
 
+/**
+ * The binary exists but the OS refused to start it. In practice that is
+ * Windows declining a `.cmd`/`.bat` shim spawned without a shell; kept
+ * apart from "not installed" because reinstalling would not help.
+ */
+export class SubscriptionCliSpawnError extends Error {
+  constructor(binary: string, installHint: string) {
+    super(
+      `"${binary}" could not be started (spawn EINVAL) — on Windows a .cmd/.bat shim cannot be spawned directly. ${installHint}`,
+    );
+    this.name = "SubscriptionCliSpawnError";
+  }
+}
+
 export class SubscriptionCliAuthError extends Error {
   constructor(binary: string, authHint: string, detail?: string) {
     super(
@@ -55,6 +69,20 @@ export function isEnoent(err: unknown): boolean {
     err !== null &&
     (err as { code?: unknown }).code === "ENOENT"
   );
+}
+
+/**
+ * A spawn that failed with EINVAL. Node hands EACCES/EAGAIN/EMFILE/
+ * ENFILE/ENOENT to the async `error` event and *throws* every other
+ * errno straight out of `ChildProcess.prototype.spawn`, so unlike an
+ * ENOENT this one arrives synchronously and has to be caught at the
+ * call site rather than on the child.
+ */
+export function isSpawnEinval(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const { code, syscall } = err as { code?: unknown; syscall?: unknown };
+  if (code !== "EINVAL") return false;
+  return syscall === undefined || syscall === "spawn";
 }
 
 export interface CliFailureInput {

--- a/src/llm/provider/subscription-cli/subscription-cli-errors.ts
+++ b/src/llm/provider/subscription-cli/subscription-cli-errors.ts
@@ -5,8 +5,10 @@
  */
 
 export class SubscriptionCliNotInstalledError extends Error {
-  constructor(binary: string, installHint: string) {
-    super(`"${binary}" was not found on PATH. ${installHint}`);
+  constructor(binary: string, installHint = "") {
+    // Trimmed: the Windows shim raises this for a configured `binPath`
+    // that is not on disk and has no hint of its own to add.
+    super(`"${binary}" was not found on PATH. ${installHint}`.trim());
     this.name = "SubscriptionCliNotInstalledError";
   }
 }
@@ -22,6 +24,29 @@ export class SubscriptionCliSpawnError extends Error {
       `"${binary}" could not be started (spawn EINVAL) — on Windows a .cmd/.bat shim cannot be spawned directly. ${installHint}`,
     );
     this.name = "SubscriptionCliSpawnError";
+  }
+}
+
+/**
+ * The invocation cannot be expressed as a `cmd.exe` command line at all,
+ * so it is refused before anything is spawned.
+ *
+ * Both reasons are silent corruption if they are let through: past
+ * cmd's 8191-character limit cmd answers "The input line is too long."
+ * and the CLI never runs, and a raw newline inside an argument ends the
+ * command line where it stands — cmd would run the tail as a second
+ * command. Neither has an escape, so the only honest answer is to say
+ * what happened rather than send a command line that means something
+ * else than the caller asked for.
+ */
+export type CliCommandLineRejection = "too-long" | "control-character";
+
+export class SubscriptionCliCommandLineError extends Error {
+  readonly reason: CliCommandLineRejection;
+  constructor(message: string, reason: CliCommandLineRejection) {
+    super(message);
+    this.name = "SubscriptionCliCommandLineError";
+    this.reason = reason;
   }
 }
 

--- a/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWindowsCliInvocation } from "./windows-cli-shim.js";
+
+const WIN_ENV = {
+  PATH: "C:\\npm;C:\\Windows\\System32",
+  PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  ComSpec: "C:\\Windows\\System32\\cmd.exe",
+};
+
+/**
+ * `present` lists the files as they sit on disk. The predicate matches
+ * case-insensitively because NTFS does, which is why a `claude.cmd` is
+ * found under the `.CMD` suffix PATHEXT lists — the resolved path then
+ * carries PATHEXT's casing, exactly as it would for cmd.exe itself.
+ */
+const RESOLVED_CLAUDE = "C:\\npm\\claude.CMD";
+
+function onWindows(
+  binary: string,
+  args: readonly string[],
+  present: readonly string[] = [],
+  env: NodeJS.ProcessEnv = WIN_ENV,
+) {
+  const set = new Set(present.map((p) => p.toLowerCase()));
+  return resolveWindowsCliInvocation({
+    binary,
+    args,
+    platform: "win32",
+    env,
+    fileExists: (p) => set.has(p.toLowerCase()),
+  });
+}
+
+describe("resolveWindowsCliInvocation on posix", () => {
+  it("hands the pair back untouched", () => {
+    for (const platform of ["darwin", "linux"] as const) {
+      expect(
+        resolveWindowsCliInvocation({
+          binary: "claude",
+          args: ["--print", "--json-schema", '{"a":1}'],
+          platform,
+          env: {},
+          fileExists: () => true,
+        }),
+      ).toEqual({
+        command: "claude",
+        args: ["--print", "--json-schema", '{"a":1}'],
+        windowsVerbatimArguments: false,
+      });
+    }
+  });
+});
+
+describe("resolveWindowsCliInvocation on win32", () => {
+  it("routes a resolved .cmd shim through cmd.exe with verbatim argv", () => {
+    const out = onWindows("claude", ["--print"], ["C:\\npm\\claude.cmd"]);
+    expect(out.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(out.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      `"${RESOLVED_CLAUDE} ^"--print^""`,
+    ]);
+    expect(out.windowsVerbatimArguments).toBe(true);
+  });
+
+  it("accepts an already-resolved absolute shim without touching PATH", () => {
+    // What `resolveCliBinary` hands over, and what a configured
+    // `binPath` looks like: no lookup should be needed.
+    const out = onWindows("C:\\npm\\codex.cmd", ["exec"], []);
+    expect(out.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(out.args[3]).toBe('"C:\\npm\\codex.cmd ^"exec^""');
+  });
+
+  it("takes .bat shims as well, in PATHEXT order", () => {
+    const out = onWindows("codex", ["exec"], ["C:\\npm\\codex.bat"]);
+    expect(out.windowsVerbatimArguments).toBe(true);
+    expect(out.args[3]).toBe('"C:\\npm\\codex.BAT ^"exec^""');
+  });
+
+  it("leaves a real executable alone", () => {
+    const out = onWindows("claude", ["--print"], ["C:\\npm\\claude.exe"]);
+    expect(out).toEqual({
+      command: "claude",
+      args: ["--print"],
+      windowsVerbatimArguments: false,
+    });
+  });
+
+  it("leaves an unresolvable name alone so spawn still raises ENOENT", () => {
+    const out = onWindows("claude", ["--print"], []);
+    expect(out).toEqual({
+      command: "claude",
+      args: ["--print"],
+      windowsVerbatimArguments: false,
+    });
+  });
+
+  it("falls back to cmd.exe when ComSpec is unset", () => {
+    const out = onWindows("claude", [], ["C:\\npm\\claude.cmd"], {
+      PATH: "C:\\npm",
+      PATHEXT: ".CMD",
+    });
+    expect(out.command).toBe("cmd.exe");
+  });
+
+  it("reads environment names case-insensitively, as Windows does", () => {
+    const out = onWindows("claude", [], ["C:\\npm\\claude.cmd"], {
+      Path: "C:\\npm",
+      PathExt: ".CMD",
+      COMSPEC: "D:\\cmd.exe",
+    });
+    expect(out.command).toBe("D:\\cmd.exe");
+    expect(out.args[3]).toBe(`"${RESOLVED_CLAUDE}"`);
+  });
+});
+
+describe("cmd argument escaping", () => {
+  function escaped(arg: string): string {
+    const out = onWindows("claude", [arg], ["C:\\npm\\claude.cmd"]);
+    // Strip the wrapping quotes and the command, leaving one argument.
+    return (out.args[3] ?? "").slice(1, -1).replace(`${RESOLVED_CLAUDE} `, "");
+  }
+
+  it("escapes a response schema delivered inline on argv", () => {
+    // `claude` has schemaDelivery: "inline", so an argument of exactly
+    // this shape is on the command line of every structured-output
+    // request — braces, quotes, brackets and commas included.
+    expect(escaped('{"type":"object","required":["reply"]}')).toBe(
+      '^"{\\^"type\\^":\\^"object\\^"^,\\^"required\\^":^[\\^"reply\\^"^]}^"',
+    );
+  });
+
+  it("escapes cmd metacharacters that would otherwise redirect or chain", () => {
+    expect(escaped("a&b")).toBe('^"a^&b^"');
+    expect(escaped("a|b")).toBe('^"a^|b^"');
+    expect(escaped("a>b<c")).toBe('^"a^>b^<c^"');
+    expect(escaped("100^2")).toBe('^"100^^2^"');
+    expect(escaped("%PATH%")).toBe('^"^%PATH^%^"');
+    expect(escaped("two words")).toBe('^"two^ words^"');
+  });
+
+  it("doubles backslashes before a quote and at the end of an argument", () => {
+    expect(escaped('say \\"hi\\"')).toBe('^"say^ \\\\\\^"hi\\\\\\^"^"');
+    expect(escaped("C:\\path\\")).toBe('^"C:\\path\\\\^"');
+  });
+
+  it("double-escapes for a node_modules/.bin shim, which re-enters cmd", () => {
+    const target = "C:\\proj\\node_modules\\.bin\\claude.cmd";
+    const out = onWindows(target, ["a&b"], []);
+    expect(out.args[3]).toBe(`"${target} ^^^"a^^^&b^^^""`);
+  });
+});

--- a/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
@@ -514,6 +514,41 @@ describe("targets that are there, missing, or unanswerable", () => {
     expect(out.args[3]).toBe(`"${binPath} ^^^"--print^^^""`);
   });
 
+  it("does not call a PATH directory it may not stat 'not installed' either", () => {
+    // The same asymmetry one level out. A PATH entry the user may
+    // traverse but not stat makes every candidate under it `unknown`;
+    // resolving nothing hands the bare name to `spawn`, which does no
+    // PATHEXT search with `shell:false` — so a working `claude.cmd`
+    // came back as "was not found on PATH". The batch candidate is
+    // handed to cmd instead, which repeats the search itself.
+    const out = onWindows("claude", ["--print"], [], WIN_ENV, () => null, [
+      "C:\\npm\\claude.COM",
+      "C:\\npm\\claude.EXE",
+      "C:\\npm\\claude.BAT",
+      "C:\\npm\\claude.CMD",
+      "C:\\npm\\claude",
+    ]);
+    expect(out.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    // PATHEXT order, which is the order cmd itself would try them.
+    expect(out.args[3]).toBe('"C:\\npm\\claude.BAT ^^^"--print^^^""');
+  });
+
+  it("prefers a definite hit further along PATH over an unanswerable one", () => {
+    // "Cannot tell" is a fallback, not a match: it must not shadow a
+    // candidate we can actually see, even one a PATH entry later.
+    const out = onWindows(
+      "claude",
+      ["--print"],
+      ["C:\\Windows\\System32\\claude.cmd"],
+      WIN_ENV,
+      () => NPM_CMD_SHIM,
+      ["C:\\npm\\claude.COM"],
+    );
+    expect(out.args[3]).toBe(
+      '"C:\\Windows\\System32\\claude.CMD ^^^"--print^^^""',
+    );
+  });
+
   it("still refuses one that is genuinely absent", () => {
     expect(() => onWindows("C:\\gone\\claude.cmd", [], [])).toThrow(
       SubscriptionCliNotInstalledError,

--- a/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
@@ -481,6 +481,14 @@ describe("the escaping rewrite is a rewrite, not a change", () => {
     // 32k backslashes with no quote to end the run: 1.47 s of
     // synchronous work under the regex form, before the length check
     // that refuses the argument anyway.
+    //
+    // LOAD-BEARING, and the only guard on the ReDoS fix: the
+    // differential test above passes for both forms by design, so
+    // nothing else here notices if the quadratic `replace` comes back.
+    // A wall-clock assertion, which is normally a smell — it survives
+    // because the headroom is ~2000x (0.2 ms observed against a 400 ms
+    // budget), not because the number was tuned. If it ever flakes,
+    // raise the budget; do not delete it.
     const started = performance.now();
     expect(() => onWindows(target, ["\\".repeat(32_000)], [target])).toThrow(
       SubscriptionCliCommandLineError,

--- a/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   MAX_CMD_COMMAND_LINE,
   resolveWindowsCliInvocation,
+  SHIM_SUBSTITUTION_MARGIN,
 } from "./windows-cli-shim.js";
 
 const WIN_ENV = {
@@ -46,15 +47,22 @@ function onWindows(
   present: readonly string[] = [],
   env: NodeJS.ProcessEnv = WIN_ENV,
   readTarget: (path: string) => string | null = () => NPM_CMD_SHIM,
+  undeterminable: readonly string[] = [],
 ) {
   const set = new Set(present.map((p) => p.toLowerCase()));
+  const unknown = new Set(undeterminable.map((p) => p.toLowerCase()));
   return resolveWindowsCliInvocation({
     binary,
     args,
     platform: "win32",
     env,
     installHint: "Install Claude Code.",
-    fileExists: (p) => set.has(p.toLowerCase()),
+    fileStatus: (p) =>
+      set.has(p.toLowerCase())
+        ? "present"
+        : unknown.has(p.toLowerCase())
+          ? "unknown"
+          : "absent",
     readTarget,
   });
 }
@@ -68,7 +76,7 @@ describe("resolveWindowsCliInvocation on posix", () => {
           args: ["--print", "--json-schema", '{"a":1}'],
           platform,
           env: {},
-          fileExists: () => true,
+          fileStatus: () => "present",
         }),
       ).toEqual({
         command: "claude",
@@ -280,9 +288,66 @@ describe("command lines cmd.exe cannot carry", () => {
     );
   });
 
+  /** The whole command line, as Node hands it to CreateProcess. */
+  function lineLength(
+    xs: number,
+    readTarget: (path: string) => string | null = () => NPM_CMD_SHIM,
+  ): number {
+    const out = onWindows(
+      target,
+      ["x".repeat(xs)],
+      [target],
+      WIN_ENV,
+      readTarget,
+    );
+    return [out.command, ...out.args].join(" ").length;
+  }
+
   it("stays under cmd's limit for an argument that only just fits", () => {
-    const out = onWindows(target, ["x".repeat(8_000)], [target]);
+    const out = onWindows(target, ["x".repeat(7_000)], [target]);
     expect([out.command, ...out.args].join(" ").length).toBeLessThanOrEqual(
+      MAX_CMD_COMMAND_LINE,
+    );
+  });
+
+  /**
+   * The boundary itself, not "somewhere around there": with 8000 and
+   * 9000 on either side, `length <= MAX` and `length <= MAX + 1` are
+   * indistinguishable.
+   */
+  it("pins the last command line cmd.exe accepts, character for character", () => {
+    const argless = () => ARGLESS_BAT;
+    expect(lineLength(8_129, argless)).toBe(MAX_CMD_COMMAND_LINE - 1);
+    expect(lineLength(8_130, argless)).toBe(MAX_CMD_COMMAND_LINE);
+    expect(() =>
+      onWindows(target, ["x".repeat(8_131)], [target], WIN_ENV, argless),
+    ).toThrow(/is 8192 characters and only 8191 are usable/);
+  });
+
+  /**
+   * The outer line is not the only one with a limit. A shim that
+   * substitutes `%*` builds a second command line —
+   * `"%_prog%" "%dp0%\…\cli.js" <args>` — which cmd parses under the
+   * same 8191, and whose ~170-character prefix outweighs what the
+   * arguments lose when one `^` layer is stripped off them. Measured
+   * against the real global `claude.cmd`, the outer line passed at 8116
+   * while the inner one was already 8192: a ~76-character window in
+   * which this check said yes and cmd then answered "The input line is
+   * too long." So the substituting case is charged a margin.
+   */
+  it("holds a margin back for the line the shim itself builds", () => {
+    const budget = MAX_CMD_COMMAND_LINE - SHIM_SUBSTITUTION_MARGIN;
+    expect(lineLength(7_614)).toBe(budget);
+    expect(() => onWindows(target, ["x".repeat(7_615)], [target])).toThrow(
+      new RegExp(`only ${budget} are usable`),
+    );
+    // The reviewed hole: accepted before, rejected now.
+    expect(() => onWindows(target, ["x".repeat(8_019)], [target])).toThrow(
+      SubscriptionCliCommandLineError,
+    );
+    // A batch file that never re-substitutes builds no second line and
+    // pays no margin: the very same argument goes through.
+    expect(lineLength(8_019, () => ARGLESS_BAT)).toBeLessThanOrEqual(
       MAX_CMD_COMMAND_LINE,
     );
   });
@@ -327,6 +392,140 @@ describe("command lines cmd.exe cannot carry", () => {
     // Well under the adapter's 32 KB argv budget, well over cmd's 8191.
     expect(() => onWindows(target, schemaArgs(100), [target])).toThrow(
       SubscriptionCliCommandLineError,
+    );
+  });
+});
+
+/**
+ * The CRT escaping was two regex passes and is now one scan, because the
+ * quote rule — `arg.replace(/(\\*)"/g, …)` — is quadratic on a run of
+ * backslashes that never reaches a quote, and this runs synchronously on
+ * the TUI's event loop in the spawn path. The rules themselves must not
+ * have moved a character: cross-spawn's own 7.0.5 "fix" for the same
+ * ReDoS changed the trailing-backslash semantics and under-doubles, so
+ * "it matches cross-spawn" is not the check. This is.
+ */
+describe("the escaping rewrite is a rewrite, not a change", () => {
+  const target = "C:\\npm\\claude.cmd";
+  const META = /([()\][%!^"`<>&|;, *?])/g;
+
+  /** The previous implementation, verbatim. */
+  function referenceEscape(arg: string, doubleEscape: boolean): string {
+    let escaped = arg.replace(/(\\*)"/g, '$1$1\\"');
+    escaped = escaped.replace(/(\\*)$/, "$1$1");
+    escaped = `"${escaped}"`;
+    escaped = escaped.replace(META, "^$1");
+    if (doubleEscape) escaped = escaped.replace(META, "^$1");
+    return escaped;
+  }
+
+  function escapeThrough(arg: string, doubleEscape: boolean): string {
+    const out = onWindows(target, [arg], [target], WIN_ENV, () =>
+      doubleEscape ? NPM_CMD_SHIM : ARGLESS_BAT,
+    );
+    return (out.args[3] ?? "").slice(1, -1).replace(`${target} `, "");
+  }
+
+  /** Deterministic corpus; no seed drift between runs or machines. */
+  function* corpus(): Generator<string> {
+    const alphabet = [
+      "\\", '"', "a", " ", "&", "^", "%", "|", "<", ">", "(", ")", "!", ",",
+      "*", "?", "`", ";", "[", "]", "{", "}", ":", "$", "~", "/",
+    ];
+    let seed = 0x2f6e2b1;
+    const next = () => {
+      seed ^= seed << 13;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5;
+      return (seed >>> 0) / 0x100000000;
+    };
+    // Every string of length <= 2 over the alphabet, then random ones.
+    for (const a of alphabet) {
+      yield a;
+      for (const b of alphabet) yield a + b;
+    }
+    for (let i = 0; i < 20_000; i += 1) {
+      const length = 1 + Math.floor(next() * 12);
+      let value = "";
+      for (let j = 0; j < length; j += 1) {
+        value += alphabet[Math.floor(next() * alphabet.length)];
+      }
+      yield value;
+    }
+    yield "";
+    for (let run = 1; run <= 8; run += 1) {
+      yield "\\".repeat(run);
+      yield `a${"\\".repeat(run)}`;
+      yield `${"\\".repeat(run)}"b`;
+      yield `a${"\\".repeat(run)}"${"\\".repeat(run)}`;
+    }
+  }
+
+  it("agrees with the regex form on every input in a 21k corpus", () => {
+    let compared = 0;
+    for (const arg of corpus()) {
+      for (const doubleEscape of [false, true]) {
+        const expected = referenceEscape(arg, doubleEscape);
+        if (escapeThrough(arg, doubleEscape) !== expected) {
+          // Reported through `expect` so the failure names the input.
+          expect({ arg, doubleEscape, got: escapeThrough(arg, doubleEscape) })
+            .toEqual({ arg, doubleEscape, got: expected });
+        }
+        compared += 1;
+      }
+    }
+    expect(compared).toBeGreaterThan(40_000);
+  });
+
+  it("does not spend a second escaping an argument it then rejects", () => {
+    // 32k backslashes with no quote to end the run: 1.47 s of
+    // synchronous work under the regex form, before the length check
+    // that refuses the argument anyway.
+    const started = performance.now();
+    expect(() => onWindows(target, ["\\".repeat(32_000)], [target])).toThrow(
+      SubscriptionCliCommandLineError,
+    );
+    expect(performance.now() - started).toBeLessThan(400);
+  });
+});
+
+describe("targets that are there, missing, or unanswerable", () => {
+  it("hands a drive-relative target to cmd instead of walking PATH", () => {
+    // `C:claude.cmd` names the current directory *of drive C:*. It has
+    // no separator, so the PATH x PATHEXT walk used to swallow it,
+    // resolve nothing, and pass the raw `.cmd` to spawn — EINVAL, the
+    // very failure this shim exists to prevent.
+    const out = onWindows("C:claude.cmd", ["--print"], []);
+    expect(out.windowsVerbatimArguments).toBe(true);
+    expect(out.args[3]).toBe('"C:claude.cmd ^^^"--print^^^""');
+  });
+
+  it("does not call a binPath it was not allowed to stat 'not installed'", () => {
+    // `existsSync` answers `false` for EACCES/EPERM and for a UNC share
+    // that did not respond, so a working install under a restricted or
+    // network path came back as "was not found on PATH". Only a genuine
+    // ENOENT is absent; anything else goes to cmd, which can answer for
+    // itself.
+    const binPath = "\\\\fileserver\\tools\\claude.cmd";
+    const out = onWindows(binPath, ["--print"], [], WIN_ENV, () => null, [
+      binPath,
+    ]);
+    expect(out.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(out.args[3]).toBe(`"${binPath} ^^^"--print^^^""`);
+  });
+
+  it("still refuses one that is genuinely absent", () => {
+    expect(() => onWindows("C:\\gone\\claude.cmd", [], [])).toThrow(
+      SubscriptionCliNotInstalledError,
+    );
+  });
+
+  it("says where the unescapable character is when it is in the path", () => {
+    // "cannot be run through cmd.exe with this argument" sent the reader
+    // hunting through argv for something that is in the target's path.
+    const bad = "C:\\npm\\clau\u0000de.cmd";
+    expect(() => onWindows(bad, ["--print"], [bad])).toThrow(
+      /cannot be run through cmd\.exe at all: its resolved path contains a raw NUL/,
     );
   });
 });

--- a/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveWindowsCliInvocation } from "./windows-cli-shim.js";
+import { claudeCliAdapter } from "./claude-cli-adapter.js";
+import {
+  SubscriptionCliCommandLineError,
+  SubscriptionCliNotInstalledError,
+} from "./subscription-cli-errors.js";
+import {
+  MAX_CMD_COMMAND_LINE,
+  resolveWindowsCliInvocation,
+} from "./windows-cli-shim.js";
 
 const WIN_ENV = {
   PATH: "C:\\npm;C:\\Windows\\System32",
@@ -16,11 +24,28 @@ const WIN_ENV = {
  */
 const RESOLVED_CLAUDE = "C:\\npm\\claude.CMD";
 
+/**
+ * npm's cmd-shim, trimmed to the line that matters: it substitutes `%*`
+ * back into a command line cmd parses a second time. Identical for a
+ * global install and for `node_modules\.bin`, which is the whole point.
+ */
+const NPM_CMD_SHIM = [
+  "@ECHO off",
+  "SETLOCAL",
+  "CALL :find_dp0",
+  'IF EXIST "%dp0%\\node.exe" (SET "_prog=%dp0%\\node.exe") ELSE (SET "_prog=node")',
+  'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\cli.js" %*',
+].join("\r\n");
+
+/** A batch file that never looks at its arguments. */
+const ARGLESS_BAT = ["@ECHO off", "start notepad.exe", "EXIT /b"].join("\r\n");
+
 function onWindows(
   binary: string,
   args: readonly string[],
   present: readonly string[] = [],
   env: NodeJS.ProcessEnv = WIN_ENV,
+  readTarget: (path: string) => string | null = () => NPM_CMD_SHIM,
 ) {
   const set = new Set(present.map((p) => p.toLowerCase()));
   return resolveWindowsCliInvocation({
@@ -28,7 +53,9 @@ function onWindows(
     args,
     platform: "win32",
     env,
+    installHint: "Install Claude Code.",
     fileExists: (p) => set.has(p.toLowerCase()),
+    readTarget,
   });
 }
 
@@ -60,23 +87,24 @@ describe("resolveWindowsCliInvocation on win32", () => {
       "/d",
       "/s",
       "/c",
-      `"${RESOLVED_CLAUDE} ^"--print^""`,
+      `"${RESOLVED_CLAUDE} ^^^"--print^^^""`,
     ]);
     expect(out.windowsVerbatimArguments).toBe(true);
   });
 
   it("accepts an already-resolved absolute shim without touching PATH", () => {
     // What `resolveCliBinary` hands over, and what a configured
-    // `binPath` looks like: no lookup should be needed.
-    const out = onWindows("C:\\npm\\codex.cmd", ["exec"], []);
+    // `binPath` looks like: no lookup should be needed — but it still
+    // has to be on disk.
+    const out = onWindows("C:\\npm\\codex.cmd", ["exec"], ["C:\\npm\\codex.cmd"]);
     expect(out.command).toBe("C:\\Windows\\System32\\cmd.exe");
-    expect(out.args[3]).toBe('"C:\\npm\\codex.cmd ^"exec^""');
+    expect(out.args[3]).toBe('"C:\\npm\\codex.cmd ^^^"exec^^^""');
   });
 
   it("takes .bat shims as well, in PATHEXT order", () => {
     const out = onWindows("codex", ["exec"], ["C:\\npm\\codex.bat"]);
     expect(out.windowsVerbatimArguments).toBe(true);
-    expect(out.args[3]).toBe('"C:\\npm\\codex.BAT ^"exec^""');
+    expect(out.args[3]).toBe('"C:\\npm\\codex.BAT ^^^"exec^^^""');
   });
 
   it("leaves a real executable alone", () => {
@@ -114,11 +142,51 @@ describe("resolveWindowsCliInvocation on win32", () => {
     expect(out.command).toBe("D:\\cmd.exe");
     expect(out.args[3]).toBe(`"${RESOLVED_CLAUDE}"`);
   });
+
+  it("normalises the target and escapes the spaces and parens in it", () => {
+    // The real target on a real machine:
+    // C:\Users\<name>\AppData\Roaming\npm\claude.cmd — and a
+    // Program Files (x86) install is just as ordinary.
+    const binPath = "C:/Program Files (x86)/npm/./claude.cmd";
+    const out = onWindows(binPath, [], [binPath]);
+    expect(out.args[3]).toBe(
+      '"C:\\Program^ Files^ ^(x86^)\\npm\\claude.cmd"',
+    );
+  });
+});
+
+describe("a target that is not on disk", () => {
+  it("reports a configured binPath as not installed rather than wrapping it", () => {
+    // Wrapped in `cmd /c` instead, this came back as cmd's own "The
+    // system cannot find the path specified." inside a generic
+    // invocation error.
+    expect(() => onWindows("C:\\gone\\claude.cmd", ["--print"], [])).toThrow(
+      SubscriptionCliNotInstalledError,
+    );
+    expect(() => onWindows("C:\\gone\\claude.cmd", ["--print"], [])).toThrow(
+      /"C:\\gone\\claude\.cmd" was not found on PATH\. Install Claude Code\./,
+    );
+  });
+
+  it("does not judge a relative path — it resolves against the child's cwd", () => {
+    // Not ours to test for existence, so it is wrapped and left to cmd.
+    const out = onWindows("tools\\claude.cmd", ["--print"], []);
+    expect(out.args[3]).toBe('"tools\\claude.cmd ^^^"--print^^^""');
+  });
 });
 
 describe("cmd argument escaping", () => {
-  function escaped(arg: string): string {
-    const out = onWindows("claude", [arg], ["C:\\npm\\claude.cmd"]);
+  function escaped(
+    arg: string,
+    readTarget: (path: string) => string | null = () => NPM_CMD_SHIM,
+  ): string {
+    const out = onWindows(
+      "claude",
+      [arg],
+      ["C:\\npm\\claude.cmd"],
+      WIN_ENV,
+      readTarget,
+    );
     // Strip the wrapping quotes and the command, leaving one argument.
     return (out.args[3] ?? "").slice(1, -1).replace(`${RESOLVED_CLAUDE} `, "");
   }
@@ -128,27 +196,137 @@ describe("cmd argument escaping", () => {
     // this shape is on the command line of every structured-output
     // request — braces, quotes, brackets and commas included.
     expect(escaped('{"type":"object","required":["reply"]}')).toBe(
-      '^"{\\^"type\\^":\\^"object\\^"^,\\^"required\\^":^[\\^"reply\\^"^]}^"',
+      '^^^"{\\^^^"type\\^^^":\\^^^"object\\^^^"^^^,\\^^^"required\\^^^":^^^[\\^^^"reply\\^^^"^^^]}^^^"',
     );
   });
 
   it("escapes cmd metacharacters that would otherwise redirect or chain", () => {
-    expect(escaped("a&b")).toBe('^"a^&b^"');
-    expect(escaped("a|b")).toBe('^"a^|b^"');
-    expect(escaped("a>b<c")).toBe('^"a^>b^<c^"');
-    expect(escaped("100^2")).toBe('^"100^^2^"');
-    expect(escaped("%PATH%")).toBe('^"^%PATH^%^"');
-    expect(escaped("two words")).toBe('^"two^ words^"');
+    expect(escaped("a&b")).toBe('^^^"a^^^&b^^^"');
+    expect(escaped("a|b")).toBe('^^^"a^^^|b^^^"');
+    expect(escaped("a>b<c")).toBe('^^^"a^^^>b^^^<c^^^"');
+    expect(escaped("100^2")).toBe('^^^"100^^^^2^^^"');
+    expect(escaped("%PATH%")).toBe('^^^"^^^%PATH^^^%^^^"');
+    expect(escaped("two words")).toBe('^^^"two^^^ words^^^"');
   });
 
   it("doubles backslashes before a quote and at the end of an argument", () => {
-    expect(escaped('say \\"hi\\"')).toBe('^"say^ \\\\\\^"hi\\\\\\^"^"');
-    expect(escaped("C:\\path\\")).toBe('^"C:\\path\\\\^"');
+    expect(escaped('say \\"hi\\"')).toBe(
+      '^^^"say^^^ \\\\\\^^^"hi\\\\\\^^^"^^^"',
+    );
+    expect(escaped("C:\\path\\")).toBe('^^^"C:\\path\\\\^^^"');
+  });
+});
+
+/**
+ * The gate on the second `^` pass. It used to be a path test — cmd-shim
+ * under `node_modules\.bin` — which is not where `claude` lives for
+ * almost anybody: npm installs it globally as `%APPDATA%\npm\claude.cmd`
+ * from the *same* template, with the same `%*`. Single-escaped, an
+ * argument carrying both a quote and a metacharacter breaks out of its
+ * quotes at the shim's re-parse. So the gate now asks the file.
+ */
+describe("the double-escape gate", () => {
+  const globalShim = "C:\\Users\\Some One\\AppData\\Roaming\\npm\\claude.cmd";
+
+  it("double-escapes a global npm shim, which re-substitutes %* like any other", () => {
+    const out = onWindows(globalShim, ["a&b"], [globalShim]);
+    expect(out.args[3]).toBe(
+      '"C:\\Users\\Some^ One\\AppData\\Roaming\\npm\\claude.cmd ^^^"a^^^&b^^^""',
+    );
   });
 
-  it("double-escapes for a node_modules/.bin shim, which re-enters cmd", () => {
+  it("double-escapes a node_modules/.bin shim, which re-enters cmd the same way", () => {
     const target = "C:\\proj\\node_modules\\.bin\\claude.cmd";
-    const out = onWindows(target, ["a&b"], []);
+    const out = onWindows(target, ["a&b"], [target]);
     expect(out.args[3]).toBe(`"${target} ^^^"a^^^&b^^^""`);
+  });
+
+  it("single-escapes a batch file that never reads its arguments", () => {
+    const target = "C:\\tools\\claude.cmd";
+    const out = onWindows(target, ["a&b"], [target], WIN_ENV, () => ARGLESS_BAT);
+    expect(out.args[3]).toBe(`"${target} ^"a^&b^""`);
+  });
+
+  it("double-escapes when the shim cannot be read at all", () => {
+    // Conservative on purpose: every shim these CLIs ship
+    // re-substitutes, and a batch file that ignores its arguments cannot
+    // be corrupted by an escape it never reads.
+    const target = "C:\\tools\\claude.cmd";
+    const out = onWindows(target, ["a&b"], [target], WIN_ENV, () => null);
+    expect(out.args[3]).toBe(`"${target} ^^^"a^^^&b^^^""`);
+  });
+
+  it("counts %1 and %~dp1 as re-substitution too", () => {
+    const target = "C:\\tools\\claude.cmd";
+    for (const body of ["@node cli.js %1", "@node %~dpnx1"]) {
+      const out = onWindows(target, ["a&b"], [target], WIN_ENV, () => body);
+      expect(out.args[3]).toBe(`"${target} ^^^"a^^^&b^^^""`);
+    }
+  });
+});
+
+describe("command lines cmd.exe cannot carry", () => {
+  const target = "C:\\npm\\claude.cmd";
+
+  it("refuses a raw newline instead of letting cmd run the tail", () => {
+    expect(() => onWindows(target, ["--model", "a\nwhoami"], [target])).toThrow(
+      SubscriptionCliCommandLineError,
+    );
+    expect(() => onWindows(target, ["--model", "a\nwhoami"], [target])).toThrow(
+      /raw newline/,
+    );
+    expect(() => onWindows(target, ["a\rb"], [target])).toThrow(
+      /carriage return/,
+    );
+  });
+
+  it("stays under cmd's limit for an argument that only just fits", () => {
+    const out = onWindows(target, ["x".repeat(8_000)], [target]);
+    expect([out.command, ...out.args].join(" ").length).toBeLessThanOrEqual(
+      MAX_CMD_COMMAND_LINE,
+    );
+  });
+
+  it("names the real limit rather than letting cmd answer with 'The input line is too long.'", () => {
+    let thrown: unknown;
+    try {
+      onWindows(target, ["x".repeat(9_000)], [target]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(SubscriptionCliCommandLineError);
+    expect((thrown as SubscriptionCliCommandLineError).reason).toBe("too-long");
+    expect((thrown as Error).message).toMatch(/8191/);
+    expect((thrown as Error).message).toMatch(/response schema/);
+  });
+
+  /**
+   * The adapter caps an inline schema at 32 KB, sized for
+   * `CreateProcess`'s 32767 — through cmd the ceiling is 8191, and the
+   * escaping inflates the line further. These two counts bracket it.
+   */
+  function schemaArgs(properties: number): string[] {
+    const props: Record<string, unknown> = {};
+    for (let i = 0; i < properties; i += 1) {
+      props[`field_${i}`] = { type: "string", description: `field ${i}` };
+    }
+    return claudeCliAdapter.streamArgs({
+      model: "sonnet",
+      systemPrompt: claudeCliAdapter.systemPrompt,
+      responseSchema: { type: "object", properties: props },
+      extraArgs: [],
+    });
+  }
+
+  it("passes a modest inline schema straight through", () => {
+    const out = onWindows(target, schemaArgs(20), [target]);
+    expect(out.windowsVerbatimArguments).toBe(true);
+  });
+
+  it("rejects a schema the adapter is happy with but cmd is not", () => {
+    // Well under the adapter's 32 KB argv budget, well over cmd's 8191.
+    expect(() => onWindows(target, schemaArgs(100), [target])).toThrow(
+      SubscriptionCliCommandLineError,
+    );
   });
 });

--- a/src/llm/provider/subscription-cli/windows-cli-shim.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.ts
@@ -273,6 +273,31 @@ function assertFitsCommandLine(
  * its own error if it is not there. Anything with neither a separator
  * nor a drive letter is walked over PATH × PATHEXT, the search `spawn`
  * will not do with `shell:false`.
+ *
+ * The walk owes "cannot tell" the same answer the absolute branch gives
+ * it, for the same reason: a PATH directory the user may traverse but
+ * not stat makes *every* candidate under it `unknown`, and treating that
+ * as `absent` resolves nothing, passes the bare name through, and —
+ * because `spawn` with `shell:false` does no PATHEXT search — reports a
+ * working install as "not installed". So:
+ *
+ *   - a definite `present` hit wins outright, wherever in the walk it
+ *     is: a real answer beats an unanswerable one even from a later
+ *     PATH entry;
+ *   - failing that, the first candidate we could not tell apart from
+ *     missing is handed to cmd, which repeats the search itself;
+ *   - `null` only when every candidate was definitively absent.
+ *
+ * The fallback is narrowed to `.cmd`/`.bat` candidates because they are
+ * the only ones whose treatment differs from doing nothing: a `.exe` or
+ * an extensionless target is handed back untouched anyway, so choosing
+ * one on a guess would change nothing, while a batch target is the case
+ * that cannot survive the passthrough at all. PATHEXT order decides
+ * between `.bat` and `.cmd`, since that is the order cmd itself tries
+ * them; if the install is really under the other suffix, cmd answers
+ * with its own message about the path — which is a worse message than
+ * "not installed", but a true one, and it is not reached unless the
+ * directory is genuinely unreadable.
  */
 function resolveTarget(
   binary: string,
@@ -292,14 +317,18 @@ function resolveTarget(
       .filter((ext) => ext.length > 0),
     "",
   ];
+  let unanswered: string | null = null;
   for (const dir of (lookupEnv(env, "PATH") ?? "").split(";")) {
     if (dir.length === 0) continue;
     for (const suffix of suffixes) {
       const candidate = win32.join(dir, `${binary}${suffix}`);
-      if (fileStatus(candidate) === "present") return candidate;
+      const status = fileStatus(candidate);
+      if (status === "present") return candidate;
+      if (status === "unknown" && unanswered === null && isBatchFile(candidate))
+        unanswered = candidate;
     }
   }
-  return null;
+  return unanswered;
 }
 
 /** Windows environment names are case-insensitive; injected ones may not be. */

--- a/src/llm/provider/subscription-cli/windows-cli-shim.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.ts
@@ -110,21 +110,42 @@ export const MAX_CMD_COMMAND_LINE = 8191;
  * `"%_prog%" "%dp0%\…\cli.js" <our arguments>`. That line can be the
  * longer of the two — the arguments arrive one `^` layer lighter, but
  * the shim's prefix replaces the (shorter) `cmd.exe /d /s /c "` we
- * measured. For the real global `claude.cmd` the crossover leaves a
- * window ~76 characters wide in which the outer line passes this check
- * and cmd then refuses the inner one with the opaque message the check
- * exists to replace.
+ * measured. For a global `claude.cmd` the crossover leaves a window
+ * (~76 characters wide on the layout it was first measured on) in
+ * which the outer line passes this check and cmd then refuses the
+ * inner one with the opaque message the check exists to replace.
  *
  * A margin rather than a computed length, deliberately: at the point we
  * read the shim its line is `%_prog%` and `%dp0%`, and both expand at
  * run time to paths we do not have (`%_prog%` is chosen by a branch
  * *inside* the file). Measuring the literal text would be false
- * precision. 512 covers npm's ~170-character line with a deeply nested
- * install path and still leaves 94% of the budget — and the budget is
- * only ever contested by a large inline JSON schema, a case that
- * already ends in this error, just with an actionable message instead
- * of cmd's. Charged only when the shim actually re-substitutes: a batch
- * file that ignores its arguments builds no second line.
+ * precision.
+ *
+ * 512 is enough — but not by much, and not for the reason it looks
+ * like. Expanding the template's last line (`%COMSPEC%`, `%_prog%`,
+ * `%dp0%`, `%PATHEXT:;.JS;=;%`) over 6 install directories × 3 targets
+ * × 2 `_prog` branches × 2 PATHEXT values × 2 argument shapes puts the
+ * prefix anywhere between **157 and 813** characters — **229** for the
+ * plain global `%APPDATA%\npm` layout, not the ~170 an earlier version
+ * of this comment claimed. Across that sweep the worst margin actually
+ * *needed* is **468**, so 512 leaves 44 characters of headroom rather
+ * than the 94% of the budget it looks like it leaves.
+ *
+ * The binding case is a **metachar-free argument** under a
+ * 283-character `dp0` with `node.exe` sitting next to the shim — not
+ * the large inline JSON schema. A schema goes the other way: double
+ * escaping inflates the *outer* line by roughly 27%, so the outer runs
+ * ~1500–2000 characters longer than the inner one and the margin it
+ * needs is −1968. At the gate boundary a global-npm layout measures
+ * 7675 outer against 5707 inner — ~2484 characters of slack handed
+ * away, about 400 characters of schema the user could have had. A
+ * margin conditional on whether the argument carries metacharacters
+ * would reclaim them; that is deliberately not done. One flat number
+ * is one thing to be right about, and the cost of being generous is a
+ * refusal that names what to shorten, not a corrupted command line.
+ *
+ * Charged only when the shim actually re-substitutes: a batch file
+ * that ignores its arguments builds no second line.
  */
 export const SHIM_SUBSTITUTION_MARGIN = 512;
 

--- a/src/llm/provider/subscription-cli/windows-cli-shim.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.ts
@@ -1,5 +1,15 @@
-import { existsSync } from "node:fs";
 import { win32 } from "node:path";
+
+import {
+  hostEnv,
+  hostFileExists,
+  hostPlatform,
+  readShimHead,
+} from "./host-environment.js";
+import {
+  SubscriptionCliCommandLineError,
+  SubscriptionCliNotInstalledError,
+} from "./subscription-cli-errors.js";
 
 /**
  * Windows cannot spawn an npm shim directly.
@@ -17,15 +27,24 @@ import { win32 } from "node:path";
  * purpose — `runCommand` has many other callers and its behaviour is
  * left alone.
  *
- * Every environment input is a parameter so the Windows branch is
- * exercised from macOS/Linux in tests.
+ * Every environment input is a parameter (or comes from
+ * `host-environment.js`, which tests mock) so the Windows branch is
+ * exercised from macOS/Linux.
  */
 export interface WindowsCliShimOptions {
   binary: string;
   args: readonly string[];
+  /** Carried only so a missing target can raise the usual message. */
+  installHint?: string;
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
   fileExists?: (path: string) => boolean;
+  /**
+   * The head of a `.cmd`/`.bat`, or `null` when it cannot be read. The
+   * escaping depth depends on what the shim does with its arguments,
+   * which is a property of the file, not of where it lives.
+   */
+  readTarget?: (path: string) => string | null;
 }
 
 export interface CliInvocation {
@@ -41,13 +60,54 @@ const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
 /** Characters cmd.exe acts on before argv is parsed; `^` neutralises them. */
 const CMD_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
 
-/** npm's `node_modules\.bin` shims re-enter cmd once more — see below. */
-const CMD_SHIM = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
+/**
+ * Characters with no escape at all in a cmd command line.
+ *
+ * `^` is a line *continuation* before a newline, not an escape for it,
+ * and cmd ends its command at a raw LF or CR — the tail would be run as
+ * a second command. A NUL truncates the command line inside
+ * `CreateProcess` without any error. Reachable today only through an
+ * operator-set `extraArgs` or a configured model id (the prompt goes to
+ * stdin by design), but "reachable rarely" is not "safe".
+ */
+const UNESCAPABLE_CHARS = /[\r\n\u0000]/;
+
+/**
+ * A batch file that substitutes its arguments back into a line cmd then
+ * re-parses: `%*`, `%1`…`%9`, and the `%~dp1` modifier forms.
+ *
+ * This — not where the file sits on disk — is what decides whether the
+ * command line has to survive a *second* cmd parse, so it is what the
+ * second `^` pass keys off. npm's cmd-shim template ends in
+ * `… "%_prog%" "%dp0%\…\cli.js" %*`, and it is the same template for a
+ * global install (`%APPDATA%\npm\claude.cmd`, the dominant layout for
+ * `claude`) as for `node_modules\.bin\claude.cmd`. `cross-spawn`'s
+ * heuristic only recognises the second one, which under-escapes the
+ * case almost every real user is in: single-escaped, an argument that
+ * contains both a `"` and one of `& | < >` loses cmd's quoting at the
+ * re-parse (cmd does not read `\"` as an escaped quote, so the quoting
+ * state flips) and the metacharacter lands outside quotes — the
+ * argument is truncated and cmd runs the tail. That is the
+ * CVE-2024-24576 / BatBadBut mechanism, and `--json-schema <json>` on
+ * the `claude` adapter's argv is exactly the shape that triggers it.
+ */
+const ARG_SUBSTITUTION = /%(?:\*|~[a-zA-Z$:]*[0-9]|[0-9])/;
+
+/**
+ * cmd.exe refuses a command line longer than this, with "The input line
+ * is too long." — far below `CreateProcess`'s own 32767.
+ */
+export const MAX_CMD_COMMAND_LINE = 8191;
 
 /**
  * Map `(binary, args)` onto the pair that can actually be spawned. On
  * anything but Windows, and for any target that is not a batch shim,
  * the input is handed back untouched.
+ *
+ * Throws rather than returning a command line that would mean something
+ * other than what the caller asked for: `SubscriptionCliNotInstalledError`
+ * when an absolute target is not on disk, `SubscriptionCliCommandLineError`
+ * when the request cannot be expressed as a cmd command line.
  */
 export function resolveWindowsCliInvocation(
   options: WindowsCliShimOptions,
@@ -57,29 +117,42 @@ export function resolveWindowsCliInvocation(
     args: [...options.args],
     windowsVerbatimArguments: false,
   };
-  const platform = options.platform ?? process.platform;
+  const platform = options.platform ?? hostPlatform();
   if (platform !== "win32") return passthrough;
 
-  const env = options.env ?? process.env;
-  const target = resolveTarget(options.binary, env, options.fileExists ?? existsSync);
+  const env = options.env ?? hostEnv();
+  const fileExists = options.fileExists ?? hostFileExists;
+  const target = resolveTarget(
+    options.binary,
+    env,
+    fileExists,
+    options.installHint,
+  );
   // Nothing resolved, or a real executable: leave it alone. An unresolved
   // bare name still reaches spawn, so ENOENT — and with it the
   // not-installed message — surfaces exactly as before.
   if (target === null || !isBatchFile(target)) return passthrough;
 
-  // npm's `node_modules\.bin` shims pass their arguments through a
-  // second cmd layer, which consumes one round of `^` escaping.
-  const doubleEscape = CMD_SHIM.test(target);
+  const command = win32.normalize(target);
+  const readTarget = options.readTarget ?? readShimHead;
+  const doubleEscape = reSubstitutesArguments(command, readTarget);
+
+  for (const value of [command, ...options.args]) {
+    assertEscapable(value, options.binary);
+  }
+
   const commandLine = [
-    escapeCommand(win32.normalize(target)),
+    escapeCommand(command),
     ...options.args.map((arg) => escapeArgument(arg, doubleEscape)),
   ].join(" ");
 
-  return {
+  const invocation: CliInvocation = {
     command: lookupEnv(env, "ComSpec") ?? "cmd.exe",
     args: ["/d", "/s", "/c", `"${commandLine}"`],
     windowsVerbatimArguments: true,
   };
+  assertFitsCommandLine(invocation, options.binary);
+  return invocation;
 }
 
 function isBatchFile(target: string): boolean {
@@ -88,16 +161,71 @@ function isBatchFile(target: string): boolean {
 }
 
 /**
- * What cmd.exe would run for this name. A value that already carries a
- * directory or an extension is taken at its word; a bare name is walked
- * over PATH × PATHEXT, the search `spawn` will not do with `shell:false`.
+ * Does the shim hand our arguments to a second cmd parse?
+ *
+ * A bounded read of the file itself, because the alternative — guessing
+ * from the path — is what got this wrong. When the answer cannot be had
+ * (unreadable, gone, not a file we may open) the conservative default is
+ * `true`: every shim any of these CLIs actually ships re-substitutes, and
+ * a batch file that does *not* touch `%1`/`%*` ignores the arguments
+ * altogether, so the extra `^` pass cannot corrupt anything it reads.
+ */
+function reSubstitutesArguments(
+  target: string,
+  readTarget: (path: string) => string | null,
+): boolean {
+  const text = readTarget(target);
+  if (text === null) return true;
+  return ARG_SUBSTITUTION.test(text);
+}
+
+function assertEscapable(value: string, binary: string): void {
+  const match = UNESCAPABLE_CHARS.exec(value);
+  if (!match) return;
+  const name =
+    match[0] === "\n" ? "newline" : match[0] === "\r" ? "carriage return" : "NUL";
+  throw new SubscriptionCliCommandLineError(
+    `"${binary}" cannot be run through cmd.exe with this argument: it contains a raw ${name}, which has no escape in a cmd command line — cmd would end the command there and run the rest as a second one. Remove it from the argument (the prompt itself goes to stdin and is unaffected).`,
+    "control-character",
+  );
+}
+
+function assertFitsCommandLine(
+  invocation: CliInvocation,
+  binary: string,
+): void {
+  // What Node hands to `CreateProcess` with `windowsVerbatimArguments`:
+  // the file, then the argv entries, joined by spaces.
+  const length = [invocation.command, ...invocation.args].join(" ").length;
+  if (length <= MAX_CMD_COMMAND_LINE) return;
+  throw new SubscriptionCliCommandLineError(
+    `"${binary}" could not be started: the command line is ${length} characters and cmd.exe refuses anything over ${MAX_CMD_COMMAND_LINE} ("The input line is too long."). On Windows a .cmd shim has to be run through cmd.exe, whose limit is far below CreateProcess's 32767 — and escaping inflates the line by roughly a third. A large inline JSON response schema is the usual cause; shorten it or drop the structured-output request.`,
+    "too-long",
+  );
+}
+
+/**
+ * What cmd.exe would run for this name. A value that carries a directory
+ * is taken at its word — but only after checking that it exists, so a
+ * configured `binPath` pointing at nothing still produces the
+ * not-installed message instead of being wrapped in `cmd /c` and coming
+ * back as cmd's own "The system cannot find the path specified."
+ *
+ * Only absolute paths are checked: a relative one is resolved against
+ * the *child's* cwd, which is not ours to test against. Anything without
+ * a separator is walked over PATH × PATHEXT, the search `spawn` will not
+ * do with `shell:false`.
  */
 function resolveTarget(
   binary: string,
   env: NodeJS.ProcessEnv,
   fileExists: (path: string) => boolean,
+  installHint?: string,
 ): string | null {
-  if (/[\\/]/.test(binary) || win32.extname(binary).length > 0) return binary;
+  if (/[\\/]/.test(binary)) {
+    if (!win32.isAbsolute(binary) || fileExists(binary)) return binary;
+    throw new SubscriptionCliNotInstalledError(binary, installHint ?? "");
+  }
 
   const suffixes = [
     ...(lookupEnv(env, "PATHEXT") ?? DEFAULT_PATHEXT)
@@ -131,12 +259,26 @@ function escapeCommand(command: string): string {
 /**
  * Escape one argument for `cmd /c "…"` with verbatim argv, in the two
  * passes the layering demands: first for the CRT's `argv` parser
- * (backslash/quote rules), then for cmd's own pre-parse (`^`).
+ * (backslash/quote rules), then for cmd's own pre-parse (`^`), once per
+ * cmd parse the string will go through.
  *
  * Not theoretical here: the `claude` adapter delivers the response
  * schema inline on argv (`schemaDelivery: "inline"`), so braces, quotes,
  * brackets and commas are in every structured-output request, and a
  * prompt-derived argument can carry `&`, `|`, `^`, `<` or `>`.
+ *
+ * NOTE — do not "align this with the vendored cross-spawn". This is
+ * deliberately cross-spawn's *pre-7.0.5* algorithm, and it is the
+ * correct one. 7.0.5 hardened the trailing-backslash rule against a
+ * ReDoS by rewriting it as `/(?=(\\+?)?)\1$/`, and that lookahead is
+ * atomic in JS: it matches the empty string at the end and doubles
+ * nothing, so a run of two or more trailing backslashes is
+ * under-doubled and the closing quote is eaten. Differential fuzzing
+ * against the `cross-spawn@7.0.6` in this repo's own `node_modules`
+ * (1.2M comparisons) diverges on 938 inputs, all of them runs of >= 2
+ * backslashes; round-tripping 60026 of those through a simulated
+ * `cmd /d /s /c` plus `CommandLineToArgvW` gives 0 failures for the
+ * implementation below and 134 for the vendored one.
  */
 function escapeArgument(arg: string, doubleEscape: boolean): string {
   // Double any backslashes that precede a quote, then escape the quote.

--- a/src/llm/provider/subscription-cli/windows-cli-shim.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.ts
@@ -1,0 +1,150 @@
+import { existsSync } from "node:fs";
+import { win32 } from "node:path";
+
+/**
+ * Windows cannot spawn an npm shim directly.
+ *
+ * `claude` and `codex` install as `claude.cmd` / `codex.cmd`, and since
+ * the CVE-2024-27980 fix (Node >= 18.20.2 / 20.12.2) `spawn` refuses a
+ * `.cmd`/`.bat` target unless it goes through `cmd.exe`: the attempt
+ * fails with EINVAL, thrown *synchronously* out of `ChildProcess.spawn`
+ * rather than delivered on the `error` event. So the subscription-CLI
+ * providers cannot start at all on Windows.
+ *
+ * The fix is what `cross-spawn` does: re-point the invocation at
+ * `cmd.exe /d /s /c "…"`, escape the command line for cmd ourselves and
+ * ask Node to pass argv through verbatim. Scoped to this layer on
+ * purpose — `runCommand` has many other callers and its behaviour is
+ * left alone.
+ *
+ * Every environment input is a parameter so the Windows branch is
+ * exercised from macOS/Linux in tests.
+ */
+export interface WindowsCliShimOptions {
+  binary: string;
+  args: readonly string[];
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  fileExists?: (path: string) => boolean;
+}
+
+export interface CliInvocation {
+  command: string;
+  args: string[];
+  /** True only for the `cmd.exe` rewrite; see `escapeArgument`. */
+  windowsVerbatimArguments: boolean;
+}
+
+/** cmd.exe's own default when PATHEXT is somehow unset. */
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/** Characters cmd.exe acts on before argv is parsed; `^` neutralises them. */
+const CMD_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
+
+/** npm's `node_modules\.bin` shims re-enter cmd once more — see below. */
+const CMD_SHIM = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
+
+/**
+ * Map `(binary, args)` onto the pair that can actually be spawned. On
+ * anything but Windows, and for any target that is not a batch shim,
+ * the input is handed back untouched.
+ */
+export function resolveWindowsCliInvocation(
+  options: WindowsCliShimOptions,
+): CliInvocation {
+  const passthrough: CliInvocation = {
+    command: options.binary,
+    args: [...options.args],
+    windowsVerbatimArguments: false,
+  };
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") return passthrough;
+
+  const env = options.env ?? process.env;
+  const target = resolveTarget(options.binary, env, options.fileExists ?? existsSync);
+  // Nothing resolved, or a real executable: leave it alone. An unresolved
+  // bare name still reaches spawn, so ENOENT — and with it the
+  // not-installed message — surfaces exactly as before.
+  if (target === null || !isBatchFile(target)) return passthrough;
+
+  // npm's `node_modules\.bin` shims pass their arguments through a
+  // second cmd layer, which consumes one round of `^` escaping.
+  const doubleEscape = CMD_SHIM.test(target);
+  const commandLine = [
+    escapeCommand(win32.normalize(target)),
+    ...options.args.map((arg) => escapeArgument(arg, doubleEscape)),
+  ].join(" ");
+
+  return {
+    command: lookupEnv(env, "ComSpec") ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${commandLine}"`],
+    windowsVerbatimArguments: true,
+  };
+}
+
+function isBatchFile(target: string): boolean {
+  const ext = win32.extname(target).toLowerCase();
+  return ext === ".cmd" || ext === ".bat";
+}
+
+/**
+ * What cmd.exe would run for this name. A value that already carries a
+ * directory or an extension is taken at its word; a bare name is walked
+ * over PATH × PATHEXT, the search `spawn` will not do with `shell:false`.
+ */
+function resolveTarget(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+  fileExists: (path: string) => boolean,
+): string | null {
+  if (/[\\/]/.test(binary) || win32.extname(binary).length > 0) return binary;
+
+  const suffixes = [
+    ...(lookupEnv(env, "PATHEXT") ?? DEFAULT_PATHEXT)
+      .split(";")
+      .filter((ext) => ext.length > 0),
+    "",
+  ];
+  for (const dir of (lookupEnv(env, "PATH") ?? "").split(";")) {
+    if (dir.length === 0) continue;
+    for (const suffix of suffixes) {
+      const candidate = win32.join(dir, `${binary}${suffix}`);
+      if (fileExists(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/** Windows environment names are case-insensitive; injected ones may not be. */
+function lookupEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const wanted = name.toLowerCase();
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toLowerCase() === wanted && value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function escapeCommand(command: string): string {
+  return command.replace(CMD_META_CHARS, "^$1");
+}
+
+/**
+ * Escape one argument for `cmd /c "…"` with verbatim argv, in the two
+ * passes the layering demands: first for the CRT's `argv` parser
+ * (backslash/quote rules), then for cmd's own pre-parse (`^`).
+ *
+ * Not theoretical here: the `claude` adapter delivers the response
+ * schema inline on argv (`schemaDelivery: "inline"`), so braces, quotes,
+ * brackets and commas are in every structured-output request, and a
+ * prompt-derived argument can carry `&`, `|`, `^`, `<` or `>`.
+ */
+function escapeArgument(arg: string, doubleEscape: boolean): string {
+  // Double any backslashes that precede a quote, then escape the quote.
+  let escaped = arg.replace(/(\\*)"/g, '$1$1\\"');
+  // Trailing backslashes would otherwise escape the closing quote.
+  escaped = escaped.replace(/(\\*)$/, "$1$1");
+  escaped = `"${escaped}"`;
+  escaped = escaped.replace(CMD_META_CHARS, "^$1");
+  if (doubleEscape) escaped = escaped.replace(CMD_META_CHARS, "^$1");
+  return escaped;
+}

--- a/src/llm/provider/subscription-cli/windows-cli-shim.ts
+++ b/src/llm/provider/subscription-cli/windows-cli-shim.ts
@@ -2,9 +2,10 @@ import { win32 } from "node:path";
 
 import {
   hostEnv,
-  hostFileExists,
+  hostFileStatus,
   hostPlatform,
   readShimHead,
+  type FileStatus,
 } from "./host-environment.js";
 import {
   SubscriptionCliCommandLineError,
@@ -38,11 +39,13 @@ export interface WindowsCliShimOptions {
   installHint?: string;
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
-  fileExists?: (path: string) => boolean;
+  /** Present / absent / cannot-tell; see `hostFileStatus`. */
+  fileStatus?: (path: string) => FileStatus;
   /**
-   * The head of a `.cmd`/`.bat`, or `null` when it cannot be read. The
-   * escaping depth depends on what the shim does with its arguments,
-   * which is a property of the file, not of where it lives.
+   * The head of a `.cmd`/`.bat`, or `null` when it cannot be read —
+   * which includes a read that stopped at the probe cap. The escaping
+   * depth depends on what the shim does with its arguments, which is a
+   * property of the file, not of where it lives.
    */
   readTarget?: (path: string) => string | null;
 }
@@ -100,14 +103,41 @@ const ARG_SUBSTITUTION = /%(?:\*|~[a-zA-Z$:]*[0-9]|[0-9])/;
 export const MAX_CMD_COMMAND_LINE = 8191;
 
 /**
+ * Headroom held back for the line the *shim* builds.
+ *
+ * The limit applies to every command line cmd parses, and a shim that
+ * substitutes `%*` builds a second one:
+ * `"%_prog%" "%dp0%\…\cli.js" <our arguments>`. That line can be the
+ * longer of the two — the arguments arrive one `^` layer lighter, but
+ * the shim's prefix replaces the (shorter) `cmd.exe /d /s /c "` we
+ * measured. For the real global `claude.cmd` the crossover leaves a
+ * window ~76 characters wide in which the outer line passes this check
+ * and cmd then refuses the inner one with the opaque message the check
+ * exists to replace.
+ *
+ * A margin rather than a computed length, deliberately: at the point we
+ * read the shim its line is `%_prog%` and `%dp0%`, and both expand at
+ * run time to paths we do not have (`%_prog%` is chosen by a branch
+ * *inside* the file). Measuring the literal text would be false
+ * precision. 512 covers npm's ~170-character line with a deeply nested
+ * install path and still leaves 94% of the budget — and the budget is
+ * only ever contested by a large inline JSON schema, a case that
+ * already ends in this error, just with an actionable message instead
+ * of cmd's. Charged only when the shim actually re-substitutes: a batch
+ * file that ignores its arguments builds no second line.
+ */
+export const SHIM_SUBSTITUTION_MARGIN = 512;
+
+/**
  * Map `(binary, args)` onto the pair that can actually be spawned. On
  * anything but Windows, and for any target that is not a batch shim,
  * the input is handed back untouched.
  *
  * Throws rather than returning a command line that would mean something
  * other than what the caller asked for: `SubscriptionCliNotInstalledError`
- * when an absolute target is not on disk, `SubscriptionCliCommandLineError`
- * when the request cannot be expressed as a cmd command line.
+ * when an absolute target is known not to be on disk,
+ * `SubscriptionCliCommandLineError` when the request cannot be expressed
+ * as a cmd command line.
  */
 export function resolveWindowsCliInvocation(
   options: WindowsCliShimOptions,
@@ -121,11 +151,11 @@ export function resolveWindowsCliInvocation(
   if (platform !== "win32") return passthrough;
 
   const env = options.env ?? hostEnv();
-  const fileExists = options.fileExists ?? hostFileExists;
+  const fileStatus = options.fileStatus ?? hostFileStatus;
   const target = resolveTarget(
     options.binary,
     env,
-    fileExists,
+    fileStatus,
     options.installHint,
   );
   // Nothing resolved, or a real executable: leave it alone. An unresolved
@@ -137,8 +167,9 @@ export function resolveWindowsCliInvocation(
   const readTarget = options.readTarget ?? readShimHead;
   const doubleEscape = reSubstitutesArguments(command, readTarget);
 
-  for (const value of [command, ...options.args]) {
-    assertEscapable(value, options.binary);
+  assertEscapable(command, options.binary, "path");
+  for (const value of options.args) {
+    assertEscapable(value, options.binary, "argument");
   }
 
   const commandLine = [
@@ -151,7 +182,7 @@ export function resolveWindowsCliInvocation(
     args: ["/d", "/s", "/c", `"${commandLine}"`],
     windowsVerbatimArguments: true,
   };
-  assertFitsCommandLine(invocation, options.binary);
+  assertFitsCommandLine(invocation, options.binary, doubleEscape);
   return invocation;
 }
 
@@ -165,10 +196,11 @@ function isBatchFile(target: string): boolean {
  *
  * A bounded read of the file itself, because the alternative — guessing
  * from the path — is what got this wrong. When the answer cannot be had
- * (unreadable, gone, not a file we may open) the conservative default is
- * `true`: every shim any of these CLIs actually ships re-substitutes, and
- * a batch file that does *not* touch `%1`/`%*` ignores the arguments
- * altogether, so the extra `^` pass cannot corrupt anything it reads.
+ * (unreadable, gone, not a file we may open, or bigger than the probe
+ * window) the conservative default is `true`: every shim any of these
+ * CLIs actually ships re-substitutes, and a batch file that does *not*
+ * touch `%1`/`%*` ignores the arguments altogether, so the extra `^`
+ * pass cannot corrupt anything it reads.
  */
 function reSubstitutesArguments(
   target: string,
@@ -179,13 +211,28 @@ function reSubstitutesArguments(
   return ARG_SUBSTITUTION.test(text);
 }
 
-function assertEscapable(value: string, binary: string): void {
+function assertEscapable(
+  value: string,
+  binary: string,
+  role: "path" | "argument",
+): void {
   const match = UNESCAPABLE_CHARS.exec(value);
   if (!match) return;
   const name =
-    match[0] === "\n" ? "newline" : match[0] === "\r" ? "carriage return" : "NUL";
+    match[0] === "\n"
+      ? "newline"
+      : match[0] === "\r"
+        ? "carriage return"
+        : "NUL";
+  // The same characters are fatal in the target's own path, but "with
+  // this argument" would then send the reader looking through argv for
+  // something that is not there.
+  const subject =
+    role === "path"
+      ? "at all: its resolved path contains"
+      : "with this argument: it contains";
   throw new SubscriptionCliCommandLineError(
-    `"${binary}" cannot be run through cmd.exe with this argument: it contains a raw ${name}, which has no escape in a cmd command line — cmd would end the command there and run the rest as a second one. Remove it from the argument (the prompt itself goes to stdin and is unaffected).`,
+    `"${binary}" cannot be run through cmd.exe ${subject} a raw ${name}, which has no escape in a cmd command line — cmd would end the command there and run the rest as a second one. Remove it from the ${role} (the prompt itself goes to stdin and is unaffected).`,
     "control-character",
   );
 }
@@ -193,37 +240,49 @@ function assertEscapable(value: string, binary: string): void {
 function assertFitsCommandLine(
   invocation: CliInvocation,
   binary: string,
+  reSubstitutes: boolean,
 ): void {
   // What Node hands to `CreateProcess` with `windowsVerbatimArguments`:
   // the file, then the argv entries, joined by spaces.
   const length = [invocation.command, ...invocation.args].join(" ").length;
-  if (length <= MAX_CMD_COMMAND_LINE) return;
+  const budget =
+    MAX_CMD_COMMAND_LINE - (reSubstitutes ? SHIM_SUBSTITUTION_MARGIN : 0);
+  if (length <= budget) return;
+  const shimNote = reSubstitutes
+    ? `, and the .cmd shim substitutes the arguments back into a second command line of its own that the same limit applies to, so ${SHIM_SUBSTITUTION_MARGIN} characters are held back for it`
+    : "";
   throw new SubscriptionCliCommandLineError(
-    `"${binary}" could not be started: the command line is ${length} characters and cmd.exe refuses anything over ${MAX_CMD_COMMAND_LINE} ("The input line is too long."). On Windows a .cmd shim has to be run through cmd.exe, whose limit is far below CreateProcess's 32767 — and escaping inflates the line by roughly a third. A large inline JSON response schema is the usual cause; shorten it or drop the structured-output request.`,
+    `"${binary}" could not be started: the command line is ${length} characters and only ${budget} are usable. cmd.exe refuses anything over ${MAX_CMD_COMMAND_LINE} ("The input line is too long.")${shimNote}. On Windows a .cmd shim has to be run through cmd.exe, whose limit is far below CreateProcess's 32767 — and escaping inflates the line by roughly a third. A large inline JSON response schema is the usual cause; shorten it or drop the structured-output request.`,
     "too-long",
   );
 }
 
 /**
  * What cmd.exe would run for this name. A value that carries a directory
- * is taken at its word — but only after checking that it exists, so a
- * configured `binPath` pointing at nothing still produces the
- * not-installed message instead of being wrapped in `cmd /c` and coming
- * back as cmd's own "The system cannot find the path specified."
+ * is taken at its word — but only after checking that it is not plainly
+ * missing, so a configured `binPath` pointing at nothing still produces
+ * the not-installed message instead of being wrapped in `cmd /c` and
+ * coming back as cmd's own "The system cannot find the path specified."
+ * "Cannot tell" — a path we may not stat, a share that did not answer —
+ * is not "missing", and that target is handed to cmd like any other.
  *
- * Only absolute paths are checked: a relative one is resolved against
- * the *child's* cwd, which is not ours to test against. Anything without
- * a separator is walked over PATH × PATHEXT, the search `spawn` will not
- * do with `shell:false`.
+ * Only absolute paths are checked: a relative one (`tools\claude.cmd`,
+ * or the drive-relative `C:claude.cmd`, which is relative to that
+ * drive's own current directory) resolves against a cwd that is not
+ * ours to test against, so it is wrapped and left to cmd, which reports
+ * its own error if it is not there. Anything with neither a separator
+ * nor a drive letter is walked over PATH × PATHEXT, the search `spawn`
+ * will not do with `shell:false`.
  */
 function resolveTarget(
   binary: string,
   env: NodeJS.ProcessEnv,
-  fileExists: (path: string) => boolean,
+  fileStatus: (path: string) => FileStatus,
   installHint?: string,
 ): string | null {
-  if (/[\\/]/.test(binary)) {
-    if (!win32.isAbsolute(binary) || fileExists(binary)) return binary;
+  if (/[\\/]/.test(binary) || /^[A-Za-z]:/.test(binary)) {
+    if (!win32.isAbsolute(binary)) return binary;
+    if (fileStatus(binary) !== "absent") return binary;
     throw new SubscriptionCliNotInstalledError(binary, installHint ?? "");
   }
 
@@ -237,7 +296,7 @@ function resolveTarget(
     if (dir.length === 0) continue;
     for (const suffix of suffixes) {
       const candidate = win32.join(dir, `${binary}${suffix}`);
-      if (fileExists(candidate)) return candidate;
+      if (fileStatus(candidate) === "present") return candidate;
     }
   }
   return null;
@@ -267,24 +326,54 @@ function escapeCommand(command: string): string {
  * brackets and commas are in every structured-output request, and a
  * prompt-derived argument can carry `&`, `|`, `^`, `<` or `>`.
  *
- * NOTE — do not "align this with the vendored cross-spawn". This is
- * deliberately cross-spawn's *pre-7.0.5* algorithm, and it is the
- * correct one. 7.0.5 hardened the trailing-backslash rule against a
- * ReDoS by rewriting it as `/(?=(\\+?)?)\1$/`, and that lookahead is
- * atomic in JS: it matches the empty string at the end and doubles
- * nothing, so a run of two or more trailing backslashes is
- * under-doubled and the closing quote is eaten. Differential fuzzing
- * against the `cross-spawn@7.0.6` in this repo's own `node_modules`
- * (1.2M comparisons) diverges on 938 inputs, all of them runs of >= 2
+ * The CRT half is one left-to-right scan rather than the two regex
+ * passes cross-spawn uses, and it encodes exactly cross-spawn's
+ * *pre-7.0.5* rules:
+ *
+ *   - a run of backslashes before a `"` is doubled, and the quote is
+ *     then escaped as `\"`;
+ *   - a run of backslashes at the end of the argument is doubled, so it
+ *     cannot escape the closing quote we add;
+ *   - everything else is copied through.
+ *
+ * NOTE — do not "align this with the vendored cross-spawn". 7.0.5
+ * rewrote *two* rules. The ReDoS it was fixing is in the quote rule,
+ * `arg.replace(/(\\*)"/g, …)`, which is quadratic on a long run of
+ * backslashes that never reaches a quote: measured in-process here at
+ * 93 ms for 8k backslashes, 403 ms for 16k and 1.47 s for 32k, all of
+ * it synchronous, on the TUI's event loop, in the spawn path, and paid
+ * *before* the length check that would reject the argument anyway. The
+ * scan below is linear (0.2 ms for the same 32k) and keeps the old
+ * semantics character-for-character — a differential test pins it
+ * against the regex form over a random corpus.
+ *
+ * What must NOT be adopted is 7.0.5's *other* change, the trailing
+ * backslash rule as `/(?=(\\+?)?)\1$/`: that lookahead is atomic in JS,
+ * so it matches the empty string at the end and doubles nothing, and a
+ * run of two or more trailing backslashes is under-doubled — the
+ * closing quote is then eaten. Differential fuzzing against the
+ * `cross-spawn@7.0.6` in this repo's own `node_modules` (1.2M
+ * comparisons) diverges on 938 inputs, all of them runs of >= 2
  * backslashes; round-tripping 60026 of those through a simulated
  * `cmd /d /s /c` plus `CommandLineToArgvW` gives 0 failures for the
  * implementation below and 134 for the vendored one.
  */
 function escapeArgument(arg: string, doubleEscape: boolean): string {
-  // Double any backslashes that precede a quote, then escape the quote.
-  let escaped = arg.replace(/(\\*)"/g, '$1$1\\"');
-  // Trailing backslashes would otherwise escape the closing quote.
-  escaped = escaped.replace(/(\\*)$/, "$1$1");
+  let escaped = "";
+  let backslashes = 0;
+  for (const char of arg) {
+    if (char === "\\") {
+      backslashes += 1;
+      continue;
+    }
+    if (char === '"') {
+      escaped += "\\".repeat(backslashes * 2) + '\\"';
+    } else {
+      escaped += "\\".repeat(backslashes) + char;
+    }
+    backslashes = 0;
+  }
+  escaped += "\\".repeat(backslashes * 2);
   escaped = `"${escaped}"`;
   escaped = escaped.replace(CMD_META_CHARS, "^$1");
   if (doubleEscape) escaped = escaped.replace(CMD_META_CHARS, "^$1");

--- a/src/llm/provider/subscription-cli/windows-wiring.test.ts
+++ b/src/llm/provider/subscription-cli/windows-wiring.test.ts
@@ -1,0 +1,156 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The shim is a passthrough on every platform but Windows, so on this
+ * machine nothing proves that either CLI path calls it at all: delete
+ * the call and the whole suite still passes. These tests pretend the
+ * host is win32 (`host-environment.js` is the seam) and mock `spawn`, so
+ * the real shim runs its real win32 branch under the real wiring — and
+ * what lands on `spawn` is asserted.
+ *
+ * They also pin the pieces of the rewrite that a "simplification" would
+ * quietly drop: `win32.normalize` on the target, `escapeCommand` on it
+ * (the real path is `…\AppData\Roaming\npm\claude.cmd`, and
+ * `Program Files (x86)` is just as ordinary), and the tree-kill on abort.
+ */
+const state = vi.hoisted(() => ({
+  files: new Set<string>(),
+  shimBody: 'endLocal & "%_prog%" "%dp0%\\cli.js" %*',
+  spawns: [] as { file: string; args: readonly string[]; options: unknown }[],
+  children: [] as EventEmitter[],
+  autoClose: true,
+}));
+
+vi.mock("./host-environment.js", () => ({
+  hostPlatform: () => "win32",
+  hostEnv: () => ({
+    PATH: "C:\\npm",
+    PATHEXT: ".CMD",
+    ComSpec: "C:\\Windows\\System32\\cmd.exe",
+  }),
+  hostFileExists: (path: string) => state.files.has(path.toLowerCase()),
+  readShimHead: () => state.shimBody,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (file: string, args: readonly string[], options: unknown) => {
+      state.spawns.push({ file, args, options });
+      const child = Object.assign(new EventEmitter(), {
+        pid: 4242,
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        stdin: new PassThrough(),
+        killed: [] as unknown[],
+        kill(signal?: unknown) {
+          (child as unknown as { killed: unknown[] }).killed.push(signal);
+          return true;
+        },
+      });
+      // `taskkill` is spawned by the tree-kill; it has no streams to
+      // drive and must not be mistaken for the CLI child.
+      if (file !== "taskkill") {
+        state.children.push(child);
+        if (state.autoClose) {
+          setImmediate(() => {
+            child.stdout.end();
+            child.emit("close", 0, null);
+          });
+        }
+      }
+      return child;
+    },
+  };
+});
+
+const { runCliCommand } = await import("./run-cli-completion.js");
+const { streamCliCommand } = await import("./stream-cli-completion.js");
+
+/** A configured `binPath`, in the shape a real Windows install has. */
+const BIN_PATH = "C:/Users/Some One/AppData/Roaming/npm (x86)/claude.cmd";
+const EXPECTED_COMMAND_LINE =
+  '"C:\\Users\\Some^ One\\AppData\\Roaming\\npm^ ^(x86^)\\claude.cmd ^^^"--print^^^""';
+
+function options(extra: Record<string, unknown> = {}) {
+  return {
+    binary: BIN_PATH,
+    args: ["--print"],
+    cwd: process.cwd(),
+    timeoutMs: 5_000,
+    maxOutputBytes: 64 * 1024,
+    installHint: "Install Claude Code.",
+    authHint: "Run /login.",
+    ...extra,
+  };
+}
+
+function cliSpawns() {
+  return state.spawns.filter((call) => call.file !== "taskkill");
+}
+
+beforeEach(() => {
+  state.files = new Set([BIN_PATH.toLowerCase()]);
+  state.spawns = [];
+  state.children = [];
+  state.autoClose = true;
+  state.shimBody = 'endLocal & "%_prog%" "%dp0%\\cli.js" %*';
+});
+
+describe("the Windows shim as both CLI paths use it", () => {
+  it("sends the streaming path through cmd.exe with an escaped command line", async () => {
+    const lines: string[] = [];
+    for await (const line of streamCliCommand(options())) lines.push(line);
+
+    expect(cliSpawns()).toHaveLength(1);
+    const call = cliSpawns()[0];
+    expect(call?.file).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(call?.args).toEqual(["/d", "/s", "/c", EXPECTED_COMMAND_LINE]);
+    expect(call?.options).toMatchObject({ windowsVerbatimArguments: true });
+  });
+
+  it("sends the buffered path through cmd.exe the same way", async () => {
+    await runCliCommand(options());
+
+    expect(cliSpawns()).toHaveLength(1);
+    const call = cliSpawns()[0];
+    expect(call?.file).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(call?.args).toEqual(["/d", "/s", "/c", EXPECTED_COMMAND_LINE]);
+    expect(call?.options).toMatchObject({ windowsVerbatimArguments: true });
+  });
+
+  it("stops the whole process tree when a streaming turn is aborted", async () => {
+    // The direct child is cmd.exe; the CLI is its grandchild. Before
+    // this, `child.kill` on the wrapper's pid left the real CLI running
+    // — one orphan per Ctrl+C, which is the most routine action there is.
+    state.autoClose = false;
+    const controller = new AbortController();
+    const iterator = streamCliCommand(options({ signal: controller.signal }));
+    const first = iterator.next();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    controller.abort();
+    const child = state.children[0] as unknown as { killed: unknown[] };
+    expect(
+      state.spawns.filter((call) => call.file === "taskkill"),
+    ).toEqual([
+      {
+        file: "taskkill",
+        args: ["/PID", "4242", "/T"],
+        options: { stdio: "ignore", windowsHide: true },
+      },
+    ]);
+    expect(child.killed).toEqual([]);
+
+    // Let the generator finish so the test does not leak it.
+    state.children[0]?.emit("close", null, "SIGTERM");
+    (
+      state.children[0] as unknown as { stdout: PassThrough }
+    ).stdout.end();
+    await first.catch(() => {});
+    await iterator.return(undefined).catch(() => {});
+  });
+});

--- a/src/llm/provider/subscription-cli/windows-wiring.test.ts
+++ b/src/llm/provider/subscription-cli/windows-wiring.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * The shim is a passthrough on every platform but Windows, so on this
@@ -13,14 +13,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  * They also pin the pieces of the rewrite that a "simplification" would
  * quietly drop: `win32.normalize` on the target, `escapeCommand` on it
  * (the real path is `…\AppData\Roaming\npm\claude.cmd`, and
- * `Program Files (x86)` is just as ordinary), and the tree-kill on abort.
+ * `Program Files (x86)` is just as ordinary), and the tree-kill on abort
+ * — including its escalation, which is the only thing that reaps the
+ * tree when the polite pass is refused.
  */
 const state = vi.hoisted(() => ({
   files: new Set<string>(),
   shimBody: 'endLocal & "%_prog%" "%dp0%\\cli.js" %*',
   spawns: [] as { file: string; args: readonly string[]; options: unknown }[],
   children: [] as EventEmitter[],
+  taskkills: [] as EventEmitter[],
   autoClose: true,
+  taskkillSpawnFails: false,
 }));
 
 vi.mock("./host-environment.js", () => ({
@@ -30,7 +34,8 @@ vi.mock("./host-environment.js", () => ({
     PATHEXT: ".CMD",
     ComSpec: "C:\\Windows\\System32\\cmd.exe",
   }),
-  hostFileExists: (path: string) => state.files.has(path.toLowerCase()),
+  hostFileStatus: (path: string) =>
+    state.files.has(path.toLowerCase()) ? "present" : "absent",
   readShimHead: () => state.shimBody,
 }));
 
@@ -40,6 +45,9 @@ vi.mock("node:child_process", async (importOriginal) => {
     ...actual,
     spawn: (file: string, args: readonly string[], options: unknown) => {
       state.spawns.push({ file, args, options });
+      if (file === "taskkill" && state.taskkillSpawnFails) {
+        throw new Error("EPERM");
+      }
       const child = Object.assign(new EventEmitter(), {
         pid: 4242,
         stdout: new PassThrough(),
@@ -52,8 +60,11 @@ vi.mock("node:child_process", async (importOriginal) => {
         },
       });
       // `taskkill` is spawned by the tree-kill; it has no streams to
-      // drive and must not be mistaken for the CLI child.
-      if (file !== "taskkill") {
+      // drive and must not be mistaken for the CLI child. Its exit code
+      // is what decides whether the tree really died, so tests drive it.
+      if (file === "taskkill") {
+        state.taskkills.push(child);
+      } else {
         state.children.push(child);
         if (state.autoClose) {
           setImmediate(() => {
@@ -92,12 +103,48 @@ function cliSpawns() {
   return state.spawns.filter((call) => call.file !== "taskkill");
 }
 
+function taskkillArgs() {
+  return state.spawns
+    .filter((call) => call.file === "taskkill")
+    .map((call) => call.args);
+}
+
+/** Start a streaming turn that stays open until the test closes it. */
+async function startAbortableTurn() {
+  state.autoClose = false;
+  const controller = new AbortController();
+  const iterator = streamCliCommand(options({ signal: controller.signal }));
+  const first = iterator.next();
+  await new Promise((resolve) => setImmediate(resolve));
+  const child = state.children[0] as unknown as {
+    killed: unknown[];
+    stdout: PassThrough;
+    emit: (event: string, ...args: unknown[]) => boolean;
+  };
+  return {
+    controller,
+    child,
+    async finish() {
+      child.stdout.end();
+      child.emit("close", null, "SIGTERM");
+      await first.catch(() => {});
+      await iterator.return(undefined).catch(() => {});
+    },
+  };
+}
+
 beforeEach(() => {
   state.files = new Set([BIN_PATH.toLowerCase()]);
   state.spawns = [];
   state.children = [];
+  state.taskkills = [];
   state.autoClose = true;
+  state.taskkillSpawnFails = false;
   state.shimBody = 'endLocal & "%_prog%" "%dp0%\\cli.js" %*';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("the Windows shim as both CLI paths use it", () => {
@@ -109,7 +156,12 @@ describe("the Windows shim as both CLI paths use it", () => {
     const call = cliSpawns()[0];
     expect(call?.file).toBe("C:\\Windows\\System32\\cmd.exe");
     expect(call?.args).toEqual(["/d", "/s", "/c", EXPECTED_COMMAND_LINE]);
-    expect(call?.options).toMatchObject({ windowsVerbatimArguments: true });
+    // `windowsHide` reads the same host seam as everything else, so the
+    // faked win32 host produces the options production would.
+    expect(call?.options).toMatchObject({
+      windowsVerbatimArguments: true,
+      windowsHide: true,
+    });
   });
 
   it("sends the buffered path through cmd.exe the same way", async () => {
@@ -126,31 +178,75 @@ describe("the Windows shim as both CLI paths use it", () => {
     // The direct child is cmd.exe; the CLI is its grandchild. Before
     // this, `child.kill` on the wrapper's pid left the real CLI running
     // — one orphan per Ctrl+C, which is the most routine action there is.
-    state.autoClose = false;
-    const controller = new AbortController();
-    const iterator = streamCliCommand(options({ signal: controller.signal }));
-    const first = iterator.next();
-    await new Promise((resolve) => setImmediate(resolve));
+    const turn = await startAbortableTurn();
 
-    controller.abort();
-    const child = state.children[0] as unknown as { killed: unknown[] };
-    expect(
-      state.spawns.filter((call) => call.file === "taskkill"),
-    ).toEqual([
+    turn.controller.abort();
+    expect(state.spawns.filter((call) => call.file === "taskkill")).toEqual([
       {
         file: "taskkill",
         args: ["/PID", "4242", "/T"],
         options: { stdio: "ignore", windowsHide: true },
       },
     ]);
-    expect(child.killed).toEqual([]);
+    expect(turn.child.killed).toEqual([]);
 
-    // Let the generator finish so the test does not leak it.
-    state.children[0]?.emit("close", null, "SIGTERM");
-    (
-      state.children[0] as unknown as { stdout: PassThrough }
-    ).stdout.end();
-    await first.catch(() => {});
-    await iterator.return(undefined).catch(() => {});
+    await turn.finish();
+  });
+
+  it("escalates to taskkill /F when the polite pass is refused", async () => {
+    // taskkill without /F posts WM_CLOSE, and a console process spawned
+    // with `windowsHide: true` has no window to receive it: taskkill
+    // answers "can only be terminated forcefully" and exits non-zero.
+    // Unobserved, that refusal left the tree alive.
+    const turn = await startAbortableTurn();
+
+    turn.controller.abort();
+    expect(taskkillArgs()).toEqual([["/PID", "4242", "/T"]]);
+
+    state.taskkills[0]?.emit("close", 1, null);
+    expect(taskkillArgs()).toEqual([
+      ["/PID", "4242", "/T"],
+      ["/PID", "4242", "/T", "/F"],
+    ]);
+    // Not a TerminateProcess at the wrapper: that is what orphans the CLI.
+    expect(turn.child.killed).toEqual([]);
+
+    await turn.finish();
+  });
+
+  it("leaves the force pass armed when the polite pass could only signal the wrapper", async () => {
+    // taskkill missing from a locked-down image: the fallback is
+    // `child.kill`, which on Windows terminates `cmd.exe` alone. Its
+    // `close` used to disarm the escalation — so the grandchild survived
+    // the abort, which is exactly the orphan this whole path is about.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    state.taskkillSpawnFails = true;
+    const turn = await startAbortableTurn();
+
+    turn.controller.abort();
+    expect(turn.child.killed).toEqual(["SIGTERM"]);
+
+    await turn.finish();
+    vi.advanceTimersByTime(2_000);
+    expect(turn.child.killed).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(taskkillArgs()).toEqual([
+      ["/PID", "4242", "/T"],
+      ["/PID", "4242", "/T", "/F"],
+    ]);
+  });
+
+  it("does not force-kill once the tree is confirmed gone", async () => {
+    // The other direction: a taskkill that reports success must not be
+    // followed 2 s later by `/F` at a pid Windows may have recycled.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const turn = await startAbortableTurn();
+
+    turn.controller.abort();
+    state.taskkills[0]?.emit("close", 0, null);
+    await turn.finish();
+    vi.advanceTimersByTime(2_000);
+
+    expect(taskkillArgs()).toEqual([["/PID", "4242", "/T"]]);
+    expect(turn.child.killed).toEqual([]);
   });
 });

--- a/src/sandbox/command-runner-kill.test.ts
+++ b/src/sandbox/command-runner-kill.test.ts
@@ -1,0 +1,114 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `runCommand` is the highest-traffic caller of the shared tree-kill —
+ * every `run_test`, every bit of git plumbing — and its stop path had no
+ * coverage at all: replacing `killProcessTree(child, { force: true })`
+ * with a bare `child.kill("SIGKILL")` (and dropping the now-unused
+ * import) compiled and left the suite green, because on this host the
+ * two do the same thing. The helper exists for Windows, where they do
+ * not: `child.kill` is `TerminateProcess` at one pid and leaves a
+ * subshell's descendants running. So the call itself is what is pinned
+ * here, alongside the behaviour it has to keep on POSIX.
+ *
+ * The real implementation still runs — the spy only watches — so the
+ * children in these tests actually die.
+ */
+const { killSpy } = vi.hoisted(() => ({ killSpy: vi.fn() }));
+
+vi.mock("./kill-process-tree.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./kill-process-tree.js")>();
+  return {
+    ...actual,
+    killProcessTree: (
+      child: Parameters<typeof actual.killProcessTree>[0],
+      options?: Parameters<typeof actual.killProcessTree>[1],
+    ) => {
+      killSpy(options);
+      actual.killProcessTree(child, options);
+    },
+  };
+});
+
+const { runCommand } = await import("./command-runner.js");
+
+let dir = "";
+
+/**
+ * Traps SIGTERM and keeps running, so only a forceful stop ends it: a
+ * polite one would hang this test rather than quietly pass it.
+ */
+function stubbornChild(readyFile: string) {
+  return [
+    "-e",
+    `
+      process.on("SIGTERM", () => {});
+      require("node:fs").writeFileSync(${JSON.stringify(readyFile)}, "1");
+      setInterval(() => {}, 1000);
+    `,
+  ];
+}
+
+async function waitForReady(readyFile: string): Promise<void> {
+  for (let i = 0; i < 200; i += 1) {
+    if (existsSync(readyFile)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("child never signalled ready");
+}
+
+beforeEach(() => {
+  killSpy.mockClear();
+  dir = mkdtempSync(join(tmpdir(), "runner-kill-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true, maxRetries: 3 });
+});
+
+describe("runCommand stopping a child", () => {
+  it("goes through the tree-kill on abort, forcefully", async () => {
+    const ready = join(dir, "ready-abort");
+    const controller = new AbortController();
+    const pending = runCommand(process.execPath, stubbornChild(ready), {
+      cwd: process.cwd(),
+      timeoutMs: 0,
+      signal: controller.signal,
+    });
+
+    await waitForReady(ready);
+    controller.abort();
+    const result = await pending;
+
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    expect(killSpy).toHaveBeenCalledWith({ force: true });
+    expect(result.signal).toBe("SIGKILL");
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("goes through it on timeout too", async () => {
+    const ready = join(dir, "ready-timeout");
+    const result = await runCommand(process.execPath, stubbornChild(ready), {
+      cwd: process.cwd(),
+      timeoutMs: 400,
+    });
+
+    expect(killSpy).toHaveBeenCalledWith({ force: true });
+    expect(result.timedOut).toBe(true);
+    expect(result.signal).toBe("SIGKILL");
+  });
+
+  it("does not reach for it when the command ends on its own", async () => {
+    const result = await runCommand(process.execPath, ["-e", "0"], {
+      cwd: process.cwd(),
+      timeoutMs: 10_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/sandbox/command-runner.ts
+++ b/src/sandbox/command-runner.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 
+import { killProcessTree } from "./kill-process-tree.js";
+
 const IS_WINDOWS = process.platform === "win32";
 
 /**
@@ -102,31 +104,10 @@ export async function runCommand(
       if (settled) return;
       timedOut = reason === "timeout";
       // On Windows `child.kill` only targets the direct child, leaving a
-      // subshell's descendants (cmd.exe -> foo.exe) running. `taskkill /T`
-      // walks the whole process tree; fall back to SIGKILL if the pid is
-      // gone or taskkill itself cannot be spawned.
-      if (IS_WINDOWS && typeof child.pid === "number") {
-        try {
-          spawn("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
-            stdio: "ignore",
-            windowsHide: true,
-          }).on("error", () => {
-            try {
-              child.kill("SIGKILL");
-            } catch {
-              // process already exited
-            }
-          });
-          return;
-        } catch {
-          // fall through to the POSIX-style kill below
-        }
-      }
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        // process already exited
-      }
+      // subshell's descendants (cmd.exe -> foo.exe) running, so this goes
+      // through `taskkill /T`. Same treatment, same fallback — the shared
+      // helper exists because the streaming CLI runner needs it too.
+      killProcessTree(child, { force: true });
     };
 
     const timer =

--- a/src/sandbox/command-runner.ts
+++ b/src/sandbox/command-runner.ts
@@ -29,6 +29,13 @@ export interface CommandOptions {
   input?: string;
   signal?: AbortSignal;
   maxOutputBytes?: number;
+  /**
+   * Windows only, ignored elsewhere: hand argv to the child verbatim
+   * instead of letting Node quote it. Only for callers that have already
+   * built a `cmd.exe /c "…"` command line with cmd's own escaping.
+   * Omitted by default, which keeps Node's normal quoting.
+   */
+  windowsVerbatimArguments?: boolean;
 }
 
 export interface CommandResult {
@@ -79,6 +86,9 @@ export async function runCommand(
       // Prevent a console window flashing when the runtime is launched
       // from a GUI/TUI host on Windows.
       ...(IS_WINDOWS ? { windowsHide: true } : {}),
+      ...(options.windowsVerbatimArguments === undefined
+        ? {}
+        : { windowsVerbatimArguments: options.windowsVerbatimArguments }),
     });
     const chunks = { stdout: [] as Buffer[], stderr: [] as Buffer[] };
     let stdoutBytes = 0;

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,5 +1,10 @@
 export { isBrokenPipe, runCommand } from "./command-runner.js";
 export type { CommandOptions, CommandResult } from "./command-runner.js";
+export { killProcessTree } from "./kill-process-tree.js";
+export type {
+  KillableChild,
+  KillProcessTreeOptions,
+} from "./kill-process-tree.js";
 export {
   buildSubshellInvocation,
   quoteCmdArg,

--- a/src/sandbox/kill-process-tree.test.ts
+++ b/src/sandbox/kill-process-tree.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+
+import { killProcessTree, type KillableChild } from "./kill-process-tree.js";
+
+function fakeChild(pid?: number) {
+  const signals: (NodeJS.Signals | number | undefined)[] = [];
+  const child: KillableChild = {
+    pid,
+    kill(signal) {
+      signals.push(signal);
+      return true;
+    },
+  };
+  return { child, signals };
+}
+
+/** Stands in for a spawned `taskkill`; `fail` makes the spawn itself fail. */
+function fakeSpawn(mode: "ok" | "error-event" | "throw" = "ok") {
+  const calls: { file: string; args: readonly string[] }[] = [];
+  const impl = ((file: string, args: readonly string[]) => {
+    calls.push({ file, args });
+    if (mode === "throw") throw new Error("EPERM");
+    const emitter = new EventEmitter();
+    if (mode === "error-event") {
+      queueMicrotask(() => emitter.emit("error", new Error("ENOENT")));
+    }
+    return emitter;
+  }) as unknown as typeof import("node:child_process").spawn;
+  return { calls, impl };
+}
+
+describe("killProcessTree on posix", () => {
+  it("signals the child directly", () => {
+    const { child, signals } = fakeChild(4242);
+    const { calls, impl } = fakeSpawn();
+    killProcessTree(child, { platform: "darwin", spawnImpl: impl });
+    killProcessTree(child, { platform: "linux", force: true, spawnImpl: impl });
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("killProcessTree on win32", () => {
+  it("walks the tree with taskkill instead of TerminateProcess on one pid", () => {
+    // The whole reason this exists: with a `cmd.exe` wrapper the real
+    // CLI is a *grandchild*, and `child.kill` would leave it running.
+    const { child, signals } = fakeChild(4242);
+    const { calls, impl } = fakeSpawn();
+    killProcessTree(child, { platform: "win32", spawnImpl: impl });
+    expect(calls).toEqual([
+      { file: "taskkill", args: ["/PID", "4242", "/T"] },
+    ]);
+    expect(signals).toEqual([]);
+  });
+
+  it("adds /F when the polite stop has already been tried", () => {
+    const { child } = fakeChild(4242);
+    const { calls, impl } = fakeSpawn();
+    killProcessTree(child, { platform: "win32", force: true, spawnImpl: impl });
+    expect(calls[0]?.args).toEqual(["/PID", "4242", "/T", "/F"]);
+  });
+
+  it("falls back to a direct signal when taskkill cannot be spawned", async () => {
+    const { child, signals } = fakeChild(4242);
+    const { impl } = fakeSpawn("error-event");
+    killProcessTree(child, { platform: "win32", force: true, spawnImpl: impl });
+    await Promise.resolve();
+    expect(signals).toEqual(["SIGKILL"]);
+  });
+
+  it("falls back when the spawn throws outright", () => {
+    const { child, signals } = fakeChild(4242);
+    const { impl } = fakeSpawn("throw");
+    killProcessTree(child, { platform: "win32", spawnImpl: impl });
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
+  it("falls back when there is no pid to hand taskkill", () => {
+    const { child, signals } = fakeChild(undefined);
+    const { calls, impl } = fakeSpawn();
+    killProcessTree(child, { platform: "win32", spawnImpl: impl });
+    expect(calls).toEqual([]);
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
+  it("survives a child that has already exited", () => {
+    const child: KillableChild = {
+      pid: 1,
+      kill() {
+        throw new Error("ESRCH");
+      },
+    };
+    expect(() =>
+      killProcessTree(child, { platform: "darwin" }),
+    ).not.toThrow();
+  });
+});

--- a/src/sandbox/kill-process-tree.test.ts
+++ b/src/sandbox/kill-process-tree.test.ts
@@ -18,26 +18,41 @@ function fakeChild(pid?: number) {
 /** Stands in for a spawned `taskkill`; `fail` makes the spawn itself fail. */
 function fakeSpawn(mode: "ok" | "error-event" | "throw" = "ok") {
   const calls: { file: string; args: readonly string[] }[] = [];
+  const started: EventEmitter[] = [];
   const impl = ((file: string, args: readonly string[]) => {
     calls.push({ file, args });
     if (mode === "throw") throw new Error("EPERM");
     const emitter = new EventEmitter();
+    started.push(emitter);
     if (mode === "error-event") {
       queueMicrotask(() => emitter.emit("error", new Error("ENOENT")));
     }
     return emitter;
   }) as unknown as typeof import("node:child_process").spawn;
-  return { calls, impl };
+  return { calls, impl, started };
+}
+
+/** Collects what the caller is told about the descendants. */
+function outcome() {
+  const reported: boolean[] = [];
+  return { reported, onTreeKilled: (killed: boolean) => reported.push(killed) };
 }
 
 describe("killProcessTree on posix", () => {
   it("signals the child directly", () => {
     const { child, signals } = fakeChild(4242);
     const { calls, impl } = fakeSpawn();
-    killProcessTree(child, { platform: "darwin", spawnImpl: impl });
+    const { reported, onTreeKilled } = outcome();
+    killProcessTree(child, {
+      platform: "darwin",
+      spawnImpl: impl,
+      onTreeKilled,
+    });
     killProcessTree(child, { platform: "linux", force: true, spawnImpl: impl });
     expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
     expect(calls).toEqual([]);
+    // There is no tree here: the child *is* the process we mean.
+    expect(reported).toEqual([true]);
   });
 });
 
@@ -94,5 +109,95 @@ describe("killProcessTree on win32", () => {
     expect(() =>
       killProcessTree(child, { platform: "darwin" }),
     ).not.toThrow();
+  });
+});
+
+/**
+ * `taskkill` without `/F` posts WM_CLOSE, and a console process spawned
+ * with `windowsHide: true` has no window to receive it: taskkill answers
+ * "This process can only be terminated forcefully (with /F option)" and
+ * exits non-zero. With `stdio: "ignore"` and nobody watching `close`,
+ * that refusal was invisible and the polite pass silently did nothing.
+ */
+describe("a taskkill that refuses", () => {
+  it("is escalated to /F rather than reported as done", () => {
+    const { child, signals } = fakeChild(4242);
+    const { calls, impl, started } = fakeSpawn();
+    const { reported, onTreeKilled } = outcome();
+    killProcessTree(child, {
+      platform: "win32",
+      spawnImpl: impl,
+      onTreeKilled,
+    });
+
+    started[0]?.emit("close", 1);
+    expect(calls.map((call) => call.args)).toEqual([
+      ["/PID", "4242", "/T"],
+      ["/PID", "4242", "/T", "/F"],
+    ]);
+    // Nothing is claimed until the escalation itself answers.
+    expect(reported).toEqual([]);
+    expect(signals).toEqual([]);
+
+    started[1]?.emit("close", 0);
+    expect(reported).toEqual([true]);
+  });
+
+  it("gives up on the direct child when even /F is refused", () => {
+    const { child, signals } = fakeChild(4242);
+    const { impl, started } = fakeSpawn();
+    const { reported, onTreeKilled } = outcome();
+    killProcessTree(child, {
+      platform: "win32",
+      spawnImpl: impl,
+      onTreeKilled,
+    });
+    started[0]?.emit("close", 1);
+    started[1]?.emit("close", 1);
+    expect(signals).toEqual(["SIGKILL"]);
+    // TerminateProcess at the wrapper leaves the grandchild: say so.
+    expect(reported).toEqual([false]);
+  });
+
+  it("does not re-run taskkill at a pid that is already gone", () => {
+    // Exit 128 is "no such process" — there is nothing left to kill, and
+    // a second pass with /F could reach whatever Windows gave the pid to
+    // next.
+    const { child, signals } = fakeChild(4242);
+    const { calls, impl, started } = fakeSpawn();
+    const { reported, onTreeKilled } = outcome();
+    killProcessTree(child, {
+      platform: "win32",
+      spawnImpl: impl,
+      onTreeKilled,
+    });
+    started[0]?.emit("close", 128);
+    expect(calls).toHaveLength(1);
+    expect(signals).toEqual([]);
+    expect(reported).toEqual([true]);
+  });
+
+  it("reports a fallback as a fallback", () => {
+    const { child } = fakeChild(4242);
+    const { impl } = fakeSpawn("throw");
+    const { reported, onTreeKilled } = outcome();
+    killProcessTree(child, {
+      platform: "win32",
+      spawnImpl: impl,
+      onTreeKilled,
+    });
+    expect(reported).toEqual([false]);
+  });
+
+  it("reports a missing pid as a fallback too", () => {
+    const { child } = fakeChild(undefined);
+    const { impl } = fakeSpawn();
+    const { reported, onTreeKilled } = outcome();
+    killProcessTree(child, {
+      platform: "win32",
+      spawnImpl: impl,
+      onTreeKilled,
+    });
+    expect(reported).toEqual([false]);
   });
 });

--- a/src/sandbox/kill-process-tree.ts
+++ b/src/sandbox/kill-process-tree.ts
@@ -20,6 +20,20 @@ export interface KillProcessTreeOptions {
   force?: boolean;
   platform?: NodeJS.Platform;
   spawnImpl?: typeof spawn;
+  /**
+   * Whether the stop reached the whole tree — not whether the tree is
+   * dead. (A process is free to ignore a polite stop; that is what the
+   * caller's own escalation is for.)
+   *
+   * `true` when `taskkill` itself reported that it walked the tree, and
+   * on POSIX, where there is no tree to walk because the child is the
+   * process we mean. Every other outcome is `false`: taskkill refused,
+   * could not be started, or we fell back to a signal at the wrapper's
+   * own pid, which on Windows leaves the grandchild running. A caller
+   * with an escalation armed must keep it armed on `false` — the direct
+   * child's `close` is *not* evidence that its descendants are gone.
+   */
+  onTreeKilled?: (killed: boolean) => void;
 }
 
 /** The little of `ChildProcess` this needs; keeps fakes cheap in tests. */
@@ -28,6 +42,14 @@ export interface KillableChild {
   kill(signal?: NodeJS.Signals | number): boolean;
 }
 
+/**
+ * taskkill's "the process is not there" code. Nothing is left to kill,
+ * so it counts as success — and, importantly, must not be escalated:
+ * re-running taskkill against a pid that has already exited is the one
+ * way this can reach an unrelated process, since Windows recycles pids.
+ */
+const TASKKILL_NOT_FOUND = 128;
+
 export function killProcessTree(
   child: KillableChild,
   options: KillProcessTreeOptions = {},
@@ -35,22 +57,94 @@ export function killProcessTree(
   const force = options.force ?? false;
   const platform = options.platform ?? process.platform;
   const signal: NodeJS.Signals = force ? "SIGKILL" : "SIGTERM";
+  const report = options.onTreeKilled ?? (() => {});
 
-  if (platform === "win32" && typeof child.pid === "number") {
-    const spawnImpl = options.spawnImpl ?? spawn;
-    const args = ["/PID", String(child.pid), "/T", ...(force ? ["/F"] : [])];
-    try {
-      spawnImpl("taskkill", args, {
-        stdio: "ignore",
-        windowsHide: true,
-      }).on("error", () => killDirect(child, signal));
+  if (platform === "win32") {
+    if (typeof child.pid === "number") {
+      runTaskkill(child, child.pid, {
+        force,
+        spawnImpl: options.spawnImpl ?? spawn,
+        report,
+        mayEscalate: !force,
+      });
       return;
-    } catch {
-      // taskkill could not be spawned at all — fall through.
     }
+    killDirect(child, signal);
+    // A signal at the wrapper is not a tree kill; say so.
+    report(false);
+    return;
   }
 
   killDirect(child, signal);
+  report(true);
+}
+
+interface TaskkillRun {
+  force: boolean;
+  spawnImpl: typeof spawn;
+  report: (killed: boolean) => void;
+  /** Retry once with `/F` if this pass is refused. */
+  mayEscalate: boolean;
+}
+
+/**
+ * One `taskkill` pass, with its exit code actually read.
+ *
+ * Without `/F`, taskkill asks politely: it posts WM_CLOSE to the
+ * target's windows. A console process started with `windowsHide: true`
+ * has none, so taskkill answers "This process can only be terminated
+ * forcefully (with /F option)" and exits non-zero — and with
+ * `stdio: "ignore"` and nobody watching `close`, that refusal used to be
+ * invisible, leaving the tree alive until (or unless) something else
+ * escalated. So a refusal is retried once with `/F`.
+ *
+ * Untested on a real Windows host — see the PR's own note. The exit
+ * codes are the documented ones (0 success, 128 no such process); any
+ * other non-zero is treated as a refusal.
+ */
+function runTaskkill(
+  child: KillableChild,
+  pid: number,
+  run: TaskkillRun,
+): void {
+  const args = ["/PID", String(pid), "/T", ...(run.force ? ["/F"] : [])];
+  const signal: NodeJS.Signals = run.force ? "SIGKILL" : "SIGTERM";
+  let taskkill;
+  try {
+    taskkill = run.spawnImpl("taskkill", args, {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  } catch {
+    // taskkill could not be spawned at all.
+    killDirect(child, signal);
+    run.report(false);
+    return;
+  }
+
+  let settled = false;
+  taskkill.on("error", () => {
+    if (settled) return;
+    settled = true;
+    killDirect(child, signal);
+    run.report(false);
+  });
+  taskkill.on("close", (code) => {
+    if (settled) return;
+    settled = true;
+    if (code === 0 || code === TASKKILL_NOT_FOUND) {
+      run.report(true);
+      return;
+    }
+    if (run.mayEscalate) {
+      runTaskkill(child, pid, { ...run, force: true, mayEscalate: false });
+      return;
+    }
+    // Even `/F` could not do it (a permission problem, most likely).
+    // The direct child is all we can still reach.
+    killDirect(child, "SIGKILL");
+    run.report(false);
+  });
 }
 
 function killDirect(child: KillableChild, signal: NodeJS.Signals): void {

--- a/src/sandbox/kill-process-tree.ts
+++ b/src/sandbox/kill-process-tree.ts
@@ -14,6 +14,18 @@ import { spawn } from "node:child_process";
  *
  * `platform` and `spawnImpl` are parameters so the win32 branch is
  * exercised from a macOS/Linux test run.
+ *
+ * CONTRACT, for callers other than the two this was written for. On
+ * Windows a taskkill exit of 128 is reported to `onTreeKilled` as
+ * `true`, but 128 means taskkill found no such pid and therefore walked
+ * *nothing* — it says the root is gone, not that its descendants are.
+ * That is sound only where the root's death implies the rest of the
+ * tree's, which is true of the `cmd /c <shim>` topology here (the
+ * wrapper exists solely to host the CLI) and is *not* true in general:
+ * a root that spawns detached or re-parented children can exit while
+ * they keep running, and this helper will call that a successful tree
+ * kill. A caller with a different topology should not read `true` as
+ * "the descendants are gone".
  */
 export interface KillProcessTreeOptions {
   /** `taskkill /F` / `SIGKILL` rather than a polite stop. */
@@ -47,6 +59,21 @@ export interface KillableChild {
  * so it counts as success — and, importantly, must not be escalated:
  * re-running taskkill against a pid that has already exited is the one
  * way this can reach an unrelated process, since Windows recycles pids.
+ *
+ * Folklore-grade, and treated as such. Microsoft documents no exit codes
+ * for taskkill at all; 128 is corroborated only by secondary sources
+ * (PDQ's taskkill reference, buildbot issue #6140,
+ * dotnet/vscode-csharp #8393) and has never been observed by anyone who
+ * worked on this file. Getting it wrong is not dangerous in either
+ * direction — a 128 mistaken for a refusal only costs one extra `/F`
+ * pass; the risk is the reverse reading, which is why nothing escalates
+ * on it.
+ *
+ * The wider caveat is what 128 *means*: taskkill walked nothing. For the
+ * `cmd /c` topology this was written for that is harmless, because the
+ * wrapper's death implies the CLI's — see `killProcessTree`, where that
+ * assumption is now part of the contract rather than an accident of the
+ * only caller.
  */
 const TASKKILL_NOT_FOUND = 128;
 
@@ -99,8 +126,10 @@ interface TaskkillRun {
  * escalated. So a refusal is retried once with `/F`.
  *
  * Untested on a real Windows host — see the PR's own note. The exit
- * codes are the documented ones (0 success, 128 no such process); any
- * other non-zero is treated as a refusal.
+ * codes are *not* documented by Microsoft: 0 for success and 128 for
+ * "no such process" are the convention secondary sources agree on (see
+ * `TASKKILL_NOT_FOUND`), not a published contract. Any other non-zero
+ * is treated as a refusal.
  */
 function runTaskkill(
   child: KillableChild,

--- a/src/sandbox/kill-process-tree.ts
+++ b/src/sandbox/kill-process-tree.ts
@@ -1,0 +1,62 @@
+import { spawn } from "node:child_process";
+
+/**
+ * Stop a child *and everything it started*.
+ *
+ * On POSIX this is `child.kill(signal)` and nothing more. On Windows it
+ * cannot be: `child.kill` is `TerminateProcess` against that one pid, so
+ * a child that is really a subshell (`cmd.exe -> node -> …`, which is
+ * exactly what the Windows CLI shim produces) loses its parent and keeps
+ * running. `taskkill /T` walks the tree instead; if taskkill itself
+ * cannot be spawned — no pid left, the executable missing from a locked
+ * down image — fall back to signalling the direct child, which is still
+ * better than nothing.
+ *
+ * `platform` and `spawnImpl` are parameters so the win32 branch is
+ * exercised from a macOS/Linux test run.
+ */
+export interface KillProcessTreeOptions {
+  /** `taskkill /F` / `SIGKILL` rather than a polite stop. */
+  force?: boolean;
+  platform?: NodeJS.Platform;
+  spawnImpl?: typeof spawn;
+}
+
+/** The little of `ChildProcess` this needs; keeps fakes cheap in tests. */
+export interface KillableChild {
+  readonly pid?: number | undefined;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+export function killProcessTree(
+  child: KillableChild,
+  options: KillProcessTreeOptions = {},
+): void {
+  const force = options.force ?? false;
+  const platform = options.platform ?? process.platform;
+  const signal: NodeJS.Signals = force ? "SIGKILL" : "SIGTERM";
+
+  if (platform === "win32" && typeof child.pid === "number") {
+    const spawnImpl = options.spawnImpl ?? spawn;
+    const args = ["/PID", String(child.pid), "/T", ...(force ? ["/F"] : [])];
+    try {
+      spawnImpl("taskkill", args, {
+        stdio: "ignore",
+        windowsHide: true,
+      }).on("error", () => killDirect(child, signal));
+      return;
+    } catch {
+      // taskkill could not be spawned at all — fall through.
+    }
+  }
+
+  killDirect(child, signal);
+}
+
+function killDirect(child: KillableChild, signal: NodeJS.Signals): void {
+  try {
+    child.kill(signal);
+  } catch {
+    // process already exited
+  }
+}


### PR DESCRIPTION
## What

The `claude` / `codex` subscription-CLI providers cannot start a process at all on Windows. This routes them through `cmd.exe` when the resolved target is a `.cmd`/`.bat` shim, and gives the remaining failure a typed error instead of an opaque tool failure.

## Why

Sentry cluster `CLI-AG`: 13 events / 3 users in 14d, 11 of them on 0.5.5. Tags: `error_type=ToolExecutionError`, `cause_type=Error`, `category=tool`, `code=EINVAL`, `tool=unknown`, `os=win32` (13/13). Culprit frame `streamCliCommand`, with the innermost frames in `node:child_process` `spawn` -> `node:internal/child_process` `ChildProcess.spawn`.

Two Node behaviours combine here:

1. **The spawn fails.** npm installs these CLIs as `claude.cmd` / `codex.cmd`. Since the CVE-2024-27980 fix (Node >= 18.20.2 / 20.12.2) `spawn` refuses a `.cmd`/`.bat` target unless it goes through a shell, and reports it as `EINVAL`. `resolveCliBinary` already resolves the `.cmd` shim on Windows precisely so `spawn` can find it — which means every Windows invocation lands on exactly the target Node now rejects. Both CLI paths are affected: `stream-cli-completion.ts` (direct `spawn`) and `run-cli-completion.ts` (via `runCommand`).

2. **The error escapes untyped.** `ChildProcess.prototype.spawn` routes only `EACCES`/`EAGAIN`/`EMFILE`/`ENFILE`/`ENOENT` to the async `error` event and *throws* every other errno synchronously — which is why the Sentry frames end inside `ChildProcess.spawn` rather than in a handler. `subscription-cli-errors.ts` only recognised `ENOENT` (`isEnoent`), which is delivered on the event, so `EINVAL` bypassed the taxonomy entirely and was filed as a generic `tool` failure with `tool=unknown`.

## How

- **`src/llm/provider/subscription-cli/windows-cli-shim.ts`** (new) — `resolveWindowsCliInvocation({ binary, args, installHint, platform, env, fileStatus, readTarget })`, fully injectable so the Windows branch is exercised from macOS/Linux. It resolves a bare name over `PATH` x `PATHEXT`, and when the target is `.cmd`/`.bat` returns `cmd.exe /d /s /c "…"` with `windowsVerbatimArguments: true`. Anything else — non-Windows, a real `.exe`, an unresolvable bare name — is handed straight back.
- Escaping follows `cross-spawn`: quote-escape for the CRT argv parser (double the backslashes before a quote, double trailing backslashes, wrap in quotes), then `^`-escape cmd's metacharacters — once per cmd parse the string will go through. This is load-bearing rather than defensive: the `claude` adapter has `schemaDelivery: "inline"`, so a JSON response schema — braces, quotes, brackets, commas — is on argv for every structured-output request, and prompt-derived arguments can carry `&`, `|`, `^`, `<`, `>`.
- Wired into both paths. `runCommand` gains an optional `windowsVerbatimArguments` passthrough in `CommandOptions` — additive, omitted by default, no behaviour change for any existing caller.
- Safety net: `isSpawnEinval` plus `SubscriptionCliSpawnError`, which keeps the descriptor's `installHint` wording and stays distinct from `SubscriptionCliNotInstalledError` (reinstalling would not have helped). Applied in both paths — in `stream-cli-completion.ts` the `spawn()` call is the generator's first statement and throws synchronously, so it needed its own try/catch; the `child.on("error")` handler can only ever see ENOENT-class errors.

### Fixes from review (later commits on this branch)

- **Process-tree kill on the streaming path.** With the rewrite the direct child is `cmd.exe` and the real CLI is a grandchild, and Windows `child.kill` is `TerminateProcess` on that one pid — so every abort and every timeout orphaned the CLI. `runCommand` already solved this with `taskkill /T`; that is now `killProcessTree` in `src/sandbox/kill-process-tree.ts`, used by both, with the streaming path's SIGTERM -> SIGKILL escalation preserved (polite pass `taskkill /T`, escalation adds `/F`, direct-signal fallback if taskkill cannot be spawned). `runCommand`'s own behaviour is unchanged.
- **The double-`^` gate now asks the file, not the path.** It was `node_modules\.bin\*.cmd` (cross-spawn's heuristic). `claude` is installed globally for almost everyone, at `%APPDATA%\npm\claude.cmd` — the *same* npm cmd-shim template, re-substituting `%*` into a line cmd parses a second time — and it was getting single escaping. Single-escaped, an argument carrying both a `"` and one of `& | < >` loses cmd's quoting at that re-parse (cmd does not read `\"` as an escaped quote, so the quoting state flips) and the metacharacter lands outside quotes: the argument is truncated and cmd runs the tail — CVE-2024-24576 / BatBadBut, and `--json-schema <json>` is exactly that shape. The gate is now a bounded, cached read of the `.cmd` looking for `%*` / `%1`; unreadable falls back to double escaping (every shim these CLIs ship re-substitutes, and one that ignores its arguments cannot be corrupted by escaping it never reads).
- **cmd's 8191-character command line.** The adapter caps an inline schema at 32 KB, sized for `CreateProcess`'s 32767; through `cmd /c` the ceiling is 8191 and the escaping inflates the line further. Over it cmd answers "The input line is too long." and the failure arrived as an opaque `SubscriptionCliInvocationError`. The line is now measured before spawning and rejected with `SubscriptionCliCommandLineError` naming the real cause and the real limit. Measured through `claudeCliAdapter.streamArgs()` + the shim, with the corrected (double) escaping: a 70-property schema is 8149 characters and goes through, 80 properties is 9179 and is refused.
- **A configured `binPath` that does not exist.** An absolute target is now checked before it is wrapped, so `binPath = "C:\gone\claude.cmd"` raises `SubscriptionCliNotInstalledError` instead of being handed to cmd, which answered "The system cannot find the path specified." inside a generic invocation error. Only *absolute* targets: a relative one resolves against the child's cwd, not ours, so `tools\claude.cmd` with nothing behind it is still wrapped and still dies as a generic invocation error carrying cmd's own message. That is a deliberate limit of the check, not a case it covers. (An earlier version of this body claimed the not-installed message already covered this case; it only covered an unresolvable *bare name*, which it still does.)
- **LF / CR / NUL in an argument are refused,** not escaped: `^` before a newline is a line continuation, not an escape, and cmd would end the command there and run the tail as a second one. Reachable through operator-set `extraArgs` or a configured model id (the prompt goes to stdin by design).

### Fixes from a second review (later commits again)

The first round's own gate turned out to have a hole of exactly the kind it was built to close, and four smaller things around it.

- **A truncated shim read was reported as a whole one.** `readShimHead` caps at 8 KiB; the cap was invisible to the caller, so a `.cmd` bigger than that came back as a head with no `%*` in it and got the *single* escaping. Reproduced: a 9 KB shim with `%*` at offset ~9010 gives `head.length = 8192`, `contains %* = false`, and produces `"C:\npm\claude.cmd ^"a^&b^""` — through which `x"&whoami&"y` lands with `&whoami&` outside quotes. Unreadable was already conservative; *readable-but-partial* was not. It is now the same answer as unreadable: no answer, double escape.
- **UTF-16LE.** The head was decoded `latin1`, in which a UTF-16LE shim's `%*` is `%\0*\0` and misses the token. cmd cannot reliably run a UTF-16 batch file, so this was near-unreachable, but a BOM check costs one branch: UTF-16LE is decoded, UTF-16BE is declined outright, and UTF-8 with or without a BOM was never affected.
- **The escaping was quadratic.** `arg.replace(/(\\*)"/g, …)` backtracks on a long run of backslashes that never reaches a quote: measured in-process at 93 ms for 8k, 403 ms for 16k, 1.47 s for 32k — synchronous, on the TUI's event loop, in the spawn path, and paid *before* the length check that rejects the argument anyway (3.6 s end to end through `resolveWindowsCliInvocation`). It is now a single left-to-right scan, 0.2 ms for the same input. cross-spawn 7.0.6's form is still **not** adopted: it under-doubles `C:\path\\` (3 backslashes, not 4) and `a\\"b` (4, not 5), so the pre-7.0.5 semantics here are the correct ones. That the rewrite changed nothing but the cost is pinned by a differential test against the old regex form over a 21k-input corpus (every string of length ≤ 2 over a 26-character metacharacter alphabet, 20k pseudo-random strings, and every backslash-run shape), 42k comparisons across both escaping depths. The NOTE in the source blamed 7.0.5's hardening on the trailing-backslash rule; it names the quote rule now, and says which of the two changes must not be copied.
- **The Windows polite kill pass was almost certainly inert.** `taskkill /PID <pid> /T` without `/F` posts WM_CLOSE, and a console process spawned with `windowsHide: true` has no window to receive it — taskkill answers "can only be terminated forcefully" and exits non-zero. With `stdio: "ignore"` and only the `error` event watched, that refusal was invisible and a non-zero exit was treated as success, leaving the `force: true` escalation 2 s later as the only thing that reaped anything. Worse, if taskkill could not be spawned at all the fallback was `child.kill("SIGTERM")` = `TerminateProcess` on `cmd.exe`, whose `close` then disarmed that escalation — the grandchild orphaned, which is the failure the whole path exists to prevent. Now: taskkill's exit code is read and a refusal is retried once with `/F`; `onTreeKilled` tells the caller whether the stop actually reached the descendants; and the streaming runner disarms its force pass only on that, not on the wrapper's `close`.
- **The length check measured the outer line only.** The formula is right for what it measures — verified against Node v22.22.2 by intercepting `ChildProcess.prototype.spawn` (`opts.args === [file, ...args]`, libuv joins with single spaces under verbatim argv), boundary exact at 8126 `x` accepted / 8127 refused — but a shim that substitutes `%*` builds a *second* command line under the same 8191, and for the real global `claude.cmd` (~170-character prefix) that one crosses first: at 8019 `x` the outer line was 8116 and accepted while the inner was already 8192. A ~76-character window that passed the gate and then failed opaquely. The substituting case now holds 512 characters back. A margin, not a computed length: at the point the shim is read its line is `%_prog%` and `%dp0%`, both expanded at run time to paths we do not have (and `%_prog%` chosen by a branch inside the file), so measuring the literal text would be false precision. 512 covers npm's line with a deeply nested install path, costs 6% of a budget only ever contested by a large inline JSON schema, and is charged only when the shim actually re-substitutes.
- **The 8191 boundary is now pinned.** `length <= MAX` and `length <= MAX + 1` were indistinguishable with tests at 8000 and 9000; 8190 / 8191 / 8192 are asserted character for character.
- **`existsSync` cannot say "I could not look".** It returns `false` for EACCES/EPERM and for a UNC path whose host did not answer, so a configured absolute `binPath` under a restricted or network path was reported as "was not found on PATH". The shim's seam is now three-valued: only ENOENT/ENOTDIR is *absent*; anything else is *unknown* and goes to cmd, which can answer for itself. **This covers less than an earlier version of this body claimed — see the limitation bullet in the next section.**
- **`C:claude.cmd`.** Drive-relative, no separator: it skipped the has-a-directory branch, fell into the PATH × PATHEXT walk, resolved to nothing, passed through, and reached `spawn` as a raw `.cmd` — EINVAL, the exact failure this PR exists to fix. It is a relative path and is now treated as one.
- **`windowsHide` read `process.platform` directly**, so under the faked win32 host the spawn options differed from production and a change to that line was invisible. It goes through `hostPlatform()` like everything else.
- **`assertEscapable` runs over the target path as well as the arguments**, but always said "with this argument"; a control character in the resolved path now names the path.
- **`runCommand`'s half of the tree-kill refactor had no coverage.** Replacing `killProcessTree(child, { force: true })` with a bare `child.kill("SIGKILL")` and deleting the now-unused import compiled and left all 129 tests green — on this host the two do the same thing. The busiest caller of the moved branch now asserts the call, on abort and on timeout, against a child that traps SIGTERM.

### Fixes from a third review (later commits again)

The third review cleared the change to merge and left four items. Two of them were claims — one in the source, one in this body — that measurement contradicted.

- **The one surviving mutation, pinned.** In the shim's `PATH` × `PATHEXT` walk, `fileStatus(candidate) === "present"` could be changed to `!== "absent"` with all 158 tests still green. The branch the three-valued seam introduced was unpinned there, and it had a real consequence: on a PATH directory the user may traverse but not stat, *every* candidate is `unknown`, so the walk resolved nothing, the bare name passed through, and `spawn` with `shell: false` does no PATHEXT search — a working `claude.cmd` reported as "not installed". Exactly the asymmetry the absolute-target branch had just been changed to fix, one level out. `unknown` now means the same thing in both places. A definite `present` hit wins outright wherever in the walk it is; failing that, the first candidate that could not be told apart from missing is handed to cmd, which repeats the search itself; `null` means every candidate was definitively absent. The fallback is narrowed to `.cmd`/`.bat` — the only suffixes whose treatment differs from doing nothing, since a `.exe` is handed back untouched anyway — and PATHEXT order decides between them, as it does for cmd. Both directions are asserted now: an unreadable PATH entry still produces a `cmd.exe` invocation, and an unanswerable candidate does not shadow a definite hit one PATH entry later. `!== "absent"` fails 2 tests; reverting to the old `=== "present"` fails 1.
- **The margin comment's numbers were wrong, in the flattering direction.** It put npm's shim line at "~170 characters" and read as though 512 left the budget nearly untouched, with a large inline JSON schema as the case that contests it. Expanding the template's last line (`%COMSPEC%`, `%_prog%`, `%dp0%`, `%PATHEXT:;.JS;=;%`) across 6 install directories × 3 targets × 2 `_prog` branches × 2 PATHEXT values × 2 argument shapes puts the prefix at **157–813** characters, **229** for the plain global `%APPDATA%\npm` layout the comment named. The worst margin actually *needed* across that sweep is **468** — so 512 holds, with 44 characters of headroom, not 94% of the budget. And the binding case is a **metachar-free argument** under a 283-character `dp0` with `node.exe` adjacent, not the JSON schema: a schema needs **−1968**, because double escaping inflates the *outer* line by ~27% and it runs ~1500–2000 characters longer than the inner one. At the gate boundary a global-npm layout is 7675 outer against 5707 inner — ~2484 characters of slack given away, about 400 characters of schema. A metachar-conditional margin would reclaim them; it is named in the comment and deliberately declined, because one flat number is one thing to be right about and the cost of being generous is a refusal that says what to shorten. **The margin stays 512; only the reasoning changed.**
- **`settled && treeKilled` is not a guard.** This body called the 2 s force pass "guarded on both sides". It is the opposite: that conjunct is what makes the escalation *fire* in precisely the failure modes that matter. Confirmed in review by driving five assertions through the real production path (a harness, not added to the suite) — when taskkill is missing from a locked-down image, when `/F` is refused too, or when there is no pid, the report is `false`, `killDirect` kills the wrapper, `settled` becomes true, `disarm()` runs and clears nothing because `treeKilled` is false, and at 2 s the fire-time re-check sends `taskkill /PID <dead pid> /T /F`. Only exit 128 is a real guard, and only against escalating a pid taskkill already said was gone. Related: two `stop()` calls (timeout then abort) issue two independent polite tree kills, each of which may internally retry with `/F`, plus the timer's — **up to five taskkill processes for one stop**, the last a `/T /F` at a raw pid. This is a defensible trade — orphan avoidance bought with pid-recycling risk over a 2 s window — and it is chosen, but it is a trade, not a guard.
- **taskkill's exit codes are undocumented.** The source called 0/128 "the documented ones". Microsoft documents no exit codes for taskkill at all; the 128 convention is corroborated only by secondary sources (PDQ's reference, buildbot #6140, dotnet/vscode-csharp #8393), and it is marked folklore-grade now rather than asserted. The substantive caveat is what 128 *means*: taskkill walked nothing. It says the root is gone, not that its descendants are. Harmless for the `cmd /c <shim>` topology, where the wrapper exists solely to host the CLI — but `killProcessTree` is exported from `src/sandbox/index.ts` as a general helper, where that topology is not guaranteed, so the assumption is written into its contract instead of living in the only caller.

**F9's limitation, stated plainly.** `resolveCliBinary` (`src/llm/provider/subscription-cli/resolve-cli-binary.ts:19`) runs *first*, still uses `existsSync`, still has its own two-valued `PATH` walk over a hardcoded `[".cmd", ".exe", ".bat", ""]`, and still collapses EACCES / EPERM / unreachable UNC into `false`. With no configured `binPath` it picks the target before the shim is ever consulted. So the three-valued seam fixes the **configured-absolute-`binPath`** case, not the general "working install under a restricted or network path" this body previously claimed. What the shim's own walk now adds is the fallback for when `resolveCliBinary` gives up and hands back the bare name — which is also why the note further down about the shim's walk being "dead on the production path" is only true when `resolveCliBinary` could resolve something. Folding `resolveCliBinary` onto the same three-valued seam is a follow-up, not done here: it has its own callers and tests and belongs in its own change.

Three more, worth a line each and no code:

- **Synchronous blocking I/O in the spawn path.** `statSync` / `openSync` / `readSync` run on the TUI's event loop; `resolveTarget`'s walk does up to |PATH| × (|PATHEXT|+1) synchronous stats per spawn; and `hostFileStatus` has no cache at all, unlike `readShimHead`. Observed on this host: `readShimHead` against a FIFO blocked past a 90 s watchdog. The Windows analogue is the unanswered UNC share this code says it cares about, where an SMB timeout would freeze Ink's render and input, not just the turn. `probeCache` is also never evicted. Left as a follow-up: making this async means threading it through both runners.
- **The errno comment named the wrong errnos.** An unreachable UNC host does not arrive as ENETUNREACH/ETIMEDOUT/EBUSY — libuv has no mapping for `ERROR_BAD_NETPATH` / `ERROR_BAD_NET_NAME`, so `err.code` is the literal `"UNKNOWN"`. It still lands in the `unknown` bucket, so the behaviour was right and the reasoning was not. A disconnected mapped drive is the case the seam does *not* rescue: it maps to ENOENT → `absent` → "not installed", indistinguishable here from a path that really is gone. Both are named in the comment now.
- **The wall-clock `< 400 ms` assertion is load-bearing.** It is the only guard on the ReDoS fix — the differential test passes for both the scan and the quadratic regex by design. Kept, with ~2000× headroom (0.2 ms observed), and a comment saying to raise the budget rather than delete it if it ever flakes.

## Test evidence

```
npm run lint                                              # tsc --noEmit, clean
npx vitest run src/llm/provider/subscription-cli src/sandbox
  Test Files  15 passed (15)
       Tests  160 passed (160)
npx vitest run src/tools/os src/skills src/prompt          # every other runCommand caller
  Test Files  86 passed (86)
       Tests  846 passed | 3 skipped (849)
```

Node v22.22.2, macOS. `src/sandbox/command-runner.test.ts:73` is a known pre-existing timing flake around the 64 KiB pipe buffer; it passed on every run here.

`windows-wiring.test.ts` is the one that matters for regressions: the shim is a passthrough off Windows, so it fakes a win32 host through the `host-environment` seam and mocks `spawn`, which puts the real win32 branch under the real wiring of both runners. `host-environment.test.ts` is the other half — the probe and the file check against real files on disk, because that is where "could not tell" was being reported as an answer.

Mutation check. Every mutation from the earlier rounds was re-run against the current suite, and the branch the third review found unpinned has two of its own. All 25 die (counts are failing tests out of 160, from a scripted sweep that patches a file copy and restores it):

| mutation | result |
| --- | --- |
| remove the shim call from `stream-cli-completion.ts` | 1 failed |
| remove it from `run-cli-completion.ts` | 1 failed |
| remove it from both | 2 failed |
| drop `escapeCommand()` on the target | 4 failed |
| drop `win32.normalize()` on the target | 3 failed |
| revert the streaming tree-kill to `child.kill` | 4 failed |
| gate the double-`^` pass on `node_modules/.bin` again | 18 failed |
| drop the 8191-character check | 5 failed |
| drop the existence check on an absolute target | 2 failed |
| drop the LF/CR/NUL rejection | 2 failed |
| report a truncated shim read as a whole one | 1 failed |
| decode every shim as `latin1` | 2 failed |
| collapse "cannot tell" back into "absent" | 1 failed |
| put the quadratic regex escaping back | 1 failed |
| stop doubling the trailing backslash run | 2 failed |
| charge no margin for the shim's own line | 1 failed |
| off-by-one on the length check (`<= MAX + 1`) | 2 failed |
| send a drive-relative target back to the PATH walk | 1 failed |
| blame the argument for an unescapable target *path* | 1 failed |
| stop watching taskkill's exit code | 3 failed |
| disarm the force pass on any `close` | 1 failed |
| read `process.platform` for `windowsHide` | 1 failed |
| replace `runCommand`'s tree-kill with `child.kill`, import removed | 2 failed |
| the PATH walk's `=== "present"` -> `!== "absent"` (the one that survived) | 2 failed |
| the PATH walk answering `null` on an all-`unknown` directory again | 1 failed |

Two counts moved against the previous round's table, both because the new tests exercise the same code: the `node_modules/.bin` gate now fails 18 rather than 16, and `latin1` 2 rather than 1.

The one worth reading twice: *put the quadratic regex escaping back* fails only the timing test, and the 42k-comparison differential test still passes — which is the point. The rewrite is a rewrite; the ReDoS fix and the semantics are guarded by different tests.

### What no host here can exercise

No Windows machine was available. Nothing below was run on Windows, by anyone, at any point: **the first real Windows user is this code's first execution, and its test.** Everything in the section above is asserted against injected `platform` / `env` / `fileStatus` / `readTarget` and a mocked `spawn`.

- The `cmd.exe` invocation itself: that the escaped command line survives cmd's parse, the shim's `%*` re-substitution and the CRT's argv parse and arrives at `cli.js` as the argv we meant. The escaping is argued from cmd's documented parse order, differential-fuzzed against `cross-spawn`, and round-tripped through a model of the pipeline — not observed.
- **The whole Windows tree-kill.** That `taskkill /PID <pid> /T` reaps the grandchild; that the polite pass is refused the way its exit code is now read to assume; that 0 and 128 mean what secondary sources say they mean — Microsoft documents neither. The escalation logic is exercised end to end here only against a mocked `spawn` whose exit codes the test chooses.
- A residual risk that comes with it, **stated as the trade it is rather than as a guard**: the force pass targets a **raw pid**, so a `taskkill /T /F` that fires after the child has exited can in principle reach whatever Windows recycled that pid into — something `child.kill` on a `ChildProcess` handle could not do. The `settled && treeKilled` condition on the timer is *not* protection against that; it is what makes the escalation fire in exactly the cases that matter (taskkill missing, `/F` refused, no pid), where `treeKilled` is `false`, the child is dead, and the 2 s timer therefore sends `/T /F` at a pid that is already gone. The one real guard is that exit 128 is never escalated. On top of it, two `stop()` calls — timeout then abort — issue two independent polite tree kills, each of which may retry with `/F` internally, plus the timer's: **up to five taskkill processes for a single stop**, the last aimed at a raw pid. The choice is deliberate: orphaned CLI processes are the failure this path exists to prevent, and they are certain, while the recycled-pid collision needs a 2 s window and a pid reuse inside it. It is a trade, not a mitigation, and it is not eliminated.
- The 8191 limit as cmd enforces it, and the 512-character margin for the shim's own line: both are documented thresholds, not measured ones.
- `spawn` throwing `EINVAL` on a `.cmd` target: reproduced by mocking `spawn` to throw the errno, which is the only way to produce a Windows-only synchronous throw off Windows.
- EACCES/EPERM on a real `binPath` is covered against a `chmod 000` directory on this host; the UNC-share case it is really for is not.

Known and deliberately left alone: a quoted `PATH` entry, or a `PATHEXT` carrying spaces, still fails to resolve in the shim's `PATH` × `PATHEXT` walk — the pre-existing `resolveCliBinary` has the same blind spot. On the production path the shim's walk is mostly dead, because `resolveCliBinary` has usually already returned an absolute `…\claude.cmd` — but only usually: when it cannot resolve anything (an unstattable PATH directory among the reasons) it hands back the bare name and the shim's walk is what runs, which is the case the third-review fix above is about.

## Out of scope

Other Windows callers of `runCommand` that can end up on a `.cmd`/`.bat` target plausibly have the same defect — npm/npx-backed MCP stdio servers and tooling invocations among them. They are deliberately left alone here: the shim is scoped to the subscription-CLI layer so `runCommand`'s behaviour is unchanged for every existing caller, and a general fix deserves its own change with its own test coverage.

One more follow-up, deliberately not in this PR: `src/tools/browser/spawn-chrome.ts` has its own private `killProcessTree`, which should fold into the shared helper. It predates this change and has its own callers and tests, so it is a change of its own.
