### PR TITLE
feat(config): llm.runMode block (local | cloud | fusion) and localModels.managed.parallel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,7 @@ The TUI is clickable. Ink has no mouse layer, so this is built in `src/tui/mouse
 | `src/http/route-webhooks.ts` + `webhook-template.ts` + `webhook-session-store.ts` | Generic `POST /api/webhooks/:name` ingress. Always materialises into a `TaskRecord`, never calls `runTurn` directly. See §"Background autonomy". |
 | `src/tools/tasks/` | Agent-facing self-scheduling tools (`tasks.schedule`, `tasks.cron`, `tasks.list`, `tasks.cancel`, `tasks.show`), gated by `tasks.agentToolsEnabled`. |
 | `src/llm/provider/` | Provider abstraction layer (`LlmProvider` interface) + `LlamaServerProvider` adapter. Text completion stays on `LlamaServerClient.complete` / `completeStream` (legacy `/completion` extension with GBNF + slot ids); vision routes through `LlamaServerProvider.describeImage` against `/v1/chat/completions` with OpenAI-shape `image_url` content blocks. See §"Vision (multimodal input)". |
+| `src/llm/run-mode/` | Run-mode resolver (`resolveRunMode`): projects `llm.runMode` (local / cloud / fusion) onto the configured providers with `llm.activeTextProvider` authoritative; plus the operator-facing degradation and status sentences. See §"Run modes (Local / Cloud / Fusion)". |
 | `src/llm/fallback/` | Cross-provider circuit breaker (`ProviderFallbackChain`) that wraps the `llmComplete` / `llmCompleteStream` seams and fails over between configured provider ids when the active one is unavailable. Timer-free lazy probe. See §"Provider fallback chain". |
 | `src/tools/vision/` | `vision.describe` tool + `loadImageFile` helper. Registered whenever `config.vision.enabled` is true and a provider is constructed; the actual capability gate (`capabilities.vision`) is a dynamic getter that re-reads `ModelProfile` on every check, so vision availability tracks `ModelProfileManager` hot-swaps without a restart. See §"Vision (multimodal input)". |
 | `src/channels/telegram/` | `TelegramChannel` (lifecycle + live-control), `inbound-handler` (slash commands + dispatch into `runTurn`), `outbound-sender` (chunked replies + 429 retry), `approval-bridge` (inline-keyboard approvals with 8-min auto-deny), `pairing-mode` (60s window for first-DM owner claim), `telegram-settings` (`config.json` + `.env` persistence), `telegram-bot-factory` (grammy adapter). The **only** module that imports `grammy`. See §"Telegram remote-control channel". |
@@ -2036,6 +2037,45 @@ The LLM tab gains a fourth pane, `fallback`, reached with `←`/`→` after Loca
 4. **Keys route to the right intent** and the add-link picker owns the keyboard while open. Pinned by [src/tui/llm-panel/fallback/fallback-key-bindings.test.ts](src/tui/llm-panel/fallback/fallback-key-bindings.test.ts).
 5. **`provider_switched` is mirrored into `fallbackPanel.lastSwitch`; the pane never invents a live countdown.** Pinned by [src/tui/llm-panel/fallback/fallback-panel-reducer.test.ts](src/tui/llm-panel/fallback/fallback-panel-reducer.test.ts), [src/tui/components/llm-fallback-rows.test.tsx](src/tui/components/llm-fallback-rows.test.tsx).
 6. **Empty chain / nothing-addable shows a hint, not a broken list.** Pinned by [src/tui/components/llm-fallback-rows.test.tsx](src/tui/components/llm-fallback-rows.test.tsx), [src/tui/llm-panel/fallback/fallback-panel-reducer.test.ts](src/tui/llm-panel/fallback/fallback-panel-reducer.test.ts).
+
+## Run modes (Local / Cloud / Fusion)
+
+A run mode names *how* a chat runs, not a single model. `local` and `cloud` are what the product always had — the active provider is a llama-server one, or a cloud one. **Fusion** is the third: a cloud model is the session's orchestrator and several local-model workers run in-process as its subtasks (the orchestrator plans, writes per-worker instructions, fans independent parts out, then reviews and merges). Config lives under `llm.runMode` ([src/config/llm-run-mode-config.ts](src/config/llm-run-mode-config.ts)):
+
+```json
+"llm": {
+  "activeTextProvider": "openrouter",
+  "runMode": {
+    "mode": "fusion",
+    "fusion": { "orchestratorProvider": "openrouter", "workerProvider": "local-llama", "workers": 3 }
+  }
+}
+```
+
+`fusion.orchestratorProvider` must name a configured non-`llama-server` provider (a `subscription-cli` entry counts as cloud); `fusion.workerProvider` must name a `llama-server` one; both default to the first such entry. `workers` (1..8, default 2) caps concurrent workers; `workerMaxSteps` / `workerTimeoutMs` bound one worker turn. `orchestratorModel` / `workerModel` are informational pins only — a `CompletionRequest` carries no model field, so the orchestrator model is the provider entry's `defaultChatModel` and the worker model is whatever the managed daemon serves (`localModels.managed.modelId`). Removing a provider scrubs any pin that named it (`scrubRunModeProviderPins`), because the parser refuses a pin to an unknown id.
+
+`localModels.managed.parallel` (1..8, default 2 — the value that was hard-coded before config v52) is the llama-server `--parallel` slot count; workers run one per slot, so raising it is what lets them run concurrently rather than queue on the server. Applied on the next daemon start.
+
+### The resolver rule
+
+[src/llm/run-mode/resolve-run-mode.ts](src/llm/run-mode/resolve-run-mode.ts) is a pure projection with one load-bearing rule: **`llm.activeTextProvider` stays authoritative, `runMode.mode` is additive.**
+
+```
+derived   = kindOf(activeTextProvider) === "llama-server" ? "local" : "cloud"
+effective = stored === "fusion" && orchestratorLeg && workerLeg && active === orchestratorId
+            ? "fusion" : derived
+```
+
+An operator who switches provider by hand in Manage → LLM simply drops out of fusion on the next read — no reconciliation step, no state that lies about what is running. Fusion therefore pins the cloud provider as the fallback chain's primary and `resolveFallbackChain` needs no changes. A stored `fusion` with a missing leg reports a `degraded` reason (`no-cloud-provider` / `no-local-provider`) that `describeRunModeDegradation` turns into the one sentence every surface shows; `describeRunMode` is the `/runmode status` line. An unresolvable active id derives `local`, so a broken file can never silently start spending cloud tokens.
+
+Any TUI write that changes the mode must move `llm.runMode.mode` **and** `llm.activeTextProvider` in the same `writeUserConfigFileSync` call — split writes leave a window where the file says fusion and the runtime says local.
+
+### Locked invariants (pinned by tests)
+
+1. **Pins are validated against `llm.providers` and by kind.** An orchestrator pin to a `llama-server` entry, a worker pin to a cloud entry, or a pin to an unknown id is a `ConfigValidationError`. Pinned by [src/config/llm-run-mode-config.test.ts](src/config/llm-run-mode-config.test.ts) and [src/config/llm-config.test.ts](src/config/llm-config.test.ts).
+2. **`activeTextProvider` decides.** A stored `fusion` is effective only while the orchestrator is the active provider; a hand-switch yields the derived mode with `degraded: null`. Pinned by [src/llm/run-mode/resolve-run-mode.test.ts](src/llm/run-mode/resolve-run-mode.test.ts).
+3. **`primaryProviderId` is never empty**, and an unresolvable active provider derives `local`. Same test file.
+4. **The default launch is byte-identical**: `parallel` undefined ⇒ `--parallel 2`. Pinned by [src/local-llm/daemon-lifecycle.test.ts](src/local-llm/daemon-lifecycle.test.ts) and the v51 migration case in [src/config/config-schema.test.ts](src/config/config-schema.test.ts).
 
 ## Traceability and replay
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,26 @@ A cloud key is checked before it is saved. The key screen refuses an empty key, 
 </details>
 
 <details>
+<summary><b>Run modes: Local · Cloud · Fusion</b></summary>
+
+`local` and `cloud` are the two routes the composer always offered. **Fusion** adds a third: a cloud model orchestrates and several local llama-server workers execute the parts it delegates, so cloud tokens pay only for the heavy thinking. The block is additive and `llm.activeTextProvider` stays authoritative:
+
+```json
+"llm": {
+  "activeTextProvider": "openrouter",
+  "runMode": {
+    "mode": "fusion",
+    "fusion": { "orchestratorProvider": "openrouter", "workerProvider": "local-llama", "workers": 3 }
+  }
+},
+"localModels": { "managed": { "parallel": 3 } }
+```
+
+`workers` (1..8) caps how many workers run at once; `localModels.managed.parallel` is the llama-server `--parallel` slot count that lets them actually run concurrently (default 2, applied on the next daemon start). The orchestrator model is the provider's `defaultChatModel`; the worker model is the one the managed daemon serves.
+
+</details>
+
+<details>
 <summary><b>Managed local models</b></summary>
 
 The CLI can manage a paired `llama.cpp` setup for chat and embeddings:

--- a/src/cli/models-handlers.ts
+++ b/src/cli/models-handlers.ts
@@ -397,6 +397,7 @@ export async function runLocalModelsStart(): Promise<number> {
         modelId: mid,
         port: cfg.localModels.managed.port,
         contextSize: cfg.localModels.managed.contextSize,
+        parallel: cfg.localModels.managed.parallel,
         ...(tpl ? { chatTemplateFile: tpl } : {}),
         ...(mmprojFile ? { mmprojFile } : {}),
         ...(dev ? { device: dev } : {}),

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -875,6 +875,29 @@ describe("parseUserConfigFile", () => {
     expect(parsed.localModels.managed.tensorSplit).toEqual([3, 1]);
   });
 
+  it("defaults localModels.managed.parallel to 2 (the pre-v52 hard-coded slot count)", () => {
+    expect(parseUserConfigFile({ version: USER_CONFIG_VERSION }).localModels.managed.parallel).toBe(2);
+    expect(USER_CONFIG_DEFAULTS.localModels.managed.parallel).toBe(2);
+  });
+
+  it("migrates a v51 file by filling localModels.managed.parallel=2", () => {
+    const parsed = parseUserConfigFile({ version: 51, localModels: { managed: { port: 19091 } } });
+    expect(parsed.version).toBe(USER_CONFIG_VERSION);
+    expect(parsed.localModels.managed.parallel).toBe(2);
+  });
+
+  it("keeps an explicit localModels.managed.parallel and bounds it to 1..8", () => {
+    expect(
+      parseUserConfigFile({ version: USER_CONFIG_VERSION, localModels: { managed: { parallel: 4 } } })
+        .localModels.managed.parallel,
+    ).toBe(4);
+    for (const parallel of [0, 9, 2.5]) {
+      expect(() =>
+        parseUserConfigFile({ version: USER_CONFIG_VERSION, localModels: { managed: { parallel } } }),
+      ).toThrow(/localModels\.managed\.parallel/);
+    }
+  });
+
   it("accepts fractional ratios and zeros that skip a device", () => {
     const parsed = parseUserConfigFile({
       version: USER_CONFIG_VERSION,

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -4,6 +4,7 @@ import {
   parseUserLlmFileConfig,
   type UserLlmFileConfig,
 } from "./llm-config.js";
+import type { UserLlmRunModeConfig } from "./llm-run-mode-config.js";
 
 export type { ApprovalLevel } from "../approval/approval-level.js";
 import type { DotenvLoadResult } from "./load-dotenv.js";
@@ -965,6 +966,13 @@ export interface AtomicAgentConfig {
       probeThrottleMs?: number;
       failureWindowMs?: number;
     };
+    /**
+     * Run mode: `local` | `cloud` | `fusion`, plus the fusion legs
+     * (cloud orchestrator + llama-server workers). Additive —
+     * `activeTextProvider` stays authoritative; see
+     * `src/llm/run-mode/resolve-run-mode.ts`.
+     */
+    runMode?: UserLlmRunModeConfig;
   };
 }
 
@@ -1142,6 +1150,14 @@ export interface UserManagedLocalLlmConfig {
    * Added in config v48; older files inherit `[]` transparently.
    */
   tensorSplit: number[];
+  /**
+   * llama-server request slots (`--parallel`) for the managed chat
+   * daemon, 1..8. Default `2` — the value that was hard-coded before
+   * config v52, so older files launch byte-identically. Fusion workers
+   * run one per slot; raising this is what lets them run concurrently
+   * instead of queueing on the server. Applied on the next daemon start.
+   */
+  parallel: number;
   /**
    * Stop the managed chat daemon when the last CLI session exits.
    * `true` (default) — closing the terminal frees the RAM/VRAM the
@@ -1845,7 +1861,12 @@ export interface UserConfigFile {
 // v51: new `discord` block for the Discord remote-control channel.
 // Additive and inert by default — the channel is off, unpaired, and the
 // bot token lives in `<stateDir>/.env`, never here.
-export const USER_CONFIG_VERSION = 51;
+// v52: `llm.runMode` (mode local|cloud|fusion + the fusion legs and
+// worker count) and `localModels.managed.parallel` (llama-server
+// `--parallel`, default 2 = the previously hard-coded value). Additive:
+// an older file parses with `runMode` absent and `parallel` 2, which
+// launches the daemon with byte-identical args.
+export const USER_CONFIG_VERSION = 52;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1985,6 +2006,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   48,
   49,
   50,
+  51,
   USER_CONFIG_VERSION,
 ];
 
@@ -2004,6 +2026,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       backendVariant: "auto",
       contextSize: 0,
       tensorSplit: [],
+      parallel: 2,
     },
     embeddings: {
       enabled: false,
@@ -3551,6 +3574,12 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
     tensorSplit: parseTensorSplit(
       rawManaged.tensorSplit,
       "localModels.managed.tensorSplit",
+    ),
+    parallel: parseBoundedPositiveInt(
+      rawManaged.parallel ?? USER_CONFIG_DEFAULTS.localModels.managed.parallel,
+      "localModels.managed.parallel",
+      1,
+      8,
     ),
   };
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,6 +55,21 @@ export {
   SUBSCRIPTION_CLI_KIND,
   usesExternalCliAuth,
 } from "./provider-auth-mode.js";
+export {
+  DEFAULT_FUSION_WORKERS,
+  DEFAULT_FUSION_WORKER_MAX_STEPS,
+  DEFAULT_FUSION_WORKER_TIMEOUT_MS,
+  FUSION_WORKERS_MAX,
+  FUSION_WORKERS_MIN,
+  LOCAL_PROVIDER_KIND,
+  RUN_MODE_NAMES,
+  parseLlmRunModeConfig,
+  scrubRunModeProviderPins,
+  type RunModeName,
+  type RunModeProviderRef,
+  type UserLlmFusionConfig,
+  type UserLlmRunModeConfig,
+} from "./llm-run-mode-config.js";
 export type {
   DotenvLoadResult,
   DotenvReadFailure,

--- a/src/config/llm-config.test.ts
+++ b/src/config/llm-config.test.ts
@@ -203,6 +203,37 @@ describe("llm-config", () => {
     expect(parsed.llm?.fallback).toBeUndefined();
   });
 
+  it("round-trips llm.runMode and validates its pins against llm.providers", () => {
+    const parsed = parseUserConfigFile({
+      ...baseLlm(undefined),
+      llm: {
+        ...baseLlm(undefined).llm,
+        runMode: {
+          mode: "fusion",
+          fusion: { orchestratorProvider: "openrouter", workerProvider: "local-llama", workers: 3 },
+        },
+      },
+    });
+    expect(parsed.llm?.runMode).toEqual({
+      mode: "fusion",
+      fusion: { orchestratorProvider: "openrouter", workerProvider: "local-llama", workers: 3 },
+    });
+    expect(() =>
+      parseUserConfigFile({
+        ...baseLlm(undefined),
+        llm: {
+          ...baseLlm(undefined).llm,
+          runMode: { fusion: { orchestratorProvider: "local-llama" } },
+        },
+      }),
+    ).toThrow(/llm\.runMode\.fusion\.orchestratorProvider/);
+  });
+
+  it("omits runMode entirely when not configured", () => {
+    expect(parseUserConfigFile(baseLlm(undefined)).llm?.runMode).toBeUndefined();
+    expect("runMode" in (parseUserConfigFile(baseLlm(undefined)).llm ?? {})).toBe(false);
+  });
+
   it("parses extraBody on an openai-compatible provider entry", () => {
     const parsed = parseUserConfigFile({
       version: USER_CONFIG_VERSION,

--- a/src/config/llm-config.ts
+++ b/src/config/llm-config.ts
@@ -1,4 +1,8 @@
 import { ConfigValidationError } from "./config-validation-error.js";
+import {
+  parseLlmRunModeConfig,
+  type UserLlmRunModeConfig,
+} from "./llm-run-mode-config.js";
 import { SUBSCRIPTION_CLI_KIND } from "./provider-auth-mode.js";
 
 export type UserLlmToolTransport = "auto" | "grammar" | "native_tools";
@@ -140,6 +144,8 @@ export type UserLlmFileConfig = {
   toolTransport: UserLlmToolTransport;
   providers: UserLlmProviderEntry[];
   fallback?: UserLlmFallbackConfig;
+  /** Run mode (local | cloud | fusion) and the fusion legs. See `llm-run-mode-config.ts`. */
+  runMode?: UserLlmRunModeConfig;
 };
 
 const PROVIDER_ID_RE = /^[a-z][a-z0-9-]{0,31}$/;
@@ -661,6 +667,10 @@ export function parseUserLlmFileConfig(
           new Set(providers.map((p) => p.id)),
           "llm.fallback",
         );
+  const runMode =
+    obj.runMode === undefined || obj.runMode === null
+      ? undefined
+      : parseLlmRunModeConfig(obj.runMode, providers, "llm.runMode");
 
   return {
     activeTextProvider,
@@ -668,5 +678,6 @@ export function parseUserLlmFileConfig(
     toolTransport: toolTransportRaw,
     providers,
     ...(fallback ? { fallback } : {}),
+    ...(runMode ? { runMode } : {}),
   };
 }

--- a/src/config/llm-run-mode-config.test.ts
+++ b/src/config/llm-run-mode-config.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import { ConfigValidationError } from "./config-validation-error.js";
+import {
+  DEFAULT_FUSION_WORKERS,
+  FUSION_WORKERS_MAX,
+  FUSION_WORKERS_MIN,
+  parseLlmRunModeConfig,
+  scrubRunModeProviderPins,
+} from "./llm-run-mode-config.js";
+
+const providers = [
+  { id: "local-llama", kind: "llama-server" },
+  { id: "openrouter", kind: "openrouter" },
+  { id: "claude-cli", kind: "subscription-cli" },
+];
+
+describe("parseLlmRunModeConfig", () => {
+  it("accepts an empty block", () => {
+    expect(parseLlmRunModeConfig({}, providers, "llm.runMode")).toEqual({});
+  });
+
+  it.each(["local", "cloud", "fusion"] as const)("accepts mode %s", (mode) => {
+    expect(parseLlmRunModeConfig({ mode }, providers, "llm.runMode")).toEqual({ mode });
+  });
+
+  it("rejects an unknown mode", () => {
+    expect(() => parseLlmRunModeConfig({ mode: "hybrid" }, providers, "llm.runMode")).toThrow(
+      ConfigValidationError,
+    );
+    expect(() => parseLlmRunModeConfig({ mode: "hybrid" }, providers, "llm.runMode")).toThrow(
+      /llm\.runMode\.mode/,
+    );
+  });
+
+  it("rejects a non-object block", () => {
+    expect(() => parseLlmRunModeConfig("fusion", providers, "llm.runMode")).toThrow(
+      /expected object/,
+    );
+    expect(() => parseLlmRunModeConfig([], providers, "llm.runMode")).toThrow(/expected object/);
+  });
+
+  it("round-trips a full fusion block", () => {
+    const fusion = {
+      orchestratorProvider: "openrouter",
+      orchestratorModel: "anthropic/claude-sonnet-4.5",
+      workerProvider: "local-llama",
+      workerModel: "qwen-3.5-4b",
+      workers: 4,
+      workerMaxSteps: 25,
+      workerTimeoutMs: 120_000,
+    };
+    expect(parseLlmRunModeConfig({ mode: "fusion", fusion }, providers, "llm.runMode")).toEqual({
+      mode: "fusion",
+      fusion,
+    });
+  });
+
+  it("omits fusion keys that were not given", () => {
+    const parsed = parseLlmRunModeConfig(
+      { fusion: { workers: 3 } },
+      providers,
+      "llm.runMode",
+    );
+    expect(parsed).toEqual({ fusion: { workers: 3 } });
+    expect("orchestratorProvider" in (parsed.fusion ?? {})).toBe(false);
+  });
+
+  it("accepts a subscription-cli provider as the orchestrator", () => {
+    expect(
+      parseLlmRunModeConfig(
+        { fusion: { orchestratorProvider: "claude-cli" } },
+        providers,
+        "llm.runMode",
+      ),
+    ).toEqual({ fusion: { orchestratorProvider: "claude-cli" } });
+  });
+
+  it("rejects an orchestrator pin that names a llama-server provider", () => {
+    expect(() =>
+      parseLlmRunModeConfig(
+        { fusion: { orchestratorProvider: "local-llama" } },
+        providers,
+        "llm.runMode",
+      ),
+    ).toThrow(/llm\.runMode\.fusion\.orchestratorProvider.*must be a cloud provider/);
+  });
+
+  it("rejects a worker pin that names a cloud provider", () => {
+    expect(() =>
+      parseLlmRunModeConfig(
+        { fusion: { workerProvider: "openrouter" } },
+        providers,
+        "llm.runMode",
+      ),
+    ).toThrow(/llm\.runMode\.fusion\.workerProvider.*must be llama-server/);
+  });
+
+  it("rejects a pin to a provider that is not configured", () => {
+    expect(() =>
+      parseLlmRunModeConfig(
+        { fusion: { orchestratorProvider: "nope" } },
+        providers,
+        "llm.runMode",
+      ),
+    ).toThrow(/unknown provider id "nope"/);
+    expect(() =>
+      parseLlmRunModeConfig({ fusion: { workerProvider: "" } }, providers, "llm.runMode"),
+    ).toThrow(/expected non-empty string/);
+  });
+
+  it.each([0, 9, 2.5, "3", -1])("rejects workers = %s", (workers) => {
+    expect(() =>
+      parseLlmRunModeConfig({ fusion: { workers } }, providers, "llm.runMode"),
+    ).toThrow(/llm\.runMode\.fusion\.workers/);
+  });
+
+  it("accepts the worker-count bounds", () => {
+    for (const workers of [FUSION_WORKERS_MIN, FUSION_WORKERS_MAX]) {
+      expect(
+        parseLlmRunModeConfig({ fusion: { workers } }, providers, "llm.runMode").fusion?.workers,
+      ).toBe(workers);
+    }
+    expect(DEFAULT_FUSION_WORKERS).toBeGreaterThanOrEqual(FUSION_WORKERS_MIN);
+    expect(DEFAULT_FUSION_WORKERS).toBeLessThanOrEqual(FUSION_WORKERS_MAX);
+  });
+
+  it("bounds the worker step and time ceilings", () => {
+    expect(() =>
+      parseLlmRunModeConfig({ fusion: { workerMaxSteps: 0 } }, providers, "llm.runMode"),
+    ).toThrow(/workerMaxSteps/);
+    expect(() =>
+      parseLlmRunModeConfig({ fusion: { workerTimeoutMs: 10 } }, providers, "llm.runMode"),
+    ).toThrow(/workerTimeoutMs/);
+  });
+
+  it("rejects an empty model label", () => {
+    expect(() =>
+      parseLlmRunModeConfig({ fusion: { orchestratorModel: "" } }, providers, "llm.runMode"),
+    ).toThrow(/orchestratorModel/);
+  });
+});
+
+describe("scrubRunModeProviderPins", () => {
+  it("returns the block untouched when nothing points at the removed id", () => {
+    const block = { mode: "fusion" as const, fusion: { orchestratorProvider: "openrouter" } };
+    expect(scrubRunModeProviderPins(block, "groq")).toBe(block);
+    expect(scrubRunModeProviderPins(undefined, "groq")).toBeUndefined();
+    const noFusion = { mode: "cloud" as const };
+    expect(scrubRunModeProviderPins(noFusion, "openrouter")).toBe(noFusion);
+  });
+
+  it("drops only the pin that names the removed provider", () => {
+    const block = {
+      mode: "fusion" as const,
+      fusion: { orchestratorProvider: "openrouter", workerProvider: "local-llama", workers: 3 },
+    };
+    expect(scrubRunModeProviderPins(block, "openrouter")).toEqual({
+      mode: "fusion",
+      fusion: { workerProvider: "local-llama", workers: 3 },
+    });
+    expect(scrubRunModeProviderPins(block, "local-llama")).toEqual({
+      mode: "fusion",
+      fusion: { orchestratorProvider: "openrouter", workers: 3 },
+    });
+  });
+});

--- a/src/config/llm-run-mode-config.ts
+++ b/src/config/llm-run-mode-config.ts
@@ -1,0 +1,224 @@
+import { ConfigValidationError } from "./config-validation-error.js";
+
+/**
+ * Operator-facing run mode. Names *how* a chat runs, not a single model:
+ *
+ * - `local`  — the active provider is a llama-server one; everything
+ *   runs on this machine.
+ * - `cloud`  — the active provider is a cloud one; everything runs there.
+ * - `fusion` — a cloud model orchestrates and several local-model
+ *   workers execute the parts it delegates. See AGENTS.md §"Run modes
+ *   (Local / Cloud / Fusion)".
+ *
+ * `llm.activeTextProvider` stays authoritative in every mode; this block
+ * is additive (see `resolveRunMode`).
+ */
+export type RunModeName = "local" | "cloud" | "fusion";
+
+export type UserLlmFusionConfig = {
+  /**
+   * The orchestrator leg. Must name a configured provider whose kind is
+   * NOT `llama-server`. Default: the active provider when it is a cloud
+   * one, else the first cloud provider in `llm.providers`.
+   */
+  orchestratorProvider?: string;
+  /**
+   * Informational pin for the orchestrator model. The wire request
+   * carries no model field — the provider entry's `defaultChatModel` is
+   * what actually serves — so this only overrides what is *displayed*
+   * and priced. Left unset by the TUI.
+   */
+  orchestratorModel?: string;
+  /**
+   * The worker leg. Must name a configured `llama-server` provider.
+   * Default: the first `llama-server` provider in `llm.providers`.
+   */
+  workerProvider?: string;
+  /**
+   * Informational pin for the worker model. The managed daemon serves
+   * whatever `localModels.managed.modelId` names; this only overrides
+   * the label. Left unset by the TUI.
+   */
+  workerModel?: string;
+  /** How many workers may run at once, 1..8. Default 2. */
+  workers?: number;
+  /** Step ceiling per worker turn. Default 40. */
+  workerMaxSteps?: number;
+  /** Wall-clock ceiling per worker turn, in ms. Default 600 000. */
+  workerTimeoutMs?: number;
+};
+
+export type UserLlmRunModeConfig = {
+  mode?: RunModeName;
+  fusion?: UserLlmFusionConfig;
+};
+
+export const RUN_MODE_NAMES: readonly RunModeName[] = ["local", "cloud", "fusion"];
+
+/** Provider kind that identifies a local (worker-capable) leg. */
+export const LOCAL_PROVIDER_KIND = "llama-server";
+
+export const FUSION_WORKERS_MIN = 1;
+export const FUSION_WORKERS_MAX = 8;
+export const DEFAULT_FUSION_WORKERS = 2;
+export const DEFAULT_FUSION_WORKER_MAX_STEPS = 40;
+export const DEFAULT_FUSION_WORKER_TIMEOUT_MS = 600_000;
+
+export type RunModeProviderRef = { readonly id: string; readonly kind: string };
+
+function parseLegProviderId(
+  raw: unknown,
+  providers: ReadonlyArray<RunModeProviderRef>,
+  field: string,
+  leg: "orchestrator" | "worker",
+): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ConfigValidationError(field, "expected non-empty string");
+  }
+  const entry = providers.find((p) => p.id === raw);
+  if (!entry) {
+    throw new ConfigValidationError(field, `unknown provider id ${JSON.stringify(raw)}`);
+  }
+  const isLocal = entry.kind === LOCAL_PROVIDER_KIND;
+  if (leg === "orchestrator" && isLocal) {
+    throw new ConfigValidationError(
+      field,
+      `orchestrator must be a cloud provider, ${JSON.stringify(raw)} is ${LOCAL_PROVIDER_KIND}`,
+    );
+  }
+  if (leg === "worker" && !isLocal) {
+    throw new ConfigValidationError(
+      field,
+      `worker provider must be ${LOCAL_PROVIDER_KIND}, ${JSON.stringify(raw)} is ${entry.kind}`,
+    );
+  }
+  return raw;
+}
+
+function parseBoundedInt(raw: unknown, field: string, min: number, max: number): number {
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < min || raw > max) {
+    throw new ConfigValidationError(
+      field,
+      `expected an integer ${min}-${max}, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return raw;
+}
+
+function parseOptionalLabel(raw: unknown, field: string): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new ConfigValidationError(field, "expected non-empty string");
+  }
+  return raw;
+}
+
+function parseFusion(
+  raw: unknown,
+  providers: ReadonlyArray<RunModeProviderRef>,
+  field: string,
+): UserLlmFusionConfig {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(field, "expected object");
+  }
+  const obj = raw as Record<string, unknown>;
+  const out: UserLlmFusionConfig = {};
+  if (obj.orchestratorProvider !== undefined) {
+    out.orchestratorProvider = parseLegProviderId(
+      obj.orchestratorProvider,
+      providers,
+      `${field}.orchestratorProvider`,
+      "orchestrator",
+    );
+  }
+  if (obj.orchestratorModel !== undefined) {
+    out.orchestratorModel = parseOptionalLabel(
+      obj.orchestratorModel,
+      `${field}.orchestratorModel`,
+    );
+  }
+  if (obj.workerProvider !== undefined) {
+    out.workerProvider = parseLegProviderId(
+      obj.workerProvider,
+      providers,
+      `${field}.workerProvider`,
+      "worker",
+    );
+  }
+  if (obj.workerModel !== undefined) {
+    out.workerModel = parseOptionalLabel(obj.workerModel, `${field}.workerModel`);
+  }
+  if (obj.workers !== undefined) {
+    out.workers = parseBoundedInt(
+      obj.workers,
+      `${field}.workers`,
+      FUSION_WORKERS_MIN,
+      FUSION_WORKERS_MAX,
+    );
+  }
+  if (obj.workerMaxSteps !== undefined) {
+    out.workerMaxSteps = parseBoundedInt(obj.workerMaxSteps, `${field}.workerMaxSteps`, 1, 1000);
+  }
+  if (obj.workerTimeoutMs !== undefined) {
+    out.workerTimeoutMs = parseBoundedInt(
+      obj.workerTimeoutMs,
+      `${field}.workerTimeoutMs`,
+      1_000,
+      86_400_000,
+    );
+  }
+  return out;
+}
+
+/**
+ * Validate the `llm.runMode` block against the sibling `llm.providers`
+ * array. A pinned leg that names a provider which does not exist, or
+ * one of the wrong kind, is a config error rather than a silent
+ * degradation: the operator meant something specific.
+ */
+export function parseLlmRunModeConfig(
+  raw: unknown,
+  providers: ReadonlyArray<RunModeProviderRef>,
+  field: string,
+): UserLlmRunModeConfig {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(field, "expected object");
+  }
+  const obj = raw as Record<string, unknown>;
+  const out: UserLlmRunModeConfig = {};
+  if (obj.mode !== undefined) {
+    const mode = obj.mode;
+    if (typeof mode !== "string" || !RUN_MODE_NAMES.includes(mode as RunModeName)) {
+      throw new ConfigValidationError(`${field}.mode`, `expected ${RUN_MODE_NAMES.join("|")}`);
+    }
+    out.mode = mode as RunModeName;
+  }
+  if (obj.fusion !== undefined) {
+    out.fusion = parseFusion(obj.fusion, providers, `${field}.fusion`);
+  }
+  return out;
+}
+
+/**
+ * Drop fusion leg pins that name a provider being removed. The parser
+ * refuses a pin to an unknown id, so leaving one behind would make the
+ * file unreadable on the next start. Returns the input untouched when
+ * nothing is pinned to `removedId`.
+ */
+export function scrubRunModeProviderPins(
+  runMode: UserLlmRunModeConfig | undefined,
+  removedId: string,
+): UserLlmRunModeConfig | undefined {
+  if (!runMode?.fusion) return runMode;
+  const { orchestratorProvider, workerProvider, ...rest } = runMode.fusion;
+  if (orchestratorProvider !== removedId && workerProvider !== removedId) return runMode;
+  return {
+    ...runMode,
+    fusion: {
+      ...rest,
+      ...(orchestratorProvider && orchestratorProvider !== removedId
+        ? { orchestratorProvider }
+        : {}),
+      ...(workerProvider && workerProvider !== removedId ? { workerProvider } : {}),
+    },
+  };
+}

--- a/src/config/load-config.test.ts
+++ b/src/config/load-config.test.ts
@@ -135,6 +135,23 @@ describe("loadConfig", () => {
     expect(config.agent.approvalLevel).toBe(5);
   });
 
+  it("maps llm.runMode from the file onto the runtime config", () => {
+    writeUserConfigFileSync(getUserConfigPath(stateDir), {
+      ...USER_CONFIG_DEFAULTS,
+      llm: {
+        activeTextProvider: "openrouter",
+        activeEmbeddingProvider: "local-llama",
+        toolTransport: "auto",
+        providers: [
+          { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:19091" },
+          { id: "openrouter", kind: "openrouter", defaultChatModel: "gpt" },
+        ],
+        runMode: { mode: "fusion", fusion: { workers: 3 } },
+      },
+    });
+    expect(loadConfig().llm?.runMode).toEqual({ mode: "fusion", fusion: { workers: 3 } });
+  });
+
   it("keeps non-user-facing knobs on environment variables", () => {
     process.env.ATOMIC_AGENT_LLAMA_API_KEY = "secret";
     process.env.ATOMIC_AGENT_BROWSER_CHANNEL = "msedge";

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -562,5 +562,6 @@ function mapUserLlmToRuntime(
       };
     }),
     ...(llm.fallback ? { fallback: llm.fallback } : {}),
+    ...(llm.runMode ? { runMode: llm.runMode } : {}),
   };
 }

--- a/src/llm/provider/registry/provider-types.ts
+++ b/src/llm/provider/registry/provider-types.ts
@@ -1,5 +1,6 @@
 import type { AtomicAgentConfig } from "../../../config/index.js";
 import type { UserSubscriptionCliOptions } from "../../../config/llm-config.js";
+import type { UserLlmRunModeConfig } from "../../../config/llm-run-mode-config.js";
 import type { LlamaServerClient } from "../../llama-server-client.js";
 import type { ModelProfile } from "../../model-profile.js";
 import type { StructuredLogger } from "../../../tracing/index.js";
@@ -97,6 +98,7 @@ export type ResolvedLlmConfig = {
   providers: LlmProviderConfigEntry[];
   toolTransport: "auto" | "grammar" | "native_tools";
   fallback?: LlmFallbackConfig;
+  runMode?: UserLlmRunModeConfig;
 };
 
 const factories = new Map<string, ProviderFactory>();
@@ -125,6 +127,7 @@ export function resolveLlmConfig(config: AtomicAgentConfig): ResolvedLlmConfig {
       providers: [...llm.providers],
       toolTransport: llm.toolTransport,
       ...(llm.fallback ? { fallback: llm.fallback } : {}),
+      ...(llm.runMode ? { runMode: llm.runMode } : {}),
     };
   }
   return {

--- a/src/llm/run-mode/index.ts
+++ b/src/llm/run-mode/index.ts
@@ -1,0 +1,9 @@
+export { resolveRunMode } from "./resolve-run-mode.js";
+export type {
+  ResolvedRunMode,
+  ResolveRunModeOptions,
+  RunModeDegradation,
+  RunModeDegradationReason,
+} from "./resolve-run-mode.js";
+export { describeRunModeDegradation } from "./run-mode-degradation.js";
+export { describeRunMode, runModeLabel } from "./run-mode-summary.js";

--- a/src/llm/run-mode/resolve-run-mode.test.ts
+++ b/src/llm/run-mode/resolve-run-mode.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import type { UserLlmRunModeConfig } from "../../config/llm-run-mode-config.js";
+import type { ResolvedLlmConfig } from "../provider/registry/provider-types.js";
+import { resolveRunMode } from "./resolve-run-mode.js";
+
+function llm(
+  active: string,
+  runMode?: UserLlmRunModeConfig,
+  providers: ResolvedLlmConfig["providers"] = [
+    { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:19091" },
+    { id: "openrouter", kind: "openrouter", defaultChatModel: "anthropic/claude-sonnet-4.5" },
+    { id: "groq", kind: "openai-compatible", defaultChatModel: "llama-3.3" },
+  ],
+): ResolvedLlmConfig {
+  return {
+    activeTextProvider: active,
+    activeEmbeddingProvider: "local-llama",
+    providers,
+    toolTransport: "auto",
+    ...(runMode ? { runMode } : {}),
+  };
+}
+
+describe("resolveRunMode", () => {
+  it("derives local from a llama-server active provider when the block is absent", () => {
+    const rm = resolveRunMode(llm("local-llama"));
+    expect(rm.stored).toBeNull();
+    expect(rm.effective).toBe("local");
+    expect(rm.primaryProviderId).toBe("local-llama");
+    expect(rm.degraded).toBeNull();
+  });
+
+  it("derives cloud from a cloud active provider when the block is absent", () => {
+    const rm = resolveRunMode(llm("groq"));
+    expect(rm.effective).toBe("cloud");
+    expect(rm.primaryProviderId).toBe("groq");
+  });
+
+  it("finds the legs by kind: first llama-server is the worker, active cloud is the orchestrator", () => {
+    const rm = resolveRunMode(llm("groq", { mode: "fusion" }));
+    expect(rm.workerProviderId).toBe("local-llama");
+    expect(rm.orchestratorProviderId).toBe("groq");
+    expect(rm.effective).toBe("fusion");
+  });
+
+  it("falls back to the first cloud provider when the active one is local", () => {
+    const rm = resolveRunMode(llm("local-llama", { mode: "fusion" }));
+    expect(rm.orchestratorProviderId).toBe("openrouter");
+    // Fusion is stored but the orchestrator is not active, so it is not effective.
+    expect(rm.effective).toBe("local");
+    expect(rm.degraded).toBeNull();
+  });
+
+  it("honours pinned legs", () => {
+    const rm = resolveRunMode(
+      llm("openrouter", {
+        mode: "fusion",
+        fusion: { orchestratorProvider: "openrouter", workerProvider: "local-llama" },
+      }),
+    );
+    expect(rm.effective).toBe("fusion");
+    expect(rm.orchestratorProviderId).toBe("openrouter");
+    expect(rm.primaryProviderId).toBe("openrouter");
+  });
+
+  it("drops to the derived mode when the operator switched provider by hand", () => {
+    const rm = resolveRunMode(
+      llm("groq", { mode: "fusion", fusion: { orchestratorProvider: "openrouter" } }),
+    );
+    expect(rm.stored).toBe("fusion");
+    expect(rm.effective).toBe("cloud");
+    expect(rm.degraded).toBeNull();
+  });
+
+  it("degrades fusion with no cloud provider to local", () => {
+    const rm = resolveRunMode(
+      llm("local-llama", { mode: "fusion" }, [
+        { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:19091" },
+      ]),
+    );
+    expect(rm.effective).toBe("local");
+    expect(rm.degraded).toEqual({ reason: "no-cloud-provider", requested: "fusion" });
+    expect(rm.orchestratorProviderId).toBeNull();
+  });
+
+  it("degrades fusion with no llama-server provider to cloud-only", () => {
+    const rm = resolveRunMode(
+      llm("groq", { mode: "fusion" }, [
+        { id: "groq", kind: "openai-compatible", defaultChatModel: "llama-3.3" },
+      ]),
+    );
+    expect(rm.effective).toBe("cloud");
+    expect(rm.degraded).toEqual({ reason: "no-local-provider", requested: "fusion" });
+    expect(rm.workerProviderId).toBeNull();
+  });
+
+  it("degrades a stored cloud mode with no cloud provider", () => {
+    const rm = resolveRunMode(
+      llm("local-llama", { mode: "cloud" }, [
+        { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:19091" },
+      ]),
+    );
+    expect(rm.degraded).toEqual({ reason: "no-cloud-provider", requested: "cloud" });
+  });
+
+  it("assumes local for an unresolvable active provider and never leaves primary empty", () => {
+    const rm = resolveRunMode(llm("ghost", { mode: "fusion" }));
+    expect(rm.effective).toBe("local");
+    expect(rm.primaryProviderId).toBe("local-llama");
+    const bare = resolveRunMode(llm("ghost", undefined, []));
+    expect(bare.primaryProviderId).toBe("ghost");
+  });
+
+  it("accepts a subscription-cli provider as the orchestrator", () => {
+    const rm = resolveRunMode(
+      llm("claude-cli", { mode: "fusion" }, [
+        { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:19091" },
+        { id: "claude-cli", kind: "subscription-cli", defaultChatModel: "sonnet" },
+      ]),
+    );
+    expect(rm.effective).toBe("fusion");
+    expect(rm.orchestratorProviderId).toBe("claude-cli");
+  });
+
+  it("labels the models from the provider default and the managed daemon, unless pinned", () => {
+    const rm = resolveRunMode(llm("openrouter", { mode: "fusion" }), {
+      managedModelId: "qwen-3.5-4b",
+    });
+    expect(rm.orchestratorModel).toBe("anthropic/claude-sonnet-4.5");
+    expect(rm.workerModel).toBe("qwen-3.5-4b");
+    const pinned = resolveRunMode(
+      llm("openrouter", {
+        mode: "fusion",
+        fusion: { orchestratorModel: "opus", workerModel: "gemma" },
+      }),
+      { managedModelId: "qwen-3.5-4b" },
+    );
+    expect(pinned.orchestratorModel).toBe("opus");
+    expect(pinned.workerModel).toBe("gemma");
+    expect(resolveRunMode(llm("openrouter", { mode: "fusion" })).workerModel).toBeNull();
+  });
+
+  it("applies the worker defaults and honours overrides", () => {
+    expect(resolveRunMode(llm("openrouter", { mode: "fusion" }))).toMatchObject({
+      workers: 2,
+      workerMaxSteps: 40,
+      workerTimeoutMs: 600_000,
+    });
+    expect(
+      resolveRunMode(
+        llm("openrouter", {
+          mode: "fusion",
+          fusion: { workers: 5, workerMaxSteps: 10, workerTimeoutMs: 5_000 },
+        }),
+      ),
+    ).toMatchObject({ workers: 5, workerMaxSteps: 10, workerTimeoutMs: 5_000 });
+  });
+});

--- a/src/llm/run-mode/resolve-run-mode.ts
+++ b/src/llm/run-mode/resolve-run-mode.ts
@@ -1,0 +1,138 @@
+import type { RunModeName } from "../../config/llm-run-mode-config.js";
+import {
+  DEFAULT_FUSION_WORKER_MAX_STEPS,
+  DEFAULT_FUSION_WORKER_TIMEOUT_MS,
+  DEFAULT_FUSION_WORKERS,
+  LOCAL_PROVIDER_KIND,
+} from "../../config/llm-run-mode-config.js";
+import type {
+  LlmProviderConfigEntry,
+  ResolvedLlmConfig,
+} from "../provider/registry/provider-types.js";
+
+export type RunModeDegradationReason = "no-cloud-provider" | "no-local-provider";
+
+export type RunModeDegradation = {
+  reason: RunModeDegradationReason;
+  /** The mode the operator asked for, before degradation. */
+  requested: RunModeName;
+};
+
+export type ResolvedRunMode = {
+  /** What the config file says, or `null` when the block is absent. */
+  stored: RunModeName | null;
+  /** What the runtime will actually do. */
+  effective: RunModeName;
+  /** The cloud leg (fusion's orchestrator), or `null` when none is configured. */
+  orchestratorProviderId: string | null;
+  /** Display/pricing label for the orchestrator model; the provider's default chat model unless pinned. */
+  orchestratorModel: string | null;
+  /** The local leg (fusion's workers), or `null` when none is configured. */
+  workerProviderId: string | null;
+  /** Display label for the worker model; the managed daemon's model unless pinned. */
+  workerModel: string | null;
+  workers: number;
+  workerMaxSteps: number;
+  workerTimeoutMs: number;
+  /**
+   * The provider that must be `llm.activeTextProvider` for `effective`
+   * to hold. Never empty — falls back to the configured active provider
+   * when neither leg resolves.
+   */
+  primaryProviderId: string;
+  degraded: RunModeDegradation | null;
+};
+
+export type ResolveRunModeOptions = {
+  /** `localModels.managed.modelId`, the model the worker daemon serves. */
+  managedModelId?: string | null;
+};
+
+function isLocalKind(entry: LlmProviderConfigEntry | undefined): boolean {
+  return entry?.kind === LOCAL_PROVIDER_KIND;
+}
+
+/**
+ * Project the `llm.runMode` block onto the providers that actually exist.
+ *
+ * `llm.activeTextProvider` stays AUTHORITATIVE — `runMode.mode` is purely
+ * additive. The effective mode is derived from which provider is active,
+ * and a stored `fusion` is only honoured while the orchestrator (cloud)
+ * leg is the active one and a worker (llama-server) leg exists:
+ *
+ * ```
+ * derived   = kindOf(activeTextProvider) === "llama-server" ? "local" : "cloud"
+ * effective = stored === "fusion" && bothLegs && active === orchestratorId
+ *             ? "fusion" : derived
+ * ```
+ *
+ * That rule keeps the two keys from ever contradicting each other: an
+ * operator who switches provider by hand in Manage → LLM simply drops
+ * out of fusion on the next read, with no reconciliation step and no
+ * state that lies about what is running. Fusion therefore pins the
+ * cloud provider as the fallback chain's primary and `resolveFallbackChain`
+ * needs no changes of its own.
+ *
+ * A `subscription-cli` provider counts as cloud: it is not a
+ * llama-server and cannot host workers.
+ */
+export function resolveRunMode(
+  resolved: ResolvedLlmConfig,
+  opts: ResolveRunModeOptions = {},
+): ResolvedRunMode {
+  const runMode = resolved.runMode;
+  const fusion = runMode?.fusion;
+  const stored = runMode?.mode ?? null;
+  const byId = (id: string | undefined): LlmProviderConfigEntry | undefined =>
+    id === undefined ? undefined : resolved.providers.find((p) => p.id === id);
+
+  const active = byId(resolved.activeTextProvider);
+  // An unresolvable active provider means a broken config; assume local
+  // so a broken file can never silently start spending cloud tokens.
+  const derived: RunModeName = active === undefined || isLocalKind(active) ? "local" : "cloud";
+
+  const orchestrator =
+    byId(fusion?.orchestratorProvider) ??
+    (active !== undefined && !isLocalKind(active) ? active : undefined) ??
+    resolved.providers.find((p) => !isLocalKind(p));
+  const worker = byId(fusion?.workerProvider) ?? resolved.providers.find((p) => isLocalKind(p));
+
+  const orchestratorProviderId = orchestrator?.id ?? null;
+  const workerProviderId = worker?.id ?? null;
+
+  let effective: RunModeName = derived;
+  let degraded: RunModeDegradation | null = null;
+  if (stored === "fusion") {
+    if (orchestratorProviderId === null) {
+      degraded = { reason: "no-cloud-provider", requested: stored };
+    } else if (workerProviderId === null) {
+      degraded = { reason: "no-local-provider", requested: stored };
+    } else if (resolved.activeTextProvider === orchestratorProviderId) {
+      effective = "fusion";
+    }
+    // else: the operator switched the active provider by hand — report
+    // `derived`. That is the non-contradiction rule working, not a
+    // degradation, so nothing to warn about.
+  } else if (stored === "cloud" && orchestratorProviderId === null) {
+    degraded = { reason: "no-cloud-provider", requested: stored };
+  }
+
+  const primaryProviderId =
+    (effective === "local" ? workerProviderId : orchestratorProviderId) ??
+    resolved.activeTextProvider;
+
+  return {
+    stored,
+    effective,
+    orchestratorProviderId,
+    orchestratorModel:
+      fusion?.orchestratorModel ?? orchestrator?.defaultChatModel ?? orchestrator?.model ?? null,
+    workerProviderId,
+    workerModel: fusion?.workerModel ?? opts.managedModelId ?? worker?.model ?? null,
+    workers: fusion?.workers ?? DEFAULT_FUSION_WORKERS,
+    workerMaxSteps: fusion?.workerMaxSteps ?? DEFAULT_FUSION_WORKER_MAX_STEPS,
+    workerTimeoutMs: fusion?.workerTimeoutMs ?? DEFAULT_FUSION_WORKER_TIMEOUT_MS,
+    primaryProviderId,
+    degraded,
+  };
+}

--- a/src/llm/run-mode/run-mode-degradation.test.ts
+++ b/src/llm/run-mode/run-mode-degradation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { describeRunModeDegradation } from "./run-mode-degradation.js";
+
+describe("describeRunModeDegradation", () => {
+  it("names the missing cloud leg for fusion and for cloud mode differently", () => {
+    expect(describeRunModeDegradation({ reason: "no-cloud-provider", requested: "fusion" })).toMatch(
+      /^Fusion needs a cloud orchestrator/,
+    );
+    expect(describeRunModeDegradation({ reason: "no-cloud-provider", requested: "cloud" })).toMatch(
+      /^Cloud mode needs a cloud provider/,
+    );
+  });
+
+  it("names the missing local leg", () => {
+    expect(describeRunModeDegradation({ reason: "no-local-provider", requested: "fusion" })).toMatch(
+      /needs local workers.*Running cloud-only/,
+    );
+  });
+
+  it("always points at where to fix it", () => {
+    expect(describeRunModeDegradation({ reason: "no-cloud-provider", requested: "fusion" })).toContain(
+      "Manage → LLM → Cloud",
+    );
+  });
+});

--- a/src/llm/run-mode/run-mode-degradation.ts
+++ b/src/llm/run-mode/run-mode-degradation.ts
@@ -1,0 +1,19 @@
+import type { RunModeDegradation } from "./resolve-run-mode.js";
+
+/**
+ * Operator-visible sentence for a run-mode degradation.
+ *
+ * Kept out of `resolveRunMode` so the resolver stays a pure projection
+ * and the wording can be asserted on its own — and so the TUI, the CLI
+ * and any HTTP surface all say exactly the same thing.
+ */
+export function describeRunModeDegradation(degraded: RunModeDegradation): string {
+  switch (degraded.reason) {
+    case "no-cloud-provider":
+      return degraded.requested === "fusion"
+        ? "Fusion needs a cloud orchestrator — no cloud provider is configured. Staying on local. Add one in Manage → LLM → Cloud (or /llm)."
+        : "Cloud mode needs a cloud provider — none is configured. Staying on local. Add one in Manage → LLM → Cloud (or /llm).";
+    case "no-local-provider":
+      return "Fusion needs local workers — no llama-server provider is configured. Running cloud-only.";
+  }
+}

--- a/src/llm/run-mode/run-mode-summary.test.ts
+++ b/src/llm/run-mode/run-mode-summary.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { ResolvedRunMode } from "./resolve-run-mode.js";
+import { describeRunMode, runModeLabel } from "./run-mode-summary.js";
+
+const base: ResolvedRunMode = {
+  stored: "fusion",
+  effective: "fusion",
+  orchestratorProviderId: "openrouter",
+  orchestratorModel: "anthropic/claude-sonnet-4.5",
+  workerProviderId: "local-llama",
+  workerModel: "qwen-3.5-4b",
+  workers: 3,
+  workerMaxSteps: 40,
+  workerTimeoutMs: 600_000,
+  primaryProviderId: "openrouter",
+  degraded: null,
+};
+
+describe("describeRunMode", () => {
+  it("describes an effective fusion with both legs and the worker count", () => {
+    expect(describeRunMode(base)).toBe(
+      "Fusion — orchestrator openrouter (anthropic/claude-sonnet-4.5), 3 workers on local-llama (qwen-3.5-4b)",
+    );
+    expect(describeRunMode({ ...base, workers: 1, workerModel: null })).toContain(
+      "1 worker on local-llama",
+    );
+  });
+
+  it("describes a plain mode by its active provider", () => {
+    expect(
+      describeRunMode({ ...base, stored: null, effective: "local", primaryProviderId: "local-llama" }),
+    ).toBe("Local — active provider local-llama");
+  });
+
+  it("says when the stored and the effective mode disagree", () => {
+    const line = describeRunMode({ ...base, effective: "cloud", primaryProviderId: "groq" });
+    expect(line).toContain("Cloud — active provider groq");
+    expect(line).toContain("stored fusion, effective cloud");
+    expect(line).toContain("orchestrator provider is not the active one");
+  });
+
+  it("appends the degradation sentence when there is one", () => {
+    const line = describeRunMode({
+      ...base,
+      effective: "local",
+      orchestratorProviderId: null,
+      primaryProviderId: "local-llama",
+      degraded: { reason: "no-cloud-provider", requested: "fusion" },
+    });
+    expect(line).toContain("Local — active provider local-llama");
+    expect(line).toContain("Fusion needs a cloud orchestrator");
+    expect(line).not.toContain("stored fusion, effective");
+  });
+
+  it("capitalises the mode words", () => {
+    expect(["local", "cloud", "fusion"].map(runModeLabel)).toEqual(["Local", "Cloud", "Fusion"]);
+  });
+});

--- a/src/llm/run-mode/run-mode-summary.ts
+++ b/src/llm/run-mode/run-mode-summary.ts
@@ -1,0 +1,38 @@
+import { describeRunModeDegradation } from "./run-mode-degradation.js";
+import type { ResolvedRunMode } from "./resolve-run-mode.js";
+
+/** Capitalised mode word for operator-facing lines. */
+export function runModeLabel(mode: ResolvedRunMode["effective"]): string {
+  return mode === "fusion" ? "Fusion" : mode === "cloud" ? "Cloud" : "Local";
+}
+
+/**
+ * One operator-facing line describing what the run mode resolves to —
+ * the body of `/runmode status`. Says when the stored and the effective
+ * mode disagree, because that is the one state a reader cannot infer
+ * from the chip alone.
+ */
+export function describeRunMode(rm: ResolvedRunMode): string {
+  const parts: string[] = [];
+  if (rm.effective === "fusion") {
+    parts.push(
+      `Fusion — orchestrator ${rm.orchestratorProviderId}${
+        rm.orchestratorModel ? ` (${rm.orchestratorModel})` : ""
+      }, ${rm.workers} worker${rm.workers === 1 ? "" : "s"} on ${rm.workerProviderId}${
+        rm.workerModel ? ` (${rm.workerModel})` : ""
+      }`,
+    );
+  } else {
+    parts.push(`${runModeLabel(rm.effective)} — active provider ${rm.primaryProviderId}`);
+  }
+  if (rm.degraded) {
+    parts.push(describeRunModeDegradation(rm.degraded));
+  } else if (rm.stored !== null && rm.stored !== rm.effective) {
+    parts.push(
+      `stored ${rm.stored}, effective ${rm.effective} — the ${
+        rm.stored === "fusion" ? "orchestrator" : rm.stored
+      } provider is not the active one; pick the mode again to re-apply`,
+    );
+  }
+  return parts.join(". ");
+}

--- a/src/local-llm/daemon-lifecycle.test.ts
+++ b/src/local-llm/daemon-lifecycle.test.ts
@@ -75,6 +75,23 @@ describe("buildLlamaServerArgs", () => {
     expect(args).not.toContain("--ctx-size");
   });
 
+  it("threads localModels.managed.parallel into --parallel, default 2", () => {
+    const args = buildLlamaServerArgs(
+      { ...baseOpts, parallel: 4 },
+      "/tmp/data/models/qwen-3.5-4b/Qwen3.5-4B-Q4_K_M.gguf",
+      "qwen-3.5-4b",
+    );
+    const at = args.indexOf("--parallel");
+    expect(at).toBeGreaterThan(0);
+    expect(args[at + 1]).toBe("4");
+    const defaults = buildLlamaServerArgs(
+      baseOpts,
+      "/tmp/data/models/qwen-3.5-4b/Qwen3.5-4B-Q4_K_M.gguf",
+      "qwen-3.5-4b",
+    );
+    expect(defaults[defaults.indexOf("--parallel") + 1]).toBe("2");
+  });
+
   it("appends --ctx-size when an effective context size is provided", () => {
     const args = buildLlamaServerArgs(
       baseOpts,

--- a/src/local-llm/daemon-lifecycle.ts
+++ b/src/local-llm/daemon-lifecycle.ts
@@ -72,6 +72,11 @@ export interface DaemonStartOptions {
    * byte-identical.
    */
   tensorSplit?: readonly number[];
+  /**
+   * Request slots (`localModels.managed.parallel`). Undefined keeps the
+   * historical `--parallel 2` so existing launches stay byte-identical.
+   */
+  parallel?: number;
 }
 
 /**
@@ -105,7 +110,7 @@ export function buildLlamaServerArgs(
     "--cache-type-v",
     "turbo3",
     "--parallel",
-    "2",
+    String(opts.parallel ?? 2),
     "-kvu",
     "-a",
     modelAlias,

--- a/src/tui/local-models/local-models-orchestrator.ts
+++ b/src/tui/local-models/local-models-orchestrator.ts
@@ -1248,6 +1248,7 @@ export class LocalModelsOrchestrator {
           chatTemplateFile: tpl,
           mmprojFile,
           contextSize: cfg.localModels.managed.contextSize,
+          parallel: cfg.localModels.managed.parallel,
           ...(device ? { device } : {}),
           ...(multiGpu ? { tensorSplit } : {}),
         },

--- a/src/tui/persist-llm-provider.ts
+++ b/src/tui/persist-llm-provider.ts
@@ -12,6 +12,7 @@ import {
   type UserLlmFileConfig,
   type UserLlmProviderEntry,
 } from "../config/index.js";
+import { scrubRunModeProviderPins } from "../config/llm-run-mode-config.js";
 import type { ProvidersWizardKind } from "./providers/providers-wizard-state.js";
 
 export class LlmAddProviderError extends Error {
@@ -199,6 +200,7 @@ export function removeLlmProvider(id: string): void {
   if (!remaining.some((p) => p.id === activeEmbeddingProvider)) {
     activeEmbeddingProvider = remaining[0]?.id ?? "local-llama";
   }
+  const runMode = scrubRunModeProviderPins(file.llm.runMode, id);
   const next: UserConfigFile = {
     ...file,
     llm: {
@@ -206,6 +208,7 @@ export function removeLlmProvider(id: string): void {
       activeTextProvider,
       activeEmbeddingProvider,
       providers: remaining,
+      ...(runMode ? { runMode } : {}),
     },
   };
   writeUserConfigFileSync(path, next);


### PR DESCRIPTION
## What
Adds the config half of the **Fusion** run mode. `llm.runMode` names how a chat runs — `local`, `cloud`, or `fusion` (a cloud orchestrator plus local llama-server workers) — with the fusion legs, worker count and per-worker ceilings validated against `llm.providers` by kind. A pure resolver in `src/llm/run-mode/` projects the block onto the configured providers; `describeRunModeDegradation` / `describeRunMode` are the one-sentence operator lines every surface will share.

`localModels.managed.parallel` (1..8, default 2) replaces the hard-coded `--parallel 2` in the managed llama-server launch. Default launches are byte-identical.

Config version 51 → 52, additive: older files parse with `runMode` absent and `parallel` 2. Removing a provider scrubs any run-mode pin that named it, so the stricter parser can still read the file afterwards.

Nothing user-visible changes yet — this is the base of a stack: the composer-switch row, the configurators, the runtime seams and the `fusion.delegate` orchestrator follow as separate PRs on top of this branch.

## Why
Fusion needs a place to record which provider orchestrates and which one hosts the workers, and a rule that keeps that record from ever contradicting `llm.activeTextProvider`. The resolver's rule is the same one the earlier run-mode design settled on: the active provider stays authoritative, a stored `fusion` is effective only while the orchestrator is the active provider, so a hand switch in Manage → LLM simply drops out of fusion on the next read. Workers run one per llama-server slot, so the slot count has to be configurable for them to run concurrently at all.

Design notes are in AGENTS.md §"Run modes (Local / Cloud / Fusion)".

## How it was verified
- `npm run lint` clean
- `npx vitest run src/config src/llm/run-mode src/llm/provider/registry src/local-llm/daemon-lifecycle.test.ts src/tui/persist-llm-provider.test.ts` — 19 files / 362 tests green (baseline failures: none in scope)
- New tests: `llm-run-mode-config.test.ts` (22), `resolve-run-mode.test.ts` (13), `run-mode-degradation.test.ts`, `run-mode-summary.test.ts`; extended `llm-config`, `config-schema` (v51 migration + bounds), `load-config`, `daemon-lifecycle` (`--parallel` follows the option, default unchanged)

---

**Note on the config version:** this bumps `USER_CONFIG_VERSION` 51 → 52. Several other open PRs claim 52 as well; whichever lands second needs a re-bump plus the outgoing number appended to `SUPPORTED_INPUT_VERSIONS`. Nothing else in the diff is order-sensitive.
