### PR TITLE
fix(agent): recover from a length-truncated completion instead of failing the turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,65 @@ two app restarts and a fresh session — with nothing on screen to say the link 
    <reason>` until a turn actually succeeds. The context readout is not touched: it is driven by
    `prompt_built` / `llm_completed`, and a parked turn produces neither.
 
+### Truncated completions
+
+A reply the server cut short arrives as `finish_reason: "length"` on every OpenAI-compatible route and
+as `truncated: true` from llama-server, and it used to end the turn on the spot — `Turn failed [model]:
+model response truncated`, with no token count on a streamed reply because the request never asked for
+one. Different walls produce it, and they want different remedies: a reasoning model that spent the
+whole reply cap (`max_tokens` / `n_predict` = `localModels.completionMaxTokens`, 8192) before it emitted
+the tool call needs a **bigger cap**; a server whose context window filled mid-reply (llama.cpp `-c`,
+Lemonade's auto-sizing — both routinely below the model's advertised window) needs a **smaller prompt**;
+a provider that clamps the model's output below our cap needs a **lower cap** and nothing else.
+Locked invariants (pinned by [src/agent/agent-loop.test.ts](src/agent/agent-loop.test.ts),
+[src/agent/truncation-recovery.test.ts](src/agent/truncation-recovery.test.ts),
+[src/agent/step-executor.test.ts](src/agent/step-executor.test.ts),
+[src/llm/reliability/detect-model-failure.test.ts](src/llm/reliability/detect-model-failure.test.ts),
+[src/llm/reliability/request-size-rejection.test.ts](src/llm/reliability/request-size-rejection.test.ts)
+and [src/runtime/llm-fallback-seam.test.ts](src/runtime/llm-fallback-seam.test.ts)):
+
+1. **Streamed requests ask for usage.** `buildOpenAiChatBody` sends `stream_options: { include_usage:
+   true }` on every streamed body, and the contract probe carries it too, so the last chunk's `usage`
+   reaches `CompletionResult.usage`. Without it llama.cpp, OpenAI and Gemini send none. `extraBody` can
+   drop it for a vendor that rejects it.
+2. **The cause is classified, never guessed.** `classifyTruncation` compares `completion_tokens` with
+   the cap the request carried: within 16 tokens of it ⇒ `reply_cap`; short of it ⇒ `context_window`
+   (prompt + reply *is* the window) — unless the runtime knows a window and prompt + reply sit under
+   90 % of it, which is the provider's `output_limit` for the model, not the window. A timings-only
+   completion (llama-server, whose `truncated` means the context overflowed) is `context_window`
+   whatever the count. No usage ⇒ `unknown`. Cause and counts travel on `ModelError.truncation`;
+   `formatTruncatedMessage` names the wall and the knob.
+3. **A cut reply dispatches nothing.** The execution-integrity suite's rule stands: an explicit
+   `length` fails closed at the dispatch boundary even when the tool-call arguments parse — a cut
+   between call A and call B of a batch would otherwise run A alone. The loop re-asks instead.
+4. **One retry per step, with a different request.** `planTruncationRetry` ([src/agent/truncation-recovery.ts](src/agent/truncation-recovery.ts)):
+   `reply_cap` / `unknown` ⇒ the same step index again with the cap raised to `min(4 × cap, 32768)`,
+   clamped under a known window; `context_window` ⇒ `onContextWindowObserved(prompt + reply)` so
+   bootstrap records the window per provider/model, the re-packed prompt fits, and the same step runs
+   again under the same cap; `output_limit` ⇒ no retry. The per-step cap travels as
+   `StepContext.maxTokens` and **both** fallback seams forward it (the streaming seam used to drop it).
+   The retry keeps the `### notice` the cut attempt carried and adds its own; it runs on the
+   finalization step too; `stepsTaken` does not move; a leg boundary re-entered by a retry runs its
+   check once (`lastBoundaryIndex`), never reading the retry as an unproductive leg. A second cut on
+   the same index fails the turn with the classified message.
+5. **A request-size 400 is deterministic.** `isRequestSizeRejection` (a 400/413 whose body names the
+   cap or the context length *and* says it is too large) keeps `shouldAdvance` from falling the chain
+   over to a link that may not be running; on the raised-cap retry the turn fails with the *original*
+   truncation, and elsewhere the provider's own sentence about the limit stays in the message.
+6. **A learned window is forgotten the moment the server disproves it.** A successful completion whose
+   prompt + reply exceed the believed window fires `onContextWindowExceeded`, and bootstrap drops the
+   observation (catalogue windows are never touched). Learned windows live for the process; a
+   restart may change the server.
+7. **The repair pass on `native_tools` runs under the step's cap, not `REPAIR_MAX_TOKENS`.** The
+   1024-token cap is a grammar-link guard: the prefill strip keeps the think block short there. On the
+   chat transport a reasoning model thinks server-side and 1024 is a guaranteed truncation, so every
+   repair ended the turn it was meant to save. Grammar repairs keep the cap.
+8. **It is visible.** `completion_truncated` on the loop event union carries cause, counts and the retry
+   taken; the TUI renders one yellow feed line, the trace records it, `atomic-agent trace` prints it.
+
+Known gap: a window learned while a fallback link served the completion is keyed to the configured
+provider (`activeModelKey`), not the serving link.
+
 ### No-progress loop detection
 
 The runtime guards against "stuck" turns where the model re-emits the same tool call (same args, same result) without making progress. The detector is [src/agent/loop-detector.ts](src/agent/loop-detector.ts) `ToolLoopTracker` — **one instance per turn**, owned by `AgentLoop.runTurn`, threaded into `executeStep` → `executeBatch` via `BatchExecutionContext.tracker`. Ported from OpenClaw 2026.6.5; the design goal is **graceful termination, never a hard failure**.
@@ -1936,7 +1995,7 @@ Every terminal failure the agent loop surfaces is normalised into a canonical `L
 | ----------- | -------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `transport` | `TransportError`     | `LlamaServerError` with `status === null` or `status >= 500` (after the bounded retry is exhausted).  | Carries `status` and `url`. Transport retries already fired; runtime does not retry again here.  |
 | `grammar`   | `GrammarError`       | `LlamaServerError` 4xx, or `ToolCallParseError` that survives the one-shot parser retry.              | Carries `rawPreview` of the completion body so postmortems can diagnose without replaying SSE.   |
-| `model`     | `ModelError`         | `detectModelFailure` returns `truncated` / `empty` / `no_stop` on the initial or retry completion.    | **Never retried in-place** — the same prompt would reproduce the same wall. Parser retry skipped. |
+| `model`     | `ModelError`         | `detectModelFailure` returns `truncated` / `empty` / `no_stop` on the initial or retry completion.    | **Never retried with the same request** — the same prompt under the same cap reproduces the same wall. `truncated` is retried once with a *different* request (§"Truncated completions"); `empty` / `no_stop` are not. Parser retry skipped. Carries `truncation` (cause + token counts) for `truncated`. |
 | `tool`      | `ToolExecutionError` | Tool missing from the registry, or any unexpected error escaping the tool dispatch path.              | Carries `tool` name. Runtime tool failures from `registry.invoke` are folded into `CompressedToolResult { status: "error" }` and do **not** reach this category. |
 | `cancelled` | `CancelledError`     | `ctx.signal.aborted` is true, or the caught error is an `AbortError` / message mentions `aborted`.    | The agent loop closes the turn with `reason: cancelled` and status `cancelled`, not `failed`.    |
 

--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -368,6 +368,397 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(calls).toBe(4);
   });
 
+  it("retries a step whose reply spent the cap, with a bigger cap and a notice", async () => {
+    // A reasoning model thinks past `max_tokens` before it emits the tool
+    // call. The old outcome was `Turn failed [model]: model response
+    // truncated`; the same request would hit the same wall, so the retry
+    // is a different one.
+    const registry = buildDefaultToolRegistry();
+    const events: Array<{ type: string } & Record<string, unknown>> = [];
+    const capsSeen: Array<number | undefined> = [];
+    const prompts: string[] = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async ({ maxTokens, prompt }) => {
+        calls += 1;
+        capsSeen.push(maxTokens);
+        prompts.push(prompt);
+        if (calls === 1) {
+          return {
+            ...makeCompletion(""),
+            reasoningContent: "Let me think about this at great length",
+            stop: false,
+            truncated: true,
+            usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+          };
+        }
+        return makeCompletion(
+          JSON.stringify({ tool: "reply", args: { text: "short answer" } }),
+        );
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "completion_truncated" || event.type === "loop_failed") {
+          events.push(event as { type: string } & Record<string, unknown>);
+        }
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-cap", workingDir }),
+      {
+        userMessage: "write the module",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: new AbortController().signal,
+      },
+    );
+
+    expect(result.reason).toBe("reply");
+    expect(calls).toBe(2);
+    // The first completion ran under the config cap; the retry under 4×.
+    expect(capsSeen[0]).toBeUndefined();
+    expect(capsSeen[1]).toBe(32_768);
+    // The model is told why it is being asked again.
+    expect(prompts[1]).toContain("cut off after 8192 tokens");
+    expect(prompts[1]).toContain("Keep your reasoning brief");
+    expect(prompts[0]).not.toContain("cut off after");
+    // One event, carrying the cause and the retry; no failure.
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "completion_truncated",
+        stepIndex: 0,
+        cause: "reply_cap",
+        completionTokens: 8_192,
+        promptTokens: 6_000,
+        requestedMaxTokens: 8_192,
+        retry: { kind: "raise_cap", maxTokens: 32_768 },
+      }),
+    ]);
+    // A retried step is one step.
+    expect(result.session.stepCount).toBe(1);
+  });
+
+  it("retries a cut on a leg boundary instead of calling the leg unproductive", async () => {
+    // A retry re-enters the loop at the same index. If that index is a
+    // leg boundary, the boundary check must not run a second time: its
+    // first pass reset the progress flag, and a second pass would read
+    // the retry as a whole leg with nothing to show.
+    const registry = buildDefaultToolRegistry();
+    registry.register({
+      name: "noop",
+      description: "no-op",
+      readonly: true,
+      async run() {
+        return { tool: "noop", status: "ok" as const, summary: "noop", details: {}, truncated: false };
+      },
+    });
+    const kinds: string[] = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        calls += 1;
+        if (calls <= 2) return makeCompletion(JSON.stringify({ tool: "noop", args: {} }));
+        if (calls === 3) {
+          return {
+            ...makeCompletion(""),
+            stop: false,
+            truncated: true,
+            usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+          };
+        }
+        return makeCompletion(JSON.stringify({ tool: "reply", args: { text: "done" } }));
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (
+          event.type === "task_continued" ||
+          event.type === "completion_truncated" ||
+          event.type === "loop_completed"
+        ) {
+          kinds.push(event.type === "loop_completed" ? `loop_completed:${event.reason}` : event.type);
+        }
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-leg", workingDir }),
+      {
+        userMessage: "keep going",
+        maxSteps: 2,
+        taskMaxSteps: 10,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("reply");
+    expect(calls).toBe(4);
+    expect(kinds).toEqual(["task_continued", "completion_truncated", "loop_completed:reply"]);
+  });
+
+  it("retries a cut on the finalization step, where a reasoning model is likeliest to think past the cap", async () => {
+    const registry = buildDefaultToolRegistry();
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            ...makeCompletion(""),
+            stop: false,
+            truncated: true,
+            usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+          };
+        }
+        return makeCompletion(JSON.stringify({ tool: "reply", args: { text: "summary" } }));
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-final", workingDir }),
+      {
+        userMessage: "summarise",
+        // One step: it is the finalization step from the start.
+        maxSteps: 1,
+        taskMaxSteps: 1,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("reply");
+    expect(calls).toBe(2);
+  });
+
+  it("keeps the notice the cut attempt carried on the retry", async () => {
+    const registry = buildDefaultToolRegistry();
+    const prompts: string[] = [];
+    let calls = 0;
+    let drained = false;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async ({ prompt }) => {
+        calls += 1;
+        prompts.push(prompt);
+        if (calls === 1) {
+          return {
+            ...makeCompletion(""),
+            stop: false,
+            truncated: true,
+            usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+          };
+        }
+        return makeCompletion(JSON.stringify({ tool: "reply", args: { text: "ok" } }));
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      steeringInbox: {
+        open: () => {},
+        drain: () => {
+          if (drained) return [];
+          drained = true;
+          return ["also add the tests"];
+        },
+        closeAndDrain: () => [],
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-notice", workingDir }),
+      {
+        userMessage: "write it",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("reply");
+    expect(prompts[0]).toContain("also add the tests");
+    expect(prompts[1]).toContain("also add the tests");
+    expect(prompts[1]).toContain("cut off after 8192 tokens");
+  });
+
+  it("forgets a learned window the server just proved too small", async () => {
+    const registry = buildDefaultToolRegistry();
+    const exceeded: number[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => ({
+        ...makeCompletion(JSON.stringify({ tool: "reply", args: { text: "ok" } })),
+        usage: { promptTokens: 20_000, completionTokens: 500, totalTokens: 20_500 },
+      }),
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      contextWindow: () => 16_384,
+      onContextWindowExceeded: (tokens) => exceeded.push(tokens),
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-unlearn", workingDir }),
+      { userMessage: "hi", maxSteps: 5, taskMaxSteps: 5, signal: new AbortController().signal },
+    );
+    expect(result.reason).toBe("reply");
+    expect(exceeded).toEqual([20_500]);
+  });
+
+  it("fails the turn on the second cut of the same step, naming the wall", async () => {
+    const registry = buildDefaultToolRegistry();
+    const failures: string[] = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async ({ maxTokens }) => {
+        calls += 1;
+        const cap = maxTokens ?? 8_192;
+        return {
+          ...makeCompletion(""),
+          stop: false,
+          truncated: true,
+          usage: { promptTokens: 6_000, completionTokens: cap, totalTokens: 6_000 + cap },
+        };
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "loop_failed") {
+          failures.push(`${event.category}: ${event.error.message}`);
+        }
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-twice", workingDir }),
+      {
+        userMessage: "write the module",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("failed");
+    expect(calls).toBe(2);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("model: model response truncated at 32768 tokens");
+    expect(failures[0]).toContain("localModels.completionMaxTokens");
+    expect(result.session.lastError).toContain("model response truncated");
+  });
+
+  it("learns the context window when the reply stopped short of the cap, and retries under it", async () => {
+    // Lemonade / llama.cpp sized the window below the model's advertised
+    // one; the runtime believed the catalogue. Prompt + reply *is* the
+    // window, so the retry is packed to it.
+    const registry = buildDefaultToolRegistry();
+    const observed: number[] = [];
+    let learned: number | null = null;
+    const prompts: string[] = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async ({ prompt, maxTokens }) => {
+        calls += 1;
+        prompts.push(prompt);
+        if (calls === 1) {
+          return {
+            ...makeCompletion(""),
+            stop: false,
+            truncated: true,
+            usage: { promptTokens: 30_000, completionTokens: 2_768, totalTokens: 32_768 },
+          };
+        }
+        // Same cap as the first attempt: the window was the wall, not the cap.
+        expect(maxTokens).toBeUndefined();
+        return makeCompletion(
+          JSON.stringify({ tool: "reply", args: { text: "fits now" } }),
+        );
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      contextWindow: () => learned,
+      onContextWindowObserved: (contextWindow) => {
+        observed.push(contextWindow);
+        learned = contextWindow;
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-window", workingDir }),
+      {
+        userMessage: "keep going",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("reply");
+    expect(observed).toEqual([32_768]);
+    expect(prompts[1]).toContain("ran out of context");
+    expect(calls).toBe(2);
+  });
+
+  it("fails with the truncation, not the 400, when the provider refuses the raised cap", async () => {
+    const registry = buildDefaultToolRegistry();
+    const failures: string[] = [];
+    let calls = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            ...makeCompletion(""),
+            stop: false,
+            truncated: true,
+            usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+          };
+        }
+        throw new TransportError('"vendor" rejected the request (400).', 400, "https://x/v1", {
+          cause: new Error("max_tokens is too large: 32768. This model supports at most 16384 completion tokens"),
+        });
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "loop_failed") {
+          failures.push(`${event.category}: ${event.error.message}`);
+        }
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-trunc-400", workingDir }),
+      {
+        userMessage: "write the module",
+        maxSteps: 5,
+        taskMaxSteps: 5,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("failed");
+    expect(calls).toBe(2);
+    expect(failures[0]).toContain("model: model response truncated at 8192 tokens");
+    expect(failures[0]).not.toContain("rejected the request");
+  });
+
   it("does not wait out a failure that will never fix itself", async () => {
     // `transport` also covers a wrong URL answering 404 and a dead key
     // answering 401. Parking a turn for five minutes in front of a typo

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -17,8 +17,13 @@ import {
   LlmFailure,
   TransportError,
   classifyFailure,
+  isRequestSizeRejection,
 } from "../llm/index.js";
-import type { LlmFailureCategory } from "../llm/index.js";
+import type {
+  LlmFailureCategory,
+  TruncationCause,
+  TruncationDetail,
+} from "../llm/index.js";
 import type { SessionState } from "../session/session-state.js";
 import {
   incrementTurnCount,
@@ -55,6 +60,12 @@ import {
 } from "./loop-detector.js";
 import type { BatchLoopSignal } from "./batch-executor.js";
 import { composeSteerNotice } from "./steer-notice.js";
+import {
+  composeTruncationNotice,
+  planTruncationRetry,
+  type TruncationRetry,
+  type TruncationRetryPlan,
+} from "./truncation-recovery.js";
 import { getConfig } from "../config/index.js";
 import type { AgentMetrics } from "../tracing/agent-metrics.js";
 import type { StructuredLogger } from "../tracing/structured-logger.js";
@@ -91,6 +102,22 @@ export interface AgentLoopDependencies {
    * reflected without restarting the loop.
    */
   contextWindow?: () => number | null;
+  /**
+   * The model server just revealed its real context window: a reply
+   * stopped `context_window`-truncated after this many prompt + reply
+   * tokens. Bootstrap records it per provider/model so the next prompt
+   * is packed to fit (`contextWindow` above then returns it). Absent in
+   * test / legacy wiring, where a window truncation ends the turn.
+   */
+  onContextWindowObserved?: (contextWindow: number) => void;
+  /**
+   * A completion just succeeded with prompt + reply tokens above the
+   * window the runtime believes in. Whatever taught it that window was
+   * wrong (a provider clamping output, a stale observation); bootstrap
+   * forgets the learned value so the prompt is not packed to a number
+   * the server just disproved.
+   */
+  onContextWindowExceeded?: (tokens: number) => void;
   /** Defaults to `grammar` when omitted (test / legacy wiring). */
   toolTransport?: ToolCallTransport;
   toolCallAdapter?: ToolCallAdapter | null;
@@ -471,6 +498,22 @@ export type AgentLoopEvent =
     }
   | {
       /**
+       * The completion for step `stepIndex` came back cut off, and the
+       * same step is being retried with a different request: a larger
+       * reply cap, or a prompt re-packed to the context window the
+       * server just revealed. Fired once per retry; a second cut on the
+       * same step fails the turn with the cause in the message.
+       */
+      type: "completion_truncated";
+      stepIndex: number;
+      cause: TruncationCause;
+      completionTokens: number;
+      promptTokens: number;
+      requestedMaxTokens: number;
+      retry: TruncationRetry;
+    }
+  | {
+      /**
        * A leg of the task finished and the work is continuing. Fired at
        * every `maxSteps` boundary that does not end the task, so a long
        * job reports itself instead of going quiet for an hour.
@@ -729,6 +772,29 @@ export class AgentLoop {
     let outageAttempts = 0;
     /** Retried a step after an outage and have not yet seen it succeed. */
     let awaitingRecovery = false;
+    // Truncation retry. A reply the server cut short is not a verdict on
+    // the step either — but unlike an outage, replaying the same request
+    // is pointless, so the retry changes it: a larger reply cap when the
+    // cap was spent, a re-packed prompt when the window filled. One
+    // retry per step index; the second cut ends the turn.
+    // Declared through a cast rather than a `null` literal: the literal
+    // narrows the binding to `null`, and the catch clause below — which
+    // TypeScript enters from the start of the `try`, before the loop's
+    // back-edge from this very clause is folded in — then reads it as
+    // `never`.
+    let truncationRetry = null as {
+      stepIndex: number;
+      maxTokens?: number;
+      /** The truncation that started the retry, for the message if the retry is refused. */
+      original: Error;
+    } | null;
+    /**
+     * The step index whose leg boundary already ran. A retried step
+     * (outage or truncation) re-enters the loop at the same index; the
+     * boundary must not run twice, or its progress flag — reset by the
+     * first pass — reads the retry as a whole leg with nothing to show.
+     */
+    let lastBoundaryIndex = -1;
     // Per-turn no-progress loop tracker (OpenClaw-style). Threaded into
     // `executeStep` so the synchronous batch gate can veto looping calls
     // before they are dispatched; the agent loop consumes the resulting
@@ -785,7 +851,8 @@ export class AgentLoop {
       }
       // Leg boundary. Everything the task needs to keep running is
       // decided here, once per `legSteps` steps, and never mid-leg.
-      if (i > 0 && i % legSteps === 0) {
+      if (i > 0 && i % legSteps === 0 && i !== lastBoundaryIndex) {
+        lastBoundaryIndex = i;
         if (!legMadeProgress) {
           // A whole leg with nothing usable coming back is the honest
           // place to stop: the loop detector's breaker catches a model
@@ -907,6 +974,10 @@ export class AgentLoop {
                 }
               : {}),
             ...(finalizationStep ? { terminalOnly: true } : {}),
+            ...(truncationRetry?.stepIndex === i &&
+            truncationRetry.maxTokens !== undefined
+              ? { maxTokens: truncationRetry.maxTokens }
+              : {}),
             ...(profileFacts !== undefined ? { profileFacts } : {}),
             ...(options.userMessage !== undefined
               ? { userMessage: options.userMessage }
@@ -968,6 +1039,18 @@ export class AgentLoop {
         const tokensUsed =
           (outcome.completion.timing?.promptTokens ?? outcome.prompt.tokens.total) +
           (outcome.completion.timing?.predictedTokens ?? 0);
+        // The server just held more than the runtime thought it could:
+        // a learned window was wrong, and packing to it would only
+        // throw context away.
+        const believedWindow = this.deps.contextWindow?.() ?? null;
+        const usage = outcome.completion.usage;
+        if (
+          usage !== undefined &&
+          believedWindow !== null &&
+          usage.promptTokens + usage.completionTokens > believedWindow
+        ) {
+          this.deps.onContextWindowExceeded?.(usage.promptTokens + usage.completionTokens);
+        }
         // Step-level outcome rolls up batched results: any failed call
         // marks the step as `error` so metrics catch partial failures.
         const stepStatus: "ok" | "error" = outcome.toolResults.some(
@@ -1192,7 +1275,7 @@ export class AgentLoop {
         recordSurfacedProcedures(state);
       } catch (err) {
         runError = err instanceof Error ? err : new Error(String(err));
-        const category = classifyFailure(err);
+        let category = classifyFailure(err);
         // `cancelled` is user-initiated and should close the turn
         // cleanly without marking the session as failed. Classified
         // BEFORE the finalization guard below: a user abort during the
@@ -1203,6 +1286,61 @@ export class AgentLoop {
           err instanceof CancelledError ||
           (err instanceof LlmFailure && err.category === "cancelled") ||
           category === "cancelled";
+        // The reply was cut short. Retry the step with a request the wall
+        // does not apply to — a larger cap, or a prompt packed to the
+        // window the server just revealed. Same replay argument as the
+        // outage wait below: the completion failed before any tool ran.
+        // Ahead of the finalization guard on purpose: the summary step
+        // is the one a reasoning model is likeliest to think past, and
+        // one bounded retry that replays nothing is not "more work".
+        const truncationPlan: TruncationRetryPlan | null = cancelled
+          ? null
+          : planTruncationRetry({
+              error: err,
+              alreadyRetried: truncationRetry?.stepIndex === i,
+              contextWindow: this.deps.contextWindow?.() ?? null,
+              fallbackMaxTokens: getConfig().localModels.completionMaxTokens,
+              canFitWindow: this.deps.onContextWindowObserved !== undefined,
+            });
+        if (truncationPlan !== null) {
+          const detail: TruncationDetail = truncationPlan.detail;
+          const retry: TruncationRetry = truncationPlan.retry;
+          truncationRetry = {
+            stepIndex: i,
+            original: runError,
+            ...(retry.kind === "raise_cap" ? { maxTokens: retry.maxTokens } : {}),
+          };
+          if (retry.kind === "fit_window") {
+            this.deps.onContextWindowObserved?.(retry.contextWindow);
+          }
+          // The notice the cut attempt carried (loop detector, steering,
+          // a trimmed batch) is still owed to the retry.
+          pendingNotice = composeTruncationNotice(noticeForThisStep, detail, retry);
+          this.deps.onEvent?.({
+            type: "completion_truncated",
+            stepIndex: i,
+            cause: detail.cause,
+            completionTokens: detail.completionTokens,
+            promptTokens: detail.promptTokens,
+            requestedMaxTokens: detail.requestedMaxTokens,
+            retry,
+          });
+          this.deps.logger?.warn("completion truncated; retrying the step", {
+            sessionId: state.id,
+            stepIndex: i,
+            cause: detail.cause,
+            completionTokens: detail.completionTokens,
+            promptTokens: detail.promptTokens,
+            requestedMaxTokens: detail.requestedMaxTokens,
+            retry: retry.kind,
+            ...(retry.kind === "raise_cap"
+              ? { maxTokens: retry.maxTokens }
+              : { contextWindow: retry.contextWindow }),
+          });
+          runError = null;
+          i -= 1;
+          continue;
+        }
         if (finalizationStep && !cancelled) {
           // A failed finalization must not execute more work or turn a
           // bounded run into an unbounded retry. Preserve the established
@@ -1260,6 +1398,9 @@ export class AgentLoop {
           await abortableSleep(nextRetryMs, options.signal);
           outageWaitedMs += nextRetryMs;
           runError = null;
+          // The retried step still owes the model the notice this
+          // attempt carried.
+          pendingNotice = noticeForThisStep;
           if (options.signal.aborted) {
             reason = "cancelled";
             state = { ...state, status: "cancelled" };
@@ -1271,6 +1412,23 @@ export class AgentLoop {
           // so step back one to land on it again.
           i -= 1;
           continue;
+        }
+        // A raised cap the provider refused — a 400 naming `max_tokens`
+        // or the context length — is not a new failure. The turn fails
+        // with the truncation that started it, which names the knob.
+        if (
+          truncationRetry?.stepIndex === i &&
+          truncationRetry.maxTokens !== undefined &&
+          isRequestSizeRejection(err)
+        ) {
+          this.deps.logger?.warn("provider refused the raised reply cap; failing with the truncation", {
+            sessionId: state.id,
+            stepIndex: i,
+            maxTokens: truncationRetry.maxTokens,
+            rejection: runError.message,
+          });
+          runError = truncationRetry.original;
+          category = classifyFailure(runError);
         }
         this.deps.logger?.error("agent loop failed", {
           sessionId: state.id,

--- a/src/agent/step-executor.test.ts
+++ b/src/agent/step-executor.test.ts
@@ -9,6 +9,7 @@ import {
   QWEN_THINK_PROFILE,
 } from "../llm/model-profile.js";
 import { REPAIR_MAX_TOKENS } from "./step-executor.js";
+import { OpenAiHttpError } from "../llm/provider/openai/openai-http.js";
 import { buildGrammar } from "../llm/grammar/build-grammar.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import { DEFAULT_TOOL_DESCRIPTORS } from "../prompt/tool-descriptors.js";
@@ -2820,4 +2821,291 @@ describe("executeStep repair parse transport", () => {
     expect(outcome.toolCalls[0]!.args).toEqual({ text: "served-native" });
     expect(outcome.toolResults[0]!.status).toBe("ok");
   });
+});
+
+describe("truncated completions", () => {
+  function makeNativeRegistry() {
+    const registry = new ToolRegistry();
+    registry.register({
+      name: "reply",
+      description: "reply",
+      readonly: true,
+      async run(args: Record<string, unknown>) {
+        return compressToolResult({
+          tool: "reply",
+          status: "ok",
+          output: String(args.text ?? ""),
+        });
+      },
+    });
+    return registry;
+  }
+
+  function nativeCompletion(overrides: Partial<CompletionResult>): CompletionResult {
+    return {
+      content: "",
+      reasoningContent: "",
+      stop: true,
+      truncated: false,
+      timing: { promptMs: 1, predictedMs: 1, promptTokens: 20, predictedTokens: 5 },
+      cacheHitTokens: 0,
+      slotId: -1,
+      modelId: "ornith-1.0-35b",
+      ...overrides,
+    };
+  }
+
+  function ctxFor(session: ReturnType<typeof createEmptySessionState>, maxTokens?: number) {
+    return {
+      session,
+      toolDescriptors: DEFAULT_TOOL_DESCRIPTORS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      stepIndex: 0,
+      signal: new AbortController().signal,
+      userMessage: "x",
+      ...(maxTokens !== undefined ? { maxTokens } : {}),
+    };
+  }
+
+  it("native_tools: a reply the server marked `length` fails closed even when its tool calls parse", async () => {
+    // Pinned in full by native-tool-call-execution-integrity.test.ts
+    // ("explicit finish_reason: length: executions = 0"): a cut reply
+    // dispatches nothing — the agent loop re-asks with a different
+    // request instead. Kept here so the truncation detail travels too.
+    const session = createEmptySessionState({ id: "s-trunc-closed", workingDir: "/w" });
+    await expect(
+      executeStep(ctxFor(session), {
+        registry: makeNativeRegistry(),
+        slotManager: new SlotManager(2),
+        async llmComplete() {
+          return nativeCompletion({
+            stop: false,
+            truncated: true,
+            finishReason: "length",
+            usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+            toolCalls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: { name: "reply", arguments: JSON.stringify({ text: "done" }) },
+              },
+            ],
+          });
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "truncated",
+      truncation: { cause: "reply_cap" },
+    });
+  });
+
+  it("native_tools: a cut short of the cap inside a known window is the provider's output limit", async () => {
+    const session = createEmptySessionState({ id: "s-trunc-limit", workingDir: "/w" });
+    await expect(
+      executeStep(ctxFor(session), {
+        registry: makeNativeRegistry(),
+        slotManager: new SlotManager(2),
+        contextWindow: 131_072,
+        async llmComplete() {
+          return nativeCompletion({
+            reasoningContent: "thinking…",
+            stop: false,
+            truncated: true,
+            finishReason: "length",
+            usage: { promptTokens: 6_000, completionTokens: 4_096, totalTokens: 10_096 },
+          });
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      truncation: { cause: "output_limit", completionTokens: 4_096 },
+    });
+  });
+
+  it("keeps the provider's own wording on a 400 that refuses the request's size", async () => {
+    const session = createEmptySessionState({ id: "s-size-400", workingDir: "/w" });
+    await expect(
+      executeStep(ctxFor(session), {
+        registry: makeNativeRegistry(),
+        slotManager: new SlotManager(2),
+        async llmComplete() {
+          throw new OpenAiHttpError(
+            "openai provider 400: max_tokens is too large: 32768. This model supports at most 16384 completion tokens",
+            400,
+            "https://x/v1/chat/completions",
+            false,
+            null,
+            "vendor",
+          );
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      }),
+    ).rejects.toMatchObject({
+      name: "TransportError",
+      status: 400,
+      message: expect.stringContaining("at most 16384 completion tokens"),
+    });
+  });
+
+  it("native_tools: a call whose arguments were cut mid-JSON is a truncation, with the cause attached", async () => {
+    const session = createEmptySessionState({ id: "s-trunc-cut", workingDir: "/w" });
+    await expect(
+      executeStep(ctxFor(session), {
+        registry: makeNativeRegistry(),
+        slotManager: new SlotManager(2),
+        async llmComplete() {
+          return nativeCompletion({
+            stop: false,
+            truncated: true,
+            finishReason: "length",
+            usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+            toolCalls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: { name: "reply", arguments: '{"text":"the reply was going to be very lo' },
+              },
+            ],
+          });
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "truncated",
+      stage: "initial",
+      truncation: {
+        cause: "reply_cap",
+        completionTokens: 8_192,
+        promptTokens: 6_000,
+        requestedMaxTokens: 8_192,
+      },
+    });
+  });
+
+  it("native_tools: a reply cut inside its reasoning is a truncation against the step's own cap", async () => {
+    // The agent loop's retry hands the step a raised cap; the request
+    // must carry it, and the failure detector must judge against it.
+    const session = createEmptySessionState({ id: "s-trunc-cap", workingDir: "/w" });
+    const capsSeen: Array<number | undefined> = [];
+    await expect(
+      executeStep(ctxFor(session, 32_768), {
+        registry: makeNativeRegistry(),
+        slotManager: new SlotManager(2),
+        async llmComplete({ maxTokens }) {
+          capsSeen.push(maxTokens);
+          return nativeCompletion({
+            reasoningContent: "Let me think about this very carefully…",
+            stop: false,
+            truncated: true,
+            finishReason: "length",
+            usage: { promptTokens: 6_000, completionTokens: 32_768, totalTokens: 38_768 },
+          });
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      truncation: { cause: "reply_cap", requestedMaxTokens: 32_768 },
+    });
+    expect(capsSeen).toEqual([32_768]);
+  });
+
+  it("native_tools: the one-shot repair runs under the step's cap, never the 1024 grammar cap", async () => {
+    // A reasoning model on the chat transport thinks server-side; 1024
+    // tokens is a guaranteed truncation there, which turned every repair
+    // into `Turn failed [model]: model response truncated`.
+    const session = createEmptySessionState({ id: "s-trunc-repair", workingDir: "/w" });
+    const capsSeen: Array<number | undefined> = [];
+    let calls = 0;
+    const outcome = await executeStep(ctxFor(session, 20_000), {
+      registry: makeNativeRegistry(),
+      slotManager: new SlotManager(2),
+      async llmComplete({ maxTokens }) {
+        capsSeen.push(maxTokens);
+        calls += 1;
+        if (calls === 1) {
+          // Reasoning-only: survives the first check, fails the parse,
+          // routes into the repair.
+          return nativeCompletion({ reasoningContent: "I should reply now." });
+        }
+        return nativeCompletion({
+          toolCalls: [
+            {
+              id: "call-repair",
+              type: "function",
+              function: { name: "reply", arguments: JSON.stringify({ text: "ok" }) },
+            },
+          ],
+        });
+      },
+      grammar: "",
+      profile: PLAIN_INSTRUCT_PROFILE,
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      supportsSlotAffinity: false,
+    });
+    expect(outcome.terminal).toBe("turn");
+    expect(capsSeen).toEqual([20_000, 20_000]);
+    expect(capsSeen[1]).toBeGreaterThan(REPAIR_MAX_TOKENS);
+  });
+
+  it("native_tools: a repair that comes back cut off names the repair stage and its cap", async () => {
+    const session = createEmptySessionState({ id: "s-trunc-repair-cut", workingDir: "/w" });
+    let calls = 0;
+    await expect(
+      executeStep(ctxFor(session), {
+        registry: makeNativeRegistry(),
+        slotManager: new SlotManager(2),
+        async llmComplete() {
+          calls += 1;
+          if (calls === 1) {
+            return nativeCompletion({ reasoningContent: "I should reply now." });
+          }
+          return nativeCompletion({
+            reasoningContent: "Let me reconsider…",
+            stop: false,
+            truncated: true,
+            finishReason: "length",
+            usage: { promptTokens: 6_100, completionTokens: 8_192, totalTokens: 14_292 },
+          });
+        },
+        grammar: "",
+        profile: PLAIN_INSTRUCT_PROFILE,
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        supportsSlotAffinity: false,
+      }),
+    ).rejects.toMatchObject({
+      name: "ModelError",
+      reason: "truncated",
+      stage: "repair",
+      truncation: { cause: "reply_cap", requestedMaxTokens: 8_192 },
+    });
+  });
+
 });

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -35,6 +35,7 @@ import {
   classifyFailure,
   detectModelFailure,
   humanizeOpenAiHttpError,
+  isRequestSizeRejection,
 } from "../llm/index.js";
 import { getConfig } from "../config/index.js";
 import {
@@ -235,6 +236,13 @@ export interface StepContext {
   userMessage?: string | null;
   /** Restrict this step to the terminal reply/finish tools. */
   terminalOnly?: boolean;
+  /**
+   * Reply cap for this step's completions, in place of
+   * `localModels.completionMaxTokens`. The agent loop sets it when the
+   * previous attempt at this very step came back cut off by the cap
+   * (`planTruncationRetry`); nothing else overrides the config.
+   */
+  maxTokens?: number;
 }
 
 /**
@@ -453,6 +461,9 @@ async function executeStepInner(
     promptTokens: prompt.tokens.total,
   });
 
+  // The cap every completion of this step runs under. Named here so the
+  // failure detector can say which wall a cut-off reply hit.
+  const replyCap = ctx.maxTokens ?? getConfig().localModels.completionMaxTokens;
   const llmParams: LlmStreamParams = {
     ...buildLlmStreamParams({
       promptText: prompt.text,
@@ -463,6 +474,7 @@ async function executeStepInner(
       signal: ctx.signal,
     }),
     ...(grammarPrompt ? { grammarPrompt } : {}),
+    ...(ctx.maxTokens !== undefined ? { maxTokens: ctx.maxTokens } : {}),
   };
 
   const firstAttempt = await runInitialCompletion({
@@ -506,7 +518,11 @@ async function executeStepInner(
   // tool-call providers are the exception for reasoning-only empty bodies:
   // the model may have thought but failed to emit a required tool call, and
   // the existing repair path can recover with a stricter one-shot prompt.
-  const initialModelFailure = detectModelFailure(completion);
+  const initialModelFailure = detectModelFailure(completion, {
+    requestedMaxTokens: replyCap,
+    stage: "initial",
+    contextWindow: deps.contextWindow ?? null,
+  });
   if (initialModelFailure !== null) {
     const initialParseDeps = parseDepsFor(completion, deps);
     const repairable = isGrammarEmptyCompletionWorthRepairing(
@@ -536,7 +552,13 @@ async function executeStepInner(
         // `stage: "initial"` is the other half of the split: the same
         // `reason` + `transport` pair is also raised after the one-shot
         // repair below, and only this field tells the two apart.
-        { transport: initialParseDeps.toolTransport, stage: "initial" },
+        {
+          transport: initialParseDeps.toolTransport,
+          stage: "initial",
+          ...(initialModelFailure.truncation
+            ? { truncation: initialModelFailure.truncation }
+            : {}),
+        },
       );
     }
     if (repairable) {
@@ -797,7 +819,12 @@ async function executeStepInner(
       // `GrammarError: tool-call body is empty`. 1024 keeps the
       // anti-loop guard (still well under `completionMaxTokens=8192`)
       // while leaving room for one full edit call in the worst case.
-      maxTokens: REPAIR_MAX_TOKENS,
+      //
+      // Grammar links only. On the chat transport a reasoning model
+      // thinks server-side, with no prefill to strip, and 1024 is a
+      // guaranteed truncation — the repair would end every turn it was
+      // meant to save. See `repairReplyCap`.
+      maxTokens: repairReplyCap(deps.toolTransport, replyCap),
     });
     const retryDurationMs = Date.now() - retryStartedAt;
     deps.onCompletion?.(completion);
@@ -834,7 +861,11 @@ async function executeStepInner(
     // a truncated or empty reply on the second attempt, it is a model
     // failure, not a grammar one — no point emitting `GrammarError` for
     // an empty body.
-    const retryModelFailure = detectModelFailure(completion);
+    const retryModelFailure = detectModelFailure(completion, {
+      requestedMaxTokens: repairReplyCap(deps.toolTransport, replyCap),
+      stage: "repair",
+      contextWindow: deps.contextWindow ?? null,
+    });
     const retryParseDeps = parseDepsFor(completion, deps);
     if (
       retryModelFailure !== null &&
@@ -861,7 +892,13 @@ async function executeStepInner(
         // first-attempt throw was skipped) and the repair came back with
         // nothing in any channel. Same `reason=empty`, same
         // `transport=native_tools`, different story.
-        { transport: retryParseDeps.toolTransport, stage: "repair" },
+        {
+          transport: retryParseDeps.toolTransport,
+          stage: "repair",
+          ...(retryModelFailure.truncation
+            ? { truncation: retryModelFailure.truncation }
+            : {}),
+        },
       );
     }
 
@@ -1294,6 +1331,23 @@ function isNativeToolsEmptyCompletionHandledByParser(
       ? completion.reasoningContent.trim()
       : "";
   return reasoning.length > 0;
+}
+
+/**
+ * The cap the one-shot repair completion runs under.
+ *
+ * `REPAIR_MAX_TOKENS` is a grammar-link guard: the repair prompt strips
+ * the reasoning prefill there, which keeps the think block short, and
+ * the cap stops a self-deliberation loop from holding a llama-server
+ * slot for minutes. On `native_tools` neither premise holds — the chat
+ * template opens the think block server-side and there is no slot — so
+ * a reasoning model routinely needs more than 1024 tokens just to reach
+ * the tool call, and the cap turned every repair into a truncation.
+ * The step's own cap bounds it instead, the same bound as the first
+ * completion.
+ */
+function repairReplyCap(transport: ToolCallTransport, stepCap: number): number {
+  return transport === "native_tools" ? stepCap : REPAIR_MAX_TOKENS;
 }
 
 /**
@@ -1833,6 +1887,9 @@ function rawPreview(content: string): string {
  * old/new strings) hitting the 512 ceiling and surfacing as
  * `GrammarError: tool-call body is empty`. 1024 still keeps the
  * anti-runaway guard well under `completionMaxTokens` (8192).
+ *
+ * Applies to grammar links only — see `repairReplyCap` for why the chat
+ * transport runs the repair under the step's cap instead.
  */
 export const REPAIR_MAX_TOKENS = 1024;
 
@@ -2011,7 +2068,13 @@ function toLlmFailure(err: unknown, ctx: StepContext): LlmFailure {
   // The chat message gets the human wording; the raw technical string
   // stays on the cause for logs.
   if (err instanceof OpenAiHttpError) {
-    return new TransportError(humanizeOpenAiHttpError(err), err.status, err.url, {
+    // A request the provider refused for its size is the one 400 whose
+    // body the user needs to read: it names the limit. Everything else
+    // keeps the humanized line alone.
+    const message = isRequestSizeRejection(err)
+      ? `${humanizeOpenAiHttpError(err)} ${requestSizeExcerpt(err.message)}`
+      : humanizeOpenAiHttpError(err);
+    return new TransportError(message, err.status, err.url, {
       cause: err,
     });
   }
@@ -2039,6 +2102,12 @@ function toLlmFailure(err: unknown, ctx: StepContext): LlmFailure {
     return new TransportError(wrapped.message, null, "", { cause: err });
   }
   return new ToolExecutionError("unknown", wrapped.message, { cause: err });
+}
+
+/** The provider's own sentence about the limit, without the status prefix. */
+function requestSizeExcerpt(message: string): string {
+  const body = message.replace(/^openai provider \d+:\s*/, "").trim();
+  return body.length > 200 ? `${body.slice(0, 200)}…` : body;
 }
 
 function isAbortError(err: unknown): boolean {

--- a/src/agent/truncation-recovery.test.ts
+++ b/src/agent/truncation-recovery.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { ModelError, TransportError } from "../llm/index.js";
+import type { TruncationDetail } from "../llm/index.js";
+import {
+  TRUNCATION_RETRY_CAP_CEILING,
+  composeTruncationNotice,
+  formatTruncationNotice,
+  planTruncationRetry,
+} from "./truncation-recovery.js";
+
+function truncated(detail: Partial<TruncationDetail>): ModelError {
+  return new ModelError("truncated", "model response truncated", {
+    transport: "native_tools",
+    stage: "initial",
+    truncation: {
+      cause: "reply_cap",
+      completionTokens: 8_192,
+      promptTokens: 6_000,
+      requestedMaxTokens: 8_192,
+      ...detail,
+    },
+  });
+}
+
+const BASE = {
+  alreadyRetried: false,
+  contextWindow: null,
+  fallbackMaxTokens: 8_192,
+  canFitWindow: true,
+};
+
+describe("planTruncationRetry", () => {
+  it("raises the cap four-fold when the reply spent it", () => {
+    const plan = planTruncationRetry({ ...BASE, error: truncated({}) });
+    expect(plan?.retry).toEqual({ kind: "raise_cap", maxTokens: 32_768 });
+  });
+
+  it("never raises past the ceiling", () => {
+    const plan = planTruncationRetry({
+      ...BASE,
+      error: truncated({ requestedMaxTokens: 16_384, completionTokens: 16_384 }),
+    });
+    expect(plan?.retry).toEqual({ kind: "raise_cap", maxTokens: TRUNCATION_RETRY_CAP_CEILING });
+  });
+
+  it("stays under a known window", () => {
+    // 20k window, 12k prompt: 4 × 4096 would be a 400 on a strict
+    // provider and a silent clamp on llama.cpp. Leave headroom instead.
+    const plan = planTruncationRetry({
+      ...BASE,
+      contextWindow: 20_000,
+      error: truncated({ requestedMaxTokens: 4_096, completionTokens: 4_096, promptTokens: 12_000 }),
+    });
+    expect(plan?.retry).toEqual({ kind: "raise_cap", maxTokens: 20_000 - 12_000 - 512 });
+  });
+
+  it("plans nothing when the window leaves no room to raise", () => {
+    const plan = planTruncationRetry({
+      ...BASE,
+      contextWindow: 15_000,
+      error: truncated({ requestedMaxTokens: 8_192, completionTokens: 8_192, promptTokens: 6_500 }),
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("treats an unknown cause as the cap, using the fallback when the error carries none", () => {
+    const plan = planTruncationRetry({
+      ...BASE,
+      error: truncated({ cause: "unknown", completionTokens: 0, promptTokens: 0, requestedMaxTokens: 0 }),
+    });
+    expect(plan?.retry).toEqual({ kind: "raise_cap", maxTokens: 32_768 });
+  });
+
+  it("learns the window when the reply stopped short of the cap", () => {
+    const plan = planTruncationRetry({
+      ...BASE,
+      error: truncated({ cause: "context_window", completionTokens: 2_768, promptTokens: 30_000 }),
+    });
+    expect(plan?.retry).toEqual({ kind: "fit_window", contextWindow: 32_768 });
+  });
+
+  it("plans nothing for a window truncation when no one can record the window", () => {
+    const plan = planTruncationRetry({
+      ...BASE,
+      canFitWindow: false,
+      error: truncated({ cause: "context_window", completionTokens: 2_768, promptTokens: 30_000 }),
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("plans nothing for a provider's output limit — no request changes that", () => {
+    const plan = planTruncationRetry({
+      ...BASE,
+      contextWindow: 131_072,
+      error: truncated({ cause: "output_limit", completionTokens: 4_096, promptTokens: 6_000 }),
+    });
+    expect(plan).toBeNull();
+  });
+
+  it("retries a step once", () => {
+    expect(planTruncationRetry({ ...BASE, alreadyRetried: true, error: truncated({}) })).toBeNull();
+  });
+
+  it("ignores every other failure", () => {
+    expect(
+      planTruncationRetry({ ...BASE, error: new TransportError("fetch failed", null, "") }),
+    ).toBeNull();
+    expect(
+      planTruncationRetry({
+        ...BASE,
+        error: new ModelError("empty", "model returned empty content"),
+      }),
+    ).toBeNull();
+    // A truncated ModelError from a caller that did not classify it.
+    expect(
+      planTruncationRetry({ ...BASE, error: new ModelError("truncated", "model response truncated") }),
+    ).toBeNull();
+  });
+});
+
+describe("truncation notice", () => {
+  const detail: TruncationDetail = {
+    cause: "reply_cap",
+    completionTokens: 8_192,
+    promptTokens: 6_000,
+    requestedMaxTokens: 8_192,
+  };
+
+  it("tells the model its reply was cut and what the retry allows", () => {
+    const notice = formatTruncationNotice(detail, { kind: "raise_cap", maxTokens: 32_768 });
+    expect(notice).toContain("cut off after 8192 tokens");
+    expect(notice).toContain("32768 tokens");
+    expect(notice).toContain("Keep your reasoning brief");
+  });
+
+  it("explains the trimmed conversation on a window retry", () => {
+    const notice = formatTruncationNotice(
+      { ...detail, cause: "context_window" },
+      { kind: "fit_window", contextWindow: 32_768 },
+    );
+    expect(notice).toContain("ran out of context");
+    expect(notice).toContain("trimmed");
+  });
+
+  it("keeps whatever notice the step already carried, first", () => {
+    const composed = composeTruncationNotice("loop detector says stop", detail, {
+      kind: "raise_cap",
+      maxTokens: 32_768,
+    });
+    expect(composed.startsWith("loop detector says stop\n\n")).toBe(true);
+    expect(composeTruncationNotice(undefined, detail, { kind: "raise_cap", maxTokens: 1 })).not.toContain("\n\n");
+  });
+});

--- a/src/agent/truncation-recovery.ts
+++ b/src/agent/truncation-recovery.ts
@@ -1,0 +1,139 @@
+import { ModelError } from "../llm/index.js";
+import type { TruncationDetail } from "../llm/index.js";
+
+/**
+ * How the agent loop recovers from a reply the server cut short.
+ *
+ * A truncated completion is not a verdict on the step, but replaying the
+ * same request is pointless — the same prompt under the same cap hits the
+ * same wall. What helps depends on which wall it was
+ * (`classifyTruncation`), and the two want opposite things:
+ *
+ *  - `reply_cap`: the model spent the whole `max_tokens` — typically a
+ *    reasoning model thinking past the cap before it emits the tool
+ *    call. The retry raises the cap for this one step.
+ *  - `context_window`: the reply stopped short of the cap because the
+ *    server ran out of context. Raising the cap cannot help; the retry
+ *    reports the window the server just demonstrated so the next prompt
+ *    is packed to fit, and runs under the same cap.
+ *  - `output_limit`: the provider clamps this model's output below our
+ *    cap. A bigger cap is refused or clamped again, a smaller prompt
+ *    changes nothing — no retry; the message names the limit.
+ *  - `unknown`: no usage came back. Treated as the cap — one wasted
+ *    generation if it was the window, and the second cut ends the turn
+ *    with a message that says so.
+ *
+ * One retry per step index. The model also reads a `### notice` saying
+ * its reply was cut, so the retry is a different request in prompt as
+ * well as in cap.
+ */
+
+/** Multiplier on the cap a truncated reply spent. */
+export const TRUNCATION_RETRY_CAP_MULTIPLIER = 4;
+
+/**
+ * Ceiling on the raised cap. 32k covers a long think block plus a whole
+ * file write; a reply that needs more is the problem, not the cap.
+ */
+export const TRUNCATION_RETRY_CAP_CEILING = 32_768;
+
+/**
+ * Headroom kept between a raised cap and a known window, for the drift
+ * between our token estimate of the prompt and the server's count.
+ */
+const WINDOW_HEADROOM_TOKENS = 512;
+
+export type TruncationRetry =
+  | { kind: "raise_cap"; maxTokens: number }
+  | { kind: "fit_window"; contextWindow: number };
+
+export interface TruncationRetryPlan {
+  detail: TruncationDetail;
+  retry: TruncationRetry;
+}
+
+export interface PlanTruncationRetryInput {
+  /** The failure the step threw. Anything but a truncated `ModelError` plans nothing. */
+  error: unknown;
+  /** The step was already retried once; a second cut ends the turn. */
+  alreadyRetried: boolean;
+  /** The window the runtime believes in, when it knows one. */
+  contextWindow: number | null;
+  /** The cap the step ran under when the error does not say. */
+  fallbackMaxTokens: number;
+  /** Whether a learned window has anywhere to go (`onContextWindowObserved` wired). */
+  canFitWindow: boolean;
+}
+
+export function planTruncationRetry(
+  input: PlanTruncationRetryInput,
+): TruncationRetryPlan | null {
+  const { error } = input;
+  if (!(error instanceof ModelError) || error.reason !== "truncated") return null;
+  const detail = error.truncation;
+  if (detail === undefined || input.alreadyRetried) return null;
+  if (detail.cause === "output_limit") return null;
+  if (detail.cause === "context_window") {
+    if (!input.canFitWindow) return null;
+    const contextWindow = detail.promptTokens + detail.completionTokens;
+    if (contextWindow <= 0) return null;
+    return { detail, retry: { kind: "fit_window", contextWindow } };
+  }
+  const requested =
+    detail.requestedMaxTokens > 0 ? detail.requestedMaxTokens : input.fallbackMaxTokens;
+  if (requested <= 0) return null;
+  let raised = Math.min(
+    TRUNCATION_RETRY_CAP_CEILING,
+    requested * TRUNCATION_RETRY_CAP_MULTIPLIER,
+  );
+  // A cap the window cannot hold is a 400 waiting to happen on a strict
+  // provider, and a silent clamp on llama.cpp. Stay under what is known.
+  if (input.contextWindow !== null && input.contextWindow > 0 && detail.promptTokens > 0) {
+    raised = Math.min(
+      raised,
+      input.contextWindow - detail.promptTokens - WINDOW_HEADROOM_TOKENS,
+    );
+  }
+  if (raised <= requested) return null;
+  return { detail, retry: { kind: "raise_cap", maxTokens: raised } };
+}
+
+/**
+ * The `### notice` the retried step carries. Imperative and short: the
+ * step's transcript already shows nothing of the cut reply, so this is
+ * the only place the model learns why it is being asked again.
+ */
+export function formatTruncationNotice(
+  detail: TruncationDetail,
+  retry: TruncationRetry,
+): string {
+  const cut =
+    detail.completionTokens > 0
+      ? `Your previous reply to this step was cut off after ${detail.completionTokens} tokens, before it finished.`
+      : "Your previous reply to this step was cut off before it finished.";
+  if (retry.kind === "raise_cap") {
+    return (
+      `${cut} The reply limit is ${retry.maxTokens} tokens for this attempt. ` +
+      "Keep your reasoning brief and emit the tool call now; if the output is long, split it across several steps."
+    );
+  }
+  return (
+    `${cut} The model server ran out of context, so older conversation has been trimmed to fit. ` +
+    "Continue from the latest tool results, keep your reasoning brief, and emit the tool call now."
+  );
+}
+
+/**
+ * Fold the truncation notice into whatever one-shot notice the step
+ * already carries (loop detector, steering). Existing text first: it
+ * describes what the model did, which is context for what to do now.
+ */
+export function composeTruncationNotice(
+  existing: string | undefined,
+  detail: TruncationDetail,
+  retry: TruncationRetry,
+): string {
+  const block = formatTruncationNotice(detail, retry);
+  if (existing === undefined || existing.length === 0) return block;
+  return `${existing}\n\n${block}`;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -152,7 +152,7 @@ function printHelp(): void {
     "Bootstrap env:",
     "  ATOMIC_AGENT_STATE_DIR         Directory for persistent state + config.json (default ~/.atomic-agent)",
     "  ATOMIC_AGENT_LLAMA_API_KEY     Optional bearer token for the llama-server",
-    "  ATOMIC_AGENT_LLAMA_MAX_TOKENS  Max new tokens per completion (n_predict), default 4096, clamped 64..131072",
+    "  ATOMIC_AGENT_LLAMA_MAX_TOKENS  Max new tokens per completion (n_predict / max_tokens), default 8192, clamped 64..131072",
     "  ATOMIC_AGENT_BROWSER_CHANNEL           Preferred browser family: chrome | msedge | chromium (default chrome)",
     "  ATOMIC_AGENT_BROWSER_EXECUTABLE_PATH   Explicit path to a Chromium-family binary (overrides auto-detect)",
     "  ATOMIC_AGENT_BROWSER_HEADLESS          1 to run headless (default 0)",

--- a/src/cli/trace-formatter.test.ts
+++ b/src/cli/trace-formatter.test.ts
@@ -30,6 +30,29 @@ function render(events: readonly TraceEvent[]): string {
   return formatTraceChronology(events);
 }
 
+describe("formatTraceChronology completion_truncated", () => {
+  it("prints the cause, the counts and the retry on one line", () => {
+    const out = render([
+      {
+        type: "completion_truncated",
+        seq: 3,
+        sessionId: "s-1",
+        ts: Date.parse("2026-09-01T10:00:00.000Z"),
+        turnIndex: 0,
+        stepIndex: 2,
+        cause: "reply_cap",
+        completionTokens: 8_192,
+        promptTokens: 6_000,
+        requestedMaxTokens: 8_192,
+        retry: "raise_cap",
+        retryValue: 32_768,
+      },
+    ]);
+    expect(out).toContain("completion_truncated");
+    expect(out).toContain("step=2 cause=reply_cap reply=8192 prompt=6000 cap=8192 retry=raise_cap:32768");
+  });
+});
+
 describe("formatTraceChronology loop_detected", () => {
   it("renders the bare line for a trace that predates the detector fields", () => {
     const line = render([loopDetected({ tool: "noop", count: 3 })]);

--- a/src/cli/trace-formatter.ts
+++ b/src/cli/trace-formatter.ts
@@ -92,6 +92,8 @@ function formatTraceEvent(event: TraceEvent, raw: boolean): string {
       )}s reason=${truncate(event.reason, 120, raw)}`;
     case "provider_recovered":
       return `${head} waited=${Math.round(event.waitedMs / 1000)}s`;
+    case "completion_truncated":
+      return `${head} step=${event.stepIndex} cause=${event.cause} reply=${event.completionTokens} prompt=${event.promptTokens} cap=${event.requestedMaxTokens} retry=${event.retry}:${event.retryValue}`;
     case "loop_detected":
       return `${head} step=${event.stepIndex} tool=${event.tool} count=${event.count}${
         event.detector !== undefined ? ` detector=${event.detector}` : ""

--- a/src/llm/fallback/should-advance.test.ts
+++ b/src/llm/fallback/should-advance.test.ts
@@ -63,6 +63,33 @@ describe("shouldAdvance", () => {
     });
   });
 
+  it("does NOT advance on a cloud 400 that names the reply cap or the context length", () => {
+    // The request is too big for the model; the next link would refuse
+    // it too, and the local fallback usually has the smaller window.
+    expect(
+      shouldAdvance(
+        new OpenAiHttpError(
+          "openai provider 400: max_tokens is too large: 32768. This model supports at most 16384 completion tokens",
+          400,
+          "u",
+        ),
+      ),
+    ).toEqual({ advance: false, immediate: false });
+    expect(
+      shouldAdvance(
+        new TransportError('"vendor" rejected the request (400).', 400, "u", {
+          cause: new OpenAiHttpError("openai provider 400: This model's maximum context length is 8192 tokens", 400, "u"),
+        }),
+      ),
+    ).toEqual({ advance: false, immediate: false });
+  });
+
+  it("still advances on any other cloud 400 — the body may be wrong for this vendor only", () => {
+    expect(
+      shouldAdvance(new OpenAiHttpError("openai provider 400: unsupported parameter: tools", 400, "u")),
+    ).toEqual({ advance: true, immediate: false });
+  });
+
   it("advances (transport) on a cloud 401 — a dead key should try the fallback", () => {
     // OpenAiHttpError is always transport-category; 401 is not an
     // immediate provider-down signal, so it advances via the threshold.

--- a/src/llm/fallback/should-advance.ts
+++ b/src/llm/fallback/should-advance.ts
@@ -2,6 +2,7 @@ import { classifyFailure } from "../reliability/classify-failure.js";
 import { OpenAiHttpError } from "../provider/openai/openai-http.js";
 import { LlamaServerError } from "../llama-server-client.js";
 import { TransportError } from "../reliability/llm-failures.js";
+import { isRequestSizeRejection } from "../reliability/request-size-rejection.js";
 
 /**
  * Fallover decision for a single thrown error.
@@ -58,6 +59,13 @@ const NO: AdvanceDecision = { advance: false, immediate: false };
  * only counts toward the threshold).
  */
 export function shouldAdvance(err: unknown): AdvanceDecision {
+  // A 400/413 that names the reply cap or the context length is the
+  // request being too big for the model, not the link being down. It is
+  // deterministic on every link (the local fallback usually has the
+  // smaller window), and falling over on it once sent a cloud turn to a
+  // llama-server that was not running — and from there into the outage
+  // wait. Same standing as the local 400/413/422 band below.
+  if (isRequestSizeRejection(err)) return NO;
   const category = classifyFailure(err);
   if (category !== "transport" && category !== "model") {
     return NO;

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -45,15 +45,21 @@ export {
   ToolExecutionError,
   TransportError,
   classifyFailure,
+  classifyTruncation,
   detectModelFailure,
+  formatTruncatedMessage,
+  isRequestSizeRejection,
 } from "./reliability/index.js";
 export type {
+  DetectModelFailureOptions,
   DetectedModelFailure,
   LlmFailureCategory,
   LlmFailureOptions,
   ModelErrorOptions,
   ModelFailureReason,
   ModelFailureStage,
+  TruncationCause,
+  TruncationDetail,
 } from "./reliability/index.js";
 export {
   LlamaServerProvider,

--- a/src/llm/provider/openai/openai-build-body.test.ts
+++ b/src/llm/provider/openai/openai-build-body.test.ts
@@ -39,6 +39,24 @@ describe("buildOpenAiChatBody", () => {
     });
   });
 
+  it("asks for the usage block on a streamed request, and only there", () => {
+    // A streamed reply cut off by `finish_reason: "length"` arrives with
+    // no token counts unless the request asks; the counts are what tell
+    // a spent reply cap apart from a full context window.
+    const streamed = buildOpenAiChatBody({ prompt: "hi" }, "m", true);
+    expect(streamed.stream_options).toEqual({ include_usage: true });
+    const unary = buildOpenAiChatBody({ prompt: "hi" }, "m", false);
+    expect(unary).not.toHaveProperty("stream_options");
+  });
+
+  it("lets extraBody drop stream_options for a vendor that rejects it", () => {
+    const body = buildOpenAiChatBody({ prompt: "hi" }, "m", true, {
+      stream_options: undefined,
+    });
+    expect(body.stream_options).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(body))).not.toHaveProperty("stream_options");
+  });
+
   it("honours explicit strict=false override", () => {
     const body = buildOpenAiChatBody(
       {

--- a/src/llm/provider/openai/openai-build-body.ts
+++ b/src/llm/provider/openai/openai-build-body.ts
@@ -24,6 +24,17 @@ export function buildOpenAiChatBody(
     max_tokens: filtered.maxTokens ?? getConfig().localModels.completionMaxTokens,
     stream,
   };
+  if (stream) {
+    // Ask for the usage block on the stream's last chunk. Without it
+    // most servers send none — OpenAI, llama.cpp and everything built on
+    // it — and a reply cut off by `finish_reason: "length"` then arrives
+    // with no token counts, which is exactly what tells a spent reply
+    // cap apart from a full context window (`classifyTruncation`).
+    // Providers that never needed the flag ignore it (OpenRouter,
+    // Anthropic's compatibility layer); Gemini honours it from 2.5. A
+    // vendor that rejects it can drop it through `extraBody`.
+    body.stream_options = { include_usage: true };
+  }
   if (filtered.stop) body.stop = filtered.stop;
   if (typeof filtered.seed === "number") body.seed = filtered.seed;
   if (filtered.tools && filtered.tools.length > 0) {

--- a/src/llm/provider/openai/openai-stream-consumer.test.ts
+++ b/src/llm/provider/openai/openai-stream-consumer.test.ts
@@ -40,6 +40,38 @@ const DONE = sseFrame({
   choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
 }) + "data: [DONE]\n\n";
 
+describe("openai stream consumer usage", () => {
+  it("keeps a length finish_reason and reads usage from the trailing empty-choices chunk", async () => {
+    // With `stream_options.include_usage`, OpenAI-style servers send the
+    // usage block on one more chunk after the finish_reason, with an
+    // empty `choices` array. Both must survive to the final result: the
+    // cut is what fails the step, the counts are what explain it.
+    const result = await drain(
+      sseFrame({
+        model: "test-model",
+        choices: [{ index: 0, delta: { content: "<think>still thinking" }, finish_reason: null }],
+      }) +
+        sseFrame({
+          model: "test-model",
+          choices: [{ index: 0, delta: {}, finish_reason: "length" }],
+        }) +
+        sseFrame({
+          model: "test-model",
+          choices: [],
+          usage: { prompt_tokens: 6100, completion_tokens: 8192, total_tokens: 14292 },
+        }) +
+        "data: [DONE]\n\n",
+    );
+    expect(result.finishReason).toBe("length");
+    expect(result.terminalObserved).toBe(true);
+    expect(result.usage).toEqual({
+      promptTokens: 6100,
+      completionTokens: 8192,
+      totalTokens: 14292,
+    });
+  });
+});
+
 describe("openai stream consumer tool-call assembly", () => {
   it("keeps unindexed calls with distinct ids apart", async () => {
     const result = await drain(

--- a/src/llm/provider/verify/run-contract-probe.test.ts
+++ b/src/llm/provider/verify/run-contract-probe.test.ts
@@ -170,6 +170,9 @@ describe("runProviderContractProbe", () => {
 
     const body = script.bodies()[0]!;
     expect(body.stream).toBe(true);
+    // The probe must show the route every field a turn sends, and a
+    // turn asks for usage on every stream.
+    expect(body.stream_options).toEqual({ include_usage: true });
     expect(body.model).toBe("vendor/some-model");
     expect(body.tool_choice).toEqual({
       type: "function",

--- a/src/llm/provider/verify/run-contract-probe.ts
+++ b/src/llm/provider/verify/run-contract-probe.ts
@@ -364,7 +364,8 @@ async function runRung(
 /**
  * The probe request, in the same shape `buildOpenAiChatBody` gives a
  * real turn — the streamed transport, the tools payload,
- * `parallel_tool_calls`, and the `max_tokens` cap a turn always carries.
+ * `parallel_tool_calls`, the `max_tokens` cap a turn always carries and
+ * the `stream_options` usage request that goes with every stream.
  * Sending anything less would let a route pass the probe and then fail
  * the first message on a field the probe never showed it.
  *
@@ -387,6 +388,7 @@ function probeBody(
     temperature: 0,
     max_tokens: PROBE_MAX_TOKENS,
     stream: true,
+    stream_options: { include_usage: true },
   };
   if (mode === null) return body;
   body.tools = [contractProbeToolDefinition()];

--- a/src/llm/reliability/detect-model-failure.test.ts
+++ b/src/llm/reliability/detect-model-failure.test.ts
@@ -47,6 +47,128 @@ describe("detectModelFailure", () => {
     expect(result?.message).toMatch(/256/);
   });
 
+  it("names the reply cap when the reply spent it", () => {
+    const completion = makeCompletion({
+      content: "",
+      truncated: true,
+      usage: { promptTokens: 6_000, completionTokens: 8_192, totalTokens: 14_192 },
+    });
+    const result = detectModelFailure(completion, { requestedMaxTokens: 8_192 });
+    expect(result?.reason).toBe("truncated");
+    expect(result?.truncation).toEqual({
+      cause: "reply_cap",
+      completionTokens: 8_192,
+      promptTokens: 6_000,
+      requestedMaxTokens: 8_192,
+    });
+    expect(result?.message).toContain("at 8192 tokens");
+    expect(result?.message).toContain("localModels.completionMaxTokens");
+    expect(result?.message).toContain("8192");
+  });
+
+  it("treats a reply within a few tokens of the cap as having spent it", () => {
+    // llama.cpp stops one short of `n_predict` after the stop-token test.
+    const completion = makeCompletion({
+      content: "",
+      truncated: true,
+      usage: { promptTokens: 100, completionTokens: 8_190, totalTokens: 8_290 },
+    });
+    expect(
+      detectModelFailure(completion, { requestedMaxTokens: 8_192 })?.truncation?.cause,
+    ).toBe("reply_cap");
+  });
+
+  it("blames the context window when the reply stopped short of the cap", () => {
+    const completion = makeCompletion({
+      content: "",
+      truncated: true,
+      usage: { promptTokens: 30_000, completionTokens: 2_768, totalTokens: 32_768 },
+    });
+    const result = detectModelFailure(completion, { requestedMaxTokens: 8_192 });
+    expect(result?.truncation?.cause).toBe("context_window");
+    expect(result?.message).toContain("ran out of context");
+    expect(result?.message).toContain("30000-token prompt");
+    expect(result?.message).toContain("larger context size");
+  });
+
+  it("blames the provider's output limit when a known window is nowhere near full", () => {
+    // OpenRouter/Groq-style clamp: a 128k model whose route caps output
+    // at 4096. Learning 10k as the window here would shrink every later
+    // prompt for nothing.
+    const completion = makeCompletion({
+      content: "",
+      truncated: true,
+      usage: { promptTokens: 6_000, completionTokens: 4_096, totalTokens: 10_096 },
+    });
+    const result = detectModelFailure(completion, {
+      requestedMaxTokens: 8_192,
+      contextWindow: 131_072,
+    });
+    expect(result?.truncation?.cause).toBe("output_limit");
+    expect(result?.message).toContain("output limit is about 4096 tokens");
+    expect(result?.message).toContain("lower the cap");
+  });
+
+  it("still blames the window when prompt + reply reach it", () => {
+    const completion = makeCompletion({
+      content: "",
+      truncated: true,
+      usage: { promptTokens: 30_000, completionTokens: 2_700, totalTokens: 32_700 },
+    });
+    expect(
+      detectModelFailure(completion, { requestedMaxTokens: 8_192, contextWindow: 32_768 })
+        ?.truncation?.cause,
+    ).toBe("context_window");
+  });
+
+  it("says it cannot tell when the provider reported no usage", () => {
+    const completion = makeCompletion({ content: "", truncated: true });
+    const result = detectModelFailure(completion, { requestedMaxTokens: 8_192 });
+    expect(result?.truncation?.cause).toBe("unknown");
+    expect(result?.message).toContain("8192-token reply cap");
+    expect(result?.message).toContain("context window");
+    expect(result?.message).toContain("no token counts");
+  });
+
+  it("names the repair pass's own cap on the repair stage", () => {
+    const completion = makeCompletion({
+      content: "",
+      truncated: true,
+      usage: { promptTokens: 100, completionTokens: 1_024, totalTokens: 1_124 },
+    });
+    const result = detectModelFailure(completion, {
+      requestedMaxTokens: 1_024,
+      stage: "repair",
+    });
+    expect(result?.message).toContain("repair pass");
+    expect(result?.message).not.toContain("localModels.completionMaxTokens");
+  });
+
+  it("reads llama-server timings when there is no usage block", () => {
+    // The grammar path reports `predicted_n`, never `usage`, and its
+    // `truncated` flag means one thing: the context overflowed. Even a
+    // count that lands on the cap is the window there.
+    const completion = makeCompletion({
+      content: "",
+      truncated: true,
+      timing: { promptMs: 1, predictedMs: 1, promptTokens: 7_000, predictedTokens: 900 },
+    });
+    expect(detectModelFailure(completion, { requestedMaxTokens: 8_192 })?.truncation).toEqual({
+      cause: "context_window",
+      completionTokens: 900,
+      promptTokens: 7_000,
+      requestedMaxTokens: 8_192,
+    });
+    const onTheCap = makeCompletion({
+      content: "",
+      truncated: true,
+      timing: { promptMs: 1, predictedMs: 1, promptTokens: 7_000, predictedTokens: 8_192 },
+    });
+    expect(
+      detectModelFailure(onTheCap, { requestedMaxTokens: 8_192 })?.truncation?.cause,
+    ).toBe("context_window");
+  });
+
   it("reports empty output when content is blank", () => {
     const completion = makeCompletion({
       content: "   ",

--- a/src/llm/reliability/detect-model-failure.ts
+++ b/src/llm/reliability/detect-model-failure.ts
@@ -1,18 +1,48 @@
 import type { CompletionResult } from "../llama-server-client.js";
-import type { ModelFailureReason } from "./failure-category.js";
+import type {
+  ModelFailureReason,
+  ModelFailureStage,
+  TruncationCause,
+  TruncationDetail,
+} from "./failure-category.js";
 
 export interface DetectedModelFailure {
   reason: ModelFailureReason;
   message: string;
+  /** Present only when `reason === "truncated"`. */
+  truncation?: TruncationDetail;
+}
+
+export interface DetectModelFailureOptions {
+  /**
+   * The `max_tokens` / `n_predict` cap the request carried. Without it a
+   * truncated reply cannot be told apart from a full context window, so
+   * the message can only say "truncated".
+   */
+  requestedMaxTokens?: number;
+  /**
+   * Which attempt produced the completion. The repair pass runs under
+   * its own cap, and the message names that instead of the config key.
+   */
+  stage?: ModelFailureStage;
+  /**
+   * The context window the runtime believes in (catalogue or learned),
+   * when it knows one. A reply cut short of the cap with prompt + reply
+   * well inside this window is the provider's output limit, not the
+   * window — and must not be learned as one.
+   */
+  contextWindow?: number | null;
 }
 
 /**
  * Inspect a completion for model-side defects that make a retry on the
  * same prompt pointless:
  *
- *  - `truncated`: llama-server flagged the output as cut off (n_predict
- *    exhausted or context overflow). Re-running the same prompt just
- *    reproduces the wall.
+ *  - `truncated`: the server cut the reply off — either the reply cap
+ *    the request carried (`max_tokens` / `n_predict`) ran out, or the
+ *    server's context window filled up mid-generation. Re-running the
+ *    same prompt under the same cap just reproduces the wall; the agent
+ *    loop retries with a *different* request (see `truncation`).
  *  - `empty`:     neither `content` nor `reasoningContent` carry usable
  *    text. Most often a misrouted grammar or a model that stopped
  *    immediately after the first token.
@@ -27,11 +57,18 @@ export interface DetectedModelFailure {
  */
 export function detectModelFailure(
   completion: CompletionResult,
+  options: DetectModelFailureOptions = {},
 ): DetectedModelFailure | null {
   if (completion.truncated) {
+    const truncation = classifyTruncation(
+      completion,
+      options.requestedMaxTokens,
+      options.contextWindow ?? null,
+    );
     return {
       reason: "truncated",
-      message: truncatedMessage(completion),
+      message: formatTruncatedMessage(truncation, options.stage),
+      truncation,
     };
   }
   // The grammar parser runs over `content` only — `reasoningContent` is a
@@ -53,12 +90,109 @@ export function detectModelFailure(
   return null;
 }
 
-function truncatedMessage(completion: CompletionResult): string {
-  const predicted = completion.timing?.predictedTokens ?? 0;
-  if (predicted > 0) {
-    return `model response truncated at ${predicted} tokens`;
+/**
+ * A reply that stopped this close to the cap spent the cap. Servers
+ * count the cap in decoded tokens and some stop one short of it
+ * (llama.cpp checks `n_decoded >= n_predict` after the stop-token
+ * test), and a proxy's tokenizer may disagree by a token or two.
+ */
+const REPLY_CAP_SLACK_TOKENS = 16;
+
+/**
+ * Prompt + reply this far under a known window is not the window: the
+ * provider clamped the reply at its own output limit for the model.
+ */
+const WINDOW_FILL_RATIO = 0.9;
+
+/**
+ * Which wall a truncated completion hit, decided from the provider's
+ * usage block against the cap the request carried.
+ *
+ * The walls all arrive as the same `finish_reason: "length"`, and they
+ * want different remedies: a reply that spent the whole cap needs a
+ * bigger cap; a reply that stopped short of it ran into the server's
+ * context window and needs a *smaller prompt* (or a bigger window) —
+ * unless the runtime knows the window and prompt + reply sit well
+ * inside it, in which case the provider's own output limit for the
+ * model is the wall and only a lower cap helps. A provider that reports
+ * no usage leaves them indistinguishable.
+ *
+ * llama-server never sends `usage`, only `timings`, and its `truncated`
+ * flag has one meaning — the context overflowed — so a timings-only
+ * completion is the window whatever the count says.
+ */
+export function classifyTruncation(
+  completion: CompletionResult,
+  requestedMaxTokens?: number,
+  contextWindow: number | null = null,
+): TruncationDetail {
+  const completionTokens =
+    completion.usage?.completionTokens ?? completion.timing?.predictedTokens ?? 0;
+  const promptTokens =
+    completion.usage?.promptTokens ?? completion.timing?.promptTokens ?? 0;
+  const requested = requestedMaxTokens ?? 0;
+  let cause: TruncationCause = "unknown";
+  if (completion.usage === undefined && completionTokens > 0) {
+    cause = "context_window";
+  } else if (completionTokens > 0 && requested > 0) {
+    if (completionTokens + REPLY_CAP_SLACK_TOKENS >= requested) {
+      cause = "reply_cap";
+    } else if (
+      contextWindow !== null &&
+      contextWindow > 0 &&
+      promptTokens + completionTokens < contextWindow * WINDOW_FILL_RATIO
+    ) {
+      cause = "output_limit";
+    } else {
+      cause = "context_window";
+    }
   }
-  return "model response truncated";
+  return { cause, completionTokens, promptTokens, requestedMaxTokens: requested };
+}
+
+/**
+ * The sentence the user reads when a truncated reply ends the turn.
+ * Names the wall and the knob — "model response truncated" on its own
+ * sent people to change models, which cannot help either cause.
+ */
+export function formatTruncatedMessage(
+  truncation: TruncationDetail,
+  stage?: ModelFailureStage,
+): string {
+  const at =
+    truncation.completionTokens > 0
+      ? ` at ${truncation.completionTokens} tokens`
+      : "";
+  const capName =
+    stage === "repair"
+      ? "the repair pass's reply cap"
+      : "the reply cap (localModels.completionMaxTokens)";
+  switch (truncation.cause) {
+    case "reply_cap":
+      return (
+        `model response truncated${at}: it spent ${capName} of ` +
+        `${truncation.requestedMaxTokens} — raise it, or use a model that thinks less before answering`
+      );
+    case "context_window":
+      return (
+        `model response truncated${at}: the model server ran out of context ` +
+        `after a ${truncation.promptTokens}-token prompt — start it with a larger ` +
+        `context size, or start a new session`
+      );
+    case "output_limit":
+      return (
+        `model response truncated${at}: the provider stopped the reply below ${capName} ` +
+        `of ${truncation.requestedMaxTokens} — this model's output limit is about ` +
+        `${truncation.completionTokens} tokens; lower the cap to it, or pick another model`
+      );
+    default: {
+      const walls =
+        truncation.requestedMaxTokens > 0
+          ? `the ${truncation.requestedMaxTokens}-token reply cap (localModels.completionMaxTokens) or the model server's context window`
+          : "the reply cap (localModels.completionMaxTokens) or the model server's context window";
+      return `model response truncated${at}: it hit ${walls}; the provider reported no token counts`;
+    }
+  }
 }
 
 /**

--- a/src/llm/reliability/failure-category.ts
+++ b/src/llm/reliability/failure-category.ts
@@ -38,6 +38,40 @@ export type LlmFailureCategory =
 export type ModelFailureReason = "truncated" | "empty" | "no_stop";
 
 /**
+ * Which wall a `truncated` completion hit. Both arrive from the provider
+ * as the same `finish_reason: "length"`; the usage block against the cap
+ * the request carried is what tells them apart.
+ *
+ *  - `reply_cap`:      the reply spent the whole `max_tokens` /
+ *                      `n_predict` cap — the remedy is a bigger cap.
+ *  - `context_window`: the reply stopped short of the cap, so the server
+ *                      ran out of context — the remedy is a smaller
+ *                      prompt (or a bigger window on the server).
+ *  - `output_limit`:   the reply stopped short of the cap while prompt +
+ *                      reply sit well inside a window the runtime knows
+ *                      — the provider clamps this model's output below
+ *                      our cap. Neither a bigger cap nor a smaller prompt
+ *                      helps; the cap has to come down to the limit.
+ *  - `unknown`:        no usage came back; the walls cannot be told apart.
+ */
+export type TruncationCause =
+  | "reply_cap"
+  | "context_window"
+  | "output_limit"
+  | "unknown";
+
+/** What is known about a truncation, for the message and the retry. */
+export interface TruncationDetail {
+  cause: TruncationCause;
+  /** Reply tokens the model produced before the cut; `0` when unreported. */
+  completionTokens: number;
+  /** Prompt tokens as the provider counted them; `0` when unreported. */
+  promptTokens: number;
+  /** The reply cap the request carried; `0` when the caller did not say. */
+  requestedMaxTokens: number;
+}
+
+/**
  * Which attempt inside a single step raised the model-side defect. A
  * fixed 2-value enum, mirrored verbatim by the error scrubber's
  * allowlist.

--- a/src/llm/reliability/index.ts
+++ b/src/llm/reliability/index.ts
@@ -2,6 +2,8 @@ export type {
   LlmFailureCategory,
   ModelFailureReason,
   ModelFailureStage,
+  TruncationCause,
+  TruncationDetail,
 } from "./failure-category.js";
 export {
   CancelledError,
@@ -16,6 +18,7 @@ export type {
   ModelErrorOptions,
 } from "./llm-failures.js";
 export { classifyFailure } from "./classify-failure.js";
+export { isRequestSizeRejection } from "./request-size-rejection.js";
 // `looksLikeDroppedConnection` is deliberately NOT re-exported: it is the
 // classifier's own key, used inside `network-error.ts` by `isNetworkError`
 // and asserted directly by that module's test, with no consumer outside
@@ -27,5 +30,12 @@ export {
   looksLikeMidStreamDrop,
   readNetworkErrorCode,
 } from "./network-error.js";
-export { detectModelFailure } from "./detect-model-failure.js";
-export type { DetectedModelFailure } from "./detect-model-failure.js";
+export {
+  classifyTruncation,
+  detectModelFailure,
+  formatTruncatedMessage,
+} from "./detect-model-failure.js";
+export type {
+  DetectModelFailureOptions,
+  DetectedModelFailure,
+} from "./detect-model-failure.js";

--- a/src/llm/reliability/llm-failures.ts
+++ b/src/llm/reliability/llm-failures.ts
@@ -3,6 +3,7 @@ import type {
   LlmFailureCategory,
   ModelFailureReason,
   ModelFailureStage,
+  TruncationDetail,
 } from "./failure-category.js";
 
 export interface LlmFailureOptions {
@@ -25,6 +26,12 @@ export interface LlmFailureOptions {
 export interface ModelErrorOptions extends LlmFailureOptions {
   transport?: ToolCallTransport;
   stage?: ModelFailureStage;
+  /**
+   * For `reason === "truncated"`: which wall the reply hit and the token
+   * counts that decided it. The agent loop reads this to choose between
+   * retrying with a larger cap and retrying with a smaller prompt.
+   */
+  truncation?: TruncationDetail;
 }
 
 /**
@@ -119,6 +126,9 @@ export class ModelError extends LlmFailure {
   /** Which attempt inside the step raised this defect. */
   readonly stage?: ModelFailureStage;
 
+  /** Present for `truncated`: the wall the reply hit and the counts behind it. */
+  readonly truncation?: TruncationDetail;
+
   constructor(
     readonly reason: ModelFailureReason,
     message: string,
@@ -131,6 +141,9 @@ export class ModelError extends LlmFailure {
     }
     if (options?.stage !== undefined) {
       this.stage = options.stage;
+    }
+    if (options?.truncation !== undefined) {
+      this.truncation = options.truncation;
     }
   }
 }

--- a/src/llm/reliability/request-size-rejection.test.ts
+++ b/src/llm/reliability/request-size-rejection.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { isRequestSizeRejection } from "./request-size-rejection.js";
+import { OpenAiHttpError } from "../provider/openai/openai-http.js";
+import { LlamaServerError } from "../llama-server-client.js";
+import { TransportError } from "./llm-failures.js";
+
+describe("isRequestSizeRejection", () => {
+  it("recognises a cloud 400 that names the cap, as the provider phrases it", () => {
+    expect(
+      isRequestSizeRejection(
+        new OpenAiHttpError(
+          'openai provider 400: {"error":{"message":"max_tokens is too large: 32768. This model supports at most 16384 completion tokens"}}',
+          400,
+          "https://x/v1/chat/completions",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRequestSizeRejection(
+        new OpenAiHttpError("openai provider 400: This model's maximum context length is 8192 tokens", 400, "u"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reads through the humanized chat message to the provider's body on the cause", () => {
+    const rejected = new TransportError('"vendor" rejected the request (400).', 400, "https://x/v1", {
+      cause: new OpenAiHttpError("openai provider 400: max_completion_tokens exceeds the limit", 400, "u"),
+    });
+    expect(isRequestSizeRejection(rejected)).toBe(true);
+  });
+
+  it("recognises llama-server's own context-size refusal", () => {
+    expect(
+      isRequestSizeRejection(
+        new LlamaServerError(
+          "the request exceeds the available context size. try increasing the context size or enable context shift",
+          400,
+          "http://127.0.0.1:8080/completion",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not mistake a body-shape 400 that merely names the field", () => {
+    // OpenAI's o-series: a different link may accept the request as is,
+    // so the chain must keep falling over on it.
+    expect(
+      isRequestSizeRejection(
+        new OpenAiHttpError(
+          "openai provider 400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+          400,
+          "u",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("leaves every other failure alone", () => {
+    expect(isRequestSizeRejection(new TransportError("bad request", 400, ""))).toBe(false);
+    expect(isRequestSizeRejection(new OpenAiHttpError("openai provider 400: invalid tool schema", 400, "u"))).toBe(false);
+    expect(isRequestSizeRejection(new TransportError("max_tokens", 500, ""))).toBe(false);
+    expect(isRequestSizeRejection(new TransportError("max_tokens", null, ""))).toBe(false);
+    expect(isRequestSizeRejection(new Error("max_tokens"))).toBe(false);
+  });
+});

--- a/src/llm/reliability/request-size-rejection.ts
+++ b/src/llm/reliability/request-size-rejection.ts
@@ -1,0 +1,67 @@
+import { LlamaServerError } from "../llama-server-client.js";
+import { OpenAiHttpError } from "../provider/openai/openai-http.js";
+import { TransportError } from "./llm-failures.js";
+
+/**
+ * Did the provider refuse the request for its *size* — a 400 or 413
+ * whose wording names the reply cap or the context length?
+ *
+ * Such a rejection is deterministic: the same request is too big for
+ * this model, and it will be too big on the next link of the fallback
+ * chain too (the local llama-server behind a cloud primary usually has
+ * the smaller window). Two callers read it:
+ *
+ *  - `shouldAdvance` keeps the chain where it is, instead of falling
+ *    over to a link that may not even be running and parking the turn
+ *    on the outage wait.
+ *  - The agent loop, when the rejected request was its own truncation
+ *    retry with a raised cap, fails the turn with the truncation that
+ *    started it — which names the knob — rather than with "rejected the
+ *    request (400)".
+ *
+ * Wording is matched over the error's `cause` chain, because the chat
+ * message (`humanizeOpenAiHttpError`) drops the provider's body text and
+ * keeps it on the cause.
+ */
+export function isRequestSizeRejection(error: unknown): boolean {
+  const status = statusOf(error);
+  if (status !== 400 && status !== 413) return false;
+  const text = messageChain(error);
+  return SIZE_FIELD_WORDING.test(text) && SIZE_VERDICT_WORDING.test(text);
+}
+
+/**
+ * Both halves must match. The field name alone is not enough: OpenAI's
+ * o-series answers `Unsupported parameter: 'max_tokens' is not supported
+ * with this model. Use 'max_completion_tokens' instead.` — a body-shape
+ * rejection another link may well accept, which must keep falling over.
+ */
+const SIZE_FIELD_WORDING =
+  /max_tokens|max_completion_tokens|context[ _-]?(?:length|window|size)|tokens/i;
+const SIZE_VERDICT_WORDING =
+  /too large|too long|too many|exceed|maximum|at most|greater than|limit|reduce/i;
+
+function statusOf(error: unknown): number | null | undefined {
+  if (error instanceof OpenAiHttpError) return error.status;
+  if (error instanceof LlamaServerError) return error.status;
+  if (error instanceof TransportError) return error.status;
+  return undefined;
+}
+
+/** Depth cap on the `cause` walk — longer is a cycle. */
+const MAX_CAUSE_DEPTH = 5;
+
+function messageChain(error: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current !== undefined; depth += 1) {
+    if (current instanceof Error) {
+      parts.push(current.message);
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      parts.push(String(current));
+      break;
+    }
+  }
+  return parts.join(" | ");
+}

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -1525,10 +1525,42 @@ export async function createAgentRuntime(
    * Resolved per step rather than captured once, so switching model
    * mid-session is picked up by the next prompt.
    */
+  /**
+   * Context windows the model server revealed by cutting a reply short
+   * — `completion_truncated` with cause `context_window`, where prompt +
+   * reply tokens is the window. Keyed by provider and model, kept for the
+   * life of the process: the same server keeps the same window, and a
+   * restart may well change it (llama.cpp `-c`, Lemonade's auto-sizing).
+   * A demonstrated window overrides the catalogue's nominal 128k default
+   * and clamps a real catalogue entry, since a server can run a model
+   * with less context than the model supports.
+   */
+  const observedContextWindows = new Map<string, number>();
+  const activeModelKey = (): string =>
+    `${resolveLlmConfig(getConfig()).activeTextProvider}/${resolveActiveModelName()}`;
+  const observeContextWindow = (contextWindow: number): void => {
+    if (!Number.isFinite(contextWindow) || contextWindow <= 0) return;
+    const key = activeModelKey();
+    const known = observedContextWindows.get(key);
+    observedContextWindows.set(
+      key,
+      known === undefined ? contextWindow : Math.min(known, contextWindow),
+    );
+  };
+  const forgetContextWindowBelow = (tokens: number): void => {
+    const key = activeModelKey();
+    const known = observedContextWindows.get(key);
+    if (known !== undefined && tokens > known) observedContextWindows.delete(key);
+  };
   const resolveCatalogContextWindow = (): number | null => {
+    const observed = observedContextWindows.get(activeModelKey());
     const model = resolveModelPricing(resolveActiveModelName());
-    if (!model || model.source === "default") return null;
-    return model.contextWindow > 0 ? model.contextWindow : null;
+    const catalogued =
+      !model || model.source === "default" || model.contextWindow <= 0
+        ? null
+        : model.contextWindow;
+    if (observed === undefined) return catalogued;
+    return catalogued === null ? observed : Math.min(observed, catalogued);
   };
 
   // Vision reuses the active text provider when it exposes describeImage.
@@ -2137,6 +2169,8 @@ export async function createAgentRuntime(
     capabilities,
     profile,
     contextWindow: resolveCatalogContextWindow,
+    onContextWindowObserved: observeContextWindow,
+    onContextWindowExceeded: forgetContextWindowBelow,
     ...(profileManager ? { profileManager } : {}),
     // Gates the two `/props` refreshes the loop owns, and carries the
     // lazy restore for a switch back to a local provider (issue #112).

--- a/src/runtime/llm-fallback-seam.test.ts
+++ b/src/runtime/llm-fallback-seam.test.ts
@@ -174,6 +174,27 @@ describe("createFallbackStreamer (real bootstrap seam)", () => {
     expect(result.servedTransport).not.toBe("native_tools");
   });
 
+  it("forwards the per-request reply cap to the served link, like the unary seam", async () => {
+    // The agent loop's truncation retry raises `maxTokens` per step, and
+    // every turn streams. A cap that reached only the unary path was a
+    // retry that changed nothing on the wire.
+    const seen: Array<number | undefined> = [];
+    const providers = new Map<string, LlmProvider>([
+      [
+        "cloud",
+        fakeProvider("cloud", "native_tools", async (request) => {
+          seen.push(request.maxTokens);
+          return answer("cloud");
+        }),
+      ],
+      ["local", fakeProvider("local", "grammar", async () => answer("local"))],
+    ]);
+    const streamer = createFallbackStreamer(seamDeps(providers));
+    await drain(streamer({ ...baseParams, maxTokens: 32_768 }));
+    await drain(streamer(baseParams));
+    expect(seen).toEqual([32_768, undefined]);
+  });
+
   it("stamps the primary's transport when the stream opens on the primary", async () => {
     const providers = new Map<string, LlmProvider>([
       ["cloud", fakeProvider("cloud", "native_tools", async () => answer("cloud"))],

--- a/src/runtime/llm-fallback-seam.ts
+++ b/src/runtime/llm-fallback-seam.ts
@@ -173,6 +173,13 @@ export function createFallbackStreamer(
     const base = {
       prompt: promptFor(params, transport),
       sessionId: params.sessionId,
+      // Same field the unary seam forwards. The agent loop's truncation
+      // retry raises the cap per step, and every turn streams — a cap
+      // that only reached the unary path was a retry that changed
+      // nothing on the wire.
+      ...(typeof params.maxTokens === "number"
+        ? { maxTokens: params.maxTokens }
+        : {}),
       ...(params.signal ? { signal: params.signal } : {}),
     };
     const stream =

--- a/src/tracing/trace/trace-event.ts
+++ b/src/tracing/trace/trace-event.ts
@@ -30,6 +30,7 @@ export type TraceEvent =
   | TraceTaskContinued
   | TraceProviderWaiting
   | TraceProviderRecovered
+  | TraceCompletionTruncated
   | TraceLessonDeprecated
   | TraceVoteApplied
   | TraceVoteRejected
@@ -194,6 +195,23 @@ export interface TraceProviderRecovered extends TraceEventBase {
   type: "provider_recovered";
   turnIndex: number;
   waitedMs: number;
+}
+
+/**
+ * A reply the server cut short is being retried with a different
+ * request. `retry` says which: `raise_cap` with the new cap in
+ * `retryValue`, or `fit_window` with the learned context window.
+ */
+export interface TraceCompletionTruncated extends TraceEventBase {
+  type: "completion_truncated";
+  turnIndex: number;
+  stepIndex: number;
+  cause: "reply_cap" | "context_window" | "output_limit" | "unknown";
+  completionTokens: number;
+  promptTokens: number;
+  requestedMaxTokens: number;
+  retry: "raise_cap" | "fit_window";
+  retryValue: number;
 }
 
 export interface TraceLoopDetected extends TraceEventBase {

--- a/src/tracing/trace/trace-recorder.test.ts
+++ b/src/tracing/trace/trace-recorder.test.ts
@@ -270,6 +270,50 @@ describe("createTraceRecorder", () => {
     });
   });
 
+  it("records a truncation retry with its cause, counts and the retry taken", () => {
+    const { events, emit } = collector();
+    const rec = createTraceRecorder({ sessionId: "s-trunc", emit, now });
+    rec.onAgentEvent({ type: "turn_started", turnIndex: 2 });
+    rec.onAgentEvent({
+      type: "completion_truncated",
+      stepIndex: 5,
+      cause: "reply_cap",
+      completionTokens: 8_192,
+      promptTokens: 6_000,
+      requestedMaxTokens: 8_192,
+      retry: { kind: "raise_cap", maxTokens: 32_768 },
+    });
+    rec.onAgentEvent({
+      type: "completion_truncated",
+      stepIndex: 6,
+      cause: "context_window",
+      completionTokens: 2_768,
+      promptTokens: 30_000,
+      requestedMaxTokens: 8_192,
+      retry: { kind: "fit_window", contextWindow: 32_768 },
+    });
+    const recorded = events.filter((e) => e.type === "completion_truncated");
+    expect(recorded).toEqual([
+      expect.objectContaining({
+        type: "completion_truncated",
+        turnIndex: 2,
+        stepIndex: 5,
+        cause: "reply_cap",
+        completionTokens: 8_192,
+        promptTokens: 6_000,
+        requestedMaxTokens: 8_192,
+        retry: "raise_cap",
+        retryValue: 32_768,
+      }),
+      expect.objectContaining({
+        stepIndex: 6,
+        cause: "context_window",
+        retry: "fit_window",
+        retryValue: 32_768,
+      }),
+    ]);
+  });
+
   it("carries the read-repeat detector payload into the recorded event", () => {
     // A `read_repeat` trace line is unreadable without the file, the
     // range and the fingerprint pair: those three are the whole evidence

--- a/src/tracing/trace/trace-recorder.ts
+++ b/src/tracing/trace/trace-recorder.ts
@@ -408,6 +408,25 @@ export function createTraceRecorder(
             waitedMs: event.waitedMs,
           });
           return;
+        case "completion_truncated":
+          push({
+            type: "completion_truncated",
+            seq: nextSeq(),
+            sessionId,
+            ts: now(),
+            turnIndex: currentTurnIndex,
+            stepIndex: event.stepIndex,
+            cause: event.cause,
+            completionTokens: event.completionTokens,
+            promptTokens: event.promptTokens,
+            requestedMaxTokens: event.requestedMaxTokens,
+            retry: event.retry.kind,
+            retryValue:
+              event.retry.kind === "raise_cap"
+                ? event.retry.maxTokens
+                : event.retry.contextWindow,
+          });
+          return;
         case "loop_detected":
           push({
             type: "loop_detected",

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -856,6 +856,46 @@ describe("reduceTuiState", () => {
   });
 });
 
+describe("truncated completion", () => {
+  it("says what was cut and what the retry changes", () => {
+    const next = reduceTuiState(createInitialTuiState(fakeSession()), {
+      type: "agent_event",
+      event: {
+        type: "completion_truncated",
+        stepIndex: 3,
+        cause: "reply_cap",
+        completionTokens: 8_192,
+        promptTokens: 6_000,
+        requestedMaxTokens: 8_192,
+        retry: { kind: "raise_cap", maxTokens: 32_768 },
+      } as never,
+    });
+    const line = next.feed.at(-1)?.line ?? "";
+    expect(line).toContain("reply cut off at 8192 tokens");
+    expect(line).toContain("step 4");
+    expect(line).toContain("32768-token cap");
+    expect(next.feed.at(-1)?.color).toBe("yellow");
+  });
+
+  it("explains a window retry in the operator's terms", () => {
+    const next = reduceTuiState(createInitialTuiState(fakeSession()), {
+      type: "agent_event",
+      event: {
+        type: "completion_truncated",
+        stepIndex: 0,
+        cause: "context_window",
+        completionTokens: 2_768,
+        promptTokens: 30_000,
+        requestedMaxTokens: 8_192,
+        retry: { kind: "fit_window", contextWindow: 32_768 },
+      } as never,
+    });
+    const line = next.feed.at(-1)?.line ?? "";
+    expect(line).toContain("ran out of context at ~32768 tokens");
+    expect(line).toContain("trimming the conversation");
+  });
+});
+
 describe("provider outage", () => {
   const waiting = (over: Record<string, unknown> = {}): TuiAction => ({
     type: "agent_event",

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -584,6 +584,25 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
           color: "green",
         },
       );
+    case "completion_truncated": {
+      // One line per retry, in the operator's terms: what was cut, and
+      // what the retry changes. The turn only fails on the second cut,
+      // and that message names the wall and the knob.
+      const cut =
+        event.completionTokens > 0
+          ? `reply cut off at ${event.completionTokens} tokens`
+          : "reply cut off";
+      const line =
+        event.retry.kind === "raise_cap"
+          ? `» ${cut} (cap ${event.requestedMaxTokens}) — retrying step ${event.stepIndex + 1} with a ${event.retry.maxTokens}-token cap`
+          : `» ${cut}: the model server ran out of context at ~${event.retry.contextWindow} tokens — trimming the conversation to fit and retrying step ${event.stepIndex + 1}`;
+      return appendFeed(state, {
+        kind: "runtime_info",
+        stepIndex: null,
+        line,
+        color: "yellow",
+      });
+    }
     case "task_continued": {
       // A long task must not go quiet. One line per leg, carrying the
       // two numbers someone deciding whether to wait actually wants:


### PR DESCRIPTION
## What

A reply the model server cut short — `finish_reason: "length"` on any OpenAI-compatible route — used to end the turn on the spot:

```
⚠️ Turn failed (model): model response truncated
```

No token count, no cause, no way forward; reported from Discord DMs against Lemonade Server serving Ornith-1.0-35B, on every longer coding task. Discord is not the cause: the channels, the TUI and the CLI share `runtime.runTurn`, the same request body and the same failure path. Changing model does not help either, because the failure is in the request shape and in what the runtime does with the cut.

Two different walls produce that `length`, and they want opposite remedies:

- **The reply cap was spent.** Every OpenAI-compatible request carries `max_tokens: 8192` (`localModels.completionMaxTokens`). A reasoning model opens each turn with a `<think>` block; on a hard coding step it thinks past 8192 tokens before it emits the tool call, and nothing comes back but cut-off reasoning. Needs a bigger cap.
- **The server's context window filled.** Lemonade (and llama.cpp `-c`) sizes the window to device memory, routinely below the model's advertised 262k. The runtime treats an OpenAI-compatible model's window as unknown and packs the transcript to the configured 32k; once the prompt fills the window, generation stops mid-think with the same `length`. Needs a smaller prompt.

A third path produced the same message on its own: the one-shot parse repair was capped at 1024 tokens on every transport, and on the chat transport a thinking model cannot reach the tool call in 1024 tokens — so any step whose first reply failed validation ended the turn with `model response truncated`.

After this change:

1. **Streamed requests ask for usage** (`stream_options: { include_usage: true }`), so a cut reply arrives with token counts. Verified against the vendors the registry serves: llama.cpp/Lemonade, OpenAI and Gemini ≥ 2.5 need the flag; OpenRouter and Anthropic's compatibility layer ignore it. The contract probe carries it too; `extraBody` can drop it.
2. **The cause is classified, not guessed.** `classifyTruncation` compares `completion_tokens` with the cap the request carried: within 16 tokens ⇒ `reply_cap`; short of it ⇒ `context_window` (prompt + reply *is* the window) — unless the runtime knows a window and prompt + reply sit under 90 % of it, which is the provider clamping this model's output (`output_limit`), not the window; a timings-only completion (llama-server, whose `truncated` means the context overflowed) is `context_window` whatever the count; no usage ⇒ `unknown`. Cause and counts ride on `ModelError.truncation`, and the message names the wall and the knob:
   - `model response truncated at 8192 tokens: it spent the reply cap (localModels.completionMaxTokens) of 8192 — raise it, or use a model that thinks less before answering`
   - `model response truncated at 2768 tokens: the model server ran out of context after a 30000-token prompt — start it with a larger context size, or start a new session`
   - `model response truncated at 4096 tokens: the provider stopped the reply below the reply cap (localModels.completionMaxTokens) of 8192 — this model's output limit is about 4096 tokens; lower the cap to it, or pick another model`
3. **A cut reply still dispatches nothing.** The execution-integrity suite's rule ("explicit `finish_reason: length`: executions = 0") stands even when the tool-call arguments parse — a cut between call A and call B of a batch would otherwise run A alone. The loop re-asks instead.
4. **One retry per step, with a different request.** `reply_cap` / `unknown` ⇒ the same step again with the cap raised to `min(4 × cap, 32768)`, clamped under a known window. `context_window` ⇒ the server's demonstrated window is recorded per provider/model, the next prompt is packed to fit, and the same step runs again under the same cap. `output_limit` ⇒ no retry, nothing would change the outcome. Either way the model reads a `### notice` saying its reply was cut and to keep reasoning short, on top of whatever notice the cut attempt carried (loop detector, steering, trimmed batch — the outage retry now keeps it too). The retry runs on the finalization step as well; `stepsTaken` does not move; a leg boundary re-entered by a retry runs its check once, so a retry is never read as an unproductive leg (the outage retry had the same latent defect). A second cut on the same index fails the turn with the classified message.
5. **A request-size 400 is deterministic.** A 400/413 whose body names the cap or the context length *and* says it is too large no longer falls the chain over — before, it fell over to the auto-appended local llama-server, which was not running, and the turn then sat on the outage wait for five minutes. The bare field name is not enough (OpenAI's o-series `Unsupported parameter: 'max_tokens'` keeps falling over). On the raised-cap retry the turn fails with the *original* truncation; elsewhere the provider's own sentence about the limit stays in the message instead of `rejected the request (400)`.
6. **A learned window is forgotten the moment the server disproves it.** A successful completion whose prompt + reply exceed the believed window drops the observation, so a stale or mistaken window cannot ratchet the transcript down for the rest of the process. Catalogue windows are never touched.
7. **The repair pass on `native_tools` runs under the step's cap.** `REPAIR_MAX_TOKENS` (1024) stays for grammar links, where the prefill strip keeps the think block short.
8. **The streaming fallback seam forwards `maxTokens`.** It was dropped there (the unary seam forwarded it), so a per-step cap never reached the wire on a streamed turn.
9. **It is visible.** A `completion_truncated` loop event carries cause, counts and the retry taken: one yellow feed line in the TUI, a trace row, a line in `atomic-agent trace`.

Known gap, deliberately left: a window learned while a fallback link served the completion is keyed to the configured provider, not the serving link.

Also fixes the `--help` text for `ATOMIC_AGENT_LLAMA_MAX_TOKENS`, which said the default was 4096 (it is 8192).

## Why

The failure taxonomy pinned `model` errors as "never retried in-place — the same prompt would reproduce the same wall". That stays true; this retries with a *different* request, the same argument the existing empty-completion repair makes, and the AGENTS.md row and a new "Truncated completions" section pin the invariants. The learned window lives for the life of the process only: the same server keeps the same window, a restart may change it. The retry ceiling is a constant, not config; the cost is bounded by one extra generation per step and the two task ceilings.

Immediate workaround for anyone on an older build: `ATOMIC_AGENT_LLAMA_MAX_TOKENS=32768` (or `localModels.completionMaxTokens` in the config), and a larger window on the server (`lemonade config set ctx_size=65536`, or `--ctx-size` on load).

## How it was verified

- `npm run lint` clean.
- `npx vitest run src/agent src/llm/reliability src/llm/fallback src/runtime/llm-fallback-seam.test.ts src/llm/provider/openai src/llm/provider/verify src/tui/agent-event-reducer.test.ts src/tracing/trace src/cli/trace-formatter.test.ts src/error-reporting` — 60 files / 856 tests green (baseline failures: none). Includes `native-tool-call-execution-integrity.test.ts` unchanged.
- An adversarial review pass mutated 13 of the new code paths one at a time; every guarded test went red on its mutation. Two findings from that pass are fixed above (the leg-boundary interaction and the salvage path, which had broken the integrity suite) along with the seam, probe, notice, finalization, request-size wording and window-ratchet points.
- Live, through the built CLI (`atomic-agent run`) against a scripted fake OpenAI-compatible SSE server registered as an `openai-compatible` provider:

  | scenario | request 1 | request 2 | outcome |
  |---|---|---|---|
  | reply cap spent (`length`, usage 6100 + 8192) | `max_tokens: 8192`, `stream_options` present | `max_tokens: 32768`, `### notice … cut off after 8192 tokens … reply limit is 32768` | reply delivered, exit 0 |
  | window filled (`length`, usage 30000 + 2768) | 8192 | 8192, notice `… ran out of context, so older conversation has been trimmed …` | window 32768 recorded, reply delivered, exit 0 |
  | cut twice, no usage | 8192 | 32768 | `model response truncated: it hit the 32768-token reply cap (localModels.completionMaxTokens) or the model server's context window; the provider reported no token counts`, exit 1 |
  | 400 on the raised cap (`max_tokens is too large`) | 8192 | 32768 → 400 | fails at once with `… it spent the reply cap … of 8192 — raise it …`; no fallover, no outage wait, exit 1 |
  | output limit (`length` at 4096, `userModels` window 131072) | 8192 | — | no retry; `… this model's output limit is about 4096 tokens; lower the cap to it …`, exit 1 |

  Before the seam fix, request 2 in the first scenario still carried 8192; before the `shouldAdvance` rule, the fourth scenario fell over to the local link and parked the turn until killed.
