### PR TITLE
fix(models): background downloads wait out offline periods and resume on relaunch

### DIFF
--- a/src/cli/models-downloads.test.ts
+++ b/src/cli/models-downloads.test.ts
@@ -41,8 +41,10 @@ function job(patch: Partial<DownloadJob> = {}): DownloadJob {
     transferredBytes: 4_000_000,
     totalBytes: 10_000_000,
     error: null,
+    waiting: null,
+    resumable: false,
     startedAt: "2026-09-07T10:00:00.000Z",
-    updatedAt: "2026-09-07T10:00:05.000Z",
+    updatedAt: new Date().toISOString(),
     finishedAt: null,
     ...patch,
   };

--- a/src/cli/models-downloads.ts
+++ b/src/cli/models-downloads.ts
@@ -1,6 +1,8 @@
 import { getConfig } from "../config/index.js";
 import {
   downloadJobId,
+  downloadJobSilenceMs,
+  isDownloadJobStale,
   listDownloadJobs,
   readDownloadJob,
   removeDownloadJob,
@@ -72,17 +74,35 @@ function formatBytes(bytes: number): string {
   return `${Math.round(bytes / (1024 * 1024))} MB`;
 }
 
-export function describeDownloadJob(job: DownloadJob): string {
+/** `waiting for network (attempt 4, retry in 32s)` — or `null` while bytes flow. */
+export function describeDownloadWait(
+  job: Pick<DownloadJob, "waiting">,
+  now: number = Date.now(),
+): string | null {
+  if (!job.waiting) return null;
+  const inMs = Date.parse(job.waiting.nextRetryAt) - now;
+  const when = Number.isFinite(inMs) && inMs > 0 ? `retry in ${Math.ceil(inMs / 1000)}s` : "retrying";
+  return `waiting for network (attempt ${job.waiting.attempt}, ${when})`;
+}
+
+export function describeDownloadJob(job: DownloadJob, now: number = Date.now()): string {
   const size =
     job.totalBytes > 0
       ? `${formatBytes(job.transferredBytes)} / ${formatBytes(job.totalBytes)}`
       : formatBytes(job.transferredBytes);
-  const state =
-    job.status === "running"
-      ? `running (pid ${job.pid}) ${job.percent}%`
-      : job.status === "failed"
-        ? `failed: ${job.error ?? "unknown error"}`
-        : job.status;
+  let state: string;
+  if (job.status === "running") {
+    const wait = describeDownloadWait(job, now);
+    state = `running (pid ${job.pid}) ${job.percent}%`;
+    if (wait) state += ` · ${wait}`;
+    else if (isDownloadJobStale(job, now)) {
+      state += ` · not reporting for ${Math.round(downloadJobSilenceMs(job, now) / 60_000)} min`;
+    }
+  } else if (job.status === "failed") {
+    state = `failed: ${job.error ?? "unknown error"}${job.resumable ? " (resumes on next launch)" : ""}`;
+  } else {
+    state = job.status;
+  }
   return `${job.id.padEnd(40)} ${state.padEnd(28)} ${size}  ${job.label}`;
 }
 
@@ -187,6 +207,7 @@ export async function followDownloadJob(
   };
   if (opts?.sigint !== false) process.once("SIGINT", onSigint);
   let lastPercent = -1;
+  let lastWait: string | null = null;
   try {
     for (;;) {
       const job = readDownloadJob(dataDir, jobId);
@@ -205,12 +226,17 @@ export async function followDownloadJob(
         process.stderr.write(`${line}\n`);
       }
       lastPercent = job.percent;
+      const wait = describeDownloadWait(job);
+      if (wait !== lastWait) {
+        if (wait) process.stderr.write(`${tty ? "\n" : ""}${wait} — the partial file is kept\n`);
+        lastWait = wait;
+      }
       if (job.status !== "running") {
         if (tty) process.stderr.write("\n");
         if (job.status === "done") return 0;
         process.stderr.write(
           job.status === "failed"
-            ? `background download failed: ${job.error ?? "unknown error"}\n`
+            ? `background download failed: ${job.error ?? "unknown error"}${job.resumable ? ` — partial kept; run 'models pull ${job.modelId}' or relaunch the app to resume` : ""}\n`
             : `background download ${job.status}; partial kept — run 'models pull ${job.modelId}' to resume\n`,
         );
         return 1;

--- a/src/cli/models-handlers.ts
+++ b/src/cli/models-handlers.ts
@@ -9,6 +9,7 @@ import {
   downloadEmbeddingModel,
   downloadJobId,
   downloadMmproj,
+  DownloadGaveUpError,
   downloadModel,
   EMBEDDING_MODELS_CATALOG,
   fallBackToCpuBackend,
@@ -162,6 +163,11 @@ export async function runLocalModelsPull(args: string[]): Promise<number> {
   } catch (e) {
     if (tty) process.stderr.write(`\n`);
     process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
+    if (e instanceof DownloadGaveUpError) {
+      process.stderr.write(
+        `the partial file is kept — 'models pull --background ${m.id}' waits out an outage for days and resumes by itself\n`,
+      );
+    }
     return 1;
   }
 }

--- a/src/cli/pull-progress.ts
+++ b/src/cli/pull-progress.ts
@@ -15,11 +15,18 @@ export function formatGb(bytes: number): string {
  */
 export function renderPullRetry(info: {
   attempt: number;
+  kind?: "transport" | "server";
   maxRetries: number;
   delayMs: number;
   error: Error;
 }): string {
-  return `download interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s, resuming from the partial file`;
+  const wait = `${Math.round(info.delayMs / 1000)}s`;
+  if (info.kind === "server") {
+    return `download interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${wait}, resuming from the partial file`;
+  }
+  // The link, not the server: there is no count to run out of. The
+  // partial waits for the network to come back — for days if it must.
+  return `download interrupted (${info.error.message}) — waiting for the network, attempt ${info.attempt}, next try in ${wait}; the partial file is kept`;
 }
 
 export function renderPullProgress(

--- a/src/local-llm/backend-installer.test.ts
+++ b/src/local-llm/backend-installer.test.ts
@@ -248,10 +248,11 @@ describe("backend-installer", () => {
     }) as typeof fetch;
 
     try {
-      // One quick retry: the failure has to survive the downloader's own
-      // resume-and-retry loop before the staging cleanup is exercised.
+      // No patience: a dropped connection is retried for days by default,
+      // and the staging cleanup is only exercised once the downloader has
+      // given up. A zero no-progress window makes that the first failure.
       await expect(
-        downloadBackend(dir, { maxRetries: 1, retryDelayMs: 1 }),
+        downloadBackend(dir, { maxRetries: 1, retryDelayMs: 1, giveUpAfterMs: 0 }),
       ).rejects.toThrow(/socket hang up/);
 
       const binPath = resolveServerBinPath(dir, "llama-server");

--- a/src/local-llm/backend-installer.ts
+++ b/src/local-llm/backend-installer.ts
@@ -243,7 +243,7 @@ export async function downloadBackend(
   dataDir: string,
   opts?: Pick<
     DownloadFileOptions,
-    "onProgress" | "onRetry" | "signal" | "maxRetries" | "retryDelayMs"
+    "onProgress" | "onRetry" | "signal" | "maxRetries" | "retryDelayMs" | "giveUpAfterMs"
   >,
 ): Promise<{ ok: true; tag: string }> {
   const { assetName, binaryName } = resolveDownloadAsset();

--- a/src/local-llm/download-errors.test.ts
+++ b/src/local-llm/download-errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DownloadGaveUpError,
+  DownloadHttpError,
+  StalledError,
+  classifyDownloadError,
+  createAbortError,
+  isResumableDownloadError,
+  isRetryableDownloadError,
+} from "./download-errors.js";
+
+function fetchFailed(code: string): TypeError {
+  return Object.assign(new TypeError("fetch failed"), {
+    cause: Object.assign(new Error(code), { code }),
+  });
+}
+
+describe("classifyDownloadError", () => {
+  it("sorts the link, the server, the setup and the caller apart", () => {
+    expect(classifyDownloadError(fetchFailed("ENOTFOUND"))).toBe("transport");
+    expect(classifyDownloadError(fetchFailed("ECONNRESET"))).toBe("transport");
+    expect(classifyDownloadError(new StalledError(60_000))).toBe("transport");
+    expect(classifyDownloadError(new Error("other side closed"))).toBe("transport");
+    // A body cut mid-stream, as undici reports it.
+    expect(
+      classifyDownloadError(
+        Object.assign(new TypeError("terminated"), {
+          cause: Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" }),
+        }),
+      ),
+    ).toBe("transport");
+    expect(classifyDownloadError(fetchFailed("UND_ERR_CONNECT_TIMEOUT"))).toBe("transport");
+    expect(classifyDownloadError(new DownloadHttpError(503, "Unavailable"))).toBe("server");
+    expect(classifyDownloadError(new DownloadHttpError(429, "Too Many"))).toBe("server");
+    expect(classifyDownloadError(new DownloadHttpError(404, "Not Found"))).toBe("fatal");
+    expect(classifyDownloadError(Object.assign(new Error("ENOSPC"), { code: "ENOSPC" }))).toBe("fatal");
+    expect(classifyDownloadError(fetchFailed("DEPTH_ZERO_SELF_SIGNED_CERT"))).toBe("fatal");
+    expect(classifyDownloadError(Object.assign(new TypeError("Invalid URL"), { code: "ERR_INVALID_URL" }))).toBe("fatal");
+    expect(classifyDownloadError(new TypeError("x is not a function"))).toBe("fatal");
+    expect(classifyDownloadError(createAbortError())).toBe("aborted");
+    expect(
+      classifyDownloadError(new DownloadGaveUpError("no-progress", "no progress", new Error("x"))),
+    ).toBe("fatal");
+  });
+
+  it("answers retryable and resumable from the same classification", () => {
+    expect(isRetryableDownloadError(fetchFailed("EAI_AGAIN"))).toBe(true);
+    expect(isRetryableDownloadError(new DownloadHttpError(500, "x"))).toBe(true);
+    expect(isRetryableDownloadError(new DownloadHttpError(401, "x"))).toBe(false);
+    expect(isResumableDownloadError(fetchFailed("EAI_AGAIN"))).toBe(true);
+    // A give-up is fatal for this call but resumable for the next one.
+    expect(isResumableDownloadError(new DownloadGaveUpError("deadline", "d", new Error("x")))).toBe(true);
+    expect(isResumableDownloadError(new DownloadHttpError(503, "x"))).toBe(false);
+    expect(isResumableDownloadError(new DownloadHttpError(404, "x"))).toBe(false);
+  });
+});

--- a/src/local-llm/download-errors.ts
+++ b/src/local-llm/download-errors.ts
@@ -1,0 +1,201 @@
+/**
+ * How a failed download attempt is sorted into a retry policy. Kept
+ * apart from the transfer loop so the worker, the CLI and the TUI can
+ * ask "is this worth starting again later?" without importing `fetch`
+ * plumbing.
+ */
+
+/**
+ * Why an attempt died, as far as retrying is concerned.
+ *
+ * - `transport`: the link, not the file — DNS, a reset, a stall, a
+ *   captive portal. The bytes on disk are still right; the next attempt
+ *   asks for the rest. Retried until the outage outlives `giveUpAfterMs`.
+ * - `server`: the origin answered but would not serve (5xx, 408, 429).
+ *   Retried a bounded number of times: a mirror that is broken now is
+ *   usually broken in a minute too, and the operator should hear about it.
+ * - `fatal`: nothing another attempt could change — a 404, a 401, a full
+ *   disk, a file that changed under us.
+ * - `aborted`: the caller's signal fired.
+ */
+export type DownloadErrorKind = "transport" | "server" | "fatal" | "aborted";
+
+export class DownloadHttpError extends Error {
+  constructor(
+    readonly status: number,
+    statusText: string,
+  ) {
+    super(`Download failed: HTTP ${status} ${statusText}`);
+    this.name = "DownloadHttpError";
+  }
+}
+
+export class StalledError extends Error {
+  constructor(ms: number) {
+    super(`Download stalled: no data for ${Math.round(ms / 1000)}s`);
+    this.name = "StalledError";
+  }
+}
+
+/**
+ * The link was answered by something that is not the file: a hotel
+ * Wi-Fi splash page, a proxy's block page. Retried like any transport
+ * failure — the partial is kept, the next attempt asks again once the
+ * portal has been clicked through.
+ */
+export class InterceptedError extends Error {
+  constructor(detail: string) {
+    super(`Download intercepted: ${detail}`);
+    this.name = "InterceptedError";
+  }
+}
+
+/**
+ * A transport outage outlived its budget (or the caller's deadline).
+ * The partial is intact; a later `downloadFile` for the same destination
+ * resumes it. Classified `fatal` so nothing retries it further.
+ */
+export class DownloadGaveUpError extends Error {
+  constructor(
+    readonly reason: "no-progress" | "deadline",
+    detail: string,
+    override readonly cause: Error,
+  ) {
+    super(`Download gave up: ${detail} (last error: ${cause.message})`);
+    this.name = "DownloadGaveUpError";
+  }
+}
+
+/** Errno codes that mean "the network", not "this machine". */
+const TRANSPORT_ERRNO = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ECONNABORTED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EAI_FAIL",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "ENETRESET",
+  "EHOSTUNREACH",
+  "EHOSTDOWN",
+  "EADDRNOTAVAIL",
+]);
+
+/** Errno codes no retry can fix: the disk, not the link. */
+const LOCAL_ERRNO = new Set([
+  "ENOSPC",
+  "EACCES",
+  "EPERM",
+  "EROFS",
+  "EMFILE",
+  "ENFILE",
+  "EISDIR",
+  "ENOTDIR",
+  "EIO",
+  "EDQUOT",
+  "EBADF",
+]);
+
+/**
+ * Errno-style codes that name a broken *setup*, not a broken link: a
+ * malformed URL, a certificate the machine will not trust. Retrying
+ * them every minute for a week would only fill the log with the same
+ * complaint.
+ */
+const FATAL_CODE_PREFIXES = ["ERR_INVALID_", "ERR_TLS_", "ERR_SSL_", "ERR_OSSL_"];
+const FATAL_CODES = new Set([
+  "CERT_HAS_EXPIRED",
+  "CERT_NOT_YET_VALID",
+  "CERT_REVOKED",
+  "CERT_UNTRUSTED",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "HOSTNAME_MISMATCH",
+]);
+
+function isFatalCode(code: string): boolean {
+  return FATAL_CODES.has(code) || FATAL_CODE_PREFIXES.some((p) => code.startsWith(p));
+}
+
+function errnoOf(err: unknown): string | null {
+  let cur: unknown = err;
+  for (let depth = 0; depth < 4 && cur && typeof cur === "object"; depth += 1) {
+    const code = (cur as { code?: unknown }).code;
+    if (typeof code === "string") return code;
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return null;
+}
+
+export function createAbortError(): Error {
+  const err = new Error("Download aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Sort a failed attempt into the retry policy that applies to it. An
+ * undici `TypeError: fetch failed` carries the errno in `cause`; a
+ * `write` on a full disk carries it on the error itself. Anything
+ * unrecognised is treated as the link — that is the failure a download
+ * of this size meets in practice, and retrying it costs nothing.
+ */
+export function classifyDownloadError(err: unknown): DownloadErrorKind {
+  if (isAbortError(err)) return "aborted";
+  if (err instanceof DownloadGaveUpError) return "fatal";
+  if (err instanceof StalledError || err instanceof InterceptedError) {
+    return "transport";
+  }
+  if (err instanceof DownloadHttpError) {
+    return err.status === 408 || err.status === 429 || err.status >= 500
+      ? "server"
+      : "fatal";
+  }
+  const code = errnoOf(err);
+  if (code && (LOCAL_ERRNO.has(code) || isFatalCode(code))) return "fatal";
+  if (code && (TRANSPORT_ERRNO.has(code) || code.startsWith("UND_ERR_"))) return "transport";
+  // undici reports network failures as a TypeError — `fetch failed` for
+  // the connection, `terminated` for a body cut short — always with the
+  // underlying error in `cause`. A TypeError with no cause at all is a
+  // bug in this program, which no amount of waiting fixes.
+  if (
+    err instanceof TypeError &&
+    (err as { cause?: unknown }).cause === undefined &&
+    !/fetch failed|terminated/i.test(err.message)
+  ) {
+    return "fatal";
+  }
+  return "transport";
+}
+
+/**
+ * Whether another attempt can reasonably succeed. Transport-level
+ * failures (reset, timeout, DNS blip, a socket the CDN dropped mid-body)
+ * and server-side throttling are; a 404 or a 401 is not — the retries
+ * would only delay the same answer.
+ */
+export function isRetryableDownloadError(err: unknown): boolean {
+  const kind = classifyDownloadError(err);
+  return kind === "transport" || kind === "server";
+}
+
+/**
+ * Whether a download that ended with `err` is worth starting again
+ * later: the outage, not the file, was the problem. What a background
+ * worker records so a relaunch knows to pick the job back up.
+ */
+export function isResumableDownloadError(err: unknown): boolean {
+  if (err instanceof DownloadGaveUpError) return true;
+  return classifyDownloadError(err) === "transport";
+}
+

--- a/src/local-llm/download-file.test.ts
+++ b/src/local-llm/download-file.test.ts
@@ -295,7 +295,7 @@ describe("download-file", () => {
     expect(readFileSync(dest, "utf-8")).toBe("abcd");
   });
 
-  it("gives up after maxRetries and keeps the partial for the next call", async () => {
+  it("gives up once a transport outage outlives giveUpAfterMs, keeping the partial", async () => {
     const dest = join(dir, "out.bin");
     globalThis.fetch = mockFetch([
       () =>
@@ -303,17 +303,291 @@ describe("download-file", () => {
           status: 200,
           headers: { "content-length": "5", etag: '"v1"' },
         }),
+    ]).fn;
+
+    // A zero budget: the first transport failure without progress since
+    // the streak began is the last. The partial is not touched.
+    await expect(
+      downloadFile("https://example.com/x", dest, { ...FAST, giveUpAfterMs: 0 }),
+    ).rejects.toThrow(/gave up.*ECONNRESET/);
+    expect(existsSync(dest)).toBe(false);
+    expect(readPartialDownload(dest)).toEqual({ transferred: 2, total: 5 });
+  });
+
+  it("waits out an offline stretch and resumes from the partial when the link is back", async () => {
+    const dest = join(dir, "out.bin");
+    const offline = (): never => {
+      throw Object.assign(new TypeError("fetch failed"), {
+        cause: Object.assign(new Error("getaddrinfo ENOTFOUND huggingface.co"), {
+          code: "ENOTFOUND",
+        }),
+      });
+    };
+    const { calls, fn } = mockFetch([
       () =>
-        new Response(dyingBodyOf([], new Error("read ECONNRESET")), {
+        new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+          status: 200,
+          headers: { "content-length": "5", etag: '"v1"' },
+        }),
+      offline,
+      offline,
+      offline,
+      offline,
+      offline,
+      offline,
+      () =>
+        new Response(bodyOf(["cde"]), {
           status: 206,
           headers: { "content-range": "bytes 2-4/5", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const retries: Array<{ attempt: number; kind: string }> = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      // Seven attempts without progress in 0.5.6 would have been fatal
+      // twice over; here the only budget is the no-progress window.
+      maxRetries: 0,
+      onRetry: (info) => retries.push({ attempt: info.attempt, kind: info.kind }),
+    });
+
+    expect(calls).toHaveLength(8);
+    expect(calls.at(-1)?.get("range")).toBe("bytes=2-");
+    expect(retries.map((r) => r.attempt)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(retries.every((r) => r.kind === "transport")).toBe(true);
+    expect(readFileSync(dest, "utf-8")).toBe("abcde");
+  });
+
+  it("restarts the no-progress window whenever an attempt lands bytes", async () => {
+    // A clock that advances 40ms per reading and a 100ms budget. Every
+    // attempt here is a transport failure; the ones that wrote bytes
+    // first reset the window, so the download survives more of them.
+    const runWith = async (
+      responders: readonly ((headers: Headers) => Response)[],
+    ): Promise<number> => {
+      const dest = join(dir, `out-${responders.length}.bin`);
+      let t = 0;
+      const { calls, fn } = mockFetch(responders);
+      globalThis.fetch = fn;
+      await expect(
+        downloadFile("https://example.com/x", dest, {
+          ...FAST,
+          giveUpAfterMs: 100,
+          now: () => (t += 40),
+        }),
+      ).rejects.toThrow(/gave up/);
+      return calls.length;
+    };
+    const dying = (chunks: readonly string[], status: number, headers: Record<string, string>) => () =>
+      new Response(dyingBodyOf(chunks, new Error("read ECONNRESET")), { status, headers });
+    const first = dying(["ab"], 200, { "content-length": "9", etag: '"v1"' });
+    const progress = dying(["c"], 206, { "content-range": "bytes 2-8/9", etag: '"v1"' });
+    const nothing = dying([], 206, { "content-range": "bytes 2-8/9", etag: '"v1"' });
+
+    // Without progress the window closes after the third attempt …
+    expect(await runWith([first, nothing, nothing, nothing, nothing, nothing])).toBe(3);
+    // … with a byte landing on the third, it stays open two attempts longer.
+    const more = dying([], 206, { "content-range": "bytes 3-8/9", etag: '"v1"' });
+    expect(await runWith([first, nothing, progress, more, more, more, more])).toBe(5);
+  });
+
+  it("does not let a long outage use up the server-error budget", async () => {
+    // Six attempts offline, then the CDN comes back with a 503 before it
+    // serves — the usual order of events. One shared counter would have
+    // read that 503 as attempt seven and failed the download for good.
+    const dest = join(dir, "out.bin");
+    const offline = (): never => {
+      throw Object.assign(new TypeError("fetch failed"), {
+        cause: Object.assign(new Error("ENETDOWN"), { code: "ENETDOWN" }),
+      });
+    };
+    const { calls, fn } = mockFetch([
+      offline,
+      offline,
+      offline,
+      offline,
+      offline,
+      offline,
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+      () => new Response(bodyOf(["ok"]), { status: 200, headers: { "content-length": "2" } }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, { ...FAST, maxRetries: 1 });
+    expect(calls).toHaveLength(8);
+    expect(readFileSync(dest, "utf-8")).toBe("ok");
+  });
+
+  it("counts progress against the best partial so far, not per attempt", async () => {
+    // A proxy that ignores `Range` and cuts every body at two bytes:
+    // each attempt writes bytes, none gets further than the last. That
+    // is not progress, and the window must close on it.
+    const dest = join(dir, "out.bin");
+    const truncating = () =>
+      new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+        status: 200,
+        headers: { "content-length": "5", etag: '"v1"' },
+      });
+    let t = 0;
+    const { calls, fn } = mockFetch([truncating, truncating, truncating, truncating, truncating]);
+    globalThis.fetch = fn;
+
+    await expect(
+      downloadFile("https://example.com/x", dest, {
+        ...FAST,
+        giveUpAfterMs: 100,
+        now: () => (t += 40),
+      }),
+    ).rejects.toThrow(/gave up/);
+    // First attempt reaches 2 bytes (progress: window opens at t=40);
+    // the next two reach 2 again (no progress) and the window closes.
+    expect(calls).toHaveLength(3);
+  });
+
+  it("still bounds server-side errors by maxRetries", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+      () => new Response(null, { status: 503, statusText: "Unavailable" }),
+    ]);
+    globalThis.fetch = fn;
+
+    const kinds: string[] = [];
+    await expect(
+      downloadFile("https://example.com/x", dest, {
+        ...FAST,
+        maxRetries: 1,
+        onRetry: (info) => kinds.push(info.kind),
+      }),
+    ).rejects.toThrow(/HTTP 503/);
+    expect(calls).toHaveLength(2);
+    expect(kinds).toEqual(["server"]);
+  });
+
+  it("stops at once on a local error the link cannot fix", async () => {
+    const dest = join(dir, "out.bin");
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(
+          dyingBodyOf(
+            ["ab"],
+            Object.assign(new Error("ENOSPC: no space left on device, write"), {
+              code: "ENOSPC",
+            }),
+          ),
+          { status: 200, headers: { "content-length": "5" } },
+        ),
+    ]);
+    globalThis.fetch = fn;
+
+    await expect(downloadFile("https://example.com/x", dest, FAST)).rejects.toThrow(/ENOSPC/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("stops at once on a setup error no retry can change", async () => {
+    const dest = join(dir, "out.bin");
+    const cases: Array<() => never> = [
+      () => {
+        throw Object.assign(new TypeError("fetch failed"), {
+          cause: Object.assign(new Error("certificate has expired"), { code: "CERT_HAS_EXPIRED" }),
+        });
+      },
+      () => {
+        throw Object.assign(new TypeError("Invalid URL"), { code: "ERR_INVALID_URL" });
+      },
+      () => {
+        throw new TypeError("Cannot read properties of undefined (reading 'x')");
+      },
+    ];
+    for (const failing of cases) {
+      const { calls, fn } = mockFetch([failing]);
+      globalThis.fetch = fn;
+      await expect(downloadFile("https://example.com/x", dest, FAST)).rejects.toThrow();
+      expect(calls).toHaveLength(1);
+    }
+  });
+
+  it("does not schedule a retry past deadlineAt", async () => {
+    const dest = join(dir, "out.bin");
+    globalThis.fetch = mockFetch([
+      () =>
+        new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+          status: 200,
+          headers: { "content-length": "5", etag: '"v1"' },
         }),
     ]).fn;
 
     await expect(
-      downloadFile("https://example.com/x", dest, { ...FAST, maxRetries: 1 }),
-    ).rejects.toThrow(/ECONNRESET/);
-    expect(existsSync(dest)).toBe(false);
+      downloadFile("https://example.com/x", dest, { ...FAST, deadlineAt: Date.now() - 1 }),
+    ).rejects.toThrow(/time limit/);
+    expect(readPartialDownload(dest)).toEqual({ transferred: 2, total: 5 });
+  });
+
+  it("treats a web page where the file should be as an outage, not as the file", async () => {
+    // A captive portal answers every URL with its splash page. The
+    // partial must survive it: once the operator clicks through, the
+    // next attempt gets the real bytes.
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "ab", { total: 5, etag: '"v1"' });
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["<html>please log in</html>"]), {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      () =>
+        new Response(bodyOf(["cde"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-4/5", etag: '"v1"' },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    const retries: string[] = [];
+    await downloadFile("https://example.com/x", dest, {
+      ...FAST,
+      onRetry: (info) => retries.push(info.error.message),
+    });
+    expect(calls).toHaveLength(2);
+    expect(retries[0]).toMatch(/intercepted.*web page/);
+    expect(readFileSync(dest, "utf-8")).toBe("abcde");
+  });
+
+  it("restarts on a full body of a new length when the server names no validator", async () => {
+    // Without an ETag the server cannot vouch for the partial, so a 200
+    // is what it always was: the file changed, start over.
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "ab", { total: 5, etag: null });
+    const { calls, fn } = mockFetch([
+      () =>
+        new Response(bodyOf(["xyz"]), {
+          status: 200,
+          headers: { "content-length": "3" },
+        }),
+    ]);
+    globalThis.fetch = fn;
+
+    await downloadFile("https://example.com/x", dest, FAST);
+    expect(calls).toHaveLength(1);
+    expect(readFileSync(dest, "utf-8")).toBe("xyz");
+  });
+
+  it("keeps the partial when a full body of the wrong length arrives under the same validator", async () => {
+    const dest = join(dir, "out.bin");
+    seedPartial(dest, "https://example.com/x", "ab", { total: 5, etag: '"v1"' });
+    globalThis.fetch = mockFetch([
+      () =>
+        new Response(bodyOf(["x"]), {
+          status: 200,
+          headers: { "content-length": "999", etag: '"v1"' },
+        }),
+    ]).fn;
+
+    await expect(
+      downloadFile("https://example.com/x", dest, { ...FAST, giveUpAfterMs: 0 }),
+    ).rejects.toThrow(/intercepted/);
     expect(readPartialDownload(dest)).toEqual({ transferred: 2, total: 5 });
   });
 
@@ -480,7 +754,7 @@ describe("download-file", () => {
     await expect(
       downloadFile("https://example.invalid/big.bin", join(dir, "big.bin"), {
         ...FAST,
-        maxRetries: 0,
+        giveUpAfterMs: 0,
         onProgress: (percent, transferred) => {
           seen.push({ percent, transferred });
         },

--- a/src/local-llm/download-file.ts
+++ b/src/local-llm/download-file.ts
@@ -1,7 +1,24 @@
 import * as fs from "node:fs";
 import { dirname } from "node:path";
 
+import {
+  DownloadGaveUpError,
+  DownloadHttpError,
+  InterceptedError,
+  StalledError,
+  classifyDownloadError,
+  createAbortError,
+  type DownloadErrorKind,
+} from "./download-errors.js";
 import { huggingFaceToken } from "./huggingface-api.js";
+
+export {
+  DownloadGaveUpError,
+  classifyDownloadError,
+  isResumableDownloadError,
+  isRetryableDownloadError,
+  type DownloadErrorKind,
+} from "./download-errors.js";
 
 export type DownloadProgressFn = (
   percent: number,
@@ -9,34 +26,64 @@ export type DownloadProgressFn = (
   total: number,
 ) => void;
 
+
 /**
- * Called before each retry. `attempt` is the retry about to run (1-based),
- * `delayMs` how long the downloader is about to wait, `error` why the
- * previous attempt died. Surfaces a stalled link to the operator instead
- * of leaving the progress bar frozen while the backoff runs.
+ * Called before each retry. `attempt` counts consecutive attempts that
+ * made no progress (1-based) — a retry after new bytes landed starts at
+ * 1 again. `delayMs` is how long the downloader is about to wait; `error`
+ * why the previous attempt died; `since` when the no-progress streak
+ * began; `giveUpAt` when a transport streak turns into a failure. Lets a
+ * UI say "offline — retrying" instead of freezing the bar.
  */
-export type DownloadRetryFn = (info: {
+export interface DownloadRetryInfo {
   attempt: number;
+  kind: Exclude<DownloadErrorKind, "fatal" | "aborted">;
+  /** The bound on `server` retries. Transport retries have none. */
   maxRetries: number;
   delayMs: number;
   error: Error;
-}) => void;
+  /** Epoch ms. */
+  since: number;
+  /** Epoch ms. */
+  giveUpAt: number;
+}
+
+export type DownloadRetryFn = (info: DownloadRetryInfo) => void;
 
 export interface DownloadFileOptions {
   onProgress?: DownloadProgressFn;
   onRetry?: DownloadRetryFn;
   userAgent?: string;
   signal?: AbortSignal;
-  /** Retries after a network failure before giving up. Default 5. */
+  /**
+   * Retries after a server-side error (5xx, 408, 429) before giving up.
+   * Default 5. Transport errors are not counted against this — see
+   * `giveUpAfterMs`.
+   */
   maxRetries?: number;
   /** Base of the exponential backoff between retries. Default 1s. */
   retryDelayMs?: number;
+  /** Ceiling of the backoff. Default 60s. */
+  maxRetryDelayMs?: number;
+  /**
+   * How long a transport outage may go on without a single new byte
+   * before the download gives up. Default 10 minutes; the background
+   * worker passes days. Any progress restarts the clock.
+   */
+  giveUpAfterMs?: number;
+  /**
+   * Epoch ms after which no further retry is scheduled, whatever the
+   * progress. A detached worker uses it as a hard cap on its own life.
+   */
+  deadlineAt?: number;
   /**
    * How long the body may go without a single byte before the attempt is
    * declared dead and retried from the partial. Default 60s. `0` disables
    * the watchdog.
    */
   stallTimeoutMs?: number;
+  /** Test seam. */
+  now?: () => number;
 }
 
 /** Sidecar next to the `.part` file: what the partial bytes belong to. */
@@ -50,7 +97,14 @@ export interface PartialDownloadMeta {
 
 const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_RETRY_DELAY_MS = 1_000;
-const MAX_RETRY_DELAY_MS = 30_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 60_000;
+/**
+ * 10 minutes without a byte before an outage becomes a failure — for a
+ * download somebody is sitting in front of (`models pull`, the TUI's
+ * backend zip). The detached worker asks for days; see
+ * `WORKER_GIVE_UP_AFTER_MS`.
+ */
+export const DEFAULT_GIVE_UP_AFTER_MS = 10 * 60 * 1_000;
 const DEFAULT_STALL_TIMEOUT_MS = 60_000;
 
 export function resolvePartialPath(destPath: string): string {
@@ -82,52 +136,10 @@ export function discardPartialDownload(destPath: string): void {
   rmQuiet(resolvePartialMetaPath(destPath));
 }
 
-class DownloadHttpError extends Error {
-  constructor(
-    readonly status: number,
-    statusText: string,
-  ) {
-    super(`Download failed: HTTP ${status} ${statusText}`);
-    this.name = "DownloadHttpError";
-  }
-}
-
-class StalledError extends Error {
-  constructor(ms: number) {
-    super(`Download stalled: no data for ${Math.round(ms / 1000)}s`);
-    this.name = "StalledError";
-  }
-}
-
-function createAbortError(): Error {
-  const err = new Error("Download aborted");
-  err.name = "AbortError";
-  return err;
-}
-
 function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw createAbortError();
   }
-}
-
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === "AbortError";
-}
-
-/**
- * Whether another attempt can reasonably succeed. Transport-level
- * failures (reset, timeout, DNS blip, a socket the CDN dropped mid-body)
- * and server-side throttling are; a 404 or a 401 is not — the retries
- * would only delay the same answer.
- */
-export function isRetryableDownloadError(err: unknown): boolean {
-  if (isAbortError(err)) return false;
-  if (err instanceof StalledError) return true;
-  if (err instanceof DownloadHttpError) {
-    return err.status === 408 || err.status === 429 || err.status >= 500;
-  }
-  return true;
 }
 
 function partialSize(destPath: string): number {
@@ -204,6 +216,14 @@ function validatorsMatch(
   return true;
 }
 
+/** The response carries a validator and it is the one the partial was recorded under. */
+function sameValidator(stored: PartialDownloadMeta, res: Response): boolean {
+  const etag = res.headers.get("etag");
+  if (stored.etag) return etag === stored.etag;
+  const lastModified = res.headers.get("last-modified");
+  return stored.lastModified !== null && lastModified === stored.lastModified;
+}
+
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
@@ -234,9 +254,12 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
  * Only a completed transfer is renamed onto `destPath`.
  *
  * Within one call, transport failures and stalls retry from the partial
- * with exponential backoff (`maxRetries`, default 5). The caller's
- * `signal` cancels everything, including a backoff wait, and is never
- * retried.
+ * with exponential backoff for as long as the outage lasts — up to
+ * `giveUpAfterMs` without a single new byte (10 minutes by default; the
+ * detached worker asks for days, so a machine that goes offline for the
+ * night resumes by itself in the morning). Server-side errors are
+ * bounded by `maxRetries` (default 5) instead. The caller's `signal`
+ * cancels everything, including a backoff wait, and is never retried.
  *
  * Progress counts from the resumed offset, so a UI picking up a 12 GB
  * partial of a 20 GB file starts its bar at 60%, not 0%.
@@ -249,35 +272,83 @@ export async function downloadFile(
   throwIfAborted(opts?.signal);
   const maxRetries = opts?.maxRetries ?? DEFAULT_MAX_RETRIES;
   const baseDelay = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+  const maxDelay = opts?.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+  const giveUpAfterMs = opts?.giveUpAfterMs ?? DEFAULT_GIVE_UP_AFTER_MS;
+  const now = opts?.now ?? Date.now;
 
   // Pre-resume `.tmp` files are unusable: nothing records what they hold.
   rmQuiet(`${destPath}.tmp`);
 
-  for (let attempt = 0; ; attempt += 1) {
+  // The budget is a no-progress *window*, not a count: `attempt` and
+  // `since` restart whenever an attempt carries the partial past its
+  // previous high-water mark, so six blips spread over a three-hour
+  // transfer never add up to a failure, while an outage that outlives
+  // `giveUpAfterMs` does. Progress is measured against the best partial
+  // so far, not per attempt: a proxy that ignores `Range` and cuts every
+  // body at the same point makes each attempt "write bytes" without the
+  // download ever getting anywhere.
+  //
+  // Server errors keep their own counter. Sharing one would let the first
+  // 503 after a long outage — the common case when a CDN comes back —
+  // inherit the outage's attempts and fail the download for good.
+  let attempt = 0;
+  let serverFailures = 0;
+  let since = now();
+  let highWater = partialSize(destPath);
+  for (;;) {
+    const stats = { offset: 0, written: 0 };
     try {
-      await downloadAttempt(url, destPath, opts);
+      await downloadAttempt(url, destPath, opts, stats);
       return;
     } catch (err) {
       throwIfAborted(opts?.signal);
-      if (attempt >= maxRetries || !isRetryableDownloadError(err)) {
-        throw err;
+      const kind = classifyDownloadError(err);
+      if (kind === "fatal" || kind === "aborted") throw err;
+      const error = err instanceof Error ? err : new Error(String(err));
+      const reached = stats.offset + stats.written;
+      if (reached > highWater) {
+        highWater = reached;
+        attempt = 0;
+        serverFailures = 0;
+        since = now();
       }
-      const delayMs = Math.min(baseDelay * 2 ** attempt, MAX_RETRY_DELAY_MS);
-      opts?.onRetry?.({
-        attempt: attempt + 1,
-        maxRetries,
-        delayMs,
-        error: err instanceof Error ? err : new Error(String(err)),
-      });
+      attempt += 1;
+      if (kind === "server") {
+        serverFailures += 1;
+        if (serverFailures > maxRetries) throw err;
+      }
+      const delayMs = Math.min(baseDelay * 2 ** (attempt - 1), maxDelay);
+      const giveUpAt = since + giveUpAfterMs;
+      const t = now();
+      if (opts?.deadlineAt !== undefined && t + delayMs >= opts.deadlineAt) {
+        throw new DownloadGaveUpError("deadline", "the download's time limit was reached", error);
+      }
+      if (kind === "transport" && t + delayMs >= giveUpAt) {
+        throw new DownloadGaveUpError(
+          "no-progress",
+          `no progress for ${formatDuration(giveUpAfterMs)}`,
+          error,
+        );
+      }
+      opts?.onRetry?.({ attempt, kind, maxRetries, delayMs, error, since, giveUpAt });
       await sleep(delayMs, opts?.signal);
     }
   }
 }
 
+function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours} h`;
+  return `${Math.round(hours / 24)} days`;
+}
+
 async function downloadAttempt(
   url: string,
   destPath: string,
-  opts?: DownloadFileOptions,
+  opts: DownloadFileOptions | undefined,
+  stats: { offset: number; written: number },
 ): Promise<void> {
   const partPath = resolvePartialPath(destPath);
   const stallTimeoutMs = opts?.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
@@ -374,6 +445,15 @@ async function downloadAttempt(
       throw new DownloadHttpError(res.status, res.statusText);
     }
 
+    // A page where a file should be is a captive portal or a proxy's
+    // block page, never the model. Writing it over the partial — or
+    // publishing it as a GGUF — would be worse than waiting.
+    const contentType = res.headers.get("content-type") ?? "";
+    if (/^text\/html\b/i.test(contentType.trim())) {
+      await res.body.cancel().catch(() => undefined);
+      throw new InterceptedError(`the server answered with a web page (${contentType.trim()})`);
+    }
+
     let resumed = false;
     let total = 0;
     if (res.status === 206 && offset > 0 && stored) {
@@ -394,11 +474,24 @@ async function downloadAttempt(
       // A full body (200) — either a fresh download or the server would
       // not (or could not, validators changed) honour the range. Whatever
       // is on disk is not this file's prefix.
-      discardPartialDownload(destPath);
-      offset = 0;
       const totalRaw = res.headers.get("content-length");
       total = totalRaw ? parseInt(totalRaw, 10) : 0;
       if (!Number.isFinite(total) || total < 0) total = 0;
+      if (offset > 0 && stored && stored.total > 0 && total > 0 && total !== stored.total) {
+        // The server says this is the very file we have half of, yet
+        // sends a different length: not a new upload but something
+        // standing in for it. Keep the partial. A server that names no
+        // validator gets no such benefit of the doubt — its 200 is a
+        // restart, as it always was.
+        if (sameValidator(stored, res)) {
+          await res.body.cancel().catch(() => undefined);
+          throw new InterceptedError(
+            `full body of ${total} bytes for a ${stored.total}-byte file`,
+          );
+        }
+      }
+      discardPartialDownload(destPath);
+      offset = 0;
     }
 
     fs.mkdirSync(dirname(destPath), { recursive: true });
@@ -409,6 +502,7 @@ async function downloadAttempt(
       lastModified: res.headers.get("last-modified"),
     });
 
+    stats.offset = offset;
     let transferred = offset;
     let lastEmitAt = 0;
     let lastEmittedBytes = -1;
@@ -472,6 +566,7 @@ async function downloadAttempt(
         armStallTimer();
         await handle.write(next.value);
         transferred += next.value.byteLength;
+        stats.written += next.value.byteLength;
         const now = Date.now();
         if (now - lastEmitAt >= PROGRESS_INTERVAL_MS) {
           emitProgress(now);

--- a/src/local-llm/download-job-seed.ts
+++ b/src/local-llm/download-job-seed.ts
@@ -1,0 +1,92 @@
+import { resolveModelFilePath, resolveMmprojFilePath } from "./backend-paths.js";
+import { readPartialDownload } from "./download-file.js";
+import {
+  DOWNLOAD_JOB_VERSION,
+  downloadJobId,
+  type DownloadJob,
+  type DownloadJobKind,
+  type DownloadJobMode,
+} from "./download-jobs.js";
+import { isModelDownloaded } from "./model-installer.js";
+import {
+  getEmbeddingModelDef,
+  getLocalModelDef,
+  type EmbeddingModelId,
+  type LocalModelId,
+} from "./models-catalog.js";
+
+/**
+ * Seed the record a spawner writes the instant the worker is launched,
+ * so `models downloads` lists the job before the worker has opened its
+ * first socket. The worker overwrites it with real numbers as soon as
+ * they exist. The partial already on disk (if any) is reported from
+ * the start, so a resumed job never shows 0% even for a moment.
+ */
+export function initialDownloadJob(input: {
+  dataDir: string;
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+  pid: number;
+  now?: Date;
+}): DownloadJob {
+  const now = (input.now ?? new Date()).toISOString();
+  const { label, dest, estTotal } = describeFirstPhase(input);
+  const partial = readPartialDownload(dest);
+  const transferred = partial?.transferred ?? 0;
+  const total = partial?.total || estTotal;
+  return {
+    version: DOWNLOAD_JOB_VERSION,
+    id: downloadJobId(input.kind, input.modelId),
+    kind: input.kind,
+    modelId: input.modelId,
+    mode: input.mode,
+    pid: input.pid,
+    status: "running",
+    phase: input.kind === "chat" && input.mode === "mmproj-only" ? "mmproj" : "gguf",
+    label,
+    percent: total > 0 ? Math.round((transferred / total) * 100) : 0,
+    transferredBytes: transferred,
+    totalBytes: total,
+    error: null,
+    waiting: null,
+    resumable: false,
+    startedAt: now,
+    updatedAt: now,
+    finishedAt: null,
+  };
+}
+
+function describeFirstPhase(input: {
+  dataDir: string;
+  kind: DownloadJobKind;
+  modelId: string;
+  mode: DownloadJobMode;
+}): { label: string; dest: string; estTotal: number } {
+  const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
+  if (input.kind === "embedding") {
+    const def = getEmbeddingModelDef(input.modelId as EmbeddingModelId);
+    return {
+      label: def.name,
+      dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
+      estTotal: gb(def.fileSizeGb),
+    };
+  }
+  const def = getLocalModelDef(input.modelId as LocalModelId);
+  const ggufDone = isModelDownloaded(input.dataDir, def);
+  const mmprojPhase =
+    input.mode === "mmproj-only" || (input.mode === "with-mmproj" && ggufDone);
+  if (mmprojPhase && def.mmprojFilename) {
+    return {
+      label: `${def.name} (mmproj)`,
+      dest: resolveMmprojFilePath(input.dataDir, def.id, def.mmprojFilename),
+      estTotal: gb(def.mmprojFileSizeGb ?? 1),
+    };
+  }
+  return {
+    label: `${def.name} (gguf)`,
+    dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
+    estTotal: gb(def.fileSizeGb),
+  };
+}
+

--- a/src/local-llm/download-jobs.test.ts
+++ b/src/local-llm/download-jobs.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
@@ -13,7 +14,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   downloadJobId,
+  downloadJobSilenceMs,
   isDownloadJobLive,
+  isDownloadJobStale,
   listDownloadJobs,
   readDownloadJob,
   reconcileDownloadJob,
@@ -43,11 +46,19 @@ function job(patch: Partial<DownloadJob> = {}): DownloadJob {
     transferredBytes: 1200,
     totalBytes: 10_000,
     error: null,
+    waiting: null,
+    resumable: false,
     startedAt: "2026-09-07T10:00:00.000Z",
     updatedAt: "2026-09-07T10:00:05.000Z",
     finishedAt: null,
     ...patch,
   };
+}
+
+/** A 0.5.6 record: same version, no `waiting`, no `resumable`. */
+function legacyJob(patch: Partial<DownloadJob> = {}): Record<string, unknown> {
+  const { waiting: _w, resumable: _r, ...rest } = job(patch);
+  return rest;
 }
 
 describe("download-jobs", () => {
@@ -92,6 +103,47 @@ describe("download-jobs", () => {
     expect(readDownloadJob(dataDir, "bad")).toBeNull();
     expect(readDownloadJob(dataDir, "v9")).toBeNull();
     expect(listDownloadJobs(dataDir).map((j) => j.id)).toEqual(["ok"]);
+  });
+
+  it("fills the additive fields of a 0.5.6 record: an offline failure is resumable, a 404 is not", () => {
+    mkdirSync(resolveDownloadsDir(dataDir), { recursive: true });
+    const write = (id: string, patch: Partial<DownloadJob>): void =>
+      writeFileSync(resolveDownloadJobPath(dataDir, id), JSON.stringify(legacyJob({ id, ...patch })));
+    write("offline", { status: "failed", error: "Download stalled: no data for 60s" });
+    write("gone", { status: "failed", error: "Download failed: HTTP 404 Not Found" });
+    write("throttled", { status: "failed", error: "Download failed: HTTP 429 Too Many Requests" });
+    write("live", { updatedAt: new Date().toISOString() });
+    expect(readDownloadJob(dataDir, "offline")).toMatchObject({
+      version: 1,
+      status: "failed",
+      resumable: true,
+      waiting: null,
+    });
+    expect(readDownloadJob(dataDir, "gone")).toMatchObject({ resumable: false });
+    expect(readDownloadJob(dataDir, "throttled")).toMatchObject({ resumable: true });
+    expect(readDownloadJob(dataDir, "live")).toMatchObject({
+      status: "running",
+      resumable: false,
+      waiting: null,
+    });
+    // An explicit `resumable` is never second-guessed by the heuristic.
+    writeFileSync(
+      resolveDownloadJobPath(dataDir, "explicit"),
+      JSON.stringify({ ...legacyJob({ id: "explicit", status: "failed", error: "Download stalled" }), resumable: false }),
+    );
+    expect(readDownloadJob(dataDir, "explicit")).toMatchObject({ resumable: false });
+  });
+
+  it("calls a running record stale once the worker has been silent for five minutes", () => {
+    const now = Date.parse("2026-09-07T10:10:00.000Z");
+    // updatedAt 10:00:05 → 9m55s of silence.
+    expect(isDownloadJobStale(job(), now)).toBe(true);
+    expect(downloadJobSilenceMs(job(), now)).toBe(595_000);
+    expect(isDownloadJobStale(job({ updatedAt: "2026-09-07T10:06:00.000Z" }), now)).toBe(false);
+    expect(isDownloadJobStale(job({ status: "done" }), now)).toBe(false);
+    expect(isDownloadJobStale(job({ updatedAt: "not a date" }), now)).toBe(true);
+    // The pid probe is untouched by silence: reconcile still says running.
+    expect(reconcileDownloadJob(job(), () => true).status).toBe("running");
   });
 
   it("reports a running job whose worker died as interrupted, and persists that", () => {

--- a/src/local-llm/download-jobs.ts
+++ b/src/local-llm/download-jobs.ts
@@ -30,7 +30,22 @@ import { classifyPidLiveness } from "./daemon-lifecycle.js";
  * again resumes rather than restarts.
  */
 
+/**
+ * Still 1: `waiting` and `resumable` (0.5.7) are additive, and a reader
+ * that does not know them — an older binary sharing the state dir, or
+ * a downgrade — must keep seeing the record, or it would spawn a second
+ * worker onto a partial that is being written.
+ */
 export const DOWNLOAD_JOB_VERSION = 1;
+
+/**
+ * A `running` record older than this has a worker that stopped writing:
+ * the worker heartbeats every 30s even while it waits for the network,
+ * so ten missed beats is not a slow disk. Readers treat such a job as
+ * interrupted after a grace period of their own — a laptop waking from
+ * sleep shows a stale record for a moment before the worker's next beat.
+ */
+export const STALE_RUNNING_MS = 5 * 60 * 1_000;
 
 export type DownloadJobKind = "chat" | "embedding";
 
@@ -44,6 +59,21 @@ export type DownloadJobStatus =
   | "cancelled"
   /** Recorded `running`, but the worker pid is gone. Resumable. */
   | "interrupted";
+
+/**
+ * The worker is between attempts, waiting out a transport failure. The
+ * bytes on disk are not moving and that is expected; a UI shows this
+ * instead of a frozen counter.
+ */
+export interface DownloadJobWaiting {
+  /** The last attempt's error, e.g. `fetch failed`. */
+  reason: string;
+  /** Consecutive attempts without progress. */
+  attempt: number;
+  nextRetryAt: string;
+  /** When the no-progress streak began. */
+  since: string;
+}
 
 export interface DownloadJob {
   version: typeof DOWNLOAD_JOB_VERSION;
@@ -60,6 +90,14 @@ export interface DownloadJob {
   transferredBytes: number;
   totalBytes: number;
   error: string | null;
+  /** Set while the worker waits between attempts; `null` while bytes flow. */
+  waiting: DownloadJobWaiting | null;
+  /**
+   * For a `failed` job: the outage, not the file, was the problem, so
+   * starting the same job again resumes it. A relaunch does that by
+   * itself. `false` for a 404, a full disk, a changed file.
+   */
+  resumable: boolean;
   startedAt: string;
   updatedAt: string;
   finishedAt: string | null;
@@ -114,7 +152,27 @@ function parseDownloadJob(raw: string): DownloadJob | null {
   if (typeof j.id !== "string" || typeof j.modelId !== "string") return null;
   if (j.kind !== "chat" && j.kind !== "embedding") return null;
   if (typeof j.pid !== "number" || typeof j.status !== "string") return null;
-  return j as unknown as DownloadJob;
+  return fillAdditiveFields(j);
+}
+
+/**
+ * 0.5.6 wrote neither `waiting` nor `resumable`, and its worker recorded
+ * an exhausted network budget as a plain `failed`, indistinguishable
+ * from a 404 — that is the record a 0.5.6 user has on disk after going
+ * offline. Read such a failure as resumable unless the error names an
+ * HTTP status a retry cannot change, so the relaunch picks it back up.
+ */
+function fillAdditiveFields(j: Record<string, unknown>): DownloadJob {
+  const error = typeof j.error === "string" ? j.error : null;
+  const resumable =
+    typeof j.resumable === "boolean"
+      ? j.resumable
+      : j.status === "failed" && !/HTTP 4(?!08|29)\d\d/.test(error ?? "");
+  return {
+    ...(j as unknown as DownloadJob),
+    waiting: j.waiting && typeof j.waiting === "object" ? (j.waiting as DownloadJob["waiting"]) : null,
+    resumable,
+  };
 }
 
 /**
@@ -201,4 +259,26 @@ export function removeDownloadJob(dataDir: string, jobId: string): void {
 /** A job the worker may still be driving — or one that died mid-way. */
 export function isDownloadJobLive(job: DownloadJob | null): job is DownloadJob {
   return job !== null && job.status === "running";
+}
+
+/**
+ * A `running` record nobody has written for `STALE_RUNNING_MS`. The pid
+ * may still answer — after a reboot the number can belong to anything —
+ * but the worker that owned this job is not reporting.
+ */
+export function isDownloadJobStale(
+  job: DownloadJob,
+  now: number = Date.now(),
+  thresholdMs: number = STALE_RUNNING_MS,
+): boolean {
+  if (job.status !== "running") return false;
+  const updated = Date.parse(job.updatedAt);
+  if (!Number.isFinite(updated)) return true;
+  return now - updated > thresholdMs;
+}
+
+/** Milliseconds since the record was last written; `0` when unparsable. */
+export function downloadJobSilenceMs(job: DownloadJob, now: number = Date.now()): number {
+  const updated = Date.parse(job.updatedAt);
+  return Number.isFinite(updated) ? Math.max(0, now - updated) : 0;
 }

--- a/src/local-llm/download-spawn.ts
+++ b/src/local-llm/download-spawn.ts
@@ -110,6 +110,35 @@ export function spawnDownloadWorker(
   }
 }
 
+/**
+ * Whether `pid` is one of our download workers, as far as the process
+ * table can say. A `running` record whose pid answers `kill(pid, 0)`
+ * after a reboot may belong to anything — a terminal, a browser — and a
+ * SIGTERM sent on the strength of a stale record would land on it.
+ * Best-effort: an unreadable process table reads as "not ours", which
+ * errs toward leaving the pid alone.
+ */
+export function looksLikeDownloadWorker(pid: number): boolean {
+  try {
+    if (process.platform === "win32") {
+      const out = execSync(`tasklist /FI "PID eq ${pid}" /FO CSV /NH`, {
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).toString();
+      const image = out.split(",")[0]?.replace(/"/g, "").toLowerCase() ?? "";
+      const self = process.execPath.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+      return image.length > 0 && image === self;
+    }
+    const out = execSync(`ps -o args= -p ${pid}`, {
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString();
+    return out.includes("pull-worker");
+  } catch {
+    return false;
+  }
+}
+
 export type StopDownloadWorkerResult =
   | { outcome: "stopped"; job: DownloadJob }
   | { outcome: "not-running"; job: DownloadJob }

--- a/src/local-llm/download-worker.test.ts
+++ b/src/local-llm/download-worker.test.ts
@@ -35,6 +35,20 @@ function bodyOf(chunks: readonly string[]): ReadableStream {
   });
 }
 
+function dyingBodyOf(chunks: readonly string[], error: Error): ReadableStream {
+  const queue = [...chunks];
+  return new ReadableStream({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.error(error);
+        return;
+      }
+      controller.enqueue(Buffer.from(next));
+    },
+  });
+}
+
 describe("download-worker", () => {
   let dataDir: string;
   let prevFetch: typeof fetch;
@@ -106,7 +120,125 @@ describe("download-worker", () => {
     const job = readDownloadJob(dataDir, downloadJobId("chat", CHAT.id));
     expect(job?.status).toBe("failed");
     expect(job?.error).toMatch(/HTTP 404/);
+    // A 404 is the file's fault: relaunching would only ask again.
+    expect(job?.resumable).toBe(false);
     expect(log.at(-1)).toMatch(/failed: .*404/);
+  });
+
+  it("records an outage as resumable so a relaunch picks the job back up", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw Object.assign(new TypeError("fetch failed"), {
+        cause: Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" }),
+      });
+    }) as typeof fetch;
+
+    const outcome = await runDownloadWorker({
+      dataDir,
+      kind: "chat",
+      modelId: CHAT.id,
+      mode: "gguf-only",
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+      giveUpAfterMs: 0,
+      heartbeatMs: 0,
+    });
+
+    expect(outcome).toBe("failed");
+    const job = readDownloadJob(dataDir, downloadJobId("chat", CHAT.id));
+    expect(job).toMatchObject({ status: "failed", resumable: true, waiting: null });
+    expect(job?.error).toMatch(/gave up.*fetch failed/);
+    expect(log.at(-1)).toMatch(/next launch resumes it/);
+  });
+
+  it("shows the wait between attempts in the record and clears it when bytes flow", async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(dyingBodyOf(["ab"], new Error("read ECONNRESET")), {
+          status: 200,
+          headers: { "content-length": "4", etag: '"v1"' },
+        });
+      }
+      if (calls === 2) {
+        throw Object.assign(new TypeError("fetch failed"), {
+          cause: Object.assign(new Error("ENETDOWN"), { code: "ENETDOWN" }),
+        });
+      }
+      expect(new Headers(init?.headers).get("range")).toBe("bytes=2-");
+      return new Response(bodyOf(["cd"]), {
+        status: 206,
+        headers: { "content-range": "bytes 2-3/4", etag: '"v1"' },
+      });
+    }) as typeof fetch;
+
+    const pending = runDownloadWorker({
+      dataDir,
+      kind: "chat",
+      modelId: CHAT.id,
+      mode: "gguf-only",
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+      heartbeatMs: 0,
+      retryDelayMs: 40,
+    });
+    const id = downloadJobId("chat", CHAT.id);
+    await waitFor(() => readDownloadJob(dataDir, id)?.waiting?.attempt === 2);
+    const waiting = readDownloadJob(dataDir, id);
+    expect(waiting).toMatchObject({
+      status: "running",
+      transferredBytes: 2,
+      waiting: { attempt: 2, reason: "fetch failed" },
+    });
+    expect(Date.parse(waiting!.waiting!.nextRetryAt)).toBeGreaterThan(
+      Date.parse(waiting!.waiting!.since),
+    );
+
+    expect(await pending).toBe("done");
+    expect(readDownloadJob(dataDir, id)).toMatchObject({ status: "done", waiting: null });
+    expect(log.some((l) => /waiting for the network, attempt 1/.test(l))).toBe(true);
+  });
+
+  it("heartbeats the record while no bytes arrive", async () => {
+    let release: (() => void) | null = null;
+    const body = new ReadableStream({
+      async pull(controller) {
+        if (release === null) {
+          controller.enqueue(Buffer.from("ab"));
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          controller.enqueue(Buffer.from("cd"));
+          return;
+        }
+        controller.close();
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () => new Response(body, { status: 200, headers: { "content-length": "4" } }),
+    ) as typeof fetch;
+
+    const pending = runDownloadWorker({
+      dataDir,
+      kind: "chat",
+      modelId: CHAT.id,
+      mode: "gguf-only",
+      log: (l) => log.push(l),
+      writeIntervalMs: 0,
+      heartbeatMs: 15,
+    });
+    const id = downloadJobId("chat", CHAT.id);
+    await waitFor(() => release !== null);
+    // The first chunk's progress write lands on its own schedule; wait
+    // for it so the beat is measured against a settled record.
+    await waitFor(() => readDownloadJob(dataDir, id)?.transferredBytes === 2);
+    const first = readDownloadJob(dataDir, id);
+    await waitFor(() => readDownloadJob(dataDir, id)?.updatedAt !== first?.updatedAt);
+    const later = readDownloadJob(dataDir, id);
+    expect(later?.transferredBytes).toBe(first?.transferredBytes);
+    expect(later?.status).toBe("running");
+    release?.();
+    expect(await pending).toBe("done");
   });
 
   it("ends cancelled when the signal fires, with the partial kept for resume", async () => {

--- a/src/local-llm/download-worker.ts
+++ b/src/local-llm/download-worker.ts
@@ -1,7 +1,8 @@
 import { resolveModelFilePath, resolveMmprojFilePath } from "./backend-paths.js";
-import { readPartialDownload } from "./download-file.js";
+import { isResumableDownloadError } from "./download-errors.js";
+import { readPartialDownload, type DownloadRetryInfo } from "./download-file.js";
+import { initialDownloadJob } from "./download-job-seed.js";
 import {
-  downloadJobId,
   writeDownloadJob,
   type DownloadJob,
   type DownloadJobKind,
@@ -21,6 +22,8 @@ import {
   type LocalModelId,
 } from "./models-catalog.js";
 
+export { initialDownloadJob } from "./download-job-seed.js";
+
 /**
  * The body of a background download: fetch the files for one job while
  * keeping its record on disk current. Runs inside the detached worker
@@ -38,6 +41,23 @@ export interface DownloadWorkerInput {
   log?: (line: string) => void;
   /** Progress writes are throttled to this. Default 500ms. */
   writeIntervalMs?: number;
+  /**
+   * The record is rewritten at least this often even when nothing
+   * changes, so a reader can tell "alive, waiting for the network" from
+   * "dead". Default 30s; `0` disables (tests).
+   */
+  heartbeatMs?: number;
+  /** See `DownloadFileOptions.giveUpAfterMs`. Default 7 days. */
+  giveUpAfterMs?: number;
+  /** See `DownloadFileOptions.retryDelayMs`. Test seam. */
+  retryDelayMs?: number;
+  /**
+   * The longest this worker may live, from its start. Default 30 days:
+   * a download nobody has come back for in a month is not going to be
+   * finished by a process that has been waiting all along. The partial
+   * stays; the next launch resumes it.
+   */
+  maxLifetimeMs?: number;
   /** Test seam. */
   now?: () => Date;
 }
@@ -45,82 +65,18 @@ export interface DownloadWorkerInput {
 export type DownloadWorkerOutcome = "done" | "failed" | "cancelled";
 
 const DEFAULT_WRITE_INTERVAL_MS = 500;
+const DEFAULT_HEARTBEAT_MS = 30_000;
+/**
+ * 7 days without a byte before the worker gives up on an outage. Nobody
+ * is watching a detached worker, so it can afford to wait out a weekend
+ * — or a week — away from the network; the partial on disk is what the
+ * operator paid for and the relaunch resumes it either way.
+ */
+export const WORKER_GIVE_UP_AFTER_MS = 7 * 24 * 60 * 60 * 1_000;
+export const DEFAULT_WORKER_LIFETIME_MS = 30 * 24 * 60 * 60 * 1_000;
 
 function isAbortError(err: unknown): boolean {
   return err instanceof Error && err.name === "AbortError";
-}
-
-/**
- * Seed the record a spawner writes the instant the worker is launched,
- * so `models downloads` lists the job before the worker has opened its
- * first socket. The worker overwrites it with real numbers as soon as
- * they exist. The partial already on disk (if any) is reported from
- * the start, so a resumed job never shows 0% even for a moment.
- */
-export function initialDownloadJob(input: {
-  dataDir: string;
-  kind: DownloadJobKind;
-  modelId: string;
-  mode: DownloadJobMode;
-  pid: number;
-  now?: Date;
-}): DownloadJob {
-  const now = (input.now ?? new Date()).toISOString();
-  const { label, dest, estTotal } = describeFirstPhase(input);
-  const partial = readPartialDownload(dest);
-  const transferred = partial?.transferred ?? 0;
-  const total = partial?.total || estTotal;
-  return {
-    version: 1,
-    id: downloadJobId(input.kind, input.modelId),
-    kind: input.kind,
-    modelId: input.modelId,
-    mode: input.mode,
-    pid: input.pid,
-    status: "running",
-    phase: input.kind === "chat" && input.mode === "mmproj-only" ? "mmproj" : "gguf",
-    label,
-    percent: total > 0 ? Math.round((transferred / total) * 100) : 0,
-    transferredBytes: transferred,
-    totalBytes: total,
-    error: null,
-    startedAt: now,
-    updatedAt: now,
-    finishedAt: null,
-  };
-}
-
-function describeFirstPhase(input: {
-  dataDir: string;
-  kind: DownloadJobKind;
-  modelId: string;
-  mode: DownloadJobMode;
-}): { label: string; dest: string; estTotal: number } {
-  const gb = (n: number | undefined): number => Math.round((n ?? 0) * 1024 * 1024 * 1024);
-  if (input.kind === "embedding") {
-    const def = getEmbeddingModelDef(input.modelId as EmbeddingModelId);
-    return {
-      label: def.name,
-      dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
-      estTotal: gb(def.fileSizeGb),
-    };
-  }
-  const def = getLocalModelDef(input.modelId as LocalModelId);
-  const ggufDone = isModelDownloaded(input.dataDir, def);
-  const mmprojPhase =
-    input.mode === "mmproj-only" || (input.mode === "with-mmproj" && ggufDone);
-  if (mmprojPhase && def.mmprojFilename) {
-    return {
-      label: `${def.name} (mmproj)`,
-      dest: resolveMmprojFilePath(input.dataDir, def.id, def.mmprojFilename),
-      estTotal: gb(def.mmprojFileSizeGb ?? 1),
-    };
-  }
-  return {
-    label: `${def.name} (gguf)`,
-    dest: resolveModelFilePath(input.dataDir, def.id, def.filename),
-    estTotal: gb(def.fileSizeGb),
-  };
 }
 
 /**
@@ -135,7 +91,9 @@ export async function runDownloadWorker(
   const log = input.log ?? ((line: string) => process.stdout.write(`${line}\n`));
   const now = input.now ?? (() => new Date());
   const writeIntervalMs = input.writeIntervalMs ?? DEFAULT_WRITE_INTERVAL_MS;
+  const heartbeatMs = input.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
   const stamp = (): string => now().toISOString();
+  const deadlineAt = now().getTime() + (input.maxLifetimeMs ?? DEFAULT_WORKER_LIFETIME_MS);
 
   let job = initialDownloadJob({
     dataDir: input.dataDir,
@@ -157,6 +115,28 @@ export async function runDownloadWorker(
   log(
     `[${stamp()}] start ${job.id} (${job.label}), ${job.transferredBytes} bytes already on disk`,
   );
+  // Between attempts nothing moves the record; the beat is what keeps
+  // it distinguishable from one a dead worker left behind.
+  let heartbeatFailed = false;
+  const heartbeat =
+    heartbeatMs > 0
+      ? setInterval(() => {
+          if (Date.now() - lastWriteAt < heartbeatMs) return;
+          try {
+            persist({}, true);
+          } catch (err) {
+            // A downloads dir that stopped taking writes is not worth
+            // dying over — the transfer is still fine — but it must not
+            // be silent either, or the reader's "stale" verdict looks
+            // like a mystery.
+            if (!heartbeatFailed) {
+              heartbeatFailed = true;
+              log(`[${stamp()}] heartbeat write failed: ${err instanceof Error ? err.message : String(err)}`);
+            }
+          }
+        }, heartbeatMs)
+      : null;
+  heartbeat?.unref();
 
   const phaseOpts = (
     label: string,
@@ -183,20 +163,44 @@ export async function runDownloadWorker(
     let first = true;
     return {
       signal: input.signal,
+      giveUpAfterMs: input.giveUpAfterMs ?? WORKER_GIVE_UP_AFTER_MS,
+      ...(input.retryDelayMs !== undefined ? { retryDelayMs: input.retryDelayMs } : {}),
+      deadlineAt,
       onProgress: (percent: number, transferred: number, total: number) => {
+        // The first byte after an outage closes the waiting state at
+        // once — a forced write, so the UI does not show "offline" over
+        // a moving counter for the throttle interval.
+        const wasWaiting = job.waiting !== null;
         persist(
           {
             percent,
             transferredBytes: transferred,
             totalBytes: total > 0 ? total : estTotal,
+            waiting: null,
           },
-          first,
+          first || wasWaiting,
         );
         first = false;
       },
-      onRetry: (info: { attempt: number; maxRetries: number; delayMs: number; error: Error }) => {
+      onRetry: (info: DownloadRetryInfo) => {
+        const nextRetryAt = new Date(now().getTime() + info.delayMs).toISOString();
+        persist(
+          {
+            waiting: {
+              reason: info.error.message,
+              attempt: info.attempt,
+              nextRetryAt,
+              since: new Date(info.since).toISOString(),
+            },
+          },
+          true,
+        );
+        const budget =
+          info.kind === "server"
+            ? `retry ${info.attempt}/${info.maxRetries}`
+            : `waiting for the network, attempt ${info.attempt}`;
         log(
-          `[${stamp()}] interrupted (${info.error.message}) — retry ${info.attempt}/${info.maxRetries} in ${Math.round(info.delayMs / 1000)}s`,
+          `[${stamp()}] interrupted (${info.error.message}) — ${budget}, next try in ${Math.round(info.delayMs / 1000)}s`,
         );
       },
     };
@@ -249,20 +253,28 @@ export async function runDownloadWorker(
       }
     }
     persist(
-      { status: "done", percent: 100, error: null, finishedAt: stamp() },
+      { status: "done", percent: 100, error: null, waiting: null, finishedAt: stamp() },
       true,
     );
     log(`[${stamp()}] done`);
     return "done";
   } catch (err) {
     if (isAbortError(err) || input.signal?.aborted) {
-      persist({ status: "cancelled", finishedAt: stamp() }, true);
+      persist({ status: "cancelled", waiting: null, finishedAt: stamp() }, true);
       log(`[${stamp()}] cancelled — partial kept for resume`);
       return "cancelled";
     }
     const message = err instanceof Error ? err.message : String(err);
-    persist({ status: "failed", error: message, finishedAt: stamp() }, true);
-    log(`[${stamp()}] failed: ${message}`);
+    const resumable = isResumableDownloadError(err);
+    persist(
+      { status: "failed", error: message, waiting: null, resumable, finishedAt: stamp() },
+      true,
+    );
+    log(
+      `[${stamp()}] failed: ${message}${resumable ? " — partial kept; the next launch resumes it" : ""}`,
+    );
     return "failed";
+  } finally {
+    if (heartbeat) clearInterval(heartbeat);
   }
 }

--- a/src/local-llm/index.ts
+++ b/src/local-llm/index.ts
@@ -51,21 +51,30 @@ export {
 } from "./backend-paths.js";
 
 export {
+  DEFAULT_GIVE_UP_AFTER_MS,
+  DownloadGaveUpError,
+  classifyDownloadError,
   downloadFile,
   discardPartialDownload,
+  isResumableDownloadError,
   isRetryableDownloadError,
   readPartialDownload,
   resolvePartialMetaPath,
   resolvePartialPath,
+  type DownloadErrorKind,
   type DownloadFileOptions,
   type DownloadProgressFn,
   type DownloadRetryFn,
+  type DownloadRetryInfo,
   type PartialDownloadMeta,
 } from "./download-file.js";
 export {
   DOWNLOAD_JOB_VERSION,
+  STALE_RUNNING_MS,
   downloadJobId,
+  downloadJobSilenceMs,
   isDownloadJobLive,
+  isDownloadJobStale,
   listDownloadJobs,
   readDownloadJob,
   reconcileDownloadJob,
@@ -78,9 +87,11 @@ export {
   type DownloadJobKind,
   type DownloadJobMode,
   type DownloadJobStatus,
+  type DownloadJobWaiting,
 } from "./download-jobs.js";
 export {
   downloadWorkerArgs,
+  looksLikeDownloadWorker,
   spawnDownloadWorker,
   stopDownloadWorker,
   type SpawnDownloadWorkerInput,
@@ -88,6 +99,8 @@ export {
   type StopDownloadWorkerResult,
 } from "./download-spawn.js";
 export {
+  DEFAULT_WORKER_LIFETIME_MS,
+  WORKER_GIVE_UP_AFTER_MS,
   initialDownloadJob,
   runDownloadWorker,
   type DownloadWorkerInput,

--- a/src/tui/components/download-chip.test.tsx
+++ b/src/tui/components/download-chip.test.tsx
@@ -52,6 +52,23 @@ describe("DownloadChip", () => {
     expect(tight).not.toContain("█");
   });
 
+  it("swaps the bar for a paused form while the worker waits for the network", () => {
+    const waiting = pull({
+      waiting: { reason: "fetch failed", attempt: 3, nextRetryAt: new Date(Date.now() + 30_000).toISOString() },
+    });
+    const wide = strip(render(<DownloadChip pull={waiting} budget={60} />).lastFrame() ?? "");
+    expect(wide).toContain("⏸");
+    expect(wide).toContain("gemma-4-e4b");
+    expect(wide).toContain("61%");
+    expect(wide).toContain("offline");
+    expect(wide).not.toContain("█");
+    expect(wide).not.toMatch(/minute|second/);
+
+    const tight = strip(render(<DownloadChip pull={waiting} budget={16} />).lastFrame() ?? "");
+    expect(tight).toContain("61%");
+    expect(tight).not.toContain("gemma");
+  });
+
   it("disappears rather than wrapping the one-row bar", () => {
     const view = render(<DownloadChip pull={pull()} budget={6} />);
     expect(strip(view.lastFrame() ?? "").trim()).toBe("");

--- a/src/tui/components/download-chip.tsx
+++ b/src/tui/components/download-chip.tsx
@@ -32,6 +32,10 @@ const DEFAULT_BUDGET = 46;
  */
 const MAX_LABEL_COLUMNS = 30;
 
+function pct(percent: number): string {
+  return `${percent}%`;
+}
+
 function capLabel(label: string): string {
   if (label.length <= MAX_LABEL_COLUMNS) return label;
   return `${label.slice(0, MAX_LABEL_COLUMNS - 1)}…`;
@@ -59,6 +63,20 @@ export function DownloadChip({
   const filled = Math.round((percent / 100) * BAR_WIDTH);
   const label = capLabel(pull.kind === "backend" ? "llama.cpp" : String(pull.modelId));
   if (budget < MINIMAL_COLUMNS) return null;
+  const waiting = pull.waiting ?? null;
+  if (waiting) {
+    // No rate, no ETA, no bar: the worker is waiting for the network and
+    // an ETA computed from zero throughput would say "never".
+    const text = `${label} ${pct(percent)} · offline`;
+    const short = `${pct(percent)} · offline`;
+    const body = budget >= PREFIX_COLUMNS + text.length ? text : short;
+    return (
+      <Text wrap="truncate">
+        <Text color={theme.colors.warn}>{"  ⏸ "}</Text>
+        <Text color={theme.colors.muted}>{body}</Text>
+      </Text>
+    );
+  }
   const percentText = `${percent}%`;
   // prefix + label + space + bar + space + percent — what the BAR form
   // costs with THIS label, so a long-but-capped name sheds to the

--- a/src/tui/components/local-models-panel.tsx
+++ b/src/tui/components/local-models-panel.tsx
@@ -16,6 +16,7 @@ import {
   type LocalModelsPanelState,
   type RamFit,
 } from "../local-models/local-models-panel-state.js";
+import { describePullWaiting } from "../local-models/describe-pull-waiting.js";
 import type { LocalModelDef } from "../../local-llm/index.js";
 import { renderProgressBar } from "./render-progress-bar.js";
 
@@ -205,10 +206,12 @@ function DownloadBanner({
     total !== null ? ` / ${formatDownloadBytes(total)}` : "";
   const isModel = pull.modelId !== "_backend";
   const modelLine = isModel ? `model: ${pull.modelId}` : "target: backend zip";
+  const waiting = pull.waiting ?? null;
   return (
     <Box flexDirection="column">
-      <Text bold color={theme.colors.accentSoft}>
-        downloading — {pull.label}
+      <Text bold color={waiting ? theme.colors.warn : theme.colors.accentSoft}>
+        {waiting ? "download paused — " : "downloading — "}
+        {pull.label}
       </Text>
       <Text color={theme.colors.muted}>{modelLine}</Text>
       <Text>
@@ -222,9 +225,13 @@ function DownloadBanner({
           {totalPart}
         </Text>
       </Text>
+      {waiting ? (
+        <Text color={theme.colors.warn}>{describePullWaiting(waiting)}</Text>
+      ) : null}
     </Box>
   );
 }
+
 
 export function LocalModelsPanel({
   panel,

--- a/src/tui/local-models/describe-pull-waiting.test.ts
+++ b/src/tui/local-models/describe-pull-waiting.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { describePullWaiting } from "./describe-pull-waiting.js";
+
+describe("describePullWaiting", () => {
+  const now = Date.parse("2026-09-08T18:30:00.000Z");
+
+  it("says how long until the next attempt and why the last one died", () => {
+    const line = describePullWaiting(
+      { reason: "fetch failed", attempt: 4, nextRetryAt: "2026-09-08T18:30:32.000Z" },
+      now,
+    );
+    expect(line).toBe(
+      "⏸ waiting for the network — attempt 4, next try in 32s (fetch failed)",
+    );
+  });
+
+  it("reads as retrying once the scheduled time has passed", () => {
+    const line = describePullWaiting(
+      { reason: "Download stalled: no data for 60s", attempt: 1, nextRetryAt: "2026-09-08T18:29:00.000Z" },
+      now,
+    );
+    expect(line).toMatch(/attempt 1, retrying \(Download stalled/);
+  });
+});

--- a/src/tui/local-models/describe-pull-waiting.ts
+++ b/src/tui/local-models/describe-pull-waiting.ts
@@ -1,0 +1,16 @@
+import type { LocalModelsPullWaiting } from "./local-models-panel-state.js";
+
+/**
+ * `⏸ waiting for the network — attempt 4, next try in 32s (fetch failed)`.
+ * The countdown is what it was at the last state change; the record is
+ * re-read on every retry, so it is never more than one backoff old.
+ */
+export function describePullWaiting(
+  waiting: LocalModelsPullWaiting,
+  now: number = Date.now(),
+): string {
+  const inMs = Date.parse(waiting.nextRetryAt) - now;
+  const when =
+    Number.isFinite(inMs) && inMs > 0 ? `next try in ${Math.ceil(inMs / 1000)}s` : "retrying";
+  return `⏸ waiting for the network — attempt ${waiting.attempt}, ${when} (${waiting.reason})`;
+}

--- a/src/tui/local-models/local-models-actions.ts
+++ b/src/tui/local-models/local-models-actions.ts
@@ -55,6 +55,8 @@ export type LocalModelsAction =
       percent: number;
       transferredBytes: number;
       totalBytes: number;
+      /** Omitted = unchanged; `null` = bytes are flowing again. */
+      waiting?: LocalModelsPullState["waiting"];
     }
   | { type: "local_models_pull_finished"; kind?: LocalModelsPullState["kind"] }
   | {

--- a/src/tui/local-models/local-models-orchestrator-downloads.test.ts
+++ b/src/tui/local-models/local-models-orchestrator-downloads.test.ts
@@ -41,6 +41,10 @@ type EmittedAction =
       pull: { modelId: string; label: string; percent: number };
     }
   | { type: "local_models_pull_failed"; kind: string; error: string }
+  | {
+      type: "local_models_pull_progress";
+      waiting?: { attempt: number; reason: string } | null;
+    }
   | { type: "runtime_info"; line: string };
 
 function stubBackendInstalled(dataDir: string): void {
@@ -125,6 +129,8 @@ function inProcessWorker(): {
         mode: input.mode,
         signal: controller.signal,
         writeIntervalMs: 0,
+        heartbeatMs: 0,
+        retryDelayMs: 20,
         log: () => undefined,
       });
       return { outcome: "spawned", job, logPath: "" };
@@ -169,6 +175,7 @@ describe("LocalModelsOrchestrator — pulls through the download worker", () => 
         spawnDownload: worker.spawnDownload,
         stopDownload: worker.stopDownload,
         downloadPollMs: 5,
+        staleGraceMs: 10,
       },
     );
     vi.spyOn(orchestrator, "refresh").mockResolvedValue();
@@ -414,7 +421,7 @@ describe("LocalModelsOrchestrator — pulls through the download worker", () => 
       expect(getConfig().localModels.embeddings.modelId).toBe("nomic-embed-text-v1.5");
     });
 
-    it("leaves cancelled and failed jobs alone", () => {
+    it("leaves cancelled and non-resumable failed jobs alone", () => {
       const dataDir = getConfig().paths.localModelsDataDir;
       for (const status of ["cancelled", "failed"] as const) {
         writeDownloadJob(dataDir, {
@@ -426,12 +433,150 @@ describe("LocalModelsOrchestrator — pulls through the download worker", () => 
             pid: 1,
           }),
           status,
-          error: status === "failed" ? "boom" : null,
+          error: status === "failed" ? "Download failed: HTTP 404 Not Found" : null,
+          resumable: false,
         });
       }
       orchestrator.adoptBackgroundDownloads();
       expect(worker.spawned).toEqual([]);
       expect(startedPulls(actions)).toEqual([]);
+    });
+
+    it("resumes a job that gave up on an outage, from its partial", async () => {
+      // What a laptop that was offline for a week — or a 0.5.6 worker
+      // that ran out of retries — leaves behind: `failed`, partial intact.
+      const dataDir = getConfig().paths.localModelsDataDir;
+      const def = getLocalModelDef("qwen-3.5-4b");
+      const dest = resolveModelFilePath(dataDir, def.id, def.filename);
+      mkdirSync(join(dest, ".."), { recursive: true });
+      writeFileSync(resolvePartialPath(dest), "gg");
+      writeFileSync(
+        resolvePartialMetaPath(dest),
+        JSON.stringify({ url: def.huggingFaceUrl, total: 4, etag: '"v1"', lastModified: null }),
+      );
+      writeDownloadJob(dataDir, {
+        ...initialDownloadJob({ dataDir, kind: "chat", modelId: def.id, mode: "gguf-only", pid: 2_000_000_000 }),
+        status: "failed",
+        error: "Download gave up: no progress for 7 days (last error: fetch failed)",
+        resumable: true,
+        finishedAt: "2026-09-07T12:00:00.000Z",
+      });
+      globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+        expect(new Headers(init?.headers).get("range")).toBe("bytes=2-");
+        return new Response(bodyOf(["uf"]), {
+          status: 206,
+          headers: { "content-range": "bytes 2-3/4", etag: '"v1"' },
+        });
+      }) as typeof fetch;
+
+      orchestrator.adoptBackgroundDownloads();
+      await waitFor(() => startDaemon.mock.calls.length === 1);
+
+      expect(worker.spawned).toEqual(["chat-qwen-3.5-4b"]);
+      expect(infoLines(actions).some((l) => /gave up at 50%.*— resuming/.test(l))).toBe(true);
+      expect(existsSync(dest)).toBe(true);
+    });
+
+    it("declares a silent worker dead after the grace period and relaunches it", async () => {
+      // A `running` record whose pid answers (it is ours) but that
+      // nobody has written for ten minutes — a recycled pid after a
+      // reboot looks exactly like this.
+      const dataDir = getConfig().paths.localModelsDataDir;
+      const def = getLocalModelDef("qwen-3.5-4b");
+      const dest = resolveModelFilePath(dataDir, def.id, def.filename);
+      const stale = new Date(Date.now() - 10 * 60_000).toISOString();
+      writeDownloadJob(dataDir, {
+        ...initialDownloadJob({ dataDir, kind: "chat", modelId: def.id, mode: "gguf-only", pid: process.pid }),
+        percent: 30,
+        transferredBytes: 3,
+        totalBytes: 10,
+        startedAt: stale,
+        updatedAt: stale,
+      });
+      globalThis.fetch = vi.fn(
+        async () => new Response(bodyOf(["gguf"]), { status: 200, headers: { "content-length": "4" } }),
+      ) as typeof fetch;
+
+      orchestrator.adoptBackgroundDownloads();
+      await waitFor(() => startDaemon.mock.calls.length === 1);
+
+      expect(worker.spawned).toEqual(["chat-qwen-3.5-4b"]);
+      expect(infoLines(actions).some((l) => /stopped reporting at 30% — relaunching/.test(l))).toBe(true);
+      expect(existsSync(dest)).toBe(true);
+    });
+
+    it("stops a silent worker that is still ours before relaunching onto its partial", async () => {
+      const dataDir = getConfig().paths.localModelsDataDir;
+      const def = getLocalModelDef("qwen-3.5-4b");
+      const dest = resolveModelFilePath(dataDir, def.id, def.filename);
+      const stale = new Date(Date.now() - 10 * 60_000).toISOString();
+      writeDownloadJob(dataDir, {
+        ...initialDownloadJob({ dataDir, kind: "chat", modelId: def.id, mode: "gguf-only", pid: process.pid }),
+        startedAt: stale,
+        updatedAt: stale,
+      });
+      globalThis.fetch = vi.fn(
+        async () => new Response(bodyOf(["gguf"]), { status: 200, headers: { "content-length": "4" } }),
+      ) as typeof fetch;
+      const stops: number[] = [];
+      const ours = new LocalModelsOrchestrator(
+        { emit: (a: unknown) => actions.push(a as EmittedAction), subscribe: () => () => {} },
+        {
+          spawnDownload: worker.spawnDownload,
+          stopDownload: async (d, job) => {
+            stops.push(job.pid);
+            return worker.stopDownload(d, job);
+          },
+          downloadPollMs: 5,
+          staleGraceMs: 10,
+          isDownloadWorkerPid: () => true,
+        },
+      );
+      vi.spyOn(ours, "refresh").mockResolvedValue();
+      const start = vi.spyOn(ours, "startDaemon").mockResolvedValue(true);
+      vi.spyOn(ours, "startEmbeddingPairing").mockResolvedValue();
+
+      ours.adoptBackgroundDownloads();
+      await waitFor(() => start.mock.calls.length === 1);
+
+      // The old pid was asked to stop before the record was rewritten.
+      expect(stops).toEqual([process.pid]);
+      expect(worker.spawned).toEqual(["chat-qwen-3.5-4b"]);
+      expect(existsSync(dest)).toBe(true);
+      await ours.shutdown();
+    });
+
+    it("mirrors the worker's wait for the network onto the pull state", async () => {
+      const dataDir = getConfig().paths.localModelsDataDir;
+      const def = getLocalModelDef("qwen-3.5-4b");
+      let calls = 0;
+      globalThis.fetch = vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw Object.assign(new TypeError("fetch failed"), {
+            cause: Object.assign(new Error("ENETDOWN"), { code: "ENETDOWN" }),
+          });
+        }
+        return new Response(bodyOf(["gguf"]), { status: 200, headers: { "content-length": "4" } });
+      }) as typeof fetch;
+
+      void orchestrator.pullModel(def.id, "gguf-only");
+      await waitFor(() => startDaemon.mock.calls.length === 1);
+
+      const waits = actions.filter(
+        (a): a is Extract<EmittedAction, { type: "local_models_pull_progress" }> =>
+          a.type === "local_models_pull_progress" && !!a.waiting,
+      );
+      expect(waits.length).toBeGreaterThan(0);
+      expect(waits[0].waiting).toMatchObject({ attempt: 1, reason: "fetch failed" });
+      // The last progress report before landing has the wait cleared.
+      const last = actions
+        .filter(
+          (a): a is Extract<EmittedAction, { type: "local_models_pull_progress" }> =>
+            a.type === "local_models_pull_progress",
+        )
+        .at(-1);
+      expect(last?.waiting).toBeNull();
     });
   });
 });

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -10,8 +10,11 @@ import {
   downloadBackend,
   downloadJobId,
   listDownloadJobs,
+  isDownloadJobStale,
+  looksLikeDownloadWorker,
   readDownloadJob,
   removeDownloadJob,
+  writeDownloadJob,
   spawnDownloadWorker,
   stopDownloadWorker,
   type DownloadJob,
@@ -146,6 +149,10 @@ export interface LocalModelsOrchestratorHooks {
   stopDownload?: (dataDir: string, job: DownloadJob) => Promise<StopDownloadWorkerResult>;
   /** How often the worker's record is re-read. Default 300ms. */
   downloadPollMs?: number;
+  /** Grace before a silent `running` record is declared dead. Default 60s. */
+  staleGraceMs?: number;
+  /** Whether a pid is one of our workers. Test seam. */
+  isDownloadWorkerPid?: (pid: number) => boolean;
 }
 
 export class LocalModelsOrchestrator {
@@ -516,7 +523,7 @@ export class LocalModelsOrchestrator {
   ): Promise<{ outcome: "done" | "cancelled" | "detached"; job: DownloadJob }> {
     const dataDir = getConfig().paths.localModelsDataDir;
     const spawn = this.hooks?.spawnDownload ?? spawnDownloadWorker;
-    const launched = spawn({ dataDir, kind, modelId, mode });
+    let launched = spawn({ dataDir, kind, modelId, mode });
     const jobId = launched.job.id;
 
     this.watchedDownloads.get(kind)?.detach();
@@ -546,17 +553,52 @@ export class LocalModelsOrchestrator {
     let last = launched.job;
     emitStarted(last);
     const pollMs = this.hooks?.downloadPollMs ?? DOWNLOAD_POLL_MS;
+    const staleGraceMs = this.hooks?.staleGraceMs ?? STALE_GRACE_MS;
+    // A `running` record the worker has stopped writing. The pid may
+    // still answer — after a reboot it can be anyone's — so the record
+    // is watched for a grace period first: a laptop back from sleep
+    // shows a stale record until the worker's next heartbeat, and
+    // spawning a second worker onto the same partial would be far worse
+    // than a minute of patience.
+    let staleSince: number | null = null;
+    let respawned = false;
     try {
       for (;;) {
         await new Promise((r) => setTimeout(r, pollMs));
         if (detached) return { outcome: "detached", job: last };
-        const job = readDownloadJob(dataDir, jobId);
+        let job = readDownloadJob(dataDir, jobId);
         if (!job) throw new Error("download record disappeared");
+        if (job.status === "running" && isDownloadJobStale(job)) {
+          staleSince ??= Date.now();
+          if (Date.now() - staleSince >= staleGraceMs) {
+            // A worker that is alive but silent (stopped, starved, stuck
+            // on a hung disk) must not get a sibling on the same partial:
+            // stop it first, and only then declare the job interrupted.
+            // A pid that is not ours — recycled after a reboot — is left
+            // alone; the record is simply wrong about it.
+            const isOurs = this.hooks?.isDownloadWorkerPid ?? looksLikeDownloadWorker;
+            if (isOurs(job.pid)) {
+              const stop = this.hooks?.stopDownload ?? stopDownloadWorker;
+              await stop(dataDir, job);
+            }
+            job = {
+              ...job,
+              status: "interrupted",
+              error: "worker stopped reporting",
+              finishedAt: job.updatedAt,
+            };
+            writeDownloadJob(dataDir, job);
+            staleSince = null;
+          }
+        } else {
+          staleSince = null;
+        }
         if (job.label !== last.label) {
           emitStarted(job);
         } else if (
           job.transferredBytes !== last.transferredBytes ||
-          job.percent !== last.percent
+          job.percent !== last.percent ||
+          job.waiting?.nextRetryAt !== last.waiting?.nextRetryAt
         ) {
           this.bus.emit({
             type: "local_models_pull_progress",
@@ -564,10 +606,30 @@ export class LocalModelsOrchestrator {
             percent: job.percent,
             transferredBytes: job.transferredBytes,
             totalBytes: job.totalBytes,
+            waiting: job.waiting
+              ? {
+                  reason: job.waiting.reason,
+                  attempt: job.waiting.attempt,
+                  nextRetryAt: job.waiting.nextRetryAt,
+                }
+              : null,
           });
         }
         last = job;
         if (job.status === "running") continue;
+        if (job.status === "interrupted" && !respawned) {
+          // Once: the worker died (or went silent) under a watcher that
+          // still wants the model. Relaunch it onto the partial rather
+          // than hand the operator an error to press Enter on.
+          respawned = true;
+          this.bus.emit({
+            type: "runtime_info",
+            line: `local-llm: download worker ${job.error ?? "died"} at ${job.percent}% — relaunching it`,
+          });
+          launched = spawn({ dataDir, kind, modelId, mode });
+          last = launched.job;
+          continue;
+        }
         if (job.status === "done") return { outcome: "done", job };
         if (job.status === "cancelled") return { outcome: "cancelled", job };
         throw new Error(
@@ -623,8 +685,13 @@ export class LocalModelsOrchestrator {
    *   (activate, start the daemon) so the operator lands where they
    *   would have.
    *
-   * `cancelled` and `failed` are the operator's to act on and are left
-   * alone; `models downloads` still lists them.
+   * - `failed` + `resumable`: the worker gave up on an outage (offline
+   *   for a week, or it hit its own lifetime cap) or a 0.5.6 worker ran
+   *   out of retries — the file was never the problem. Relaunch it.
+   *
+   * `cancelled` and a non-resumable `failed` (a 404, a full disk) are the
+   * operator's to act on and are left alone; `models downloads` still
+   * lists them.
    */
   adoptBackgroundDownloads(opts?: { onlyRunning?: boolean }): void {
     const dataDir = getConfig().paths.localModelsDataDir;
@@ -634,7 +701,8 @@ export class LocalModelsOrchestrator {
         ? job.status === "running"
         : job.status === "running" ||
           job.status === "interrupted" ||
-          job.status === "done";
+          job.status === "done" ||
+          (job.status === "failed" && job.resumable);
       if (!adoptable) continue;
       if (job.kind === "chat") {
         if (!isKnownLocalModelId(job.modelId)) {
@@ -880,14 +948,33 @@ export class LocalModelsOrchestrator {
       },
     });
     try {
+      let lastProgress = { percent: 0, transferred: 0, total: 0 };
       await downloadBackend(dataDir, {
         onProgress: (percent, transferred, total) => {
+          lastProgress = { percent, transferred, total };
           this.bus.emit({
             type: "local_models_pull_progress",
             kind: "backend",
             percent,
             transferredBytes: transferred,
             totalBytes: total,
+            waiting: null,
+          });
+        },
+        // The zip is fetched in-process, so the banner must be told about
+        // an outage here; nothing else will.
+        onRetry: (info) => {
+          this.bus.emit({
+            type: "local_models_pull_progress",
+            kind: "backend",
+            percent: lastProgress.percent,
+            transferredBytes: lastProgress.transferred,
+            totalBytes: lastProgress.total,
+            waiting: {
+              reason: info.error.message,
+              attempt: info.attempt,
+              nextRetryAt: new Date(Date.now() + info.delayMs).toISOString(),
+            },
           });
         },
       });
@@ -2237,6 +2324,8 @@ function resolveMmprojStatus(
 
 /** How often a watched worker's record is re-read. */
 const DOWNLOAD_POLL_MS = 300;
+/** How long a stale `running` record is tolerated before it is declared dead. */
+const STALE_GRACE_MS = 60_000;
 
 function formatJobBytes(bytes: number): string {
   const gb = bytes / (1024 * 1024 * 1024);
@@ -2253,6 +2342,8 @@ function describeAdoptedJob(job: DownloadJob, name: string): string {
       return `local-llm: ${name} is downloading in the background (${job.percent}%) — picking it up`;
     case "interrupted":
       return `local-llm: ${name} download was interrupted at ${job.percent}% — resuming`;
+    case "failed":
+      return `local-llm: ${name} download gave up at ${job.percent}% (${job.error ?? "no reason recorded"}) — resuming`;
     default:
       return `local-llm: ${name} finished downloading while the app was closed`;
   }

--- a/src/tui/local-models/local-models-panel-state.ts
+++ b/src/tui/local-models/local-models-panel-state.ts
@@ -74,6 +74,20 @@ export interface LocalModelRow {
   mmprojStatus: MmprojStatus;
 }
 
+/**
+ * The worker is between attempts, waiting for the network to come
+ * back. The counter is not moving and that is expected — the banner
+ * says so instead of looking hung.
+ */
+export interface LocalModelsPullWaiting {
+  /** The last attempt's error, e.g. `fetch failed`. */
+  reason: string;
+  /** Consecutive attempts without progress. */
+  attempt: number;
+  /** ISO timestamp of the next attempt. */
+  nextRetryAt: string;
+}
+
 export interface LocalModelsPullState {
   kind: "chat" | "embedding" | "backend";
   modelId: LocalModelId | EmbeddingModelId | "_backend";
@@ -82,6 +96,8 @@ export interface LocalModelsPullState {
   transferredBytes: number;
   totalBytes: number;
   error: string | null;
+  /** Set while the worker waits out an outage; absent or `null` while bytes flow. */
+  waiting?: LocalModelsPullWaiting | null;
 }
 
 /**

--- a/src/tui/local-models/local-models-reducer.ts
+++ b/src/tui/local-models/local-models-reducer.ts
@@ -227,6 +227,7 @@ export function reduceLocalModelsAction(state: TuiState, action: TuiAction): Tui
               percent: action.percent,
               transferredBytes: action.transferredBytes,
               totalBytes: action.totalBytes,
+              ...(action.waiting !== undefined ? { waiting: action.waiting } : {}),
             },
           },
         };
@@ -241,6 +242,7 @@ export function reduceLocalModelsAction(state: TuiState, action: TuiAction): Tui
             percent: action.percent,
             transferredBytes: action.transferredBytes,
             totalBytes: action.totalBytes,
+            ...(action.waiting !== undefined ? { waiting: action.waiting } : {}),
           },
         },
       };


### PR DESCRIPTION
## What

A background model download used to die about thirty seconds after the machine lost its network, and a relaunch never picked it up again.

Before: `downloadFile` had a fixed budget of 5 retries with 1→16 s backoff, and the attempt counter never reset after successful streaming. Offline, `fetch` rejects instantly, so the six attempts burned in ~31 s (a hung socket bought ~6 min via the 60 s stall watchdog). The worker recorded the job as `failed`, and `failed` is the one status `adoptBackgroundDownloads` deliberately never resumes — even though the `.part` file and its sidecar were intact. Relaunching while still offline was worse: the adopted `interrupted` job spawned a worker that died in 31 s and demoted the record to `failed` for good. A log from a 16.5 GB pull on v0.5.6:

```
18:25 interrupted (Download stalled: no data for 60s) — retry 1/5 in 1s
…
18:30 interrupted (fetch failed) — retry 5/5 in 16s
18:32 failed: Download stalled: no data for 60s
```

After:

- **Transport failures are waited out, not counted.** The retry budget is a no-progress *window*: DNS/connect/reset/stall errors retry with backoff capped at 60 s for as long as the outage lasts. Progress — measured against the partial's high-water mark, not per attempt, so a Range-ignoring proxy that truncates every body cannot fake it — restarts the window. In-process callers (foreground `models pull`, the TUI's backend zip) get 10 minutes of that patience and a hint to use `--background`; the detached worker asks for **7 days** (`WORKER_GIVE_UP_AFTER_MS`). Server-side errors (5xx/408/429) keep a bounded counter of their own, so the first 503 after an outage does not inherit the outage's attempts; a 4xx, a full disk, a bad URL or an untrusted certificate still fail at once. (`download-errors.ts` holds the classification; undici's `TypeError: terminated` for a body cut short is a transport error — the live check caught that one.)
- **The worker kills itself eventually.** A hard 30-day lifetime (`deadlineAt`), after which it exits `failed` + `resumable`. The partial stays.
- **A relaunch resumes it.** The job record gains `resumable` (and `waiting`) as **additive fields on the v1 schema** — an older binary sharing the state dir keeps seeing the job instead of spawning a second worker onto it. A 0.5.6 `failed` whose error is not an `HTTP 4xx` (408/429 excepted) is read as resumable, and the TUI's boot-time adoption now includes `failed && resumable`, so a 0.5.6 user's stranded download is picked up by the first launch of this build.
- **The wait is visible.** The record carries `waiting {reason, attempt, nextRetryAt, since}`; the Models banner shows `download paused — … ⏸ waiting for the network — attempt 4, next try in 32s (fetch failed)`, the status-bar chip switches to `⏸ model 64% · offline` (no bar, no "never" ETA), `atag models downloads` prints `waiting for network (attempt 4, retry in 32s)`, and the foreground `models pull` follower prints the same.
- **Alive vs dead is decidable.** The worker heartbeats its record every 30 s even while waiting. A `running` record silent for 5 min (`isDownloadJobStale`) is a worker that stopped — a recycled pid after a reboot answers `kill(pid,0)` forever. The TUI watcher tolerates it for a 60 s grace (a laptop back from sleep shows a stale record until the next beat), then — if the pid still looks like one of our workers (`ps`/`tasklist`), stops it first, so an alive-but-stuck worker never gets a sibling on the same partial — marks it `interrupted` and relaunches the worker once. A pid that is not ours is left alone.
- **Captive portals no longer wipe the partial.** A `text/html` answer, or a full-body `200` of the wrong length under a validator that positively matches the partial's, is treated as a transport failure and retried — not as "the file changed, start over". A server that names no validator gets no such benefit of the doubt: its `200` is a restart, as before.

## Why

Huge GGUFs on laptops: people close the lid, switch Wi-Fi, ride the metro. A download that needs a human to notice it died and press Enter loses most of them. A worker that simply waits — for days if it must — and a launch that picks up whatever was left unfinished make the download something you start and forget.

Invariants kept: the partial file is never touched by a failure; one worker per job (spawn dedupes on a live record; stale demotion is reader-side and graced); the worker never throws for a download failure — outcome is the return value plus the record; `cancelled` and non-resumable `failed` remain the operator's.

## How it was verified

- `npm run lint` clean.
- `npx vitest run src/local-llm src/cli src/tui/local-models src/tui/components` — 115 files / 1101 tests green after the change (baseline failures: none in these dirs).
- New tests: offline ×6 then heal → resumes with `Range`; window resets on progress (pinned by arithmetic with an injected clock) and only on a new high-water mark; a 503 right after a six-attempt outage is still retried; server errors still bounded; `ENOSPC`, an expired certificate, `ERR_INVALID_URL` and a programming `TypeError` fatal at once, undici's `terminated` not; `deadlineAt`; captive-portal `text/html` and wrong-length `200` keep the partial, a validator-less `200` restarts; worker records `waiting` and clears it, `resumable` true/false, heartbeat moves `updatedAt`; additive-field fill for a 0.5.6 record (408/429 resumable, other 4xx not, explicit `resumable` respected); staleness helper; orchestrator adopts a resumable failure, demotes a silent worker after the grace (stopping it first when it is ours) and relaunches, mirrors `waiting` onto the pull state; chip and banner text.
- An adversarial review pass found the shared retry counter, the 7-day default leaking into foreground pulls, the per-attempt progress measure, the un-stopped stale pid and the over-broad transport default; all fixed above.
- Live, with the built `dist/` and a throttled local origin serving a 6 MB file with Range/ETag support:
  1. `models pull --background`, origin killed at 89%: the record showed `waiting {attempt 2…4, "fetch failed"}` with 1/2/4/8 s backoff; origin restored → `Range: bytes=5898240-` → 206 → `done`; sha256 of the result equals the origin's bytes.
  2. Relaunch: a v1 `failed` record exactly as 0.5.6 writes it plus a 2 MB partial; the orchestrator's `adoptBackgroundDownloads()` logged `download gave up at 33% (Download stalled: no data for 60s) — resuming`, the worker asked for `bytes=2097152-`, `local_models_pull_finished`, file complete.
