### PR TITLE
feat(local-llm): pull a vision model's GGUF and mmproj together

### DIFF
--- a/src/local-llm/download-worker-pair.ts
+++ b/src/local-llm/download-worker-pair.ts
@@ -1,0 +1,113 @@
+import { resolveMmprojFilePath, resolveModelFilePath } from "./backend-paths.js";
+import { readPartialDownload } from "./download-file.js";
+import type { DownloadJob } from "./download-jobs.js";
+import type { DownloadWorkerInput } from "./download-worker.js";
+import { downloadMmproj, downloadModel } from "./model-installer.js";
+import type { LocalModelDef } from "./models-catalog.js";
+
+const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * A vision pull that needs both files fetches them side by side rather
+ * than one after the other: the projector is a few hundred MB next to a
+ * multi-GB GGUF, and waiting for the weights to finish before starting
+ * it added its whole transfer time to the pull. The record carries the
+ * sum of both files; `phase` stays `gguf` until the weights land, then
+ * reads `mmproj` for whatever the projector still owes. A failure in
+ * either file cancels the other — partials are kept, and the retry
+ * resumes both from where they stopped.
+ */
+export async function downloadGgufAndMmprojTogether(
+  def: LocalModelDef,
+  input: DownloadWorkerInput,
+  io: {
+    persist: (patch: Partial<DownloadJob>, force?: boolean) => void;
+    log: (line: string) => void;
+    stamp: () => string;
+  },
+): Promise<void> {
+  const ggufDest = resolveModelFilePath(input.dataDir, def.id, def.filename);
+  const mmprojDest = resolveMmprojFilePath(input.dataDir, def.id, def.mmprojFilename ?? "");
+  const parts = {
+    gguf: openingNumbers(ggufDest, gb(def.fileSizeGb)),
+    mmproj: openingNumbers(mmprojDest, gb(def.mmprojFileSizeGb ?? 1)),
+  };
+  let ggufDone = false;
+  const report = (force: boolean): void => {
+    const transferred = parts.gguf.transferred + parts.mmproj.transferred;
+    const total = parts.gguf.total + parts.mmproj.total;
+    io.persist(
+      {
+        label: `${def.name} (gguf + mmproj)`,
+        phase: ggufDone ? "mmproj" : "gguf",
+        percent: total > 0 ? Math.round((transferred / total) * 100) : 0,
+        transferredBytes: transferred,
+        totalBytes: total,
+      },
+      force,
+    );
+  };
+  report(true);
+
+  // One controller for the pair: the caller's cancel and either file's
+  // failure both stop the other file.
+  const pair = new AbortController();
+  const onCallerAbort = (): void => pair.abort();
+  if (input.signal?.aborted) pair.abort();
+  input.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  const fileOpts = (key: keyof typeof parts) => {
+    let first = true;
+    return {
+      signal: pair.signal,
+      onProgress: (_percent: number, transferred: number, total: number) => {
+        parts[key] = { transferred, total: total > 0 ? total : parts[key].total };
+        report(first);
+        first = false;
+      },
+      onRetry: (info: { attempt: number; maxRetries: number; delayMs: number; error: Error }) => {
+        io.log(
+          `[${io.stamp()}] ${key} interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s`,
+        );
+      },
+    };
+  };
+  const guard = (work: Promise<void>): Promise<void> =>
+    work.catch((err: unknown) => {
+      pair.abort();
+      throw err;
+    });
+  try {
+    const results = await Promise.allSettled([
+      guard(
+        downloadModel(input.dataDir, def, fileOpts("gguf")).then(() => {
+          ggufDone = true;
+          io.log(`[${io.stamp()}] gguf complete`);
+          report(true);
+        }),
+      ),
+      guard(
+        downloadMmproj(input.dataDir, def, fileOpts("mmproj")).then(() => {
+          io.log(`[${io.stamp()}] mmproj complete`);
+          report(true);
+        }),
+      ),
+    ]);
+    const failures = results.flatMap((r) => (r.status === "rejected" ? [r.reason as unknown] : []));
+    if (failures.length > 0) {
+      // The real cause comes first; the other file's AbortError is the
+      // echo of our own cancel.
+      throw failures.find((f) => !isAbortError(f)) ?? failures[0];
+    }
+  } finally {
+    input.signal?.removeEventListener("abort", onCallerAbort);
+  }
+}
+
+function openingNumbers(dest: string, estTotal: number): { transferred: number; total: number } {
+  const partial = readPartialDownload(dest);
+  return { transferred: partial?.transferred ?? 0, total: partial?.total || estTotal };
+}

--- a/src/local-llm/download-worker.test.ts
+++ b/src/local-llm/download-worker.test.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { resolveModelFilePath } from "./backend-paths.js";
+import { resolveMmprojFilePath, resolveModelFilePath } from "./backend-paths.js";
 import { resolvePartialMetaPath, resolvePartialPath } from "./download-file.js";
 import { downloadJobId, readDownloadJob } from "./download-jobs.js";
 import { initialDownloadJob, runDownloadWorker } from "./download-worker.js";
@@ -20,6 +20,7 @@ import { getEmbeddingModelDef, getLocalModelDef } from "./models-catalog.js";
 
 const EMB = getEmbeddingModelDef("nomic-embed-text-v1.5");
 const CHAT = getLocalModelDef("qwen-3.5-4b");
+const VISION = getLocalModelDef("gemma-4-e4b");
 
 function bodyOf(chunks: readonly string[]): ReadableStream {
   const queue = [...chunks];
@@ -149,6 +150,126 @@ describe("download-worker", () => {
     const dest = resolveModelFilePath(dataDir, CHAT.id, CHAT.filename);
     expect(existsSync(dest)).toBe(false);
     expect(readFileSync(resolvePartialPath(dest), "utf-8")).toBe("ab");
+  });
+
+  it("fetches a vision model's GGUF and mmproj together under one summed record", async () => {
+    // Each body parks until the other request has arrived, so the test
+    // only completes when the two downloads overlap in time.
+    let arrived = 0;
+    const releases: Array<() => void> = [];
+    const bothArrived = new Promise<void>((resolve) => releases.push(resolve));
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      arrived += 1;
+      if (arrived === 2) releases.forEach((r) => r());
+      const isMmproj = String(url) === VISION.mmprojUrl;
+      const payload = isMmproj ? "mm" : "weights!";
+      const body = new ReadableStream({
+        async pull(controller) {
+          await bothArrived;
+          controller.enqueue(Buffer.from(payload));
+          controller.close();
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "content-length": String(payload.length) },
+      });
+    }) as typeof fetch;
+
+    const outcome = await runDownloadWorker({
+      dataDir,
+      kind: "chat",
+      modelId: VISION.id,
+      mode: "with-mmproj",
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+    });
+
+    expect(outcome).toBe("done");
+    expect(
+      readFileSync(resolveModelFilePath(dataDir, VISION.id, VISION.filename), "utf-8"),
+    ).toBe("weights!");
+    expect(
+      readFileSync(
+        resolveMmprojFilePath(dataDir, VISION.id, VISION.mmprojFilename ?? ""),
+        "utf-8",
+      ),
+    ).toBe("mm");
+    const job = readDownloadJob(dataDir, downloadJobId("chat", VISION.id));
+    expect(job).toMatchObject({
+      status: "done",
+      label: `${VISION.name} (gguf + mmproj)`,
+      percent: 100,
+      transferredBytes: 10,
+      totalBytes: 10,
+    });
+    expect(log.some((l) => /gguf complete/.test(l))).toBe(true);
+    expect(log.some((l) => /mmproj complete/.test(l))).toBe(true);
+  });
+
+  it("a failing mmproj cancels the GGUF transfer and keeps its partial", async () => {
+    let releaseGguf: (() => void) | null = null;
+    const ggufDest = resolveModelFilePath(dataDir, VISION.id, VISION.filename);
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (String(url) === VISION.mmprojUrl) {
+        // Fail only once the weights have bytes on disk, so the test
+        // shows the cancel keeps them rather than racing the first chunk.
+        await waitFor(() => {
+          try {
+            return readFileSync(resolvePartialPath(ggufDest), "utf-8") === "ab";
+          } catch {
+            return false;
+          }
+        });
+        return new Response(null, { status: 404, statusText: "Not Found" });
+      }
+      const body = new ReadableStream({
+        async pull(controller) {
+          if (releaseGguf === null) {
+            controller.enqueue(Buffer.from("ab"));
+            await new Promise<void>((resolve) => {
+              releaseGguf = resolve;
+            });
+            controller.enqueue(Buffer.from("cd"));
+            return;
+          }
+          controller.close();
+        },
+      });
+      return new Response(body, { status: 200, headers: { "content-length": "4" } });
+    }) as typeof fetch;
+
+    const outcome = await runDownloadWorker({
+      dataDir,
+      kind: "chat",
+      modelId: VISION.id,
+      mode: "with-mmproj",
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+    });
+    releaseGguf?.();
+
+    expect(outcome).toBe("failed");
+    const job = readDownloadJob(dataDir, downloadJobId("chat", VISION.id));
+    expect(job?.status).toBe("failed");
+    expect(job?.error).toMatch(/HTTP 404/);
+    const dest = resolveModelFilePath(dataDir, VISION.id, VISION.filename);
+    expect(existsSync(dest)).toBe(false);
+    expect(readFileSync(resolvePartialPath(dest), "utf-8")).toBe("ab");
+  });
+
+  it("initialDownloadJob sums both files of a vision pull that needs both", () => {
+    const job = initialDownloadJob({
+      dataDir,
+      kind: "chat",
+      modelId: VISION.id,
+      mode: "with-mmproj",
+      pid: 1,
+    });
+    const gb = (n: number): number => Math.round(n * 1024 * 1024 * 1024);
+    expect(job.label).toBe(`${VISION.name} (gguf + mmproj)`);
+    expect(job.phase).toBe("gguf");
+    expect(job.totalBytes).toBe(gb(VISION.fileSizeGb) + gb(VISION.mmprojFileSizeGb ?? 1));
   });
 
   it("initialDownloadJob reports the partial already on disk instead of 0%", () => {

--- a/src/local-llm/download-worker.ts
+++ b/src/local-llm/download-worker.ts
@@ -7,6 +7,7 @@ import {
   type DownloadJobKind,
   type DownloadJobMode,
 } from "./download-jobs.js";
+import { downloadGgufAndMmprojTogether } from "./download-worker-pair.js";
 import {
   downloadEmbeddingModel,
   downloadMmproj,
@@ -24,8 +25,8 @@ import {
 /**
  * The body of a background download: fetch the files for one job while
  * keeping its record on disk current. Runs inside the detached worker
- * process (`models pull-worker`), but takes everything as arguments so
- * a test can drive it in-process against a mocked `fetch`.
+ * (`models pull-worker`) but takes everything as arguments, so a test can
+ * drive it in-process against a mocked `fetch`.
  */
 export interface DownloadWorkerInput {
   dataDir: string;
@@ -46,16 +47,15 @@ export type DownloadWorkerOutcome = "done" | "failed" | "cancelled";
 
 const DEFAULT_WRITE_INTERVAL_MS = 500;
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === "AbortError";
-}
+const isAbortError = (err: unknown): boolean =>
+  err instanceof Error && err.name === "AbortError";
 
 /**
  * Seed the record a spawner writes the instant the worker is launched,
  * so `models downloads` lists the job before the worker has opened its
  * first socket. The worker overwrites it with real numbers as soon as
- * they exist. The partial already on disk (if any) is reported from
- * the start, so a resumed job never shows 0% even for a moment.
+ * they exist; partials already on disk count from the start, so a
+ * resumed job never shows 0% even for a moment.
  */
 export function initialDownloadJob(input: {
   dataDir: string;
@@ -66,10 +66,14 @@ export function initialDownloadJob(input: {
   now?: Date;
 }): DownloadJob {
   const now = (input.now ?? new Date()).toISOString();
-  const { label, dest, estTotal } = describeFirstPhase(input);
-  const partial = readPartialDownload(dest);
-  const transferred = partial?.transferred ?? 0;
-  const total = partial?.total || estTotal;
+  const { label, phase, files } = describeJobFiles(input);
+  let transferred = 0;
+  let total = 0;
+  for (const file of files) {
+    const partial = readPartialDownload(file.dest);
+    transferred += partial?.transferred ?? 0;
+    total += partial?.total || file.estTotal;
+  }
   return {
     version: 1,
     id: downloadJobId(input.kind, input.modelId),
@@ -78,7 +82,7 @@ export function initialDownloadJob(input: {
     mode: input.mode,
     pid: input.pid,
     status: "running",
-    phase: input.kind === "chat" && input.mode === "mmproj-only" ? "mmproj" : "gguf",
+    phase,
     label,
     percent: total > 0 ? Math.round((transferred / total) * 100) : 0,
     transferredBytes: transferred,
@@ -90,44 +94,68 @@ export function initialDownloadJob(input: {
   };
 }
 
-function describeFirstPhase(input: {
+const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
+
+interface JobFile {
+  dest: string;
+  estTotal: number;
+}
+
+/**
+ * What a job is about to fetch, as the record describes it from its
+ * first write. A vision pull that still needs both files is one job over
+ * two files fetched together: the label names both and the byte counts
+ * are their sum, so the TUI's bar never resets between files.
+ */
+function describeJobFiles(input: {
   dataDir: string;
   kind: DownloadJobKind;
   modelId: string;
   mode: DownloadJobMode;
-}): { label: string; dest: string; estTotal: number } {
-  const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
+}): { label: string; phase: DownloadJob["phase"]; files: JobFile[] } {
   if (input.kind === "embedding") {
     const def = getEmbeddingModelDef(input.modelId as EmbeddingModelId);
     return {
       label: def.name,
-      dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
-      estTotal: gb(def.fileSizeGb),
+      phase: "gguf",
+      files: [
+        {
+          dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
+          estTotal: gb(def.fileSizeGb),
+        },
+      ],
     };
   }
   const def = getLocalModelDef(input.modelId as LocalModelId);
-  const ggufDone = isModelDownloaded(input.dataDir, def);
-  const mmprojPhase =
-    input.mode === "mmproj-only" || (input.mode === "with-mmproj" && ggufDone);
-  if (mmprojPhase && def.mmprojFilename) {
-    return {
-      label: `${def.name} (mmproj)`,
-      dest: resolveMmprojFilePath(input.dataDir, def.id, def.mmprojFilename),
-      estTotal: gb(def.mmprojFileSizeGb ?? 1),
-    };
-  }
-  return {
-    label: `${def.name} (gguf)`,
+  const gguf: JobFile = {
     dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
     estTotal: gb(def.fileSizeGb),
   };
+  const mmproj: JobFile | null = def.mmprojFilename
+    ? {
+        dest: resolveMmprojFilePath(input.dataDir, def.id, def.mmprojFilename),
+        estTotal: gb(def.mmprojFileSizeGb ?? 1),
+      }
+    : null;
+  const needGguf = input.mode !== "mmproj-only" && !isModelDownloaded(input.dataDir, def);
+  const needMmproj =
+    mmproj !== null &&
+    (input.mode === "with-mmproj" || input.mode === "mmproj-only") &&
+    !isMmprojDownloaded(input.dataDir, def);
+  if (needGguf && needMmproj && mmproj) {
+    return { label: `${def.name} (gguf + mmproj)`, phase: "gguf", files: [gguf, mmproj] };
+  }
+  if (needMmproj && mmproj) {
+    return { label: `${def.name} (mmproj)`, phase: "mmproj", files: [mmproj] };
+  }
+  return { label: `${def.name} (gguf)`, phase: "gguf", files: [gguf] };
 }
 
 /**
  * Run one job to completion. Never throws for a download failure — the
- * outcome is the return value and the record on disk; the worker
- * process maps it to an exit code. Throws only for a bad job spec (an
- * unknown model id), which the spawner should have rejected already.
+ * outcome is the return value and the record on disk; the worker maps it
+ * to an exit code. Throws only for a bad job spec (an unknown model id),
+ * which the spawner should have rejected already.
  */
 export async function runDownloadWorker(
   input: DownloadWorkerInput,
@@ -201,8 +229,6 @@ export async function runDownloadWorker(
       },
     };
   };
-  const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
-
   try {
     if (input.kind === "embedding") {
       const def = getEmbeddingModelDef(input.modelId as EmbeddingModelId);
@@ -221,7 +247,12 @@ export async function runDownloadWorker(
       const wantGguf = input.mode !== "mmproj-only";
       const wantMmproj =
         def.supportsVision && (input.mode === "with-mmproj" || input.mode === "mmproj-only");
-      if (wantGguf && !isModelDownloaded(input.dataDir, def)) {
+      const needGguf = wantGguf && !isModelDownloaded(input.dataDir, def);
+      const needMmproj = wantMmproj && !isMmprojDownloaded(input.dataDir, def);
+      if (needGguf && needMmproj) {
+        await downloadGgufAndMmprojTogether(def, input, { persist, log, stamp });
+      }
+      if (needGguf && !needMmproj) {
         await downloadModel(
           input.dataDir,
           def,
@@ -234,7 +265,7 @@ export async function runDownloadWorker(
         );
         log(`[${stamp()}] gguf complete`);
       }
-      if (wantMmproj && !isMmprojDownloaded(input.dataDir, def)) {
+      if (needMmproj && !needGguf) {
         await downloadMmproj(
           input.dataDir,
           def,
@@ -266,3 +297,4 @@ export async function runDownloadWorker(
     return "failed";
   }
 }
+

--- a/src/tui/local-models/local-models-orchestrator-downloads.test.ts
+++ b/src/tui/local-models/local-models-orchestrator-downloads.test.ts
@@ -12,6 +12,7 @@ import {
   initialDownloadJob,
   readDownloadJob,
   resolveBackendDir,
+  resolveMmprojFilePath,
   resolveModelFilePath,
   resolvePartialMetaPath,
   resolvePartialPath,
@@ -207,7 +208,7 @@ describe("LocalModelsOrchestrator — pulls through the download worker", () => 
     expect(readDownloadJob(dataDir, "chat-qwen-3.5-4b")).toBeNull();
   });
 
-  it("re-emits pull_started when the worker moves from the GGUF to the mmproj phase", async () => {
+  it("pulls a vision model's GGUF and mmproj as one job with a summed record", async () => {
     globalThis.fetch = vi.fn(async () =>
       new Response(bodyOf(["zz"]), { status: 200, headers: { "content-length": "2" } }),
     ) as typeof fetch;
@@ -215,16 +216,20 @@ describe("LocalModelsOrchestrator — pulls through the download worker", () => 
     // qwen-3.5-9b is vision-capable in the current catalog.
     await orchestrator.pullModel("qwen-3.5-9b");
 
-    const labels = actions
-      .filter(
-        (a): a is Extract<EmittedAction, { type: "local_models_pull_started" }> =>
-          a.type === "local_models_pull_started",
-      )
-      .map((a) => a.pull.label);
-    expect(labels).toHaveLength(2);
-    expect(labels[0]).toMatch(/gguf/);
-    expect(labels[1]).toMatch(/mmproj/);
+    const started = actions.filter(
+      (a): a is Extract<EmittedAction, { type: "local_models_pull_started" }> =>
+        a.type === "local_models_pull_started",
+    );
+    // Both files download together under one label; the bar is drawn
+    // from their summed bytes rather than restarting for the projector.
+    expect(started.map((a) => a.pull.label)).toEqual(["Qwen 3.5 9B GGUF (gguf + mmproj)"]);
     expect(actions.filter((a) => a.type === "local_models_pull_finished")).toHaveLength(1);
+    const dataDir = getConfig().paths.localModelsDataDir;
+    const def = getLocalModelDef("qwen-3.5-9b");
+    expect(existsSync(resolveModelFilePath(dataDir, def.id, def.filename))).toBe(true);
+    expect(
+      existsSync(resolveMmprojFilePath(dataDir, def.id, def.mmprojFilename ?? "")),
+    ).toBe(true);
   });
 
   it("a second pull detaches the watch; the first worker keeps going and its file still lands", async () => {

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -369,10 +369,9 @@ export class LocalModelsOrchestrator {
    * worker's job record and turns it into the panel's pull events.
    *
    * Modes:
-   * - `"with-mmproj"` (default for vision-capable rows): pull GGUF then
-   *   mmproj sequentially under one download banner. The banner label
-   *   updates between phases. If the GGUF is already on disk we skip
-   *   straight to the projector phase.
+   * - `"with-mmproj"` (default for vision-capable rows): pull GGUF and
+   *   mmproj together under one download banner whose bytes are their
+   *   sum. If the GGUF is already on disk only the projector is fetched.
    * - `"gguf-only"` (`g` hotkey): pull the GGUF only, even for
    *   vision-capable models — used when the operator wants a fast
    *   text-only smoke test.


### PR DESCRIPTION
## What
A vision model's background pull (`models pull <id> --mmproj --background`, and every pull started from the TUI Models tab) fetched the GGUF weights and then the mmproj projector one after the other. When both files are missing the worker now downloads them side by side under one job record: the label reads `<model> (gguf + mmproj)`, `transferredBytes`/`totalBytes` are the sum of both files so the TUI bar never resets between them, `phase` flips from `gguf` to `mmproj` once the weights land, and a failure or cancel in either file stops the other with both partials kept for resume. Pulls that need only one of the two files (`gguf-only`, `mmproj-only`, or a projector added to an already-downloaded model) behave exactly as before.

`initialDownloadJob` seeds the summed totals, so the record the spawner writes before the worker opens its first socket already shows the right size and the right "already on disk" share.

## Why
The projector is a few hundred MB next to a multi-GB GGUF; waiting for the weights to finish before starting it added the projector's whole transfer time to every vision pull. Overlapping the two costs nothing on a per-connection-throttled CDN and simplifies what the TUI shows: one banner, one bar, one total.

The pair lives in `download-worker-pair.ts` to keep `download-worker.ts` under the 300-line rule. Independent of #354 (parallel connections per file); the two compose.

## How it was verified
- `npm run lint` clean
- `npx vitest run src/local-llm/download-worker.test.ts src/tui/local-models src/cli` — 26 files / 258 tests green (baseline failures: none)
- New tests: both files fetched concurrently (each mocked body waits for the other request before delivering, so the test only passes when the transfers overlap) under a summed `done` record; a 404 on the projector cancels the weights and keeps their partial; `initialDownloadJob` sums both files. The TUI orchestrator test that asserted two sequential `pull_started` labels now asserts the single combined label and both files on disk.
