### PR TITLE
feat(agent): wait out a provider outage instead of failing the turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,36 @@ Locked invariants (pinned by [src/agent/agent-loop.test.ts](src/agent/agent-loop
 6. **The closing message names the ceiling, the work done and the way onward** (`formatTaskStoppedReply`),
    and `lastError` carries `task_stopped:<cause>` for post-mortem tooling.
 
+### Waiting out a provider outage
+
+A `transport` failure used to end the turn after the HTTP client's three fast retries (~1s). A field
+trace shows what that costs: the provider went unreachable mid-task, the turn died at step 14 after
+107 seconds of browser work, and the next **nine** messages each failed in about a second — across
+two app restarts and a fresh session — with nothing on screen to say the link was down.
+
+`agent.providerWait` (`enabled` true, `maxWaitMs` 300 000) parks the turn instead. Locked invariants
+(pinned by [src/agent/agent-loop.test.ts](src/agent/agent-loop.test.ts) and
+[src/tui/agent-event-reducer.test.ts](src/tui/agent-event-reducer.test.ts)):
+
+1. **The same step is retried, never a new one.** A completion failure throws before any tool is
+   dispatched — tool failures come back as results, not throws — so replaying the step replays no
+   side effect. `stepsTaken` does not move while parked, so a parked turn cannot eat the task budget.
+2. **Only failures that plausibly recover are waited on.** No HTTP response at all (DNS, refused,
+   TLS, reset), 5xx, 408, 429. A 404 from a wrong `localModels.url` and a 401 from a dead key are
+   `transport` too — they classify that way so fallover works — and they fail **immediately**:
+   parking a turn for five minutes in front of a typo is worse than the failure it replaces.
+3. **Backoff is 2s doubling to 30s, clipped so the last wait ends exactly at `maxWaitMs`.** The
+   budget the operator configured is the budget they get.
+4. **Esc during a wait ends the turn at once** — the sleep is abort-aware, and the turn settles
+   `cancelled`, not `failed`.
+5. **The budget resets after a recovery**, so a second outage later in a long task gets its own; the
+   task's wall-clock ceiling is what bounds the total.
+6. **The UI says it once, then keeps it live.** One feed line per outage (not per retry — the
+   backoff fires every few seconds at first), the composer meta-row carries `waiting for provider
+   14s/300s — <reason>`, and when the wait runs out the row stays as `provider unreachable —
+   <reason>` until a turn actually succeeds. The context readout is not touched: it is driven by
+   `prompt_built` / `llm_completed`, and a parked turn produces neither.
+
 ### No-progress loop detection
 
 The runtime guards against "stuck" turns where the model re-emits the same tool call (same args, same result) without making progress. The detector is [src/agent/loop-detector.ts](src/agent/loop-detector.ts) `ToolLoopTracker` — **one instance per turn**, owned by `AgentLoop.runTurn`, threaded into `executeStep` → `executeBatch` via `BatchExecutionContext.tracker`. Ported from OpenClaw 2026.6.5; the design goal is **graceful termination, never a hard failure**.

--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -7,6 +7,7 @@ import type { AgentLoopEvent } from "./agent-loop.js";
 import { buildDefaultToolRegistry } from "../tools/index.js";
 import { osFsReadTool } from "../tools/os/fs-read.js";
 import { SlotManager } from "../llm/slot-manager.js";
+import { TransportError } from "../llm/reliability/llm-failures.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import type {
   CompletionResult,
@@ -285,6 +286,253 @@ describe("AgentLoop end-to-end with mock LLM", () => {
       kind: "assistant_reply",
       text: expect.stringContaining("nothing came back"),
     });
+  });
+
+  it("parks the turn on a transport failure and resumes when the provider answers", async () => {
+    // The field case: the provider stops answering mid-task. Killing
+    // the turn throws away the work already done and makes every later
+    // message fail in one second; waiting keeps the task alive.
+    const registry = buildDefaultToolRegistry();
+    let noopRuns = 0;
+    registry.register({
+      name: "noop",
+      description: "no-op",
+      readonly: true,
+      async run() {
+        noopRuns += 1;
+        return {
+          tool: "noop",
+          status: "ok" as const,
+          summary: `noop ${noopRuns}`,
+          details: {},
+          truncated: false,
+        };
+      },
+    });
+    const events: Array<{ type: string } & Record<string, unknown>> = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        calls += 1;
+        // Step 0 works, the provider dies for two attempts, then it is
+        // back and the task finishes.
+        if (calls === 1) {
+          return makeCompletion(JSON.stringify({ tool: "noop", args: {} }));
+        }
+        if (calls <= 3) {
+          throw new TransportError("fetch failed", null, "");
+        }
+        return makeCompletion(
+          JSON.stringify({ tool: "reply", args: { text: "back online" } }),
+        );
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "provider_waiting" || event.type === "provider_recovered") {
+          events.push(event as { type: string } & Record<string, unknown>);
+        }
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-park", workingDir }),
+      {
+        userMessage: "keep going",
+        maxSteps: 10,
+        taskMaxSteps: 10,
+        signal: new AbortController().signal,
+      },
+    );
+
+    expect(result.reason).toBe("reply");
+    // Two outages waited out, then one recovery notice.
+    expect(events.map((e) => e.type)).toEqual([
+      "provider_waiting",
+      "provider_waiting",
+      "provider_recovered",
+    ]);
+    // Backoff grows, and the budget is reported so a UI can show it.
+    expect(events[0]!.nextRetryMs).toBe(2_000);
+    expect(events[1]!.nextRetryMs).toBe(4_000);
+    expect(events[0]!.reason).toBe("fetch failed");
+    // The parked attempts are not steps and replay nothing: one tool
+    // step plus the reply, not four steps and two noops.
+    expect(noopRuns).toBe(1);
+    expect(result.session.stepCount).toBe(2);
+    // Four completions were requested (one good, two dead, one good) —
+    // the same step was retried, not a new one started.
+    expect(calls).toBe(4);
+  });
+
+  it("does not wait out a failure that will never fix itself", async () => {
+    // `transport` also covers a wrong URL answering 404 and a dead key
+    // answering 401. Parking a turn for five minutes in front of a typo
+    // is worse than the failure it replaces — the operator would get no
+    // message at all until the budget ran out.
+    const registry = buildDefaultToolRegistry();
+    const waits: unknown[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        throw new TransportError("not found", 404, "http://127.0.0.1:8080/v1");
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "provider_waiting") waits.push(event);
+      },
+    });
+    const started = Date.now();
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-park-404", workingDir }),
+      {
+        userMessage: "wrong url",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("failed");
+    expect(waits).toEqual([]);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  it("waits out a 503, which is exactly the kind that fixes itself", async () => {
+    const registry = buildDefaultToolRegistry();
+    const waits: unknown[] = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new TransportError("service unavailable", 503, "https://x/v1");
+        }
+        return makeCompletion(
+          JSON.stringify({ tool: "reply", args: { text: "recovered" } }),
+        );
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "provider_waiting") waits.push(event);
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-park-503", workingDir }),
+      {
+        userMessage: "busy provider",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("reply");
+    expect(waits).toHaveLength(1);
+  });
+
+  it("gives up after the wait budget and fails the turn once", async () => {
+    const registry = buildDefaultToolRegistry();
+    const waits: number[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        throw new TransportError("fetch failed", null, "");
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "provider_waiting") waits.push(event.nextRetryMs);
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-park-out", workingDir }),
+      {
+        userMessage: "hopeless",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        // Two waits: 2s, then 1s clipped to the remaining budget.
+        providerWaitMaxMs: 3_000,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("failed");
+    expect(waits).toEqual([2_000, 1_000]);
+  });
+
+  it("an abort during the wait stops the turn immediately", async () => {
+    const registry = buildDefaultToolRegistry();
+    const controller = new AbortController();
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        // The operator presses Esc while the turn is parked.
+        setTimeout(() => controller.abort(), 5);
+        throw new TransportError("fetch failed", null, "");
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const started = Date.now();
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-park-abort", workingDir }),
+      {
+        userMessage: "stop me",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: controller.signal,
+      },
+    );
+    expect(result.reason).toBe("cancelled");
+    // Returned on the abort, not after the full 2s backoff.
+    expect(Date.now() - started).toBeLessThan(1_500);
+  });
+
+  it("providerWaitEnabled: false fails the turn as it used to", async () => {
+    const registry = buildDefaultToolRegistry();
+    const waits: unknown[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        throw new TransportError("fetch failed", null, "");
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "provider_waiting") waits.push(event);
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-park-off", workingDir }),
+      {
+        userMessage: "fail fast",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        providerWaitEnabled: false,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("failed");
+    expect(waits).toEqual([]);
   });
 
   it("stops on the wall clock and says so", async () => {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -15,6 +15,7 @@ import type { ToolRegistry } from "../tools/tool-registry.js";
 import {
   CancelledError,
   LlmFailure,
+  TransportError,
   classifyFailure,
 } from "../llm/index.js";
 import type { LlmFailureCategory } from "../llm/index.js";
@@ -322,6 +323,55 @@ export interface SteeringChannel {
  * which starts it over. This says which ceiling was hit, how far the
  * work got, and that "continue" resumes from here rather than restarts.
  */
+/**
+ * Is this failure the kind that fixes itself?
+ *
+ * `transport` is a broad category — it is also what a wrong
+ * `localModels.url` answering 404, a dead API key (401) and a
+ * not-installed CLI provider classify as, because all of them mean
+ * "this link is unusable, fall over". None of those become usable by
+ * waiting, and parking a turn for five minutes in front of a typo is
+ * worse than the failure it replaces: the operator gets no message at
+ * all until the budget runs out.
+ *
+ * So the wait is for the failures that plausibly recover on their own —
+ * no HTTP response at all (DNS, refused connection, TLS, socket reset),
+ * a server error, or the server saying "busy, later" (408 / 429).
+ */
+function isWaitableOutage(err: unknown): boolean {
+  if (!(err instanceof TransportError)) {
+    // An untyped socket failure that reached the classifier through
+    // `isNetworkError` — no status to inspect, and by construction it is
+    // a connection problem rather than a rejection.
+    return true;
+  }
+  if (err.status === null) return true;
+  return err.status >= 500 || err.status === 408 || err.status === 429;
+}
+
+/** First backoff after the provider stops answering. */
+const PROVIDER_WAIT_BASE_MS = 2_000;
+/**
+ * Ceiling on one backoff. An outage lasting minutes should be probed
+ * every half-minute, not once an hour — the point is to notice the
+ * moment it comes back.
+ */
+const PROVIDER_WAIT_MAX_BACKOFF_MS = 30_000;
+
+/** Sleep that returns early when the operator aborts the turn. */
+async function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(done, ms);
+    function done(): void {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", done);
+      resolve();
+    }
+    signal.addEventListener("abort", done, { once: true });
+  });
+}
+
 export function formatTaskStoppedReply(input: {
   cause: "step_ceiling" | "time_ceiling" | "no_progress";
   stepsTaken: number;
@@ -363,6 +413,13 @@ export interface RunTurnOptions {
    * "stop at `maxSteps`" behaviour for a caller that wants one leg only.
    */
   autoContinue?: boolean;
+  /**
+   * Wait out a provider outage instead of failing the turn. Defaults to
+   * `config.agent.providerWait.enabled`; `false` is the old behaviour.
+   */
+  providerWaitEnabled?: boolean;
+  /** Wait budget for one outage. Defaults to `config.agent.providerWait.maxWaitMs`. */
+  providerWaitMaxMs?: number;
   signal: AbortSignal;
   /** Optional new user message to append before stepping. */
   userMessage?: string;
@@ -392,6 +449,25 @@ export type AgentLoopEvent =
       reason: AgentLoopReason;
       stepCount: number;
       durationMs: number;
+    }
+  | {
+      /**
+       * The provider stopped answering and the turn is parked rather
+       * than failed: the same step will be retried after `nextRetryMs`.
+       * Fired once per wait, so a UI can show a live "waiting" state
+       * instead of nine mystery failures in a row.
+       */
+      type: "provider_waiting";
+      attempt: number;
+      waitedMs: number;
+      maxWaitMs: number;
+      nextRetryMs: number;
+      reason: string;
+    }
+  | {
+      /** The provider answered again; the parked turn is running on. */
+      type: "provider_recovered";
+      waitedMs: number;
     }
   | {
       /**
@@ -635,6 +711,21 @@ export class AgentLoop {
     let stopCause: "step_ceiling" | "time_ceiling" | "no_progress" = "step_ceiling";
     /** Set by any step in the current leg that produced a usable result. */
     let legMadeProgress = false;
+    // Provider-outage parking. A transport failure means "this link is
+    // not answering", which is a state of the world, not a verdict on
+    // the turn — so the turn waits for it rather than dying and taking
+    // the work in flight with it. Reset after a recovery so a second
+    // outage later in a long task gets its own budget; the task's
+    // wall-clock ceiling is what bounds the total.
+    const providerWaitDefaults = getConfig().agent.providerWait;
+    const providerWaitCfg = {
+      enabled: options.providerWaitEnabled ?? providerWaitDefaults.enabled,
+      maxWaitMs: options.providerWaitMaxMs ?? providerWaitDefaults.maxWaitMs,
+    };
+    let outageWaitedMs = 0;
+    let outageAttempts = 0;
+    /** Retried a step after an outage and have not yet seen it succeed. */
+    let awaitingRecovery = false;
     // Per-turn no-progress loop tracker (OpenClaw-style). Threaded into
     // `executeStep` so the synchronous batch gate can veto looping calls
     // before they are dispatched; the agent loop consumes the resulting
@@ -837,6 +928,22 @@ export class AgentLoop {
           },
         );
         const durationMs = Date.now() - started;
+        if (awaitingRecovery) {
+          // The step that came back after the wait. Say so once, then
+          // hand the next outage a fresh budget.
+          this.deps.onEvent?.({
+            type: "provider_recovered",
+            waitedMs: outageWaitedMs,
+          });
+          this.deps.logger?.info("provider answered again; turn resumed", {
+            sessionId: state.id,
+            stepIndex: i,
+            waitedMs: outageWaitedMs,
+          });
+          awaitingRecovery = false;
+          outageWaitedMs = 0;
+          outageAttempts = 0;
+        }
         state = outcome.nextSession;
         stepsTaken += 1;
         const tokensUsed =
@@ -1093,6 +1200,58 @@ export class AgentLoop {
           stepsTaken += 1;
           reason = "max_steps";
           break;
+        }
+        // The provider is not answering. Park the turn instead of
+        // killing it: nothing of this step has been committed (a
+        // completion failure throws before any tool is dispatched —
+        // tool failures come back as results, not throws), so retrying
+        // the same index replays nothing and duplicates no side effect.
+        if (
+          category === "transport" &&
+          !cancelled &&
+          providerWaitCfg.enabled &&
+          isWaitableOutage(err) &&
+          outageWaitedMs < providerWaitCfg.maxWaitMs
+        ) {
+          const nextRetryMs = Math.min(
+            PROVIDER_WAIT_MAX_BACKOFF_MS,
+            PROVIDER_WAIT_BASE_MS * 2 ** outageAttempts,
+            // Never sleep past the budget: the last wait ends exactly at
+            // it, so the operator's configured ceiling is the truth.
+            Math.max(1, providerWaitCfg.maxWaitMs - outageWaitedMs),
+          );
+          outageAttempts += 1;
+          awaitingRecovery = true;
+          this.deps.onEvent?.({
+            type: "provider_waiting",
+            attempt: outageAttempts,
+            waitedMs: outageWaitedMs,
+            maxWaitMs: providerWaitCfg.maxWaitMs,
+            nextRetryMs,
+            reason: runError.message,
+          });
+          this.deps.logger?.warn("provider unreachable; parking the turn", {
+            sessionId: state.id,
+            stepIndex: i,
+            attempt: outageAttempts,
+            waitedMs: outageWaitedMs,
+            nextRetryMs,
+            error: runError.message,
+          });
+          await abortableSleep(nextRetryMs, options.signal);
+          outageWaitedMs += nextRetryMs;
+          runError = null;
+          if (options.signal.aborted) {
+            reason = "cancelled";
+            state = { ...state, status: "cancelled" };
+            this.deps.onEvent?.({ type: "loop_completed", reason: "cancelled" });
+            state = incrementTurnCount(state);
+            break;
+          }
+          // Retry the very same step index: `i += 1` runs on `continue`,
+          // so step back one to land on it again.
+          i -= 1;
+          continue;
         }
         this.deps.logger?.error("agent loop failed", {
           sessionId: state.id,

--- a/src/cli/trace-formatter.ts
+++ b/src/cli/trace-formatter.ts
@@ -80,6 +80,18 @@ function formatTraceEvent(event: TraceEvent, raw: boolean): string {
       }`;
     case "parse_retry":
       return `${head} step=${event.stepIndex} attempt=${event.attempt} reason=${event.reason}`;
+    case "task_continued":
+      return `${head} steps=${event.stepsTaken}/${event.stepCeiling} elapsed=${Math.round(
+        event.elapsedMs / 1000,
+      )}s`;
+    case "provider_waiting":
+      return `${head} attempt=${event.attempt} waited=${Math.round(
+        event.waitedMs / 1000,
+      )}s/${Math.round(event.maxWaitMs / 1000)}s next=${Math.round(
+        event.nextRetryMs / 1000,
+      )}s reason=${truncate(event.reason, 120, raw)}`;
+    case "provider_recovered":
+      return `${head} waited=${Math.round(event.waitedMs / 1000)}s`;
     case "loop_detected":
       return `${head} step=${event.stepIndex} tool=${event.tool} count=${event.count}${
         event.detector !== undefined ? ` detector=${event.detector}` : ""

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -262,6 +262,22 @@ export interface AtomicAgentConfig {
      */
     maxSteps: number;
     /**
+     * What to do when the model provider stops answering.
+     *
+     * A dead endpoint used to end the turn after three fast retries
+     * (~1s), so an outage of minutes turned every message the operator
+     * sent into a one-second failure and the work in flight was
+     * abandoned. Waiting is the honest response: the turn is parked,
+     * the same step is retried on a backoff, and the run continues the
+     * moment the provider answers.
+     */
+    providerWait: {
+      /** `false` restores the old behaviour: fail the turn immediately. */
+      enabled: boolean;
+      /** Give up (and fail the turn) after waiting this long in one outage. */
+      maxWaitMs: number;
+    };
+    /**
      * Ceilings for one task. These, not `maxSteps`, are what actually
      * end a run that is still making progress.
      */
@@ -1145,6 +1161,11 @@ export interface UserConfigFile {
     tokenBudget: number;
     /** Steps in one leg of a task — a checkpoint, not the end of it. */
     maxSteps: number;
+    /** Wait out a provider outage instead of failing the turn. */
+    providerWait: {
+      enabled: boolean;
+      maxWaitMs: number;
+    };
     /** Ceilings that actually end a task. See the runtime type above. */
     task: {
       maxSteps: number;
@@ -1906,6 +1927,14 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
   agent: {
     tokenBudget: 3000,
     maxSteps: 25,
+    providerWait: {
+      enabled: true,
+      // Five minutes covers the outages people actually hit — a laptop
+      // waking, a VPN reconnecting, a provider's gateway restarting —
+      // without leaving a turn parked all afternoon. The task's own
+      // wall-clock ceiling still applies on top.
+      maxWaitMs: 300_000,
+    },
     task: {
       // ~40 legs of 25. Large enough for the multi-hour browser jobs
       // people actually ask for, small enough that a runaway is bounded
@@ -2391,6 +2420,30 @@ function coerceFloatLike(raw: unknown): number {
  * make `agent.maxSteps` the terminator again through the back door, and
  * silently, which is the exact confusion this block exists to remove.
  */
+function parseProviderWait(
+  raw: unknown,
+): UserConfigFile["agent"]["providerWait"] {
+  const defaults = USER_CONFIG_DEFAULTS.agent.providerWait;
+  if (raw === undefined || raw === null) return defaults;
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(
+      "agent.providerWait",
+      `expected object, got ${JSON.stringify(raw)}`,
+    );
+  }
+  const wait = raw as Record<string, unknown>;
+  return {
+    enabled: parseBool(
+      wait.enabled ?? defaults.enabled,
+      "agent.providerWait.enabled",
+    ),
+    maxWaitMs: parsePositiveInt(
+      wait.maxWaitMs ?? defaults.maxWaitMs,
+      "agent.providerWait.maxWaitMs",
+    ),
+  };
+}
+
 function parseAgentTask(raw: unknown): UserConfigFile["agent"]["task"] {
   const defaults = USER_CONFIG_DEFAULTS.agent.task;
   if (raw === undefined || raw === null) return defaults;
@@ -3453,6 +3506,7 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
         agent.maxSteps ?? USER_CONFIG_DEFAULTS.agent.maxSteps,
         "agent.maxSteps",
       ),
+      providerWait: parseProviderWait(agent.providerWait),
       task: parseAgentTask(agent.task),
       toolTimeoutMs: parsePositiveInt(
         agent.toolTimeoutMs ?? USER_CONFIG_DEFAULTS.agent.toolTimeoutMs,

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -206,6 +206,7 @@ export function loadConfig(): AtomicAgentConfig {
     agent: {
       tokenBudget: user.agent.tokenBudget,
       maxSteps: user.agent.maxSteps,
+      providerWait: user.agent.providerWait,
       task: user.agent.task,
       toolTimeoutMs: user.agent.toolTimeoutMs,
       approvalLevel: user.agent.approvalLevel,

--- a/src/tracing/trace/trace-event.ts
+++ b/src/tracing/trace/trace-event.ts
@@ -27,6 +27,9 @@ export type TraceEvent =
   | TraceToolInvocation
   | TraceParseRetry
   | TraceLoopDetected
+  | TraceTaskContinued
+  | TraceProviderWaiting
+  | TraceProviderRecovered
   | TraceLessonDeprecated
   | TraceVoteApplied
   | TraceVoteRejected
@@ -159,6 +162,38 @@ export interface TraceParseRetry extends TraceEventBase {
   stepIndex: number;
   attempt: number;
   reason: string;
+}
+
+/**
+ * A leg of the task finished and the work carried on. The trace is
+ * where "did it stop, or is it still going?" gets answered after the
+ * fact, so the two numbers that decide it are both here.
+ */
+export interface TraceTaskContinued extends TraceEventBase {
+  type: "task_continued";
+  turnIndex: number;
+  stepsTaken: number;
+  elapsedMs: number;
+  stepCeiling: number;
+}
+
+/** The turn was parked because the provider stopped answering. */
+export interface TraceProviderWaiting extends TraceEventBase {
+  type: "provider_waiting";
+  turnIndex: number;
+  stepIndex?: number;
+  attempt: number;
+  waitedMs: number;
+  maxWaitMs: number;
+  nextRetryMs: number;
+  reason: string;
+}
+
+/** The provider answered again and the parked turn resumed. */
+export interface TraceProviderRecovered extends TraceEventBase {
+  type: "provider_recovered";
+  turnIndex: number;
+  waitedMs: number;
 }
 
 export interface TraceLoopDetected extends TraceEventBase {

--- a/src/tracing/trace/trace-recorder.ts
+++ b/src/tracing/trace/trace-recorder.ts
@@ -369,6 +369,45 @@ export function createTraceRecorder(
           currentStepIndex = null;
           pendingCalls = new Map();
           return;
+        case "task_continued":
+          push({
+            type: "task_continued",
+            seq: nextSeq(),
+            sessionId,
+            ts: now(),
+            turnIndex: currentTurnIndex,
+            stepsTaken: event.stepsTaken,
+            elapsedMs: event.elapsedMs,
+            stepCeiling: event.stepCeiling,
+          });
+          return;
+        case "provider_waiting":
+          push({
+            type: "provider_waiting",
+            seq: nextSeq(),
+            sessionId,
+            ts: now(),
+            turnIndex: currentTurnIndex,
+            ...(currentStepIndex !== null
+              ? { stepIndex: currentStepIndex }
+              : {}),
+            attempt: event.attempt,
+            waitedMs: event.waitedMs,
+            maxWaitMs: event.maxWaitMs,
+            nextRetryMs: event.nextRetryMs,
+            reason: event.reason,
+          });
+          return;
+        case "provider_recovered":
+          push({
+            type: "provider_recovered",
+            seq: nextSeq(),
+            sessionId,
+            ts: now(),
+            turnIndex: currentTurnIndex,
+            waitedMs: event.waitedMs,
+          });
+          return;
         case "loop_detected":
           push({
             type: "loop_detected",

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -817,6 +817,114 @@ describe("reduceTuiState", () => {
   });
 });
 
+describe("provider outage", () => {
+  const waiting = (over: Record<string, unknown> = {}): TuiAction => ({
+    type: "agent_event",
+    event: {
+      type: "provider_waiting",
+      attempt: 1,
+      waitedMs: 0,
+      maxWaitMs: 300_000,
+      nextRetryMs: 2_000,
+      reason: "fetch failed",
+      ...over,
+    } as never,
+  });
+
+  it("shows the outage and says how long it will keep trying", () => {
+    const next = reduceTuiState(createInitialTuiState(fakeSession()), waiting());
+    expect(next.providerOutage).toMatchObject({
+      reason: "fetch failed",
+      attempt: 1,
+      givenUp: false,
+    });
+    expect(next.feed.at(-1)?.line).toContain("provider not answering");
+    expect(next.feed.at(-1)?.line).toContain("retrying in 2s");
+  });
+
+  it("does not repeat the feed line on every retry", () => {
+    // The backoff fires every few seconds at first; the meta-row carries
+    // the live numbers, so a wall of identical lines would only bury the
+    // work above it.
+    const next = apply(createInitialTuiState(fakeSession()), [
+      waiting(),
+      waiting({ attempt: 2, waitedMs: 2_000, nextRetryMs: 4_000 }),
+      waiting({ attempt: 3, waitedMs: 6_000, nextRetryMs: 8_000 }),
+    ]);
+    expect(next.feed.filter((f) => f.line.includes("provider not answering"))).toHaveLength(1);
+    expect(next.providerOutage).toMatchObject({ attempt: 3, waitedMs: 6_000 });
+  });
+
+  it("clears on recovery and says how long it waited", () => {
+    const next = apply(createInitialTuiState(fakeSession()), [
+      waiting(),
+      {
+        type: "agent_event",
+        event: { type: "provider_recovered", waitedMs: 6_000 } as never,
+      },
+    ]);
+    expect(next.providerOutage).toBeNull();
+    expect(next.feed.at(-1)?.line).toContain("provider answered again after 6s");
+  });
+
+  it("stays on screen when the wait ran out and the turn failed", () => {
+    // The sticky half: the next message will fail the same way, and a
+    // state that cleared between attempts is how eight identical
+    // failures read as eight separate surprises.
+    const next = apply(createInitialTuiState(fakeSession()), [
+      waiting(),
+      {
+        type: "agent_event",
+        event: {
+          type: "loop_failed",
+          error: new Error("fetch failed"),
+          category: "transport",
+        },
+      },
+    ]);
+    expect(next.providerOutage).toMatchObject({ givenUp: true });
+  });
+
+  it("clears when a turn actually completes", () => {
+    const next = apply(createInitialTuiState(fakeSession()), [
+      waiting(),
+      {
+        type: "agent_event",
+        event: {
+          type: "turn_finished",
+          turnIndex: 0,
+          reason: "reply",
+          stepCount: 3,
+          durationMs: 10,
+        },
+      },
+    ]);
+    expect(next.providerOutage).toBeNull();
+  });
+
+  it("leaves the context gauge alone", () => {
+    // The readout at the bottom of the screen is driven by
+    // `prompt_built` / `llm_completed` only. A parked turn builds no new
+    // prompt and gets no completion, so the gauge must hold the last
+    // measured value rather than resetting, moving or disappearing.
+    const built = createInitialTuiState(fakeSession());
+    const withUsage: TuiState = {
+      ...built,
+      contextUsage: { ...built.contextUsage, tokens: 12_345, window: 32_768 },
+    };
+    const next = apply(withUsage, [
+      waiting(),
+      waiting({ attempt: 2, waitedMs: 2_000 }),
+      {
+        type: "agent_event",
+        event: { type: "provider_recovered", waitedMs: 6_000 } as never,
+      },
+    ]);
+    expect(next.contextUsage.tokens).toBe(12_345);
+    expect(next.contextUsage.window).toBe(32_768);
+  });
+});
+
 describe("llm health visibility", () => {
   it("does not mark local as configured just because a probe failed", () => {
     const state = apply(createInitialTuiState(fakeSession()), [

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -370,7 +370,15 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         runStartedAt: Date.now(),
       };
     case "turn_finished":
-      return finishTurn(state, event.reason, event.stepCount);
+      // A turn that reached the model clears the outage: the link is
+      // demonstrably answering again. A failed one leaves it standing.
+      return finishTurn(
+        event.reason === "reply" || event.reason === "finish"
+          ? { ...state, providerOutage: null }
+          : state,
+        event.reason,
+        event.stepCount,
+      );
     case "step_started":
       return {
         ...appendFeed(state, {
@@ -510,9 +518,19 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
           llamaUrl: state.session.llamaUrl,
         },
       );
+      // The wait ran out and the turn died with it. Keep the outage on
+      // screen: the next message the operator sends will fail the same
+      // way, and a state that clears itself between attempts is how
+      // eight identical failures read as eight separate surprises.
+      const outageState: TuiState = state.providerOutage
+        ? {
+            ...state,
+            providerOutage: { ...state.providerOutage, givenUp: true },
+          }
+        : state;
       return finishRun(
         appendChatMessage(
-          appendFeed(state, {
+          appendFeed(outageState, {
             kind: "loop_failed",
             stepIndex: null,
             line: `» ${lastRunStatus}`,
@@ -523,6 +541,46 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         { outcome: "failed", reason: event.error.message, lastRunStatus },
       );
     }
+    case "provider_waiting": {
+      const line = `» provider not answering (${event.reason}) — retrying in ${Math.round(
+        event.nextRetryMs / 1000,
+      )}s, waited ${Math.round(event.waitedMs / 1000)}s of ${Math.round(
+        event.maxWaitMs / 1000,
+      )}s · Esc stops`;
+      const next: TuiState = {
+        ...state,
+        providerOutage: {
+          reason: event.reason,
+          waitedMs: event.waitedMs,
+          maxWaitMs: event.maxWaitMs,
+          attempt: event.attempt,
+          givenUp: false,
+        },
+      };
+      // One feed line per outage, not per retry: the backoff fires every
+      // few seconds at the start and the meta-row carries the live
+      // numbers. A wall of identical lines would bury the work above it.
+      return event.attempt === 1
+        ? appendFeed(next, {
+            kind: "runtime_info",
+            stepIndex: null,
+            line,
+            color: "yellow",
+          })
+        : next;
+    }
+    case "provider_recovered":
+      return appendFeed(
+        { ...state, providerOutage: null },
+        {
+          kind: "runtime_info",
+          stepIndex: null,
+          line: `» provider answered again after ${Math.round(
+            event.waitedMs / 1000,
+          )}s — continuing`,
+          color: "green",
+        },
+      );
     case "task_continued": {
       // A long task must not go quiet. One line per leg, carrying the
       // two numbers someone deciding whether to wait actually wants:

--- a/src/tui/format-provider-outage.test.ts
+++ b/src/tui/format-provider-outage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { formatProviderOutage } from "./format-provider-outage.js";
+
+describe("formatProviderOutage", () => {
+  it("counts the wait against its budget while the turn is parked", () => {
+    expect(
+      formatProviderOutage({
+        reason: "fetch failed",
+        waitedMs: 14_000,
+        maxWaitMs: 300_000,
+        attempt: 3,
+        givenUp: false,
+      }),
+    ).toBe("waiting for provider 14s/300s — fetch failed");
+  });
+
+  it("switches wording once the wait has run out", () => {
+    // Different question for the operator: nothing to wait for any
+    // more, so the line says the state of the link, not a countdown.
+    expect(
+      formatProviderOutage({
+        reason: "fetch failed",
+        waitedMs: 300_000,
+        maxWaitMs: 300_000,
+        attempt: 9,
+        givenUp: true,
+      }),
+    ).toBe("provider unreachable — fetch failed");
+  });
+
+  it("keeps the line short enough for the meta bar", () => {
+    // It shares a row with the route, the context readout and the mode
+    // chip; a wrapped meta bar costs the composer a line.
+    const line = formatProviderOutage({
+      reason:
+        "Can't reach \"aimlapi\" — no response from api.aimlapi.com after three attempts, check the provider URL or your connection",
+      waitedMs: 4_000,
+      maxWaitMs: 300_000,
+      attempt: 2,
+      givenUp: false,
+    });
+    expect(line.length).toBeLessThanOrEqual(80);
+    expect(line.endsWith("…")).toBe(true);
+  });
+
+  it("flattens a multi-line reason", () => {
+    expect(
+      formatProviderOutage({
+        reason: "socket hang up\n  at Socket.onClose",
+        waitedMs: 0,
+        maxWaitMs: 60_000,
+        attempt: 1,
+        givenUp: false,
+      }),
+    ).toBe("waiting for provider 0s/60s — socket hang up at Socket.onClose");
+  });
+});

--- a/src/tui/format-provider-outage.ts
+++ b/src/tui/format-provider-outage.ts
@@ -1,0 +1,37 @@
+import type { TuiState } from "./tui-state.js";
+
+/** Longest reason fragment carried into the one-row meta bar. */
+const REASON_MAX_LEN = 48;
+
+/**
+ * The composer's provider-outage readout.
+ *
+ * Two states, because they ask for different things from the operator:
+ * while the turn is parked there is nothing to do but wait (or press
+ * Esc), and the useful facts are how long it has waited and how long it
+ * will keep trying. Once the wait has run out, the useful fact is that
+ * every message from here on will fail the same way until the link is
+ * back — which is exactly what nine identical one-second failures in a
+ * row failed to say.
+ *
+ * Kept short and reason-first: this shares a row with the route, the
+ * context readout and the mode chip, and a wrapped meta bar would cost
+ * the composer a line.
+ */
+export function formatProviderOutage(
+  outage: NonNullable<TuiState["providerOutage"]>,
+): string {
+  const reason = shortenReason(outage.reason);
+  if (outage.givenUp) {
+    return `provider unreachable — ${reason}`;
+  }
+  const waited = Math.round(outage.waitedMs / 1000);
+  const budget = Math.round(outage.maxWaitMs / 1000);
+  return `waiting for provider ${waited}s/${budget}s — ${reason}`;
+}
+
+function shortenReason(raw: string): string {
+  const flat = raw.trim().replace(/\s+/g, " ");
+  if (flat.length <= REASON_MAX_LEN) return flat;
+  return `${flat.slice(0, REASON_MAX_LEN - 1)}…`;
+}

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -1,4 +1,5 @@
 import { ContextChip } from "./components/context-chip.js";
+import { formatProviderOutage } from "./format-provider-outage.js";
 import type { ApprovalLevel } from "../approval/approval-level.js";
 import {
   codingModeLook,
@@ -1560,7 +1561,17 @@ export function TuiApp({
   // Rail tokens, not page ones: both slots are handed to `PromptMetaBar`,
   // which paints them on the rail ground. `success` / `accentSoft` /
   // `muted` are all picked to be read on the terminal's own page.
-  const promptLeftSlot = state.composerNotice ? (
+  // An unreachable provider outranks the transient composer notice: it
+  // is the reason nothing is happening, and it is the one thing the
+  // operator needs on screen for as long as it is true. It shares this
+  // slot rather than taking a row of its own so the meta-bar keeps its
+  // shape — `contextSlot` and `modeSlot` are separate props at the far
+  // end and are not touched by it.
+  const promptLeftSlot = state.providerOutage ? (
+    <Text color={theme.colors.railError}>
+      {formatProviderOutage(state.providerOutage)}
+    </Text>
+  ) : state.composerNotice ? (
     <Text color={theme.colors.railSuccess}>{state.composerNotice}</Text>
   ) : null;
   // While a turn is running the meta-row gains a second job: the operator

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -355,6 +355,26 @@ export interface TuiState {
    */
   composerNotice: string | null;
   /**
+   * Live provider outage, or `null` when the link is answering.
+   *
+   * Sticky on purpose: it survives the failed turn that ended the wait
+   * and stays on screen until a turn actually succeeds. Nine identical
+   * one-second failures with nothing on screen between them is what a
+   * dead provider used to look like from the operator's chair.
+   */
+  providerOutage: {
+    /** Scrubbed reason from the transport failure. */
+    reason: string;
+    /** Wall-clock ms already spent waiting in this outage. */
+    waitedMs: number;
+    /** Ceiling from `agent.providerWait.maxWaitMs`. */
+    maxWaitMs: number;
+    /** Retry attempts made so far. */
+    attempt: number;
+    /** `true` once the wait budget ran out and the turn failed. */
+    givenUp: boolean;
+  } | null;
+  /**
    * Open "delete the session?" confirmation, or `null`. Carries the
    * preview so the dialog can name what is about to go, and the focused
    * button so Enter has an unambiguous meaning.
@@ -702,6 +722,7 @@ export function createInitialTuiState(
     approvalPathDraft: null,
     composerHasSelection: false,
     composerNotice: null,
+    providerOutage: null,
     sessionDelete: null,
     uninstall: null,
     loadedSkills: [],


### PR DESCRIPTION
> **Stacked on #344.** Retarget to `main` once that lands. Implements B1 + B2 from the silent-stop analysis.

## What the trace showed

The provider went unreachable mid-task. The turn died at step 14 after **107 seconds of browser work**, and the next **nine** messages each failed in about a second — across two app restarts and a brand-new session — with nothing on screen saying the link was down. The HTTP client's three fast retries (~1 s) are right for a blip and useless for an outage lasting minutes.

## B2 — park and resume

`agent.providerWait` (`enabled: true`, `maxWaitMs: 300000`) parks the turn instead of failing it: the **same step** is retried on a 2 s → 30 s backoff, and the run continues the moment the provider answers.

- **No replay, no double side effects.** A completion failure throws *before* any tool is dispatched — tool failures come back as results, not throws — so retrying the step re-issues only the completion. `stepsTaken` does not move while parked, so a parked turn cannot eat the task budget from #344.
- **Only failures that plausibly recover are waited on:** no HTTP response at all (DNS, refused, TLS, reset), 5xx, 408, 429. A **404** from a wrong `localModels.url` and a **401** from a dead key are `transport` too — they classify that way so fallover works — and they still fail immediately. Parking a turn for five minutes in front of a typo is worse than the failure it replaces.
- **Esc ends it at once** — the sleep is abort-aware and the turn settles `cancelled`, not `failed`.
- **The backoff is clipped so the last wait ends exactly at `maxWaitMs`** — the configured budget is the budget you get.
- **The budget resets after a recovery**, so a second outage later in a long task gets its own; the task's wall-clock ceiling bounds the total.

## B1 — say it on screen

`provider_waiting` / `provider_recovered` drive a sticky `providerOutage` state:

```
» provider not answering (fetch failed) — retrying in 4s, waited 2s of 300s · Esc stops
```

- **one feed line per outage, not per retry** — the backoff fires every few seconds at first, and a wall of identical lines would bury the work above it;
- the composer meta-row carries the live figure: `waiting for provider 14s/300s — fetch failed`;
- when the budget runs out the row **stays** as `provider unreachable — fetch failed` until a turn actually succeeds. Nine identical one-second failures with a clean screen between them is how one outage reads as eight separate surprises.

## The context readout is untouched

It is driven by `prompt_built` (estimate) and `llm_completed` (the provider's own count). A parked turn builds no new prompt and receives no completion, so the gauge holds its last measured value — it does not reset, move or disappear. There is a test that says exactly that, and the outage indicator lives in the meta-bar's **left** slot (sharing with the composer notice, outranking it) while `contextSlot` and `modeSlot` are separate props at the far end.

## Config

v53 adds `agent.providerWait`; v52 appended to `SUPPORTED_INPUT_VERSIONS`. `enabled: false` — or the per-call `providerWaitEnabled: false` — restores the old fail-fast behaviour exactly.

## Testing

`npm run lint` clean; full suite green apart from the pre-existing `sidecar/send-message-concurrency` failure.

- **loop (6):** parks and resumes with no replay (one tool run, four completions, two waits, one recovery); gives up after the budget with the backoff clipped to it (`2000, 1000` for a 3 s budget); abort during a wait returns in <1.5 s as `cancelled`; a 404 does not park and fails in <1 s; a 503 does park and then succeeds; `providerWaitEnabled: false` fails fast with no events.
- **reducer (6):** shown once with the retry figure; not repeated on retries 2 and 3; cleared on recovery; sticky (`givenUp`) after the turn fails; cleared by a successful `turn_finished`; **context gauge unchanged across park → retry → recover**.
- **readout (4):** budget wording while parked, different wording once given up, ≤80 chars with a long reason, multi-line reason flattened.

Two existing `format-agent-error-for-chat` tests caught the 404 case during development — they drive a real turn against a llama endpoint that 404s and would have hung for the whole wait budget. That is what the waitable/non-waitable split above is for.