### PR TITLE
fix(models-catalog): uncensored Qwen3.8 projector moved to mmproj-Qwen3.8-27B-Uncensored-F16.gguf

### DIFF
--- a/src/local-llm/models-catalog.test.ts
+++ b/src/local-llm/models-catalog.test.ts
@@ -97,10 +97,11 @@ describe("models-catalog", () => {
     // noMTP on purpose: the fused quants carry an inline MTP head the
     // daemon has no --model-draft wiring for; noMTP is plain GGUF.
     expect(last?.filename).toBe("Qwen3.8-27B-Uncensored-noMTP-Q4_K_M.gguf");
-    // The projector is not named "mmproj" in this repo — the installer
-    // keys on these fields, not on filename patterns, so that is fine.
+    // The repo renamed its projector to the conventional `mmproj-`
+    // prefix; the previous `…-vision-f16.gguf` URL answers 404 and
+    // stranded a fully downloaded model.
     expect(last?.supportsVision).toBe(true);
-    expect(last?.mmprojFilename).toBe("Qwen3.8-27B-Uncensored-vision-f16.gguf");
+    expect(last?.mmprojFilename).toBe("mmproj-Qwen3.8-27B-Uncensored-F16.gguf");
   });
 
   // Every uncensored entry must carry a warning tag — the onboarding row
@@ -110,6 +111,17 @@ describe("models-catalog", () => {
     for (const def of LOCAL_MODELS_CATALOG) {
       if (def.uncensored !== true) continue;
       expect(def.tag, `${def.id} must warn the operator`).toBeTruthy();
+    }
+  });
+
+  // The installer saves the projector under `mmprojFilename` and the
+  // daemon loads it from there; a filename that drifts from what the
+  // URL actually serves would download one file and look for another.
+  it("names each projector file exactly as its URL serves it", () => {
+    for (const def of LOCAL_MODELS_CATALOG) {
+      if (!def.mmprojUrl) continue;
+      const served = def.mmprojUrl.slice(def.mmprojUrl.lastIndexOf("/") + 1);
+      expect(def.mmprojFilename, `${def.id} projector filename`).toBe(served);
     }
   });
 

--- a/src/local-llm/models-catalog.ts
+++ b/src/local-llm/models-catalog.ts
@@ -373,17 +373,15 @@ export const LOCAL_MODELS_CATALOG: readonly LocalModelDef[] = [
     tag: "Use at your own risk",
     uncensored: true,
     supportsVision: true,
-    // The vision file IS the projector — the model card states both
-    // vision files carry the same 334-tensor projector; it is simply not
-    // named "mmproj". Safe here: the installer and daemon key on the
-    // mmprojUrl/mmprojFilename *fields* (see `model-installer.ts`,
-    // `backend-paths.resolveMmprojFilePath`), never on filename patterns
-    // — `judgeGgufFile`'s "projector"/f16 rejections only run in the
-    // Hugging Face custom-add flow when picking MAIN weights.
+    // The repo renamed its projector from `…-vision-f16.gguf` to the
+    // conventional `mmproj-` prefix after this entry first shipped; the
+    // old URL answers 404, which stranded a fully downloaded model
+    // (installer and daemon key on these two fields, so the filename
+    // here must track the repo exactly).
     mmprojUrl:
-      "https://huggingface.co/JonathanColetti/Qwen3.8-27B-Uncensored-GGUF/resolve/main/Qwen3.8-27B-Uncensored-vision-f16.gguf",
-    mmprojFilename: "Qwen3.8-27B-Uncensored-vision-f16.gguf",
-    mmprojFileSizeGb: 0.9,
+      "https://huggingface.co/JonathanColetti/Qwen3.8-27B-Uncensored-GGUF/resolve/main/mmproj-Qwen3.8-27B-Uncensored-F16.gguf",
+    mmprojFilename: "mmproj-Qwen3.8-27B-Uncensored-F16.gguf",
+    mmprojFileSizeGb: 0.93,
   },
 ];
 


### PR DESCRIPTION
## What
The catalog entry for `qwen-3.8-27b-uncensored` pointed its vision projector at `Qwen3.8-27B-Uncensored-vision-f16.gguf`. The Hugging Face repo has since renamed that file to `mmproj-Qwen3.8-27B-Uncensored-F16.gguf` (the model card now says the projector "uses the standard `mmproj` prefix"). The old URL answers HTTP 404. A `with-mmproj` pull therefore downloaded the full 16.5 GB GGUF, failed on the projector, and the model ended up neither activated nor startable from the TUI — every Enter on the row re-ran the same 404.

After this change the projector URL and filename track the repo again (927,606,912 bytes), so the pull completes and vision comes up.

## Why
The installer saves the projector under `mmprojFilename` and the daemon loads it from the same path; the fields must mirror the repo exactly. A new catalog test pins that every entry's `mmprojFilename` equals the basename its `mmprojUrl` serves, so a future rename fails in CI rather than on an operator's disk.

The behavioural side — a projector failure stranding a downloaded model — is a separate PR.

## How it was verified
- `npm run lint` clean
- `npx vitest run src/local-llm/models-catalog.test.ts` — 1 file / 15 tests green (the updated pin fails on the old filename)
- live: `HEAD` on the new URL → 302 to the CDN with `x-linked-size: 927606912`; the old URL → 404. The renamed file was downloaded, its sha256 matches the repo's LFS object, and `llama-server` boots the model with `--mmproj` pointing at it (`vision enabled` in `atomic-agent models start`).
