### PR TITLE
fix(tui): the rail lists every session and survives an unreadable row

### DIFF
--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -3,6 +3,9 @@ export type {
   SessionStoreOptions,
   RecentWorkingDirRow,
 } from "./session-store.js";
+export { summarizeSessionState } from "./session-summary.js";
+export type { SessionSummary } from "./session-summary.js";
+export { normalizeSessionState } from "./normalize-session-state.js";
 export {
   createEmptySessionState,
   appendFact,

--- a/src/session/normalize-session-state.ts
+++ b/src/session/normalize-session-state.ts
@@ -1,0 +1,31 @@
+import type { SessionState } from "./session-state.js";
+
+/**
+ * Fill in the fields a parsed payload may lack. Rows written before a
+ * field existed, and rows imported from other agents, are missing the
+ * arrays a reader iterates (`turns`, `knownFacts`, `loadedTools`) — a
+ * missing array is a crash in a list, a defaulted one is an empty row.
+ *
+ * Throws on a payload that is not an object at all (`null`, a number):
+ * there is nothing to default, and `SessionStore.readPayload` counts
+ * the throw as an unreadable row.
+ */
+export function normalizeSessionState(raw: unknown): SessionState {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new TypeError("session payload is not an object");
+  }
+  const s = raw as SessionState;
+  return {
+    ...s,
+    knownFacts: s.knownFacts ?? [],
+    latestResult: s.latestResult ?? null,
+    loadedSkills: s.loadedSkills ?? [],
+    loadedTools: s.loadedTools ?? [],
+    worldSnapshot: s.worldSnapshot ?? null,
+    stepCount: s.stepCount ?? 0,
+    turnCount: s.turnCount ?? 0,
+    turns: Array.isArray(s.turns) ? s.turns : [],
+    metadata: s.metadata ?? {},
+    lastError: s.lastError ?? null,
+  };
+}

--- a/src/session/session-store.summaries.test.ts
+++ b/src/session/session-store.summaries.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database as DatabaseCtor } from "../native/load-better-sqlite3.js";
+import { SessionStore } from "./session-store.js";
+import { createEmptySessionState, recordTurn } from "./session-state.js";
+import { userTurn, assistantReplyTurn } from "./conversation-turn.js";
+import { summarizeSessionState } from "./session-summary.js";
+
+/**
+ * Write a row the store itself would never write, through a second
+ * handle on the same file: the store has no API for a broken payload,
+ * and that is the point — the rows come from a truncated write or a
+ * hand edit, not from `save`.
+ */
+function insertRaw(file: string, id: string, payload: string, updatedAt: number) {
+  const raw = new DatabaseCtor(file);
+  try {
+    raw
+      .prepare(
+        `INSERT INTO sessions (id, working_dir, status, payload, created_at, updated_at)
+         VALUES (?, '/raw', 'pending', ?, ?, ?)`,
+      )
+      .run(id, payload, updatedAt, updatedAt);
+  } finally {
+    raw.close();
+  }
+}
+
+describe("SessionStore.listSummaries", () => {
+  let tmp: string;
+  let file: string;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "atomic-agent-summ-"));
+    file = join(tmp, "sessions.sqlite");
+    store = new SessionStore({ dbFile: file });
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns [] on an empty table", () => {
+    expect(store.listSummaries()).toEqual([]);
+    expect(store.countUnreadable()).toBe(0);
+  });
+
+  it("lists every session newest first with the first prompt lifted out", () => {
+    const a = recordTurn(
+      createEmptySessionState({ id: "a", workingDir: "/w" }),
+      userTurn("first thing said"),
+    );
+    const b = recordTurn(
+      recordTurn(createEmptySessionState({ id: "b", workingDir: "/w" }), userTurn("hello")),
+      assistantReplyTurn("hi"),
+    );
+    const c = createEmptySessionState({ id: "c", workingDir: "/w" });
+    store.save({ ...a, updatedAt: 1000, turnCount: 3, stepCount: 7 });
+    store.save({ ...b, updatedAt: 3000 });
+    store.save({ ...c, updatedAt: 2000 });
+    const rows = store.listSummaries();
+    expect(rows.map((r) => r.id)).toEqual(["b", "c", "a"]);
+    expect(rows[2]).toMatchObject({
+      id: "a",
+      workingDir: "/w",
+      status: "pending",
+      updatedAt: 1000,
+      turnCount: 3,
+      stepCount: 7,
+      firstPrompt: "first thing said",
+      importedFrom: null,
+    });
+    expect(rows[0]?.firstPrompt).toBe("hello");
+  });
+
+  it("gives an unnamed session firstPrompt: null, and an empty prompt ''", () => {
+    const unnamed = createEmptySessionState({ id: "u", workingDir: "/w" });
+    const empty = recordTurn(
+      createEmptySessionState({ id: "e", workingDir: "/w" }),
+      userTurn(""),
+    );
+    store.save({ ...unnamed, updatedAt: 1 });
+    store.save({ ...empty, updatedAt: 2 });
+    const byId = new Map(store.listSummaries().map((r) => [r.id, r]));
+    expect(byId.get("u")?.firstPrompt).toBeNull();
+    expect(byId.get("e")?.firstPrompt).toBe("");
+  });
+
+  it("reads importedFrom out of the metadata", () => {
+    const s = createEmptySessionState({
+      id: "imp",
+      workingDir: "/w",
+      metadata: { importedFrom: "hermes" },
+    });
+    store.save(s);
+    expect(store.listSummaries()[0]?.importedFrom).toBe("hermes");
+  });
+
+  it("agrees with summarizeSessionState on a saved state", () => {
+    const s = recordTurn(
+      createEmptySessionState({ id: "same", workingDir: "/w", metadata: { importedFrom: "codex" } }),
+      userTurn("prompt"),
+    );
+    const saved = { ...s, updatedAt: 42, createdAt: 41, turnCount: 1, stepCount: 2 };
+    store.save(saved);
+    expect(store.listSummaries()[0]).toEqual(summarizeSessionState(saved));
+  });
+
+  it("skips a corrupt payload row and counts it as unreadable", () => {
+    store.save({ ...createEmptySessionState({ id: "ok", workingDir: "/w" }), updatedAt: 1 });
+    insertRaw(file, "bad", '{"id":"bad","turns":[', 9999);
+    expect(store.listSummaries().map((r) => r.id)).toEqual(["ok"]);
+    expect(store.countUnreadable()).toBe(1);
+  });
+
+  it("leaves out a payload with no turns array, without counting it unreadable", () => {
+    store.save({ ...createEmptySessionState({ id: "ok", workingDir: "/w" }), updatedAt: 1 });
+    insertRaw(file, "empty-object", "{}", 5000);
+    insertRaw(file, "string-turns", '{"id":"string-turns","turns":"x"}', 6000);
+    expect(store.listSummaries().map((r) => r.id)).toEqual(["ok"]);
+    expect(store.countUnreadable()).toBe(0);
+  });
+
+  it("coerces missing counts to 0 and non-object turns to no prompt", () => {
+    insertRaw(file, "thin", '{"id":"thin","turns":[1,"two",{"kind":"user","text":"three"}]}', 1);
+    const [row] = store.listSummaries();
+    expect(row).toMatchObject({ turnCount: 0, stepCount: 0, firstPrompt: "three" });
+  });
+});

--- a/src/session/session-store.test.ts
+++ b/src/session/session-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Database as DatabaseCtor } from "../native/load-better-sqlite3.js";
 import { SessionStore } from "./session-store.js";
 import { createEmptySessionState } from "./session-state.js";
 import { EMPTY_CONTEXT_USAGE } from "./context-usage.js";
@@ -148,6 +149,36 @@ describe("SessionStore", () => {
       { workingDir: "/w2", updatedAt: 3000 },
       { workingDir: "/w3", updatedAt: 2000 },
     ]);
+  });
+
+  describe("with a corrupt row", () => {
+    const insertCorrupt = () => {
+      const raw = new DatabaseCtor(join(tmp, "sessions.sqlite"));
+      try {
+        raw
+          .prepare(
+            `INSERT INTO sessions (id, working_dir, status, payload, created_at, updated_at)
+             VALUES ('bad', '/w', 'pending', '{not json', 9, 9000)`,
+          )
+          .run();
+      } finally {
+        raw.close();
+      }
+    };
+
+    it("listRecent and listByWorkingDir skip it instead of throwing", () => {
+      store.save({ ...createEmptySessionState({ id: "ok", workingDir: "/w" }), updatedAt: 1 });
+      insertCorrupt();
+      expect(store.listRecent(10).map((s) => s.id)).toEqual(["ok"]);
+      expect(store.listByWorkingDir("/w", 10).map((s) => s.id)).toEqual(["ok"]);
+      expect(store.unreadableRowsSkipped).toBe(2);
+    });
+
+    it("load returns null for it", () => {
+      insertCorrupt();
+      expect(store.load("bad")).toBeNull();
+      expect(store.unreadableRowsSkipped).toBe(1);
+    });
   });
 
   it("delete removes a session", () => {

--- a/src/session/session-store.ts
+++ b/src/session/session-store.ts
@@ -4,15 +4,8 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getConfig } from "../config/index.js";
 import { stripEphemeral, type SessionState } from "./session-state.js";
-
-function normalizeSessionState(raw: unknown): SessionState {
-  const s = raw as SessionState;
-  return {
-    ...s,
-    loadedTools: s.loadedTools ?? [],
-    loadedSkills: s.loadedSkills ?? [],
-  };
-}
+import { normalizeSessionState } from "./normalize-session-state.js";
+import type { SessionSummary } from "./session-summary.js";
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS sessions (
@@ -26,6 +19,73 @@ CREATE TABLE IF NOT EXISTS sessions (
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_working_dir ON sessions(working_dir);
 `;
+
+/**
+ * One row per readable session, newest first, with the fields a list
+ * renders lifted out of the JSON in SQL — no LIMIT, because the rail
+ * windows its own rows, and no JSON.parse, because one malformed payload
+ * must not take every other row down with it. The `WHERE` keeps the
+ * `json_each` subquery off payloads it cannot walk, and the subquery's
+ * `t.type = 'object'` keeps `json_extract` off array elements that are
+ * not JSON objects — a bare string element is not JSON text and would
+ * raise "malformed JSON". `AND` short-circuits, so the guard holds.
+ */
+const LIST_SUMMARIES_SQL = `
+SELECT id,
+       working_dir AS workingDir,
+       status,
+       created_at AS createdAt,
+       updated_at AS updatedAt,
+       json_extract(payload, '$.turnCount') AS turnCount,
+       json_extract(payload, '$.stepCount') AS stepCount,
+       (SELECT json_extract(t.value, '$.text')
+          FROM json_each(payload, '$.turns') AS t
+         WHERE t.type = 'object'
+           AND json_extract(t.value, '$.kind') = 'user'
+         LIMIT 1) AS firstPrompt,
+       json_extract(payload, '$.metadata.importedFrom') AS importedFrom
+  FROM sessions
+ WHERE json_valid(payload) AND json_type(payload, '$.turns') = 'array'
+ ORDER BY updated_at DESC`;
+
+const COUNT_UNREADABLE_SQL = `SELECT COUNT(*) AS n FROM sessions WHERE NOT json_valid(payload)`;
+
+interface SummaryRow {
+  id: string;
+  workingDir: string;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+  turnCount: unknown;
+  stepCount: unknown;
+  firstPrompt: unknown;
+  importedFrom: unknown;
+}
+
+function toSummary(row: SummaryRow): SessionSummary {
+  return {
+    id: row.id,
+    workingDir: row.workingDir,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    turnCount: toCount(row.turnCount),
+    stepCount: toCount(row.stepCount),
+    firstPrompt: toText(row.firstPrompt),
+    importedFrom: toText(row.importedFrom),
+  };
+}
+
+/** `json_extract` hands back whatever the JSON held; a count is a number or 0. */
+function toCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/** `NULL` stays null; a non-string JSON value is still shown, as text. */
+function toText(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return typeof value === "string" ? value : String(value);
+}
 
 export interface SessionStoreOptions {
   dbFile?: string;
@@ -50,7 +110,16 @@ export class SessionStore {
   private readonly listByWorkingDirStmt: Database.Statement;
   private readonly listRecentStmt: Database.Statement;
   private readonly listRecentDirsStmt: Database.Statement;
+  private readonly listSummariesStmt: Database.Statement;
+  private readonly countUnreadableStmt: Database.Statement;
   private readonly deleteStmt: Database.Statement;
+  /**
+   * How many rows `load` / `listRecent` / `listByWorkingDir` have skipped
+   * because their payload would not parse. Counts every skip, so the
+   * same bad row read twice counts twice; `countUnreadable` is the
+   * number of such rows in the table.
+   */
+  private unreadableSkips = 0;
 
   constructor(options: SessionStoreOptions = {}) {
     const config = getConfig();
@@ -83,6 +152,8 @@ export class SessionStore {
       `SELECT working_dir AS workingDir, updated_at AS updatedAt
        FROM sessions ORDER BY updated_at DESC LIMIT ?`,
     );
+    this.listSummariesStmt = this.db.prepare(LIST_SUMMARIES_SQL);
+    this.countUnreadableStmt = this.db.prepare(COUNT_UNREADABLE_SQL);
     this.deleteStmt = this.db.prepare(`DELETE FROM sessions WHERE id = ?`);
   }
 
@@ -99,14 +170,14 @@ export class SessionStore {
   load(id: string): SessionState | null {
     const row = this.selectStmt.get(id) as { payload: string } | undefined;
     if (!row) return null;
-    return normalizeSessionState(JSON.parse(row.payload));
+    return this.readPayload(row);
   }
 
   listByWorkingDir(workingDir: string, limit = 25): SessionState[] {
     const rows = this.listByWorkingDirStmt.all(workingDir, limit) as Array<{
       payload: string;
     }>;
-    return rows.map((row) => normalizeSessionState(JSON.parse(row.payload)));
+    return this.readPayloads(rows);
   }
 
   /**
@@ -116,7 +187,29 @@ export class SessionStore {
    */
   listRecent(limit = 25): SessionState[] {
     const rows = this.listRecentStmt.all(limit) as Array<{ payload: string }>;
-    return rows.map((row) => normalizeSessionState(JSON.parse(row.payload)));
+    return this.readPayloads(rows);
+  }
+
+  /**
+   * Every readable session as a list row, newest first, projected in
+   * SQL (see `LIST_SUMMARIES_SQL`). Rows whose payload is not valid JSON
+   * or whose `turns` is not an array are left out; `countUnreadable`
+   * says how many of the former there are.
+   */
+  listSummaries(): SessionSummary[] {
+    const rows = this.listSummariesStmt.all() as SummaryRow[];
+    return rows.map(toSummary);
+  }
+
+  /** Rows whose payload is not valid JSON — the ones every reader skips. */
+  countUnreadable(): number {
+    const row = this.countUnreadableStmt.get() as { n: number };
+    return row.n;
+  }
+
+  /** Skips recorded by `load` / `listRecent` / `listByWorkingDir` so far. */
+  get unreadableRowsSkipped(): number {
+    return this.unreadableSkips;
   }
 
   /**
@@ -138,6 +231,28 @@ export class SessionStore {
     this.db.close();
   }
 
+  /**
+   * Parse one stored payload, or `null` when it will not parse. A row
+   * that is not JSON — a truncated write, a hand edit — used to throw
+   * out of every list and empty the rail; now it is skipped and counted.
+   */
+  private readPayload(row: { payload: string }): SessionState | null {
+    try {
+      return normalizeSessionState(JSON.parse(row.payload));
+    } catch {
+      this.unreadableSkips += 1;
+      return null;
+    }
+  }
+
+  private readPayloads(rows: Array<{ payload: string }>): SessionState[] {
+    const states: SessionState[] = [];
+    for (const row of rows) {
+      const state = this.readPayload(row);
+      if (state) states.push(state);
+    }
+    return states;
+  }
 
   private serialize(state: SessionState): Record<string, unknown> {
     const persistable = stripEphemeral(state);

--- a/src/session/session-summary.ts
+++ b/src/session/session-summary.ts
@@ -1,0 +1,42 @@
+import type { SessionState } from "./session-state.js";
+
+/**
+ * Column-level view of one stored session: what a list needs to render
+ * a row without parsing the transcript. `SessionStore.listSummaries`
+ * projects it straight out of SQL; `summarizeSessionState` is the same
+ * projection over an in-memory state, so a stub can stand in for the
+ * store and a test can check the two agree.
+ */
+export interface SessionSummary {
+  id: string;
+  workingDir: string;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+  turnCount: number;
+  stepCount: number;
+  /**
+   * Text of the first `user` turn, which is what names a session. `null`
+   * when nobody has spoken to it yet — an empty string is still a prompt
+   * and keeps the row visible.
+   */
+  firstPrompt: string | null;
+  /** `metadata.importedFrom` for sessions migrated from another agent. */
+  importedFrom: string | null;
+}
+
+export function summarizeSessionState(state: SessionState): SessionSummary {
+  const firstUser = state.turns.find((turn) => turn.kind === "user");
+  const importedFrom = state.metadata?.importedFrom;
+  return {
+    id: state.id,
+    workingDir: state.workingDir,
+    status: state.status,
+    createdAt: state.createdAt,
+    updatedAt: state.updatedAt,
+    turnCount: state.turnCount,
+    stepCount: state.stepCount,
+    firstPrompt: firstUser?.kind === "user" ? firstUser.text : null,
+    importedFrom: typeof importedFrom === "string" ? importedFrom : null,
+  };
+}

--- a/src/tui/chat-orchestrator-steering.test.ts
+++ b/src/tui/chat-orchestrator-steering.test.ts
@@ -62,6 +62,8 @@ function makeHarness(): Harness {
   const runtime = {
     createSession: () => session,
     sessionStore: {
+      listSummaries: () => [],
+      countUnreadable: () => 0,
       listRecent: () => [],
       load: () => session,
     },
@@ -275,7 +277,12 @@ function makeGapHarness(): GapHarness {
 
   const runtime = {
     createSession: () => session,
-    sessionStore: { listRecent: () => [], load: () => session },
+    sessionStore: {
+      listSummaries: () => [],
+      countUnreadable: () => 0,
+      listRecent: () => [],
+      load: () => session,
+    },
     approvals: { clearSessionGrants: () => undefined },
     steer: (sessionId: string, text: string) => inbox.push(sessionId, text),
     runTurn: (

--- a/src/tui/chat-orchestrator-switch.test.ts
+++ b/src/tui/chat-orchestrator-switch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ApprovalGate } from "../approval/approval-gate.js";
 import { createEmptySessionState } from "../session/session-state.js";
+import { summarizeSessionState } from "../session/session-summary.js";
 import type { AgentRuntime } from "../runtime/bootstrap.js";
 import { ChatOrchestrator } from "./chat-orchestrator.js";
 import { SWITCHED_AWAY_APPROVAL_REASON } from "./detached-turns.js";
@@ -81,6 +82,8 @@ function makeHarness(
         });
       }),
     sessionStore: {
+      listSummaries: () => stored.map(summarizeSessionState),
+      countUnreadable: () => 0,
       listRecent: () => stored,
       load: (id: string) => stored.find((s) => s.id === id) ?? null,
       delete: () => undefined,

--- a/src/tui/chat-orchestrator.test.ts
+++ b/src/tui/chat-orchestrator.test.ts
@@ -52,7 +52,12 @@ function stubRuntime(
     steer: () => false,
     runTurn: (_s: unknown, text: string, opts: { signal: AbortSignal }) =>
       runTurn(text, opts),
-    sessionStore: { listRecent: () => [], load: () => null },
+    sessionStore: {
+      listSummaries: () => [],
+      countUnreadable: () => 0,
+      listRecent: () => [],
+      load: () => null,
+    },
     approvals: { clearSessionGrants: () => undefined },
     config: { update: { checkOnStartup: false, repo: "x/y" }, tracing: { trace: { dir: "/tmp", enabled: false } } },
     profileStore: { list: () => [] },

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -8,6 +8,7 @@ import {
   isFailedSessionStatus,
   type SessionState,
 } from "../session/session-state.js";
+import type { SessionSummary } from "../session/session-summary.js";
 import { getConfig } from "../config/index.js";
 import { resolveLlmConfig } from "../llm/provider/registry/index.js";
 import {
@@ -212,6 +213,7 @@ export class ChatOrchestrator {
     this.mcp = new McpOrchestrator(runtime, bus);
     this.import = new ImportOrchestrator(runtime, bus, {
       refreshTasks: () => this.tasks.refresh(),
+      refreshSessions: () => this.refreshRecentSessions(),
     });
     this.providers = new ProvidersOrchestrator(runtime, bus);
     this.fallback = new FallbackOrchestrator(bus);
@@ -285,7 +287,25 @@ export class ChatOrchestrator {
   start(): void {
     if (this.started) return;
     this.started = true;
-    this.refreshRecentSessions();
+    // The rail is the one boot step that reads every stored row. A store
+    // that cannot answer must not abort the rest of the boot — the
+    // chat, the poller and the channels work without a session list.
+    try {
+      this.refreshRecentSessions();
+      const unreadable = this.runtime.sessionStore.countUnreadable();
+      if (unreadable > 0) {
+        this.bus.emit({
+          type: "runtime_info",
+          line: `${unreadable} unreadable session(s) skipped`,
+        });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.bus.emit({
+        type: "runtime_info",
+        line: `session list unavailable: ${message}`,
+      });
+    }
     this.llmHealth.start();
     this.telegram.start();
     this.privacy.refresh();
@@ -423,17 +443,15 @@ export class ChatOrchestrator {
 
   /** Stored threads that have a first prompt, plus the pending ones. */
   private railSessions(): SessionPickerEntry[] {
-    // Read deeper than we show, because the filter runs HERE and the
-    // limit runs in SQL. Every `+ new` and every scheduled task mints a
-    // persisted, unnamed session; filtering a 25-row window would let
-    // those invisible rows squat it and push real conversations out —
-    // permanently, since a thread only re-enters the window by being
-    // spoken to, which you cannot do once it has no row.
+    // Every stored thread, not a window of them: the rail and the picker
+    // page their own rows. Every `+ new` and every scheduled task mints
+    // a persisted, unnamed session; those are hidden here (see
+    // `hasFirstPrompt`), and with no LIMIT in SQL there is no window for
+    // them to squat and push real conversations out of.
     const stored = this.runtime.sessionStore
-      .listRecent(RAIL_SCAN_LIMIT)
-      .filter((state) => hasFirstPrompt(state))
-      .map((s) => toPickerEntry(s))
-      .slice(0, RAIL_SESSION_LIMIT);
+      .listSummaries()
+      .filter((row) => row.firstPrompt !== null)
+      .map((row) => toPickerEntry(row));
     if (this.pendingRows.size === 0) return stored;
     const storedIds = new Set(stored.map((entry) => entry.sessionId));
     const pending: SessionPickerEntry[] = [];
@@ -1295,28 +1313,19 @@ function formatBytes(bytes: number): string {
  * session its name, and an unnamed row is indistinguishable from every
  * other unnamed row.
  */
-/** Rows the rail and the picker show. */
-const RAIL_SESSION_LIMIT = 25;
-/**
- * How deep to read before filtering. Generous rather than exact: unnamed
- * sessions accumulate (one per `+ new`, one per scheduled task) and each
- * one would otherwise cost a real thread its place in the list.
- */
-const RAIL_SCAN_LIMIT = 200;
-
 function hasFirstPrompt(state: SessionState): boolean {
   return state.turns.some((turn) => turn.kind === "user");
 }
 
-function toPickerEntry(state: SessionState): SessionPickerEntry {
-  const firstUser = state.turns.find((t) => t.kind === "user");
-  const preview = firstUser && firstUser.kind === "user" ? firstUser.text : "";
+/** A stored row with a first prompt (`firstPrompt !== null`) as a rail row. */
+function toPickerEntry(row: SessionSummary): SessionPickerEntry {
+  const preview = row.firstPrompt ?? "";
   return {
-    sessionId: state.id,
-    workingDir: state.workingDir,
-    turnCount: state.turnCount,
-    stepCount: state.stepCount,
-    updatedAt: state.updatedAt,
+    sessionId: row.id,
+    workingDir: row.workingDir,
+    turnCount: row.turnCount,
+    stepCount: row.stepCount,
+    updatedAt: row.updatedAt,
     preview: preview.length > 0 ? preview : "(empty)",
   };
 }

--- a/src/tui/import/import-orchestrator.test.ts
+++ b/src/tui/import/import-orchestrator.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { AgentRuntime } from "../../runtime/bootstrap.js";
+import { makeTuiEventBus } from "../make-event-bus.js";
+import type { OnboardingImportPlan } from "../onboarding/import-step.js";
+import type { TuiAction } from "../tui-action.js";
+import { ImportOrchestrator } from "./import-orchestrator.js";
+import type { ImportFormState } from "./import-panel-state.js";
+
+/**
+ * An empty source dir is a complete import run: the importer reports
+ * every domain as skipped (`no state.db at …`), writes nothing, and
+ * still reaches the completion path — which is the path under test.
+ */
+function stubRuntime(tmp: string): AgentRuntime {
+  return {
+    sessionStore: {},
+    taskStore: {},
+    config: {
+      paths: { stateDir: join(tmp, "state") },
+      tasks: { maxAttempts: 1 },
+    },
+  } as unknown as AgentRuntime;
+}
+
+function form(overrides: Partial<ImportFormState>, sourceDir: string): ImportFormState {
+  return {
+    source: "hermes",
+    sourceDir,
+    sessions: true,
+    cron: false,
+    secrets: false,
+    overwrite: false,
+    limit: "",
+    focus: "sessions",
+    ...overrides,
+  };
+}
+
+function plan(dir: string, option: string): OnboardingImportPlan {
+  return {
+    agents: [{ id: "hermes", label: "Hermes", dir, enabled: true }],
+    options: [
+      {
+        agent: "hermes",
+        agentLabel: "Hermes",
+        option,
+        label: option,
+        description: "",
+        secret: false,
+        enabled: true,
+      },
+    ],
+  };
+}
+
+async function settled(actions: TuiAction[], type: TuiAction["type"]): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (actions.some((a) => a.type === type)) return;
+    await new Promise((r) => setTimeout(r, 1));
+  }
+  throw new Error(`no ${type} action emitted`);
+}
+
+describe("ImportOrchestrator refreshSessions", () => {
+  let tmp: string;
+  let actions: TuiAction[];
+  let refreshSessions: ReturnType<typeof vi.fn>;
+  let orchestrator: ImportOrchestrator;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "atomic-agent-import-"));
+    actions = [];
+    refreshSessions = vi.fn();
+    const bus = makeTuiEventBus();
+    bus.subscribe((a) => actions.push(a));
+    orchestrator = new ImportOrchestrator(stubRuntime(tmp), bus, { refreshSessions });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("refreshes the rail after an executed tab import that included sessions", async () => {
+    orchestrator.execute(form({}, tmp));
+    await settled(actions, "import_execute_done");
+    expect(refreshSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh after a preview", async () => {
+    orchestrator.preview(form({}, tmp));
+    await settled(actions, "import_preview_ready");
+    expect(refreshSessions).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh when sessions were not part of the run", async () => {
+    orchestrator.execute(form({ sessions: false, cron: true }, tmp));
+    await settled(actions, "import_execute_done");
+    expect(refreshSessions).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the rail after an executed onboarding import with sessions", async () => {
+    await orchestrator.runOnboarding(plan(tmp, "sessions"), true);
+    expect(actions.some((a) => a.type === "onboarding_import_report")).toBe(true);
+    expect(refreshSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh after an onboarding preview", async () => {
+    await orchestrator.runOnboarding(plan(tmp, "sessions"), false);
+    expect(refreshSessions).not.toHaveBeenCalled();
+  });
+});

--- a/src/tui/import/import-orchestrator.ts
+++ b/src/tui/import/import-orchestrator.ts
@@ -30,6 +30,8 @@ import type { ImportFormState } from "./import-panel-state.js";
 export interface ImportOrchestratorDeps {
   /** Refresh the Tasks tab after a cron import created scheduled tasks. */
   refreshTasks?(): void;
+  /** Refresh the session rail after a sessions import wrote new rows. */
+  refreshSessions?(): void;
 }
 
 /**
@@ -187,6 +189,8 @@ export class ImportOrchestrator {
       });
       // Cron import may have created scheduled tasks — refresh the tab.
       if (options.includes("cron")) this.deps.refreshTasks?.();
+      // Sessions import wrote rows the rail has not seen yet.
+      if (options.includes("sessions")) this.deps.refreshSessions?.();
     } else {
       this.bus.emit({ type: "import_preview_ready", report });
     }
@@ -205,6 +209,7 @@ export class ImportOrchestrator {
     await Promise.resolve();
     const items: ImportItemResult[] = [];
     let cronImported = false;
+    let sessionsImported = false;
     try {
       for (const agent of plan.agents) {
         if (!agent.enabled) continue;
@@ -215,6 +220,7 @@ export class ImportOrchestrator {
         const report = await this.runOnboardingAgent(agent.id, agent.dir, enabled, execute);
         if (report === null) continue;
         if (execute && enabled.includes("cron")) cronImported = true;
+        if (execute && enabled.includes("sessions")) sessionsImported = true;
         for (const item of report.items) {
           items.push({ ...item, kind: `${IMPORT_AGENT_LABELS[agent.id]} ${item.kind}` });
         }
@@ -234,6 +240,7 @@ export class ImportOrchestrator {
         line: `import done: ${formatSummary(report)}`,
       });
       if (cronImported) this.deps.refreshTasks?.();
+      if (sessionsImported) this.deps.refreshSessions?.();
     }
   }
 

--- a/src/tui/rail-session-boot.test.ts
+++ b/src/tui/rail-session-boot.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { harness, spokenTo } from "./rail-session-harness.js";
+
+/**
+ * `start()` runs after Ink mounted and the rail refresh is its first
+ * step. A store that cannot answer must cost the rail, not the boot.
+ */
+describe("rail session list — boot", () => {
+  it("boots with an empty rail and a notice when the store cannot list", async () => {
+    const { orchestrator, rail, actions } = harness([], {
+      listSummaries: () => {
+        throw new Error("database disk image is malformed");
+      },
+    });
+    try {
+      expect(() => orchestrator.start()).not.toThrow();
+      expect(rail()).toEqual([]);
+      const notice = actions.find(
+        (a) => a.type === "runtime_info" && a.line.startsWith("session list unavailable:"),
+      );
+      expect(notice).toMatchObject({
+        line: "session list unavailable: database disk image is malformed",
+      });
+      // The boot went on past the rail: the tasks pane still got its data.
+      expect(actions.some((a) => a.type === "tasks_refreshed")).toBe(true);
+    } finally {
+      await orchestrator.shutdown();
+    }
+  });
+
+  it("says how many rows it skipped when the store holds unreadable ones", async () => {
+    const { orchestrator, rail, actions } = harness([spokenTo("s-old", "older")], {
+      countUnreadable: () => 2,
+    });
+    try {
+      orchestrator.start();
+      expect(rail().map((entry) => entry.sessionId)).toEqual(["s-old"]);
+      expect(actions).toContainEqual({
+        type: "runtime_info",
+        line: "2 unreadable session(s) skipped",
+      });
+    } finally {
+      await orchestrator.shutdown();
+    }
+  });
+
+  it("stays quiet about unreadable rows when there are none", async () => {
+    const { orchestrator, actions } = harness([spokenTo("s-old", "older")]);
+    try {
+      orchestrator.start();
+      expect(
+        actions.some((a) => a.type === "runtime_info" && a.line.includes("unreadable")),
+      ).toBe(false);
+    } finally {
+      await orchestrator.shutdown();
+    }
+  });
+});

--- a/src/tui/rail-session-harness.ts
+++ b/src/tui/rail-session-harness.ts
@@ -1,0 +1,127 @@
+import { createEmptySessionState, recordTurn } from "../session/session-state.js";
+import { userTurn } from "../session/conversation-turn.js";
+import { summarizeSessionState, type SessionSummary } from "../session/session-summary.js";
+import type { AgentRuntime } from "../runtime/bootstrap.js";
+import { ChatOrchestrator } from "./chat-orchestrator.js";
+import { makeTuiEventBus } from "./make-event-bus.js";
+import type { LocalTurnGateFacts } from "./local-turn-gate.js";
+import type { TuiAction } from "./tui-action.js";
+import type { SessionPickerEntry } from "./tui-state.js";
+
+/**
+ * Test harness for the session rail: a `ChatOrchestrator` over an
+ * in-memory session store. Shared by `rail-session-list.test.ts` and
+ * `rail-session-boot.test.ts`; not part of the app.
+ */
+
+/** Hermetic gate facts: never read the developer's real config/disk. */
+export const cloudGateFacts = (): LocalTurnGateFacts => ({
+  activeProviderIsLocal: false,
+  managedMode: false,
+  modelId: null,
+  modelDownloaded: true,
+  fallbackChainLength: 1,
+});
+
+/**
+ * The rail lists threads that have been spoken to. `+ new` mints a
+ * session immediately — the store row has to exist for scheduled tasks
+ * and webhooks that hold only an id — but an unnamed row says nothing,
+ * so it stays off the list until its first prompt names it.
+ */
+export function blank(id: string) {
+  return createEmptySessionState({ id, workingDir: "/tmp" });
+}
+
+export function spokenTo(id: string, text: string) {
+  return recordTurn(blank(id), userTurn(text));
+}
+
+export type StoredSession = ReturnType<typeof blank>;
+
+/** What the store's `listSummaries` does in SQL: every row, newest first. */
+export function summariesOf(stored: StoredSession[]): SessionSummary[] {
+  return [...stored]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map(summarizeSessionState);
+}
+
+export interface StubOptions {
+  /**
+   * By default the turn never settles, so the tests observe the rail at
+   * the moment the prompt is sent. `settleTurns` is for the cases that
+   * need the orchestrator idle afterwards — deleting a session is
+   * refused while a turn holds it.
+   */
+  settleTurns?: boolean;
+  listSummaries?: () => SessionSummary[];
+  countUnreadable?: () => number;
+}
+
+export function stubRuntime(
+  stored: StoredSession[],
+  { settleTurns = false, listSummaries, countUnreadable }: StubOptions = {},
+): AgentRuntime {
+  let created = 0;
+  return {
+    createSession: () => {
+      created += 1;
+      const fresh = blank(`s-new-${created}`);
+      stored.unshift(fresh);
+      return fresh;
+    },
+    steer: () => false,
+    runTurn: (session: unknown) =>
+      settleTurns
+        ? Promise.resolve({ session, reason: "reply", stepCount: 1 })
+        : new Promise(() => {}),
+    sessionStore: {
+      listSummaries: listSummaries ?? (() => summariesOf(stored)),
+      countUnreadable: countUnreadable ?? (() => 0),
+      listRecent: (limit: number) => stored.slice(0, limit),
+      load: (id: string) => stored.find((s) => s.id === id) ?? null,
+      delete: (id: string) => {
+        const at = stored.findIndex((s) => s.id === id);
+        if (at >= 0) stored.splice(at, 1);
+      },
+    },
+    approvals: {
+      clearSessionGrants: () => undefined,
+      denyPendingForSession: () => 0,
+      sessionGrants: () => [],
+    },
+    // Deleting checks every origin's turns, not just the TUI's.
+    turnController: { isBusy: () => false },
+    // What `start()` reaches for besides the session store.
+    getApprovalLevel: () => 5,
+    taskStore: { list: () => [] },
+    shutdown: async () => undefined,
+    config: {
+      update: { checkOnStartup: false, repo: "x/y" },
+      tracing: { trace: { dir: "/tmp", enabled: false } },
+    },
+    profileStore: { list: () => [] },
+    skillCatalog: [],
+  } as unknown as AgentRuntime;
+}
+
+export function harness(stored: StoredSession[], options: StubOptions = {}) {
+  const bus = makeTuiEventBus();
+  const actions: TuiAction[] = [];
+  bus.subscribe((a) => actions.push(a));
+  const orchestrator = new ChatOrchestrator(stubRuntime(stored, options), bus, {
+    maxSteps: 5,
+    llamaUrl: "http://127.0.0.1:8080",
+    readGateFacts: cloudGateFacts,
+  });
+  const lastOf = (type: "recent_sessions_updated" | "session_picker_opened") => {
+    for (let i = actions.length - 1; i >= 0; i -= 1) {
+      const action = actions[i];
+      if (action?.type === type) return action.sessions;
+    }
+    return [] as readonly SessionPickerEntry[];
+  };
+  const rail = (): readonly SessionPickerEntry[] => lastOf("recent_sessions_updated");
+  const picker = (): readonly SessionPickerEntry[] => lastOf("session_picker_opened");
+  return { orchestrator, rail, picker, actions };
+}

--- a/src/tui/rail-session-list.test.ts
+++ b/src/tui/rail-session-list.test.ts
@@ -1,107 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { createEmptySessionState, recordTurn } from "../session/session-state.js";
+import { recordTurn } from "../session/session-state.js";
 import { userTurn } from "../session/conversation-turn.js";
-import type { AgentRuntime } from "../runtime/bootstrap.js";
-import { ChatOrchestrator } from "./chat-orchestrator.js";
-import { makeTuiEventBus } from "./make-event-bus.js";
-import type { LocalTurnGateFacts } from "./local-turn-gate.js";
-import type { TuiAction } from "./tui-action.js";
-import type { SessionPickerEntry } from "./tui-state.js";
-
-/** Hermetic gate facts: never read the developer's real config/disk. */
-const cloudGateFacts = (): LocalTurnGateFacts => ({
-  activeProviderIsLocal: false,
-  managedMode: false,
-  modelId: null,
-  modelDownloaded: true,
-  fallbackChainLength: 1,
-});
-
-/**
- * The rail lists threads that have been spoken to. `+ new` mints a
- * session immediately — the store row has to exist for scheduled tasks
- * and webhooks that hold only an id — but an unnamed row says nothing,
- * so it stays off the list until its first prompt names it.
- */
-function blank(id: string) {
-  return createEmptySessionState({ id, workingDir: "/tmp" });
-}
-
-function spokenTo(id: string, text: string) {
-  return recordTurn(blank(id), userTurn(text));
-}
-
-function stubRuntime(
-  stored: ReturnType<typeof blank>[],
-  settleTurns = false,
-): AgentRuntime {
-  let created = 0;
-  return {
-    createSession: () => {
-      created += 1;
-      const fresh = blank(`s-new-${created}`);
-      stored.unshift(fresh);
-      return fresh;
-    },
-    steer: () => false,
-    // By default the turn never settles, so the tests observe the rail
-    // at the moment the prompt is sent. `settleTurns` is for the cases
-    // that need the orchestrator idle afterwards — deleting a session is
-    // refused while a turn holds it.
-    runTurn: (session: unknown) =>
-      settleTurns
-        ? Promise.resolve({ session, reason: "reply", stepCount: 1 })
-        : new Promise(() => {}),
-    sessionStore: {
-      // Honour the limit like SQL does — a stub that ignores it cannot
-      // see a filter running on the wrong side of the window.
-      listRecent: (limit: number) => stored.slice(0, limit),
-      load: (id: string) => stored.find((s) => s.id === id) ?? null,
-      delete: (id: string) => {
-        const at = stored.findIndex((s) => s.id === id);
-        if (at >= 0) stored.splice(at, 1);
-      },
-    },
-    approvals: {
-      clearSessionGrants: () => undefined,
-      denyPendingForSession: () => 0,
-    },
-    // Deleting checks every origin's turns, not just the TUI's.
-    turnController: { isBusy: () => false },
-    config: {
-      update: { checkOnStartup: false, repo: "x/y" },
-      tracing: { trace: { dir: "/tmp", enabled: false } },
-    },
-    profileStore: { list: () => [] },
-    skillCatalog: [],
-  } as unknown as AgentRuntime;
-}
-
-function harness(stored: ReturnType<typeof blank>[], settleTurns = false) {
-  const bus = makeTuiEventBus();
-  const actions: TuiAction[] = [];
-  bus.subscribe((a) => actions.push(a));
-  const orchestrator = new ChatOrchestrator(stubRuntime(stored, settleTurns), bus, {
-    maxSteps: 5,
-    llamaUrl: "http://127.0.0.1:8080", readGateFacts: cloudGateFacts,
-  });
-  const rail = (): readonly SessionPickerEntry[] => {
-    for (let i = actions.length - 1; i >= 0; i -= 1) {
-      const action = actions[i];
-      if (action?.type === "recent_sessions_updated") return action.sessions;
-    }
-    return [];
-  };
-  const picker = (): readonly SessionPickerEntry[] => {
-    for (let i = actions.length - 1; i >= 0; i -= 1) {
-      const action = actions[i];
-      if (action?.type === "session_picker_opened") return action.sessions;
-    }
-    return [];
-  };
-  return { orchestrator, rail, picker, actions };
-}
+import { blank, harness, spokenTo } from "./rail-session-harness.js";
 
 describe("rail session list", () => {
   it("hides sessions nobody has spoken to", () => {
@@ -148,11 +49,29 @@ describe("rail session list", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
+  it("lists every spoken-to session, newest first, with no cap", () => {
+    // The rail used to stop at 25 rows and scan 200: the 26th thread
+    // was unreachable, and past 200 stored sessions even the scan ran
+    // out. The rail and the picker window their own rows, so the list
+    // itself carries everything.
+    const stored = Array.from({ length: 300 }, (_, i) => ({
+      ...spokenTo(`s-${i}`, `thread ${i}`),
+      updatedAt: 1_000_000 + i,
+    }));
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.refreshRecentSessions();
+    const rows = rail();
+    expect(rows).toHaveLength(300);
+    expect(rows[0]?.sessionId).toBe("s-299");
+    expect(rows[299]?.sessionId).toBe("s-0");
+    const updatedAts = rows.map((entry) => entry.updatedAt);
+    expect(updatedAts).toEqual([...updatedAts].sort((a, b) => b - a));
+  });
+
   it("does not let unnamed sessions push real threads out of the list", () => {
     // Every `+ new` persists an unnamed session, and scheduled tasks
-    // mint one each. Filtering after the store's limit would let those
-    // invisible rows squat the window — and a thread pushed out can
-    // never come back, because it only re-enters by being spoken to.
+    // mint one each. With no window to squat there is nothing for them
+    // to push out — every real thread is listed, every blank one hidden.
     const stored = [
       ...Array.from({ length: 60 }, (_, i) => blank(`s-blank-${i}`)),
       ...Array.from({ length: 30 }, (_, i) => spokenTo(`s-real-${i}`, `thread ${i}`)),
@@ -160,8 +79,15 @@ describe("rail session list", () => {
     const { orchestrator, rail } = harness(stored);
     orchestrator.refreshRecentSessions();
     const rows = rail();
-    expect(rows).toHaveLength(25);
+    expect(rows).toHaveLength(30);
     expect(rows.every((entry) => entry.sessionId.startsWith("s-real-"))).toBe(true);
+  });
+
+  it("shows '(empty)' for a session whose first prompt is an empty string", () => {
+    const stored = [spokenTo("s-empty", "")];
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((entry) => entry.preview)).toEqual(["(empty)"]);
   });
 
   it("opens the picker on the same list the rail shows", () => {
@@ -180,7 +106,7 @@ describe("rail session list", () => {
     // stub does not write one back), so only the stand-in is keeping
     // the row on screen.
     const stored = [spokenTo("s-old", "older")];
-    const { orchestrator, rail } = harness(stored, true);
+    const { orchestrator, rail } = harness(stored, { settleTurns: true });
     orchestrator.newSession();
     orchestrator.sendMessage("about to be deleted");
     expect(rail().map((e) => e.sessionId)).toContain("s-new-1");


### PR DESCRIPTION
## What

The session rail showed at most 25 threads, and a single unreadable row in `sessions.sqlite` emptied it entirely: `SessionStore.listRecent` parsed every payload with an unguarded `JSON.parse`, the exception escaped `ChatOrchestrator.start()` after Ink had mounted, and the rail rendered "(no sessions yet)" over a store holding hundreds of conversations. Imports also never refreshed the list, so freshly imported sessions stayed invisible until something else triggered a refresh.

After this change:

- `SessionStore.listSummaries()` projects the list rows in SQL — `json_extract` for the counters and `metadata.importedFrom`, a `json_each` subquery for the first user prompt — with **no LIMIT**, guarded by `json_valid(payload)` and `json_type(payload,'$.turns') = 'array'` so a malformed row is excluded instead of aborting the query. The rail and the picker already window their rows and show "↓ N more". No payload is `JSON.parse`d on a refresh any more.
- `load` / `listRecent` / `listByWorkingDir` skip and count an unparseable row instead of throwing; `normalizeSessionState` (moved to its own file) defaults every array and counter an older or foreign payload may lack.
- `start()` no longer aborts the boot when the list cannot be read: it prints `session list unavailable: …`, and prints `N unreadable session(s) skipped` when `countUnreadable()` is non-zero.
- `ImportOrchestrator` gains a `refreshSessions` dep, invoked on both the Import-tab path and the onboarding path whenever an executed import included sessions.

## Why

The list is the operator's memory of what they were doing. A cap that silently hides the 26th thread, and a corrupt row that hides all of them, both read as "my sessions are gone". Doing the projection in SQL keeps the uncapped list cheaper than the old 200-row parse.

## How it was verified

- `npm run lint` clean
- `npx vitest run src/session src/tui/rail-session-list.test.ts src/tui/chat-orchestrator*.test.ts src/tui/import src/tui/components` — 76 files / 696 tests green (new: `session-store.summaries.test.ts`, `rail-session-boot.test.ts`, `import-orchestrator.test.ts`; the rail stub moved into `rail-session-harness.ts`). Covered: 300 sessions → 300 rail rows in `updated_at` order; unnamed session hidden; corrupt payload skipped and counted; `{}` payload hidden without a throw; `turns: [1, "two", {…}]` no longer raises `malformed JSON` (found in self-review, fixed with `t.type = 'object'`); throwing store at boot → one `runtime_info` line, boot continues.
- Live, in a PTY at 120×36 with a state dir seeded with 300 named sessions + one corrupt payload + one payload without `turns`: on `main` the rail says "(no sessions yet)"; on this branch it lists `seed prompt #299…` down to `#290…` with "↓ 290 more", and the menu's "Switch session…" reports 300 recents.
