### PR TITLE
fix(import): imported transcripts render faithfully

### DIFF
--- a/src/import/claude-code/map-session.test.ts
+++ b/src/import/claude-code/map-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { packConversation } from "../../session/conversation-turn.js";
 import {
   CLAUDE_CODE_SESSION_ID_PREFIX,
   mapClaudeCodeSession,
@@ -112,7 +113,7 @@ describe("mapClaudeCodeSession", () => {
     ]);
   });
 
-  it("keeps a thinking-only row as an empty reply with reasoning", () => {
+  it("keeps a trailing thinking-only row as an empty reply with reasoning", () => {
     const mapped = mapClaudeCodeSession(
       session({
         messages: [
@@ -128,6 +129,125 @@ describe("mapClaudeCodeSession", () => {
     expect(mapped.turns).toEqual([
       { kind: "assistant_reply", text: "", at: T0, reasoning: "interrupted" },
     ]);
+  });
+
+  it("carries a thinking-only row forward onto the next assistant row", () => {
+    const mapped = mapClaudeCodeSession(
+      session({
+        messages: [
+          {
+            role: "assistant",
+            blocks: [{ type: "thinking", thinking: "first thought" }],
+            atMs: T0,
+          },
+          {
+            role: "assistant",
+            blocks: [
+              { type: "thinking", thinking: "second thought" },
+              { type: "text", text: "answer" },
+            ],
+            atMs: T0 + 1,
+          },
+          {
+            role: "assistant",
+            blocks: [{ type: "thinking", thinking: "before a call" }],
+            atMs: T0 + 2,
+          },
+          {
+            role: "assistant",
+            blocks: [{ type: "toolUse", id: "t1", name: "Bash", args: {} }],
+            atMs: T0 + 3,
+          },
+        ],
+      }),
+      "/fallback",
+    );
+    expect(mapped.turns).toEqual([
+      {
+        kind: "assistant_reply",
+        text: "answer",
+        at: T0 + 1,
+        reasoning: "first thought\nsecond thought",
+      },
+      {
+        kind: "assistant_tool_call",
+        tool: "Bash",
+        args: {},
+        at: T0 + 3,
+        reasoning: "before a call",
+      },
+    ]);
+  });
+
+  it("surfaces an interrupted thought before the user message that cut it off", () => {
+    const mapped = mapClaudeCodeSession(
+      session({
+        messages: [
+          { role: "user", blocks: [{ type: "text", text: "go" }], atMs: T0 },
+          {
+            role: "assistant",
+            blocks: [{ type: "thinking", thinking: "interrupted" }],
+            atMs: T0 + 1,
+          },
+          { role: "user", blocks: [{ type: "text", text: "stop" }], atMs: T0 + 2 },
+          { role: "assistant", blocks: [{ type: "text", text: "ok" }], atMs: T0 + 3 },
+        ],
+      }),
+      "/fallback",
+    );
+    expect(mapped.turns).toEqual([
+      { kind: "user", text: "go", at: T0 },
+      { kind: "assistant_reply", text: "", at: T0 + 1, reasoning: "interrupted" },
+      { kind: "user", text: "stop", at: T0 + 2 },
+      { kind: "assistant_reply", text: "ok", at: T0 + 3 },
+    ]);
+  });
+
+  it("records macro-turn starts so the pairs cap segments reply-then-call tasks", () => {
+    const mapped = mapClaudeCodeSession(
+      session({
+        messages: [
+          { role: "user", blocks: [{ type: "text", text: "list files" }], atMs: T0 },
+          {
+            role: "assistant",
+            blocks: [
+              { type: "text", text: "running it" },
+              { type: "toolUse", id: "t1", name: "Bash", args: { command: "ls" } },
+            ],
+            atMs: T0 + 1,
+          },
+          {
+            role: "user",
+            blocks: [
+              { type: "toolResult", toolUseId: "t1", text: "README.md", isError: false },
+            ],
+            atMs: T0 + 2,
+          },
+          { role: "user", blocks: [{ type: "text", text: "delete them" }], atMs: T0 + 3 },
+          { role: "assistant", blocks: [{ type: "text", text: "done" }], atMs: T0 + 4 },
+        ],
+      }),
+      "/fallback",
+    );
+    expect(mapped.turns.map((t) => t.kind)).toEqual([
+      "user",
+      "assistant_reply",
+      "assistant_tool_call",
+      "tool_result",
+      "user",
+      "assistant_reply",
+    ]);
+    expect(mapped.macroTurnStarts).toEqual([4]);
+
+    const packed = packConversation(mapped.turns, 10_000, {
+      maxPairs: 1,
+      macroTurnStarts: mapped.macroTurnStarts,
+    });
+    expect(packed.visiblePairs).toBe(1);
+    expect(packed.droppedPairs).toBe(1);
+    expect(packed.visibleTurns).toEqual(mapped.turns.slice(4));
+    // Without the recorded starts the derived scan fuses both tasks.
+    expect(packConversation(mapped.turns, 10_000, { maxPairs: 1 }).droppedPairs).toBe(0);
   });
 
   it("falls back to the provided working dir", () => {

--- a/src/import/claude-code/map-session.ts
+++ b/src/import/claude-code/map-session.ts
@@ -5,6 +5,7 @@ import {
   userTurn,
   type ConversationTurn,
 } from "../../session/conversation-turn.js";
+import { macroTurnStartsFromTurns } from "../../session/macro-turn-starts.js";
 import type { SessionState } from "../../session/session-state.js";
 import type {
   ClaudeCodeBlock,
@@ -28,17 +29,30 @@ export const CLAUDE_CODE_SESSION_ID_PREFIX = "claude-code:";
  *    `thinking` blocks rides along); `toolUse` blocks → one
  *    `assistant_tool_call` each. A message with both emits the reply
  *    first, matching the order the blocks were produced in.
+ *  - a thinking-only assistant row is carried forward and prepended to
+ *    the reasoning of the next assistant row, so it never becomes an
+ *    empty reply mid-transcript. It surfaces as a reasoning-only reply
+ *    when a user message follows it (an interrupted turn) or when the
+ *    transcript ends on it.
+ *
+ * Macro-turn starts are recorded at every user row so the pairs cap
+ * segments the import like a native session.
  */
 export function mapClaudeCodeSession(
   session: ClaudeCodeSessionData,
   fallbackWorkingDir: string,
 ): SessionState {
-  const turns: ConversationTurn[] = [];
-  /** `tool_use` id → tool name, for naming the matching result rows. */
-  const toolNames = new Map<string, string>();
+  const state: MapState = {
+    turns: [],
+    toolNames: new Map(),
+    pendingReasoning: "",
+    pendingReasoningAt: 0,
+  };
   for (const message of session.messages) {
-    appendMessageTurns(turns, message, toolNames);
+    appendMessageTurns(state, message);
   }
+  flushPendingReasoning(state);
+  const { turns } = state;
 
   const createdAt =
     session.messages.length > 0 ? session.messages[0]!.atMs : 0;
@@ -59,6 +73,7 @@ export function mapClaudeCodeSession(
     worldSnapshot: null,
     stepCount: 0,
     turnCount,
+    macroTurnStarts: macroTurnStartsFromTurns(turns),
     turns,
     createdAt,
     updatedAt: lastMessageAt,
@@ -71,22 +86,32 @@ export function mapClaudeCodeSession(
   };
 }
 
-function appendMessageTurns(
-  turns: ConversationTurn[],
-  message: ClaudeCodeMessage,
-  toolNames: Map<string, string>,
-): void {
+interface MapState {
+  turns: ConversationTurn[];
+  /** `tool_use` id → tool name, for naming the matching result rows. */
+  toolNames: Map<string, string>;
+  /** Reasoning from thinking-only rows waiting for the row it belongs to. */
+  pendingReasoning: string;
+  pendingReasoningAt: number;
+}
+
+function appendMessageTurns(state: MapState, message: ClaudeCodeMessage): void {
   const at = message.atMs;
   if (message.role === "user") {
     const text = joinText(message.blocks);
-    if (text.length > 0) turns.push(userTurn(text, at));
+    // A user message after a thinking-only row means the turn was
+    // interrupted; the thought belongs before the interruption.
+    if (text.length > 0) {
+      flushPendingReasoning(state);
+      state.turns.push(userTurn(text, at));
+    }
     for (const block of message.blocks) {
       if (block.type !== "toolResult") continue;
-      turns.push(
+      state.turns.push(
         toolResultTurn({
           tool:
             (block.toolUseId !== null
-              ? toolNames.get(block.toolUseId)
+              ? state.toolNames.get(block.toolUseId)
               : undefined) ?? "unknown",
           status: block.isError ? "error" : "ok",
           summary: block.text,
@@ -96,14 +121,21 @@ function appendMessageTurns(
     }
     return;
   }
-  const reasoning = joinThinking(message.blocks);
+  const reasoning = joinNonEmpty(state.pendingReasoning, joinThinking(message.blocks));
   const text = joinText(message.blocks);
   const calls = message.blocks.filter(
     (b): b is Extract<ClaudeCodeBlock, { type: "toolUse" }> =>
       b.type === "toolUse",
   );
+  if (text.length === 0 && calls.length === 0) {
+    // Thinking-only row: hold the reasoning for the row that acts on it.
+    state.pendingReasoning = reasoning;
+    state.pendingReasoningAt = at;
+    return;
+  }
+  state.pendingReasoning = "";
   if (text.length > 0) {
-    turns.push(
+    state.turns.push(
       assistantReplyTurn(text, {
         at,
         ...(reasoning.length > 0 ? { reasoning } : {}),
@@ -111,8 +143,8 @@ function appendMessageTurns(
     );
   }
   calls.forEach((call, index) => {
-    if (call.id !== null) toolNames.set(call.id, call.name);
-    turns.push(
+    if (call.id !== null) state.toolNames.set(call.id, call.name);
+    state.turns.push(
       assistantToolCallTurn({
         tool: call.name,
         args: call.args,
@@ -125,11 +157,28 @@ function appendMessageTurns(
       }),
     );
   });
-  if (text.length === 0 && calls.length === 0 && reasoning.length > 0) {
-    // A thinking-only row (interrupted turn): keep the reasoning rather
-    // than dropping the message whole.
-    turns.push(assistantReplyTurn("", { at, reasoning }));
-  }
+}
+
+/**
+ * Surface held reasoning as a reasoning-only reply. The TUI renders an
+ * empty reply that carries reasoning as a reasoning block, so nothing
+ * the model thought is lost when it never got to act on it.
+ */
+function flushPendingReasoning(state: MapState): void {
+  if (state.pendingReasoning.length === 0) return;
+  state.turns.push(
+    assistantReplyTurn("", {
+      at: state.pendingReasoningAt,
+      reasoning: state.pendingReasoning,
+    }),
+  );
+  state.pendingReasoning = "";
+}
+
+function joinNonEmpty(first: string, second: string): string {
+  if (first.length === 0) return second;
+  if (second.length === 0) return first;
+  return `${first}\n${second}`;
 }
 
 function joinText(blocks: readonly ClaudeCodeBlock[]): string {

--- a/src/import/codex/map-session.test.ts
+++ b/src/import/codex/map-session.test.ts
@@ -103,4 +103,19 @@ describe("mapCodexSession", () => {
   it("falls back to the provided working dir", () => {
     expect(mapCodexSession(session({ cwd: null }), "/fb").workingDir).toBe("/fb");
   });
+
+  it("records macro-turn starts at every user row after the first", () => {
+    const mapped = mapCodexSession(
+      session({
+        messages: [
+          { role: "user", blocks: [{ type: "text", text: "a" }], atMs: T0 },
+          { role: "assistant", blocks: [{ type: "text", text: "b" }], atMs: T0 + 1 },
+          { role: "user", blocks: [{ type: "text", text: "c" }], atMs: T0 + 2 },
+          { role: "assistant", blocks: [{ type: "text", text: "d" }], atMs: T0 + 3 },
+        ],
+      }),
+      "/fallback",
+    );
+    expect(mapped.macroTurnStarts).toEqual([2]);
+  });
 });

--- a/src/import/codex/map-session.ts
+++ b/src/import/codex/map-session.ts
@@ -5,6 +5,7 @@ import {
   userTurn,
   type ConversationTurn,
 } from "../../session/conversation-turn.js";
+import { macroTurnStartsFromTurns } from "../../session/macro-turn-starts.js";
 import type { SessionState } from "../../session/session-state.js";
 import type { CodexBlock, CodexSessionData } from "./codex-source.js";
 
@@ -22,6 +23,9 @@ export const CODEX_SESSION_ID_PREFIX = "codex:";
  *    attaches when no reply claimed it).
  *  - `toolResult`      → `tool_result`, named through the `call_id`
  *    seen on the matching call.
+ *
+ * Macro-turn starts are recorded at every user row so the pairs cap
+ * segments the import like a native session.
  */
 export function mapCodexSession(
   session: CodexSessionData,
@@ -116,6 +120,7 @@ export function mapCodexSession(
     worldSnapshot: null,
     stepCount: 0,
     turnCount,
+    macroTurnStarts: macroTurnStartsFromTurns(turns),
     turns,
     createdAt,
     updatedAt: lastMessageAt,

--- a/src/import/hermes/map-session.test.ts
+++ b/src/import/hermes/map-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { packConversation } from "../../session/conversation-turn.js";
 import { mapHermesSession } from "./map-session.js";
 import type { HermesMessage, HermesSession } from "./hermes-source.js";
 
@@ -165,5 +166,98 @@ describe("mapHermesSession", () => {
       "/fallback",
     );
     expect(state.turns.map((t) => t.kind)).toEqual(["user"]);
+  });
+
+  it("emits the reply before the calls when a row carries both", () => {
+    const toolCalls = JSON.stringify([
+      { function: { name: "read_file", arguments: '{"path":"a"}' } },
+    ]);
+    const state = mapHermesSession(
+      session(),
+      [
+        msg({
+          id: 1,
+          role: "assistant",
+          content: "Let me read it",
+          toolCalls,
+          reasoning: "r",
+        }),
+      ],
+      "/fallback",
+    );
+    expect(state.turns).toEqual([
+      {
+        kind: "assistant_reply",
+        text: "Let me read it",
+        reasoning: "r",
+        at: 1_700_000_000_000,
+      },
+      {
+        kind: "assistant_tool_call",
+        tool: "read_file",
+        args: { path: "a" },
+        at: 1_700_000_000_000,
+      },
+    ]);
+    expect(state.turnCount).toBe(1);
+  });
+
+  it("drops assistant and user rows with nothing to show", () => {
+    const state = mapHermesSession(
+      session(),
+      [
+        msg({ id: 1, role: "user", content: "" }),
+        msg({ id: 2, role: "assistant", content: "", reasoning: "" }),
+        msg({ id: 3, role: "assistant", content: null, reasoning: "only thought" }),
+        msg({ id: 4, role: "user", content: "hi" }),
+      ],
+      "/fallback",
+    );
+    expect(state.turns).toEqual([
+      {
+        kind: "assistant_reply",
+        text: "",
+        reasoning: "only thought",
+        at: 1_700_000_000_000,
+      },
+      { kind: "user", text: "hi", at: 1_700_000_000_000 },
+    ]);
+  });
+
+  it("records macro-turn starts so the pairs cap segments reply-then-call tasks", () => {
+    const toolCalls = JSON.stringify([
+      { function: { name: "read_file", arguments: "{}" } },
+    ]);
+    const state = mapHermesSession(
+      session(),
+      [
+        msg({ id: 1, role: "user", content: "read it" }),
+        msg({ id: 2, role: "assistant", content: "reading", toolCalls }),
+        msg({ id: 3, role: "tool", toolName: "read_file", content: "..." }),
+        msg({ id: 4, role: "user", content: "now delete it" }),
+        msg({ id: 5, role: "assistant", content: "deleted" }),
+      ],
+      "/fallback",
+    );
+    expect(state.turns.map((t) => t.kind)).toEqual([
+      "user",
+      "assistant_reply",
+      "assistant_tool_call",
+      "tool_result",
+      "user",
+      "assistant_reply",
+    ]);
+    expect(state.macroTurnStarts).toEqual([4]);
+
+    const packed = packConversation(state.turns, 10_000, {
+      maxPairs: 1,
+      macroTurnStarts: state.macroTurnStarts,
+    });
+    expect(packed.visiblePairs).toBe(1);
+    expect(packed.droppedPairs).toBe(1);
+    expect(packed.visibleTurns).toEqual(state.turns.slice(4));
+    // Without the recorded starts the derived scan fuses both tasks.
+    expect(packConversation(state.turns, 10_000, { maxPairs: 1 }).visiblePairs).toBe(1);
+    expect(packConversation(state.turns, 10_000, { maxPairs: 1 }).droppedPairs).toBe(0);
   });
 });

--- a/src/import/hermes/map-session.ts
+++ b/src/import/hermes/map-session.ts
@@ -5,6 +5,7 @@ import {
   userTurn,
   type ConversationTurn,
 } from "../../session/conversation-turn.js";
+import { macroTurnStartsFromTurns } from "../../session/macro-turn-starts.js";
 import type { SessionState } from "../../session/session-state.js";
 import type { HermesMessage, HermesSession } from "./hermes-source.js";
 
@@ -20,6 +21,12 @@ interface ParsedToolCall {
  * Map one Hermes session plus its messages into a native `SessionState`.
  * Pure — no I/O. Roles are projected onto `ConversationTurn`s; REAL
  * second timestamps are converted to integer milliseconds.
+ *
+ * An assistant row that carries both `content` and `tool_calls` emits
+ * the reply first and then one `assistant_tool_call` per call, the way
+ * the model produced them; reasoning rides the reply when there is
+ * text, else the first call. Macro-turn starts are recorded at every
+ * user row so the pairs cap segments the import like a native session.
  */
 export function mapHermesSession(
   session: HermesSession,
@@ -49,6 +56,7 @@ export function mapHermesSession(
     worldSnapshot: null,
     stepCount: 0,
     turnCount,
+    macroTurnStarts: macroTurnStartsFromTurns(turns),
     turns,
     createdAt,
     updatedAt: lastMessageAt,
@@ -67,12 +75,17 @@ function appendMessageTurns(
   message: HermesMessage,
 ): void {
   const at = secondsToMs(message.timestampSeconds);
-  const reasoning = message.reasoning ?? undefined;
+  const reasoning =
+    message.reasoning !== null && message.reasoning.length > 0
+      ? message.reasoning
+      : undefined;
 
   switch (message.role) {
-    case "user":
-      turns.push(userTurn(message.content ?? "", at));
+    case "user": {
+      const text = message.content ?? "";
+      if (text.length > 0) turns.push(userTurn(text, at));
       return;
+    }
     case "tool":
       turns.push(
         toolResultTurn({
@@ -84,30 +97,34 @@ function appendMessageTurns(
       );
       return;
     case "assistant": {
+      const text = message.content ?? "";
       const calls = parseToolCalls(message.toolCalls);
-      if (calls.length > 0) {
-        calls.forEach((call, index) => {
-          turns.push(
-            assistantToolCallTurn({
-              tool: call.name,
-              args: call.args,
-              at,
-              // One inference => one reasoning block; attach to the first call.
-              ...(index === 0 && reasoning !== undefined
-                ? { reasoning }
-                : {}),
-            }),
-          );
-        });
-        return;
+      if (text.length > 0 || (calls.length === 0 && reasoning !== undefined)) {
+        // The empty-text case here is a thinking-only row: the TUI
+        // renders it as a reasoning-only message. An assistant row with
+        // no text, no calls and no reasoning has nothing to show and is
+        // dropped rather than becoming a blank bubble.
+        turns.push(
+          assistantReplyTurn(text, {
+            at,
+            ...(reasoning !== undefined ? { reasoning } : {}),
+          }),
+        );
       }
-      // Plain assistant reply (may also carry an empty content string).
-      turns.push(
-        assistantReplyTurn(message.content ?? "", {
-          at,
-          ...(reasoning !== undefined ? { reasoning } : {}),
-        }),
-      );
+      calls.forEach((call, index) => {
+        turns.push(
+          assistantToolCallTurn({
+            tool: call.name,
+            args: call.args,
+            at,
+            // One inference => one reasoning block. It rode the reply
+            // when there was one; otherwise it attaches to the first call.
+            ...(index === 0 && text.length === 0 && reasoning !== undefined
+              ? { reasoning }
+              : {}),
+          }),
+        );
+      });
       return;
     }
     default:

--- a/src/import/openclaw/map-session.test.ts
+++ b/src/import/openclaw/map-session.test.ts
@@ -145,4 +145,69 @@ describe("mapOpenclawSession", () => {
     expect(state.createdAt).toBe(1000);
     expect(state.updatedAt).toBe(2000);
   });
+
+  it("emits the reply before the calls when a row carries both", () => {
+    const state = mapOpenclawSession(
+      meta(),
+      [
+        msg("assistant", [
+          { type: "thinking", thinking: "r" },
+          { type: "text", text: "reading it" },
+          { type: "toolCall", id: "c1", name: "read", args: { path: "a.txt" } },
+        ]),
+      ],
+      "/fallback",
+    );
+    expect(state.turns).toEqual([
+      {
+        kind: "assistant_reply",
+        text: "reading it",
+        reasoning: "r",
+        at: 1_700_000_000_000,
+      },
+      {
+        kind: "assistant_tool_call",
+        tool: "read",
+        args: { path: "a.txt" },
+        at: 1_700_000_000_000,
+      },
+    ]);
+  });
+
+  it("drops user and assistant rows with nothing to show", () => {
+    const state = mapOpenclawSession(
+      meta(),
+      [
+        msg("user", []),
+        msg("user", [{ type: "text", text: "" }]),
+        msg("assistant", []),
+        msg("assistant", [{ type: "thinking", thinking: "only thought" }]),
+        msg("user", [{ type: "text", text: "hi" }], { atMs: 7 }),
+      ],
+      "/fallback",
+    );
+    expect(state.turns).toEqual([
+      {
+        kind: "assistant_reply",
+        text: "",
+        reasoning: "only thought",
+        at: 1_700_000_000_000,
+      },
+      { kind: "user", text: "hi", at: 7 },
+    ]);
+  });
+
+  it("records macro-turn starts at every user row after the first", () => {
+    const state = mapOpenclawSession(
+      meta(),
+      [
+        msg("user", [{ type: "text", text: "a" }]),
+        msg("assistant", [{ type: "text", text: "b" }]),
+        msg("user", [{ type: "text", text: "c" }]),
+        msg("assistant", [{ type: "text", text: "d" }]),
+      ],
+      "/fallback",
+    );
+    expect(state.macroTurnStarts).toEqual([2]);
+  });
 });

--- a/src/import/openclaw/map-session.ts
+++ b/src/import/openclaw/map-session.ts
@@ -5,6 +5,7 @@ import {
   userTurn,
   type ConversationTurn,
 } from "../../session/conversation-turn.js";
+import { macroTurnStartsFromTurns } from "../../session/macro-turn-starts.js";
 import type { SessionState } from "../../session/session-state.js";
 import type {
   OpenclawBlock,
@@ -20,11 +21,16 @@ export const OPENCLAW_SESSION_ID_PREFIX = "openclaw:";
  * `SessionState`. Pure — no I/O. OpenClaw's event-sourced content blocks
  * are folded onto the four-kind `ConversationTurn` model:
  *
- *  - `user`        → `user` turn (text blocks joined).
- *  - `assistant`   → one `assistant_tool_call` per `toolCall` block (the
- *                    reasoning from `thinking` blocks attaches to the first
- *                    call), or an `assistant_reply` when there are no calls.
+ *  - `user`        → `user` turn (text blocks joined; dropped when empty).
+ *  - `assistant`   → `assistant_reply` from the `text` blocks (reasoning
+ *                    from `thinking` blocks rides along), then one
+ *                    `assistant_tool_call` per `toolCall` block. Without
+ *                    text the reasoning attaches to the first call; a
+ *                    row with neither text, calls nor reasoning is dropped.
  *  - `toolResult`  → `tool_result` turn (`isError` → `status: "error"`).
+ *
+ * Macro-turn starts are recorded at every user row so the pairs cap
+ * segments the import like a native session.
  */
 export function mapOpenclawSession(
   meta: OpenclawSessionMeta,
@@ -52,6 +58,7 @@ export function mapOpenclawSession(
     worldSnapshot: null,
     stepCount: 0,
     turnCount,
+    macroTurnStarts: macroTurnStartsFromTurns(turns),
     turns,
     createdAt,
     updatedAt: lastMessageAt,
@@ -70,9 +77,11 @@ function appendMessageTurns(
 ): void {
   const at = message.atMs;
   switch (message.role) {
-    case "user":
-      turns.push(userTurn(joinText(message.blocks), at));
+    case "user": {
+      const text = joinText(message.blocks);
+      if (text.length > 0) turns.push(userTurn(text, at));
       return;
+    }
     case "toolResult":
       turns.push(
         toolResultTurn({
@@ -85,30 +94,35 @@ function appendMessageTurns(
       return;
     case "assistant": {
       const reasoning = joinThinking(message.blocks);
+      const text = joinText(message.blocks);
       const calls = message.blocks.filter(
         (b): b is Extract<OpenclawBlock, { type: "toolCall" }> =>
           b.type === "toolCall",
       );
-      if (calls.length > 0) {
-        calls.forEach((call, index) => {
-          turns.push(
-            assistantToolCallTurn({
-              tool: call.name,
-              args: call.args,
-              at,
-              // One inference => one reasoning block; attach to the first call.
-              ...(index === 0 && reasoning.length > 0 ? { reasoning } : {}),
-            }),
-          );
-        });
-        return;
+      if (text.length > 0 || (calls.length === 0 && reasoning.length > 0)) {
+        // The empty-text case is a thinking-only row, which the TUI
+        // renders as a reasoning-only message.
+        turns.push(
+          assistantReplyTurn(text, {
+            at,
+            ...(reasoning.length > 0 ? { reasoning } : {}),
+          }),
+        );
       }
-      turns.push(
-        assistantReplyTurn(joinText(message.blocks), {
-          at,
-          ...(reasoning.length > 0 ? { reasoning } : {}),
-        }),
-      );
+      calls.forEach((call, index) => {
+        turns.push(
+          assistantToolCallTurn({
+            tool: call.name,
+            args: call.args,
+            at,
+            // One inference => one reasoning block. It rode the reply
+            // when there was one; otherwise it attaches to the first call.
+            ...(index === 0 && text.length === 0 && reasoning.length > 0
+              ? { reasoning }
+              : {}),
+          }),
+        );
+      });
       return;
     }
     default:

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -38,6 +38,11 @@ export type {
   PackedConversation,
 } from "./conversation-turn.js";
 export {
+  MACRO_TURN_START_CAP,
+  appendMacroTurnStart,
+  macroTurnStartsFromTurns,
+} from "./macro-turn-starts.js";
+export {
   CONVERSATION_SECTION_LABEL,
   EMPTY_CONTEXT_USAGE,
   contextUsageFromPrompt,

--- a/src/session/macro-turn-starts.test.ts
+++ b/src/session/macro-turn-starts.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  macroTurnBoundaries,
+  packConversation,
+  type ConversationTurn,
+} from "./conversation-turn.js";
+import {
+  MACRO_TURN_START_CAP,
+  appendMacroTurnStart,
+  macroTurnStartsFromTurns,
+} from "./macro-turn-starts.js";
+
+const user = (text: string, at: number): ConversationTurn => ({
+  kind: "user",
+  text,
+  at,
+});
+const reply = (text: string, at: number): ConversationTurn => ({
+  kind: "assistant_reply",
+  text,
+  at,
+});
+const call = (at: number): ConversationTurn => ({
+  kind: "assistant_tool_call",
+  tool: "shell",
+  args: {},
+  at,
+});
+const result = (at: number): ConversationTurn => ({
+  kind: "tool_result",
+  tool: "shell",
+  status: "ok",
+  summary: "ok",
+  at,
+});
+
+describe("appendMacroTurnStart", () => {
+  it("appends and skips a repeated index", () => {
+    expect(appendMacroTurnStart(undefined, 3)).toEqual([3]);
+    expect(appendMacroTurnStart([3], 3)).toEqual([3]);
+    expect(appendMacroTurnStart([3], 7)).toEqual([3, 7]);
+  });
+
+  it("keeps only the newest entries past the cap", () => {
+    let starts: number[] = [];
+    for (let i = 1; i <= MACRO_TURN_START_CAP + 5; i += 1) {
+      starts = appendMacroTurnStart(starts, i);
+    }
+    expect(starts).toHaveLength(MACRO_TURN_START_CAP);
+    expect(starts[0]).toBe(6);
+    expect(starts[starts.length - 1]).toBe(MACRO_TURN_START_CAP + 5);
+  });
+});
+
+describe("macroTurnStartsFromTurns", () => {
+  it("opens a macro-turn at every user row after the first", () => {
+    const turns = [
+      user("a", 1),
+      reply("b", 2),
+      user("c", 3),
+      call(4),
+      result(5),
+      user("d", 6),
+      reply("e", 7),
+    ];
+    expect(macroTurnStartsFromTurns(turns)).toEqual([2, 5]);
+  });
+
+  it("returns nothing for an empty or single-task transcript", () => {
+    expect(macroTurnStartsFromTurns([])).toEqual([]);
+    expect(macroTurnStartsFromTurns([user("a", 1), reply("b", 2)])).toEqual([]);
+  });
+
+  it("applies the runtime cap", () => {
+    const turns: ConversationTurn[] = [];
+    for (let i = 0; i < MACRO_TURN_START_CAP + 10; i += 1) {
+      turns.push(user(`u${i}`, i));
+    }
+    const starts = macroTurnStartsFromTurns(turns);
+    expect(starts).toHaveLength(MACRO_TURN_START_CAP);
+    expect(starts[starts.length - 1]).toBe(MACRO_TURN_START_CAP + 9);
+  });
+
+  it("segments a reply-before-tool-call transcript where derivation cannot", () => {
+    // Claude Code emits the reply text before the tool calls of the same
+    // message, so the second task's user row follows a tool_result, not
+    // an assistant_reply — the derived scan fuses both tasks into one.
+    const turns = [
+      user("list files", 1),
+      reply("running it", 2),
+      call(3),
+      result(4),
+      user("now delete them", 5),
+      reply("done", 6),
+    ];
+    expect(macroTurnBoundaries(turns)).toEqual([0]);
+    const starts = macroTurnStartsFromTurns(turns);
+    expect(macroTurnBoundaries(turns, starts)).toEqual([0, 4]);
+
+    const packed = packConversation(turns, 10_000, {
+      maxPairs: 1,
+      macroTurnStarts: starts,
+    });
+    expect(packed.visiblePairs).toBe(1);
+    expect(packed.droppedPairs).toBe(1);
+    expect(packed.visibleTurns).toEqual(turns.slice(4));
+  });
+});

--- a/src/session/macro-turn-starts.ts
+++ b/src/session/macro-turn-starts.ts
@@ -1,0 +1,51 @@
+import type { ConversationTurn } from "./conversation-turn.js";
+
+/**
+ * Boundaries a pairs-capped prompt can only ever need the tail of, so the
+ * list is bounded. 200 is well past `agent.conversationMaxPairs`'s
+ * ceiling of 100 and keeps a session that runs for days from carrying an
+ * ever-growing array of integers it will never read.
+ */
+export const MACRO_TURN_START_CAP = 200;
+
+/**
+ * Record that a macro-turn opens at `index`, keeping the list bounded.
+ * The runtime calls this from `incrementTurnCount` at every termination.
+ */
+export function appendMacroTurnStart(
+  starts: number[] | undefined,
+  index: number,
+): number[] {
+  const prev = starts ?? [];
+  // A termination that recorded no turns (an empty steer, a cancel
+  // before the first step) would otherwise push the same index twice and
+  // read as a pair with nothing in it.
+  if (prev[prev.length - 1] === index) return prev;
+  const next = [...prev, index];
+  return next.length > MACRO_TURN_START_CAP
+    ? next.slice(next.length - MACRO_TURN_START_CAP)
+    : next;
+}
+
+/**
+ * Boundaries for a transcript that was not recorded by this runtime — an
+ * import from another agent's store. There every `user` row is a task
+ * of its own (other agents have no steer), so a macro-turn opens at
+ * each one after the first. Deriving them at load time would guess
+ * wrong instead: `macroTurnBoundaries` only opens a task at a user row
+ * that follows an `assistant_reply`, and Claude Code emits its reply
+ * *before* the tool calls of the same message, so an import's tasks
+ * fuse together and the pairs cap sees one task where there were many.
+ *
+ * Same cap and same dedupe as the live path, so a loaded import looks
+ * exactly like a session that ran here.
+ */
+export function macroTurnStartsFromTurns(
+  turns: readonly ConversationTurn[],
+): number[] {
+  let starts: number[] = [];
+  for (let i = 1; i < turns.length; i += 1) {
+    if (turns[i]?.kind === "user") starts = appendMacroTurnStart(starts, i);
+  }
+  return starts;
+}

--- a/src/session/session-state.ts
+++ b/src/session/session-state.ts
@@ -9,6 +9,7 @@ import {
   type ConversationTurn,
 } from "./conversation-turn.js";
 import type { ContextUsageState } from "./context-usage.js";
+import { appendMacroTurnStart } from "./macro-turn-starts.js";
 
 export type SessionStatus =
   | "pending"
@@ -326,29 +327,6 @@ export function incrementTurnCount(state: SessionState): SessionState {
     ),
     updatedAt: Date.now(),
   };
-}
-
-/**
- * Boundaries a pairs-capped prompt can only ever need the tail of, so the
- * list is bounded. 200 is well past `agent.conversationMaxPairs`'s
- * ceiling of 100 and keeps a session that runs for days from carrying an
- * ever-growing array of integers it will never read.
- */
-const MACRO_TURN_START_CAP = 200;
-
-function appendMacroTurnStart(
-  starts: number[] | undefined,
-  index: number,
-): number[] {
-  const prev = starts ?? [];
-  // A termination that recorded no turns (an empty steer, a cancel
-  // before the first step) would otherwise push the same index twice and
-  // read as a pair with nothing in it.
-  if (prev[prev.length - 1] === index) return prev;
-  const next = [...prev, index];
-  return next.length > MACRO_TURN_START_CAP
-    ? next.slice(next.length - MACRO_TURN_START_CAP)
-    : next;
 }
 
 /**

--- a/src/tui/turns-to-messages.test.ts
+++ b/src/tui/turns-to-messages.test.ts
@@ -104,4 +104,100 @@ describe("turnsToMessages", () => {
       "thought process for the final reply",
     );
   });
+
+  it("gives two replies that finish in the same millisecond distinct ids", () => {
+    const turns: ConversationTurn[] = [
+      { kind: "user", text: "a", at: 5 },
+      { kind: "assistant_reply", text: "one", at: 5 },
+      { kind: "user", text: "b", at: 5 },
+      { kind: "assistant_reply", text: "two", at: 5 },
+    ];
+    const ids = turnsToMessages(turns).map((m) => m.id);
+    expect(new Set(ids).size).toBe(4);
+    expect(ids[1]).toBe("msg-asst-1-5");
+    expect(ids[3]).toBe("msg-asst-3-5");
+  });
+
+  it("skips a turn of unknown kind instead of throwing", () => {
+    const turns = [
+      { kind: "user", text: "hi", at: 1 },
+      { kind: "system_note", text: "??", at: 2 },
+      { kind: "assistant_reply", text: "hello", at: 3 },
+    ] as unknown as ConversationTurn[];
+    const messages = turnsToMessages(turns);
+    expect(messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(messages[1]?.text).toBe("hello");
+  });
+
+  it("drops a reply with no text, no tool cards and no reasoning", () => {
+    const turns: ConversationTurn[] = [
+      { kind: "user", text: "hi", at: 1 },
+      { kind: "assistant_reply", text: "", at: 2 },
+      { kind: "user", text: "still there?", at: 3 },
+      { kind: "assistant_reply", text: "yes", at: 4 },
+    ];
+    const messages = turnsToMessages(turns);
+    expect(messages.map((m) => [m.role, m.text])).toEqual([
+      ["user", "hi"],
+      ["user", "still there?"],
+      ["assistant", "yes"],
+    ]);
+  });
+
+  it("keeps an empty reply that carries reasoning as a reasoning-only message", () => {
+    const turns: ConversationTurn[] = [
+      { kind: "user", text: "hi", at: 1 },
+      { kind: "assistant_reply", text: "", reasoning: "interrupted", at: 2 },
+    ];
+    const messages = turnsToMessages(turns);
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toMatchObject({
+      role: "assistant",
+      text: "",
+      reasoningBlocks: ["interrupted"],
+    });
+  });
+
+  it("keeps an empty reply that closes a tool chain", () => {
+    const turns: ConversationTurn[] = [
+      { kind: "user", text: "run", at: 1 },
+      { kind: "assistant_tool_call", tool: "shell.exec", args: {}, at: 2 },
+      { kind: "tool_result", tool: "shell.exec", status: "ok", summary: "a", at: 3 },
+      { kind: "assistant_reply", text: "", at: 4 },
+    ];
+    const messages = turnsToMessages(turns);
+    expect(messages).toHaveLength(2);
+    expect(messages[1]?.toolCards).toHaveLength(1);
+    expect(messages[1]?.toolSteps).toBe(1);
+  });
+
+  it("coerces non-string text and summaries to strings", () => {
+    const turns = [
+      { kind: "user", text: 42, at: 1 },
+      { kind: "assistant_tool_call", tool: "x", args: {}, at: 2 },
+      { kind: "tool_result", tool: "x", status: "ok", summary: { ok: true }, at: 3 },
+      { kind: "assistant_reply", text: null, reasoning: ["a", "b"], at: 4 },
+    ] as unknown as ConversationTurn[];
+    const messages = turnsToMessages(turns);
+    expect(messages[0]?.text).toBe("42");
+    expect(messages[1]?.toolCards?.[0]?.summary).toBe('{"ok":true}');
+    expect(messages[1]?.text).toBe("");
+    expect(messages[1]?.reasoningBlocks).toEqual(['["a","b"]']);
+  });
+
+  it("falls back to the previous turn's time when `at` is missing", () => {
+    const turns = [
+      { kind: "user", text: "hi", at: 100 },
+      { kind: "assistant_reply", text: "hello" },
+      { kind: "user", text: "again", at: "soon" },
+    ] as unknown as ConversationTurn[];
+    const messages = turnsToMessages(turns);
+    expect(messages.map((m) => m.timestamp)).toEqual([100, 100, 100]);
+    expect(messages[1]?.id).toBe("msg-asst-1-100");
+  });
+
+  it("uses 0 when the first turn has no usable time", () => {
+    const turns = [{ kind: "user", text: "hi" }] as unknown as ConversationTurn[];
+    expect(turnsToMessages(turns)[0]?.timestamp).toBe(0);
+  });
 });

--- a/src/tui/turns-to-messages.ts
+++ b/src/tui/turns-to-messages.ts
@@ -11,6 +11,14 @@ import type { ChatMessage, ToolCardEntry } from "./tui-state.js";
  *   user -> (assistant_tool_call + tool_result){0..N} -> assistant_reply?
  * We fold each contiguous slice into one assistant `ChatMessage` carrying
  * its associated tool cards and reasoning blocks.
+ *
+ * Imported sessions feed this the same list, but their rows come from
+ * another agent's store: timestamps are copied verbatim (so two replies
+ * can share a millisecond), fields may be missing or of the wrong type,
+ * and a row kind this build does not know may appear. The rebuild is
+ * therefore defensive — ids are index-qualified so React keys stay
+ * unique, values are coerced, unknown kinds are skipped, and a reply
+ * with nothing to show is dropped instead of rendering a blank bubble.
  */
 export function turnsToMessages(
   turns: readonly ConversationTurn[],
@@ -18,72 +26,85 @@ export function turnsToMessages(
   const messages: ChatMessage[] = [];
   let pendingAssistant: MutableAssistant | null = null;
   let toolCounter = 0;
+  let lastAt = 0;
 
-  const flushAssistant = (): void => {
+  const flushAssistant = (index: number): void => {
     if (!pendingAssistant) return;
-    messages.push(finalizeAssistant(pendingAssistant));
+    const message = finalizeAssistant(pendingAssistant, index);
+    if (message) messages.push(message);
     pendingAssistant = null;
   };
 
   for (let i = 0; i < turns.length; i += 1) {
     const turn = turns[i]!;
+    const at = asTime(turn.at, lastAt);
+    lastAt = at;
     switch (turn.kind) {
       case "user": {
-        flushAssistant();
+        flushAssistant(i);
         messages.push({
-          id: `msg-user-${i}-${turn.at}`,
+          id: `msg-user-${i}-${at}`,
           role: "user",
-          text: turn.text,
-          timestamp: turn.at,
+          text: asText(turn.text),
+          timestamp: at,
         });
         break;
       }
       case "assistant_tool_call": {
-        if (!pendingAssistant) pendingAssistant = freshAssistant(turn.at);
+        if (!pendingAssistant) pendingAssistant = freshAssistant(at);
         if (turn.reasoning) {
-          pendingAssistant.reasoningBlocks.push(turn.reasoning);
+          pendingAssistant.reasoningBlocks.push(asText(turn.reasoning));
         }
         pendingAssistant.pendingCall = {
           id: `tc-${toolCounter++}`,
           stepIndex: pendingAssistant.toolCards.length,
-          tool: turn.tool,
+          tool: asText(turn.tool),
           args: turn.args,
-          startedAt: turn.at,
+          startedAt: at,
         };
         break;
       }
       case "tool_result": {
-        if (!pendingAssistant) pendingAssistant = freshAssistant(turn.at);
+        if (!pendingAssistant) pendingAssistant = freshAssistant(at);
         const call = pendingAssistant.pendingCall;
+        const tool = asText(turn.tool);
         const card: ToolCardEntry = {
           id: call?.id ?? `tc-${toolCounter++}`,
           stepIndex: call?.stepIndex ?? pendingAssistant.toolCards.length,
-          tool: turn.tool,
+          tool,
           args: call?.args ?? {},
           status: turn.status,
-          summary: turn.summary,
+          summary: asText(turn.summary),
           truncated: Boolean(turn.truncated),
-          startedAt: call?.startedAt ?? turn.at,
-          finishedAt: turn.at,
+          startedAt: call?.startedAt ?? at,
+          finishedAt: at,
         };
         pendingAssistant.toolCards.push(card);
         pendingAssistant.pendingCall = null;
-        if (turn.tool !== "reply") pendingAssistant.toolSteps += 1;
+        if (tool !== "reply") pendingAssistant.toolSteps += 1;
         break;
       }
       case "assistant_reply": {
-        if (!pendingAssistant) pendingAssistant = freshAssistant(turn.at);
-        pendingAssistant.text = turn.text;
-        pendingAssistant.timestamp = turn.at;
-        if (turn.reasoning && turn.reasoning.length > 0) {
-          pendingAssistant.reasoningBlocks.push(turn.reasoning);
+        if (!pendingAssistant) pendingAssistant = freshAssistant(at);
+        pendingAssistant.text = asText(turn.text);
+        pendingAssistant.timestamp = at;
+        if (turn.reasoning) {
+          pendingAssistant.reasoningBlocks.push(asText(turn.reasoning));
         }
-        flushAssistant();
+        flushAssistant(i);
+        break;
+      }
+      default: {
+        // A kind this build does not know (a newer store, or an
+        // importer's slip). Nothing sensible to draw for it — skip the
+        // row rather than throw away the whole transcript.
+        const unknown: never = turn;
+        void unknown;
         break;
       }
     }
   }
-  flushAssistant();
+  flushAssistant(turns.length);
   return messages;
 }
 
@@ -113,9 +134,27 @@ function freshAssistant(at: number): MutableAssistant {
   };
 }
 
-function finalizeAssistant(a: MutableAssistant): ChatMessage {
+/**
+ * Turn the folded slice into a bubble, or `null` when there is nothing
+ * to draw: no text, no tool cards, no reasoning. Importers produce such
+ * rows for interrupted or content-less assistant messages, and a blank
+ * assistant bubble reads as a rendering bug.
+ */
+function finalizeAssistant(
+  a: MutableAssistant,
+  index: number,
+): ChatMessage | null {
+  if (
+    a.text.length === 0 &&
+    a.toolCards.length === 0 &&
+    a.reasoningBlocks.length === 0
+  ) {
+    return null;
+  }
   const base: ChatMessage = {
-    id: `msg-asst-${a.timestamp}`,
+    // Index-qualified like the user id: `at` alone is not unique on an
+    // imported transcript, and `chat-log.tsx` keys rows on this id.
+    id: `msg-asst-${index}-${a.timestamp}`,
     role: "assistant",
     text: a.text,
     toolSteps: a.toolSteps,
@@ -124,4 +163,23 @@ function finalizeAssistant(a: MutableAssistant): ChatMessage {
   if (a.toolCards.length > 0) base.toolCards = a.toolCards;
   if (a.reasoningBlocks.length > 0) base.reasoningBlocks = a.reasoningBlocks;
   return base;
+}
+
+/** A string for rendering, whatever the stored value turned out to be. */
+function asText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** A usable timestamp; falls back to the previous row's time. */
+function asTime(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }


### PR DESCRIPTION
## What

Restoring an imported session could draw a broken transcript: blank assistant bubbles, rows rendered under duplicate React keys (two macro-turns finishing in the same millisecond), Hermes/OpenClaw replies whose text vanished whenever the same message also carried tool calls, and a `maxPairs` history cut that segmented imported tasks differently from the real conversation because no importer recorded `macroTurnStarts`.

After this change:

- `turnsToMessages` is defensive: assistant ids are index-qualified (`msg-asst-<i>-<at>`), unknown turn kinds are skipped instead of throwing away the transcript, `text`/`summary`/`tool`/`reasoning` are coerced to strings, a missing `at` falls back to the previous row, and a reply with no text, no tool cards and no reasoning is dropped instead of drawn blank (reasoning-only replies stay).
- Hermes and OpenClaw mappers emit the assistant text as a reply *before* its tool calls, the way the Claude Code mapper already did; OpenClaw no longer emits empty user turns.
- Claude Code thinking-only rows carry their reasoning forward onto the next assistant row (a trailing thought is kept as a reasoning-only reply); a pending thought is flushed before a new user message rather than attributed to a different answer.
- All four mappers record `macroTurnStarts` through a new `macroTurnStartsFromTurns()` in `src/session/macro-turn-starts.ts`, which reuses the runtime's `appendMacroTurnStart` and `MACRO_TURN_START_CAP` (moved there verbatim from `session-state.ts`). `packConversation` now sees one task per user message, so `conversationMaxPairs: N` keeps N tasks of an import, not "however many the heuristic fused".

## Why

Imported history is the one place where rows come from another agent's store with copied timestamps and slightly different shapes. The rebuild path was written for the runtime's own rows and trusted every field; every fix here is a defensive default that leaves the live path unchanged (`turnsToMessages` is called only on session switch and re-sync, and the runtime never produces the empty rows that are now dropped).

## How it was verified

- `npm run lint` clean
- `npx vitest run src/tui/turns-to-messages.test.ts src/import src/session` — 29 files / 213 tests green (baseline on main: 28 / 189; 24 new tests: same-millisecond ids, unknown kind, empty-reply drop/keep, coercion, missing `at`, Hermes/OpenClaw text-beside-calls, Claude Code carry-forward, macro-turn segmentation on Claude Code + Hermes + the helper itself, each asserting the derived scan would have fused the transcript into one pair)
- `grep -rn msg-asst src` — the ids are consumed only as React keys in `chat-log.tsx`
