### PR TITLE
feat(agent): a turn is a task, not a step budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,37 @@ Pinned by [src/agent/batch-executor.test.ts](src/agent/batch-executor.test.ts), 
 
 All are env-only; not user-config-file material.
 
+### A turn is a task, not a step budget
+
+`agent.maxSteps` (default 25) is the length of a **leg** — a checkpoint interval — not the end of the
+work. What ends a task is `agent.task.maxSteps` (default 1000), `agent.task.maxDurationMs` (default
+2 h), the model finishing, the loop breaker, or the user.
+
+This used to be the other way round, and the unit was wrong. A step is one model turn plus its tool
+calls; what a person asks for ("register on these ten sites", "port this module") is a task made of
+hundreds of them. Ending the task on the step count meant a three-minute browser job stopped in the
+middle with `(stopped: max_steps reached without a reply)` — a parenthetical naming an internal
+counter — and the only way onward was to retype the task, which started it over.
+
+Locked invariants (pinned by [src/agent/agent-loop.test.ts](src/agent/agent-loop.test.ts)):
+
+1. **The leg boundary is the only place continuation is decided**, once every `maxSteps` steps,
+   never mid-leg. It emits `task_continued` (steps, elapsed, ceiling) — a long task reports itself
+   rather than going quiet for an hour.
+2. **A leg that produced nothing usable ends the task.** Progress is "at least one tool result came
+   back `ok` in this leg" — a partially failed batch still moved the work forward; a leg where every
+   call failed is a dead tool or a dead network, and continuing into the ceiling would only burn
+   tokens on it. This is the guard the loop detector cannot give: the breaker catches a model
+   repeating itself, not an environment that stopped answering.
+3. **A step is always reserved for the summary**, at whichever ceiling bites first, so a task is
+   never cut off mid-edit.
+4. **An explicit caller budget is a ceiling, not a leg.** `runtime.runTurn({ maxSteps })` — a durable
+   task pinning its own budget, `run --max-steps` — passes `taskMaxSteps`; the config value stays the
+   leg. A caller that asked for at most 50 steps gets at most 50.
+5. **`autoContinue: false` restores the historical behaviour** exactly: one leg, then stop.
+6. **The closing message names the ceiling, the work done and the way onward** (`formatTaskStoppedReply`),
+   and `lastError` carries `task_stopped:<cause>` for post-mortem tooling.
+
 ### No-progress loop detection
 
 The runtime guards against "stuck" turns where the model re-emits the same tool call (same args, same result) without making progress. The detector is [src/agent/loop-detector.ts](src/agent/loop-detector.ts) `ToolLoopTracker` — **one instance per turn**, owned by `AgentLoop.runTurn`, threaded into `executeStep` → `executeBatch` via `BatchExecutionContext.tracker`. Ported from OpenClaw 2026.6.5; the design goal is **graceful termination, never a hard failure**.

--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -131,6 +131,252 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(llmRawCompletions).toEqual([{ attempt: 1, stepIndex: 0 }]);
   });
 
+  it("keeps working past the leg length while the task is progressing", async () => {
+    // The point of the change: `maxSteps` is a checkpoint, not the end
+    // of the work. A task that is still getting usable results out of
+    // its tools must not stop because a counter says 2.
+    const registry = buildDefaultToolRegistry();
+    let noopRuns = 0;
+    registry.register({
+      name: "noop",
+      description: "no-op",
+      readonly: true,
+      async run() {
+        noopRuns += 1;
+        return {
+          tool: "noop",
+          status: "ok",
+          summary: `noop ${noopRuns}`,
+          details: { run: noopRuns },
+          truncated: false,
+        };
+      },
+    });
+    const continued: Array<{ stepsTaken: number; stepCeiling: number }> = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        calls += 1;
+        // Seven working steps, then the model finishes on its own.
+        return makeCompletion(
+          calls <= 7
+            ? JSON.stringify({ tool: "noop", args: { n: calls } })
+            : JSON.stringify({ tool: "reply", args: { text: "all done" } }),
+        );
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "task_continued") {
+          continued.push({
+            stepsTaken: event.stepsTaken,
+            stepCeiling: event.stepCeiling,
+          });
+        }
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-legs", workingDir }),
+      {
+        userMessage: "long job",
+        maxSteps: 2,
+        taskMaxSteps: 20,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("reply");
+    expect(noopRuns).toBe(7);
+    // Three leg boundaries crossed (steps 2, 4, 6), each reported.
+    expect(continued.map((c) => c.stepsTaken)).toEqual([2, 4, 6]);
+    expect(continued.every((c) => c.stepCeiling === 20)).toBe(true);
+  });
+
+  it("stops at the ceiling, not at the leg, and says which", async () => {
+    const registry = buildDefaultToolRegistry();
+    registry.register({
+      name: "noop",
+      description: "no-op",
+      readonly: true,
+      async run() {
+        return {
+          tool: "noop",
+          status: "ok" as const,
+          summary: "noop",
+          details: {},
+          truncated: false,
+        };
+      },
+    });
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () =>
+        makeCompletion(JSON.stringify({ tool: "noop", args: {} })),
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-ceiling", workingDir }),
+      {
+        userMessage: "endless",
+        maxSteps: 2,
+        taskMaxSteps: 6,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("max_steps");
+    // Six steps spent, of which the last is the reserved summary the
+    // model refused to write — so five tool steps landed in the session.
+    expect(result.session.lastError).toMatch(
+      /task_stopped:step_ceiling: 6 steps/,
+    );
+    expect(result.session.stepCount).toBe(5);
+  });
+
+  it("stops when a whole leg produced nothing usable", async () => {
+    // The environment-is-broken case from the field: every call fails,
+    // so there is nothing to continue towards. Stop after one leg
+    // rather than burning the ceiling on a dead tool.
+    const registry = buildDefaultToolRegistry();
+    registry.register({
+      name: "noop",
+      description: "no-op",
+      readonly: true,
+      async run() {
+        return {
+          tool: "noop",
+          status: "error" as const,
+          summary: "tool exploded",
+          details: {},
+          truncated: false,
+        };
+      },
+    });
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () =>
+        makeCompletion(JSON.stringify({ tool: "noop", args: {} })),
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-noprogress", workingDir }),
+      {
+        userMessage: "doomed",
+        maxSteps: 2,
+        taskMaxSteps: 50,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("max_steps");
+    // One leg, and the leg check at the boundary — not 50 steps of it.
+    expect(result.session.stepCount).toBe(2);
+    expect(result.session.lastError).toMatch(/task_stopped:no_progress/);
+    expect(result.session.turns.at(-1)).toMatchObject({
+      kind: "assistant_reply",
+      text: expect.stringContaining("nothing came back"),
+    });
+  });
+
+  it("stops on the wall clock and says so", async () => {
+    // A task that never finishes must be bounded by time as well as by
+    // steps: 1000 fast steps and 1000 slow ones are very different asks.
+    const registry = buildDefaultToolRegistry();
+    registry.register({
+      name: "noop",
+      description: "no-op",
+      readonly: true,
+      async run() {
+        return {
+          tool: "noop",
+          status: "ok" as const,
+          summary: "noop",
+          details: {},
+          truncated: false,
+        };
+      },
+    });
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () =>
+        makeCompletion(JSON.stringify({ tool: "noop", args: {} })),
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-clock", workingDir }),
+      {
+        userMessage: "slow job",
+        maxSteps: 5,
+        taskMaxSteps: 500,
+        // Already expired when the first step checks.
+        taskMaxDurationMs: 1,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("max_steps");
+    expect(result.session.lastError).toMatch(/task_stopped:time_ceiling/);
+    expect(result.session.turns.at(-1)).toMatchObject({
+      kind: "assistant_reply",
+      text: expect.stringContaining("time limit"),
+    });
+  });
+
+  it("autoContinue: false keeps the historical one-leg behaviour", async () => {
+    const registry = buildDefaultToolRegistry();
+    registry.register({
+      name: "noop",
+      description: "no-op",
+      readonly: true,
+      async run() {
+        return {
+          tool: "noop",
+          status: "ok" as const,
+          summary: "noop",
+          details: {},
+          truncated: false,
+        };
+      },
+    });
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () =>
+        makeCompletion(JSON.stringify({ tool: "noop", args: {} })),
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-noauto", workingDir }),
+      {
+        userMessage: "one leg only",
+        maxSteps: 3,
+        autoContinue: false,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("max_steps");
+    // Three steps, the third reserved for the summary: one leg, exactly
+    // as before this existed.
+    expect(result.session.lastError).toMatch(
+      /task_stopped:step_ceiling: 3 steps/,
+    );
+  });
+
   it("finishes session immediately when the LLM emits a finish tool call", async () => {
     const registry = buildDefaultToolRegistry();
     const loop = new AgentLoop({
@@ -329,15 +575,23 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     const result = await loopNoop.runTurn(session, {
       userMessage: "do stuff",
       maxSteps: 2,
+      // The ceiling, stated: `maxSteps` is only the leg length now, so a
+      // test about running out has to say what it is running out of.
+      taskMaxSteps: 2,
       signal: new AbortController().signal,
     });
     expect(result.reason).toBe("max_steps");
     expect(result.session.turns.at(-1)).toMatchObject({
       kind: "assistant_reply",
-      text: expect.stringContaining("max_steps"),
+      // Names the ceiling and what to do next, instead of an internal
+      // counter nobody outside this repo has heard of.
+      text: expect.stringContaining("step ceiling"),
+    });
+    expect(result.session.turns.at(-1)).toMatchObject({
+      text: expect.stringContaining("continue"),
     });
     expect(result.session.status).toBe("stalled");
-    expect(result.session.lastError).toMatch(/max_steps_reached: 2 steps/);
+    expect(result.session.lastError).toMatch(/task_stopped:step_ceiling: 2 steps/);
   });
 
   it("reserves the final step for a terminal reply", async () => {
@@ -377,7 +631,13 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     });
     const result = await loop.runTurn(
       createEmptySessionState({ id: "chat-finalize", workingDir }),
-      { userMessage: "verify", maxSteps: 2, signal: new AbortController().signal },
+      {
+        userMessage: "verify",
+        maxSteps: 2,
+        // The reserved final step now sits at the task ceiling.
+        taskMaxSteps: 2,
+        signal: new AbortController().signal,
+      },
     );
 
     expect(calls).toBe(2);
@@ -431,7 +691,12 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     });
     const result = await loop.runTurn(
       createEmptySessionState({ id: "chat-finalize-cancel", workingDir }),
-      { userMessage: "verify", maxSteps: 2, signal: controller.signal },
+      {
+        userMessage: "verify",
+        maxSteps: 2,
+        taskMaxSteps: 2,
+        signal: controller.signal,
+      },
     );
 
     expect(calls).toBe(2);
@@ -479,7 +744,13 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     });
     const result = await loop.runTurn(
       createEmptySessionState({ id: "chat-finalize-stubborn", workingDir }),
-      { userMessage: "verify", maxSteps: 2, signal: new AbortController().signal },
+      {
+        userMessage: "verify",
+        maxSteps: 2,
+        // The reserved final step now sits at the task ceiling.
+        taskMaxSteps: 2,
+        signal: new AbortController().signal,
+      },
     );
 
     // Step 0 executes the tool; the finalization step burns its first
@@ -490,10 +761,12 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(stepEventTypes.filter((t) => t === "parse_retry")).toHaveLength(1);
     expect(result.reason).toBe("max_steps");
     expect(result.session.status).toBe("stalled");
-    expect(result.session.lastError).toMatch(/max_steps_reached: 2 steps/);
+    expect(result.session.lastError).toMatch(
+      /task_stopped:step_ceiling: 2 steps/,
+    );
     expect(result.session.turns.at(-1)).toMatchObject({
       kind: "assistant_reply",
-      text: expect.stringContaining("max_steps"),
+      text: expect.stringContaining("step ceiling"),
     });
   });
 
@@ -536,7 +809,12 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     });
     const result = await loop.runTurn(
       createEmptySessionState({ id: "chat-one-step", workingDir }),
-      { userMessage: "hi", maxSteps: 1, signal: new AbortController().signal },
+      {
+        userMessage: "hi",
+        maxSteps: 1,
+        taskMaxSteps: 1,
+        signal: new AbortController().signal,
+      },
     );
 
     // With a budget of one, the single step IS the finalization step:

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -311,8 +311,58 @@ export interface SteeringChannel {
   closeAndDrain(sessionId: string): readonly string[];
 }
 
+/**
+ * What the user reads when the step loop ran out before the model
+ * finished the task.
+ *
+ * The old text was `(stopped: max_steps reached without a reply)` — a
+ * parenthetical naming an internal counter, offering nothing. Someone
+ * watching a browser job stop after three minutes had no way to tell a
+ * crash from a budget, and nothing to do about it but retype the task,
+ * which starts it over. This says which ceiling was hit, how far the
+ * work got, and that "continue" resumes from here rather than restarts.
+ */
+export function formatTaskStoppedReply(input: {
+  cause: "step_ceiling" | "time_ceiling" | "no_progress";
+  stepsTaken: number;
+  stepCeiling: number;
+  elapsedMs: number;
+}): string {
+  const minutes = Math.max(1, Math.round(input.elapsedMs / 60_000));
+  const spent = `${input.stepsTaken} steps over ~${minutes} min`;
+  const head =
+    input.cause === "time_ceiling"
+      ? `(paused: this task hit its time limit after ${spent}.)`
+      : input.cause === "no_progress"
+        ? `(paused: nothing came back from my last ${spent} of tool calls — something in the environment is failing.)`
+        : `(paused: this task hit its step ceiling of ${input.stepCeiling} after ${spent}.)`;
+  const tail =
+    input.cause === "no_progress"
+      ? "Here is where I got to. Check the failing tool or connection, then say `continue`."
+      : "Here is where I got to — the work so far is kept in this session. Say `continue` to pick up from here, or raise `agent.task.maxSteps` for longer runs.";
+  return `${head} ${tail}`;
+}
+
 export interface RunTurnOptions {
+  /**
+   * Steps in one leg — the checkpoint interval, not the end of the work.
+   * The loop reports progress here and carries on; what ends a task is
+   * `taskMaxSteps` / `taskMaxDurationMs` (or the model finishing).
+   */
   maxSteps: number;
+  /**
+   * Hard ceiling on steps for this task. Defaults to
+   * `config.agent.task.maxSteps`; a durable task record passes its own.
+   */
+  taskMaxSteps?: number;
+  /** Wall-clock ceiling. Defaults to `config.agent.task.maxDurationMs`. */
+  taskMaxDurationMs?: number;
+  /**
+   * Carry on past a leg boundary while the work progresses. Defaults to
+   * `config.agent.task.autoContinue`; `false` restores the historical
+   * "stop at `maxSteps`" behaviour for a caller that wants one leg only.
+   */
+  autoContinue?: boolean;
   signal: AbortSignal;
   /** Optional new user message to append before stepping. */
   userMessage?: string;
@@ -342,6 +392,17 @@ export type AgentLoopEvent =
       reason: AgentLoopReason;
       stepCount: number;
       durationMs: number;
+    }
+  | {
+      /**
+       * A leg of the task finished and the work is continuing. Fired at
+       * every `maxSteps` boundary that does not end the task, so a long
+       * job reports itself instead of going quiet for an hour.
+       */
+      type: "task_continued";
+      stepsTaken: number;
+      elapsedMs: number;
+      stepCeiling: number;
     }
   | { type: "step_started"; stepIndex: number }
   | {
@@ -549,6 +610,31 @@ export class AgentLoop {
     let reason: AgentLoopReason = "max_steps";
     let stepsTaken = 0;
     let runError: Error | null = null;
+    // What the user asked for is a *task*: "register on these ten sites"
+    // is one goal made of hundreds of steps. A step count is the wrong
+    // thing to end it with, so `maxSteps` is only the length of a leg —
+    // the loop checks in at each boundary, says where it is, and keeps
+    // going while the work progresses. These are the ceilings that
+    // actually stop it.
+    const taskCfg = getConfig().agent.task;
+    const legSteps = Math.max(1, options.maxSteps);
+    const autoContinue = options.autoContinue ?? taskCfg.autoContinue;
+    // Without auto-continue the ceiling IS the leg: one leg, then stop,
+    // exactly as before this existed.
+    const stepCeiling = autoContinue
+      ? Math.max(legSteps, options.taskMaxSteps ?? taskCfg.maxSteps)
+      : legSteps;
+    const durationCeilingMs = options.taskMaxDurationMs ?? taskCfg.maxDurationMs;
+    const taskStartedAt = Date.now();
+    /**
+     * Why the task stopped, when the step loop ran out rather than the
+     * model finishing. Drives the closing message: "ran out of steps"
+     * and "made no progress for a whole leg" are different things to
+     * tell someone, and the old single `max_steps` string said neither.
+     */
+    let stopCause: "step_ceiling" | "time_ceiling" | "no_progress" = "step_ceiling";
+    /** Set by any step in the current leg that produced a usable result. */
+    let legMadeProgress = false;
     // Per-turn no-progress loop tracker (OpenClaw-style). Threaded into
     // `executeStep` so the synchronous batch gate can veto looping calls
     // before they are dispatched; the agent loop consumes the resulting
@@ -598,10 +684,35 @@ export class AgentLoop {
     // editing, running commands through the approval gate — or a terminal
     // `reply`/`finish`. Tool results are appended to the conversation, so
     // the next step's prompt carries everything the previous step learned.
-    for (let i = 0; i < options.maxSteps; i += 1) {
+    for (let i = 0; i < stepCeiling; i += 1) {
       if (options.signal.aborted) {
         reason = "cancelled";
         break;
+      }
+      // Leg boundary. Everything the task needs to keep running is
+      // decided here, once per `legSteps` steps, and never mid-leg.
+      if (i > 0 && i % legSteps === 0) {
+        if (!legMadeProgress) {
+          // A whole leg with nothing usable coming back is the honest
+          // place to stop: the loop detector's breaker catches a model
+          // repeating itself, but not a model whose every call fails.
+          stopCause = "no_progress";
+          reason = "max_steps";
+          break;
+        }
+        legMadeProgress = false;
+        this.deps.onEvent?.({
+          type: "task_continued",
+          stepsTaken,
+          elapsedMs: Date.now() - taskStartedAt,
+          stepCeiling,
+        });
+        this.deps.logger?.info("task leg finished; continuing", {
+          sessionId: state.id,
+          stepsTaken,
+          stepCeiling,
+          elapsedMs: Date.now() - taskStartedAt,
+        });
       }
       // Reactive refresh between steps: if the previous completion
       // observed a foreign `modelId`, rebuild profile + grammar so the
@@ -646,7 +757,12 @@ export class AgentLoop {
       // On the final allowed step the tool catalog collapses to the two
       // terminal tools, so a long coding session ends with a summary of
       // what was changed instead of being cut off mid-edit.
-      const finalizationStep = i === options.maxSteps - 1;
+      // One step is always reserved for a summary, whichever ceiling is
+      // about to bite — being cut off mid-edit is what made the old
+      // stop unreadable.
+      const outOfTime = Date.now() - taskStartedAt >= durationCeilingMs;
+      if (outOfTime) stopCause = "time_ceiling";
+      const finalizationStep = i === stepCeiling - 1 || outOfTime;
       const finalizationNotice =
         "This is the final allowed step. Do not call any non-terminal tool; " +
         "summarize the completed work with reply, or end the session with finish.";
@@ -733,6 +849,14 @@ export class AgentLoop {
         )
           ? "error"
           : "ok";
+        // Progress for the leg check is "something usable came back",
+        // not "the step was clean": a batch where three calls of four
+        // succeeded moved the task forward. What it excludes is a leg
+        // whose every call failed — a dead tool, a dead network, a
+        // rejected approval loop — which is the case worth stopping on.
+        if (outcome.toolResults.some((r) => r.status === "ok")) {
+          legMadeProgress = true;
+        }
         // Feed summary mirrors the legacy single-call shape for solo
         // steps; for a batch we render `N tools: t1, t2, …` so the TUI
         // and trace consumer see at a glance that this was a batch.
@@ -1046,7 +1170,12 @@ export class AgentLoop {
       state = { ...state, status: "cancelled" };
       this.deps.onEvent?.({ type: "loop_completed", reason });
     } else if (reason === "max_steps") {
-      const synthetic = "(stopped: max_steps reached without a reply)";
+      const synthetic = formatTaskStoppedReply({
+        cause: stopCause,
+        stepsTaken,
+        stepCeiling,
+        elapsedMs: Date.now() - taskStartedAt,
+      });
       state = recordTurn(state, assistantReplyTurn(synthetic));
       this.deps.onEvent?.({ type: "llm_event", event: { type: "assistant_reply", text: synthetic } });
       this.deps.onEvent?.({ type: "loop_completed", reason });
@@ -1058,7 +1187,7 @@ export class AgentLoop {
         state = {
           ...state,
           status: "stalled",
-          lastError: `max_steps_reached: ${stepsTaken} steps without reply`,
+          lastError: `task_stopped:${stopCause}: ${stepsTaken} steps without reply`,
         };
       }
     } else if (reason === "reply") {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -147,7 +147,7 @@ function printHelp(): void {
     ),
     "",
     "User config (edit via `atomic-agent config`):",
-    "  <stateDir>/config.json         localModels.url, localModels.mode, log.level, agent.{tokenBudget,maxSteps,toolTimeoutMs,approvalLevel}",
+    "  <stateDir>/config.json         localModels.url, localModels.mode, log.level, agent.{tokenBudget,maxSteps,task.*,toolTimeoutMs,approvalLevel}",
     "",
     "Bootstrap env:",
     "  ATOMIC_AGENT_STATE_DIR         Directory for persistent state + config.json (default ~/.atomic-agent)",

--- a/src/cli/run-agent.ts
+++ b/src/cli/run-agent.ts
@@ -43,7 +43,7 @@ const HELP =
     "Options:",
     "  --cwd <dir>          Working directory for OS tools (default: current directory)",
     "  --working-dir <dir>  Alias for --cwd",
-    "  --max-steps <n>      Step budget for one turn (default: agent.maxSteps from config)",
+    "  --max-steps <n>      Hard step ceiling for one task (default: agent.task.maxSteps)",
     "  --no-approval        Force approval level 5: auto-approve every dangerous tool call",
     "",
     "In-session:  /quit exits · /abort cancels the current turn",

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -247,7 +247,38 @@ export interface AtomicAgentConfig {
   };
   agent: {
     tokenBudget: number;
+    /**
+     * Steps in one *leg* of a task — a checkpoint interval, not the end
+     * of the work.
+     *
+     * It used to be the end of the work, and that was the wrong unit: a
+     * step is one model turn plus its tool calls, while what the user
+     * asked for ("register on these ten sites") is a task made of
+     * hundreds of them. Ending the task on a step count meant a long job
+     * stopped mid-way with `(stopped: max_steps reached without a
+     * reply)` and no way to continue. Now the loop reaches this number,
+     * checks that the leg actually made progress, says so, and carries
+     * on — up to {@link UserConfigFile.agent.task}.
+     */
     maxSteps: number;
+    /**
+     * Ceilings for one task. These, not `maxSteps`, are what actually
+     * end a run that is still making progress.
+     */
+    task: {
+      /**
+       * Hard ceiling on steps for one task. Reached, the loop spends its
+       * last step summarising instead of being cut off mid-edit.
+       */
+      maxSteps: number;
+      /** Wall-clock ceiling for one task. Same graceful ending. */
+      maxDurationMs: number;
+      /**
+       * Carry on past a leg boundary while the work is progressing.
+       * Off means the historical behaviour: stop at `agent.maxSteps`.
+       */
+      autoContinue: boolean;
+    };
     toolTimeoutMs: number;
     /**
      * Boot value for the five-step approval ladder (1 = ask for
@@ -1112,7 +1143,14 @@ export interface UserConfigFile {
   log: { level: LogLevel };
   agent: {
     tokenBudget: number;
+    /** Steps in one leg of a task — a checkpoint, not the end of it. */
     maxSteps: number;
+    /** Ceilings that actually end a task. See the runtime type above. */
+    task: {
+      maxSteps: number;
+      maxDurationMs: number;
+      autoContinue: boolean;
+    };
     toolTimeoutMs: number;
     /**
      * Five-step approval ladder (config v37). Replaces the binary
@@ -1868,6 +1906,15 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
   agent: {
     tokenBudget: 3000,
     maxSteps: 25,
+    task: {
+      // ~40 legs of 25. Large enough for the multi-hour browser jobs
+      // people actually ask for, small enough that a runaway is bounded
+      // and visible: every leg boundary reports steps, elapsed time and
+      // the ceiling it is counting towards.
+      maxSteps: 1000,
+      maxDurationMs: 7_200_000,
+      autoContinue: true,
+    },
     toolTimeoutMs: 60_000,
     approvalLevel: 1,
     conversationMaxTokens: 32_000,
@@ -2333,6 +2380,41 @@ function coerceFloatLike(raw: unknown): number {
   return /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(text)
     ? Number(text)
     : NaN;
+}
+
+/**
+ * Parse `agent.task` — the ceilings that end a task that is still
+ * making progress. Absent block means the defaults, so an older config
+ * file simply gains the behaviour.
+ *
+ * The floor on `maxSteps` is deliberate: a ceiling below one leg would
+ * make `agent.maxSteps` the terminator again through the back door, and
+ * silently, which is the exact confusion this block exists to remove.
+ */
+function parseAgentTask(raw: unknown): UserConfigFile["agent"]["task"] {
+  const defaults = USER_CONFIG_DEFAULTS.agent.task;
+  if (raw === undefined || raw === null) return defaults;
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(
+      "agent.task",
+      `expected object, got ${JSON.stringify(raw)}`,
+    );
+  }
+  const task = raw as Record<string, unknown>;
+  return {
+    maxSteps: parsePositiveInt(
+      task.maxSteps ?? defaults.maxSteps,
+      "agent.task.maxSteps",
+    ),
+    maxDurationMs: parsePositiveInt(
+      task.maxDurationMs ?? defaults.maxDurationMs,
+      "agent.task.maxDurationMs",
+    ),
+    autoContinue: parseBool(
+      task.autoContinue ?? defaults.autoContinue,
+      "agent.task.autoContinue",
+    ),
+  };
 }
 
 export function parsePositiveInt(raw: unknown, field: string): number {
@@ -3371,6 +3453,7 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
         agent.maxSteps ?? USER_CONFIG_DEFAULTS.agent.maxSteps,
         "agent.maxSteps",
       ),
+      task: parseAgentTask(agent.task),
       toolTimeoutMs: parsePositiveInt(
         agent.toolTimeoutMs ?? USER_CONFIG_DEFAULTS.agent.toolTimeoutMs,
         "agent.toolTimeoutMs",

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -206,6 +206,7 @@ export function loadConfig(): AtomicAgentConfig {
     agent: {
       tokenBudget: user.agent.tokenBudget,
       maxSteps: user.agent.maxSteps,
+      task: user.agent.task,
       toolTimeoutMs: user.agent.toolTimeoutMs,
       approvalLevel: user.agent.approvalLevel,
       stablePrefixHashSalt:

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -2451,9 +2451,21 @@ export async function createAgentRuntime(
     };
     return turnContext.run({ sessionId: session.id }, async () => {
       try {
+        // An explicit `maxSteps` from a caller (a durable task that pins
+        // its own budget, `run --max-steps`) is a *ceiling* that caller
+        // chose — honour it as one. Absent that, the config value is the
+        // leg length and `agent.task.*` supplies the ceiling, so an
+        // ordinary turn runs the task to completion instead of stopping
+        // at the first checkpoint.
         const result = await loop.runTurn(session, {
           userMessage,
-          maxSteps: runOptions.maxSteps ?? config.agent.maxSteps,
+          maxSteps: Math.min(
+            config.agent.maxSteps,
+            runOptions.maxSteps ?? config.agent.maxSteps,
+          ),
+          ...(runOptions.maxSteps === undefined
+            ? {}
+            : { taskMaxSteps: runOptions.maxSteps }),
           signal: runOptions.signal ?? new AbortController().signal,
         });
         // Stamp the turn's window occupancy so the stored session can

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -523,6 +523,18 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         { outcome: "failed", reason: event.error.message, lastRunStatus },
       );
     }
+    case "task_continued": {
+      // A long task must not go quiet. One line per leg, carrying the
+      // two numbers someone deciding whether to wait actually wants:
+      // how far it has got, and how far it may go.
+      const minutes = Math.max(1, Math.round(event.elapsedMs / 60_000));
+      return appendFeed(state, {
+        kind: "runtime_info",
+        stepIndex: null,
+        line: `» still working — ${event.stepsTaken} steps, ${minutes} min (ceiling ${event.stepCeiling})`,
+        color: "gray",
+      });
+    }
     case "loop_detected":
       // Deliberately not rendered: the loop detector's own `### notice`
       // changes what the model does, and the operator sees the effect


### PR DESCRIPTION
## The unit was wrong

`agent.maxSteps` (25) ended the turn. But a **step** is one model turn plus its tool calls, while what a person asks for — *"register on these ten sites"*, *"port this module"* — is a **task** made of hundreds of them.

A field trace from a colleague's machine shows the cost. Three turns of a ten-site registration job stopped at exactly 25 steps after ~3 minutes each, and this is everything she was told:

```
(stopped: max_steps reached without a reply)
```

A parenthetical naming an internal counter. Nothing about why, nothing about how far it got, and nothing to do about it but retype the task — which starts it over. Her next three messages in the trace are `next`, `далее`, `работай`.

## What changes

`maxSteps` becomes the length of a **leg** — a checkpoint interval. What ends a task:

| | default | |
|---|---|---|
| `agent.task.maxSteps` | 1000 | hard step ceiling |
| `agent.task.maxDurationMs` | 2 h | wall clock |
| `agent.task.autoContinue` | `true` | `false` restores the old one-leg behaviour exactly |

…plus the model finishing, the loop breaker, or the user.

- **The leg boundary is the only place continuation is decided** — once every `maxSteps` steps, never mid-leg. It emits `task_continued` (steps, elapsed, ceiling); the TUI renders `» still working — 50 steps, 12 min (ceiling 1000)`. A long job reports itself instead of going quiet for an hour.
- **A leg that produced nothing usable ends the task.** Progress is "at least one tool result came back `ok`": a partially failed batch still moved the work forward, while a leg where *every* call failed is a dead tool or a dead network. This is the guard the loop detector cannot give — its breaker catches a model repeating itself, not an environment that stopped answering.
- **A step is still reserved for the summary**, now at whichever ceiling bites first, so a task is never cut off mid-edit.
- **An explicit caller budget stays a ceiling.** `runtime.runTurn({ maxSteps })` — a durable task pinning its own budget, `run --max-steps` — maps to `taskMaxSteps`; the config value stays the leg. A caller that asked for at most 50 steps gets at most 50.
- **The closing message says something useful:**

```
(paused: this task hit its step ceiling of 1000 after 1000 steps over ~74 min.)
Here is where I got to — the work so far is kept in this session.
Say `continue` to pick up from here, or raise `agent.task.maxSteps` for longer runs.
```

  and `lastError` carries `task_stopped:step_ceiling|time_ceiling|no_progress` for post-mortem tooling.

## Cost, deliberately bounded

Auto-continuation spends tokens unattended, so every boundary is visible (event + feed line + log), the two ceilings are hard, a dead leg stops the run, and `autoContinue: false` turns the whole thing off. The defaults (1000 steps / 2 h) are sized for the multi-hour browser jobs people actually ask for; they are the knob to turn down for a cost-sensitive install.

## Config

v52 adds the additive `agent.task` block; v51 was appended to `SUPPORTED_INPUT_VERSIONS`, so an older file simply gains the behaviour.

## Testing

`npm run lint` clean. Full suite green apart from the pre-existing `sidecar/send-message-concurrency` failure (fails identically on clean `main`).

Six new cases in `agent-loop.test.ts`: keeps working past the leg while progressing (and reports every boundary), stops at the ceiling rather than the leg, stops after one dead leg instead of burning 50 steps on a broken tool, stops on the wall clock, and `autoContinue: false` behaves exactly as before.

The four existing finalization tests now state their ceiling explicitly — their subject is the reserved final step, which moved from the leg to the ceiling.