### PR TITLE
feat(tui): reorder sessions in the rail — Shift+↑/↓ and mouse drag, order remembered

### DIFF
--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -1538,3 +1538,37 @@ describe("numeric coercion of string config values", () => {
     ).toThrow(/tokenBudget/);
   });
 });
+
+describe("tui.sessionRail (config v52)", () => {
+  it("gives a v51 file the recency default — an empty order", () => {
+    const parsed = parseUserConfigFile({ version: 51, tui: { theme: "nord" } });
+    expect(parsed.version).toBe(USER_CONFIG_VERSION);
+    expect(parsed.tui.sessionRail).toEqual({ order: [] });
+    expect(parsed.tui.theme).toBe("nord");
+  });
+
+  it("round-trips the operator's order", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      tui: { sessionRail: { order: ["s-b", "s-a", "s-c"] } },
+    });
+    expect(parsed.tui.sessionRail.order).toEqual(["s-b", "s-a", "s-c"]);
+  });
+
+  it("drops entries that are not ids and keeps the first of a duplicate", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      tui: { sessionRail: { order: ["s-b", 7, "", null, "s-a", "s-b"] } },
+    });
+    expect(parsed.tui.sessionRail.order).toEqual(["s-b", "s-a"]);
+  });
+
+  it("rejects an order that is not a list", () => {
+    expect(() =>
+      parseUserConfigFile({
+        version: USER_CONFIG_VERSION,
+        tui: { sessionRail: { order: "s-a" } },
+      }),
+    ).toThrow(/tui\.sessionRail\.order/);
+  });
+});

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -837,6 +837,7 @@ export interface AtomicAgentConfig {
     whileBusySubmit: WhileBusySubmitMode;
     mouse: boolean;
     onboarding: OnboardingState;
+    sessionRail: SessionRailConfig;
   };
   /**
    * Anonymous product analytics (PostHog). Mirrors
@@ -1698,12 +1699,17 @@ export interface UserConfigFile {
    * wheel scrolling. Turning it off restores the terminal's own
    * drag-to-select, which mouse reporting takes over — see `/mouse` and
    * `--no-mouse`. Older files are upgraded with `mouse: true`.
+   *
+   * `sessionRail` (config v52) remembers the operator's own ordering of
+   * the rail's Sessions list — see {@link SessionRailConfig}. Older
+   * files are upgraded with an empty order, which means "by recency".
    */
   tui: {
     theme: string;
     whileBusySubmit: WhileBusySubmitMode;
     mouse: boolean;
     onboarding: OnboardingState;
+    sessionRail: SessionRailConfig;
   };
   /**
    * Anonymous product analytics (PostHog). Added in config v33. Older
@@ -1845,7 +1851,11 @@ export interface UserConfigFile {
 // v51: new `discord` block for the Discord remote-control channel.
 // Additive and inert by default — the channel is off, unpaired, and the
 // bot token lives in `<stateDir>/.env`, never here.
-export const USER_CONFIG_VERSION = 51;
+// v52: new `tui.sessionRail` block holding the operator's manual order of
+// the rail's Sessions list (`order: string[]`, session ids). Additive: an
+// older file inherits `[]`, which keeps the list sorted by recency until
+// the operator moves a row for the first time.
+export const USER_CONFIG_VERSION = 52;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1985,6 +1995,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   48,
   49,
   50,
+  51,
   USER_CONFIG_VERSION,
 ];
 
@@ -2254,6 +2265,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
     theme: "auto",
     whileBusySubmit: "steer",
     mouse: true,
+    sessionRail: { order: [] },
     onboarding: {
       completedAt: null,
       importOfferedAt: null,
@@ -4260,6 +4272,7 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
       ),
       mouse: parseBool(tui.mouse ?? USER_CONFIG_DEFAULTS.tui.mouse, "tui.mouse"),
       onboarding: parseOnboardingState(tui.onboarding),
+      sessionRail: parseSessionRailConfig(tui.sessionRail),
     },
     analytics: {
       enabled: parseBool(
@@ -4371,6 +4384,20 @@ export function parseWhileBusySubmit(
  *   survives a launch: an interrupted first run is exactly the case
  *   where an operator would otherwise be shown it twice.
  */
+/**
+ * The rail's Sessions list order, as the operator arranged it.
+ *
+ * Empty means the list is sorted by recency, the way it always was. The
+ * first Shift+↑/↓ or row drag snapshots the list as displayed into
+ * `order`; from then on those ids keep this order and sessions the list
+ * has never seen (a newer thread, an id not in `order`) are inserted at
+ * the top. Ids that no longer exist are ignored on read and dropped on
+ * the next write.
+ */
+export interface SessionRailConfig {
+  order: string[];
+}
+
 export interface OnboardingState {
   completedAt: string | null;
   introSeenAt: string | null;
@@ -4386,6 +4413,41 @@ export interface OnboardingState {
  * throwing — an older config file must never fail to load because it
  * predates the block.
  */
+/**
+ * Parse `tui.sessionRail`. Absent → the recency default. The order is a
+ * list of session ids; entries that are not non-empty strings are
+ * dropped rather than rejected — a hand-edited or partially written id
+ * costs one row its remembered place, not the whole config file — and
+ * duplicates keep their first position so the on-disk form stays
+ * canonical.
+ */
+export function parseSessionRailConfig(raw: unknown): SessionRailConfig {
+  if (raw === undefined || raw === null) return { order: [] };
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ConfigValidationError(
+      "tui.sessionRail",
+      `expected object, got ${JSON.stringify(raw)}`,
+    );
+  }
+  const order = (raw as Record<string, unknown>).order;
+  if (order === undefined || order === null) return { order: [] };
+  if (!Array.isArray(order)) {
+    throw new ConfigValidationError(
+      "tui.sessionRail.order",
+      `expected string[], got ${JSON.stringify(order)}`,
+    );
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of order) {
+    if (typeof entry !== "string" || entry.length === 0) continue;
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    result.push(entry);
+  }
+  return { order: result };
+}
+
 export function parseOnboardingState(raw: unknown): OnboardingState {
   const defaults = USER_CONFIG_DEFAULTS.tui.onboarding;
   if (raw === undefined || raw === null) return { ...defaults };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,7 @@ export type {
   LocalLlmMode,
   LogLevel,
   OnboardingState,
+  SessionRailConfig,
   TelegramConfig,
   TelegramParseMode,
   UserConfigFile,
@@ -20,6 +21,7 @@ export {
   USER_CONFIG_DEFAULTS,
   USER_CONFIG_VERSION,
   parseOnboardingState,
+  parseSessionRailConfig,
   parseUserConfigFile,
   parseWhileBusySubmit,
 } from "./config-schema.js";

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -512,6 +512,7 @@ export function loadConfig(): AtomicAgentConfig {
       whileBusySubmit: user.tui.whileBusySubmit,
       mouse: user.tui.mouse,
       onboarding: { ...user.tui.onboarding },
+      sessionRail: { order: [...user.tui.sessionRail.order] },
     },
     analytics: {
       enabled: user.analytics.enabled,

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -27,6 +27,7 @@ import { reduceComposerSwitchAction } from "./composer-switch/composer-switch-re
 import { selectComposerBackend } from "./composer-switch/composer-switch-rows.js";
 import { reduceLocalModelsAction } from "./local-models/local-models-reducer.js";
 import { reduceTasksAction } from "./tasks/tasks-reducer.js";
+import { reduceSessionRailAction } from "./session-rail/session-rail-reducer.js";
 import { reduceSkillsAction } from "./skills/skills-reducer.js";
 import { reduceMemoryAction } from "./memory/memory-reducer.js";
 import { reduceMcpAction } from "./mcp/mcp-reducer.js";
@@ -57,6 +58,8 @@ export function reduceTuiState(state: TuiState, action: TuiAction): TuiState {
   if (localModelsHandled !== null) return localModelsHandled;
   const tasksHandled = reduceTasksAction(state, action);
   if (tasksHandled !== null) return tasksHandled;
+  const sessionRailHandled = reduceSessionRailAction(state, action);
+  if (sessionRailHandled !== null) return sessionRailHandled;
   const skillsHandled = reduceSkillsAction(state, action);
   if (skillsHandled !== null) return skillsHandled;
   const memoryHandled = reduceMemoryAction(state, action);

--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -19,6 +19,7 @@ import {
 import type { MenuNode } from "./menu/menu-registry.js";
 import { cycleNavSlot, type NavSlot } from "./section.js";
 import { selectSidebarTasks } from "./sidebar-tasks-selector.js";
+import { handleSessionMoveKey } from "./session-rail/index.js";
 import type { TuiAction } from "./tui-action.js";
 import type { TuiState } from "./tui-state.js";
 import { isUninstallConfirmed } from "./uninstall/uninstall-state.js";
@@ -70,6 +71,8 @@ export interface AppKeyCallbacks {
   onQuit(): void;
   /** Optional — called when Enter is pressed on the focused sidebar row. */
   onSessionSwitchRequested?(sessionId: string): void;
+  /** Shift+↑/↓ in the rail: put the selected session on slot `toIndex`. */
+  onSessionMoveRequested?(sessionId: string, toIndex: number): void;
   /**
    * Optional — called when Enter is pressed on a sidebar Tasks row.
    * The handler is expected to switch to the Tasks debug tab and open
@@ -684,6 +687,9 @@ function handleSidebarKey(
     dispatch({ type: "chat_focus_set", focus: "editor" });
     return true;
   }
+  // Shift+↑/↓ moves the selected session row; checked before the plain
+  // arrows because Ink reports the chord with `upArrow` set as well.
+  if (handleSessionMoveKey(key, ctx)) return true;
   if (key.upArrow) {
     if (state.sidebarSection === "tasks") {
       dispatch({ type: "sidebar_tasks_cursor_moved", delta: -1 });

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -46,6 +46,11 @@ import { FallbackOrchestrator } from "./llm-panel/fallback/fallback-orchestrator
 import { TuiTelegramOrchestrator } from "./telegram/tui-telegram-orchestrator.js";
 import { PrivacyOrchestrator } from "./privacy/privacy-orchestrator.js";
 import { IntegrationsOrchestrator } from "./integrations/integrations-orchestrator.js";
+import {
+  SessionRailOrchestrator,
+  configSessionRailOrderStore,
+  type SessionRailOrderStore,
+} from "./session-rail/index.js";
 import type { TuiEventBus } from "./tui-app.js";
 import { formatAgentErrorForChat } from "./format-agent-error-for-chat.js";
 import {
@@ -88,6 +93,12 @@ export interface ChatOrchestratorOptions {
    * `~/.atomic-agent` state.
    */
   readGateFacts?: () => LocalTurnGateFacts;
+  /**
+   * Where the rail's manual session order is read from and written to.
+   * Injectable for the same reason as `readGateFacts`; the default is
+   * `tui.sessionRail.order` in the user's config file.
+   */
+  sessionRailOrder?: SessionRailOrderStore;
 }
 
 /** Multiline text for the chat transcript (`/memory`); feed still gets `runtime_info` lines. */
@@ -197,6 +208,7 @@ export class ChatOrchestrator {
   public readonly telegram: TuiTelegramOrchestrator;
   public readonly privacy: PrivacyOrchestrator;
   public readonly integrations: IntegrationsOrchestrator;
+  private readonly sessionRail: SessionRailOrchestrator;
 
   constructor(
     private readonly runtime: AgentRuntime,
@@ -239,6 +251,10 @@ export class ChatOrchestrator {
     // The hub drives Telegram through its existing orchestrator rather
     // than reimplementing pairing / restart / enable.
     this.integrations = new IntegrationsOrchestrator(runtime, bus, this.telegram);
+    this.sessionRail = new SessionRailOrchestrator(
+      options.sessionRailOrder ?? configSessionRailOrderStore,
+      () => this.refreshRecentSessions(),
+    );
     // Tap the bus rather than the runtime handler: what the reducer was
     // offered is exactly what a switch-back may need to replay, session
     // tags included. `record` no-ops for sessions without a running
@@ -434,7 +450,7 @@ export class ChatOrchestrator {
       .filter((state) => hasFirstPrompt(state))
       .map((s) => toPickerEntry(s))
       .slice(0, RAIL_SESSION_LIMIT);
-    if (this.pendingRows.size === 0) return stored;
+    if (this.pendingRows.size === 0) return this.sessionRail.arrange(stored);
     const storedIds = new Set(stored.map((entry) => entry.sessionId));
     const pending: SessionPickerEntry[] = [];
     for (const [sessionId, entry] of this.pendingRows) {
@@ -448,7 +464,17 @@ export class ChatOrchestrator {
     }
     // Newest stand-in first, matching the store's recency order.
     pending.reverse();
-    return [...pending, ...stored];
+    // The manual order (if any) goes over the whole list: stand-ins are
+    // ids the order has never seen, so they stay on top.
+    return this.sessionRail.arrange([...pending, ...stored]);
+  }
+
+  /**
+   * Shift+↑/↓ or a row drag in the rail: put `sessionId` on slot
+   * `toIndex` of the list as displayed, remember the order, re-emit.
+   */
+  moveSession(sessionId: string, toIndex: number): void {
+    this.sessionRail.moveSession(sessionId, toIndex);
   }
 
   /**

--- a/src/tui/components/hotkey-chips.ts
+++ b/src/tui/components/hotkey-chips.ts
@@ -201,8 +201,9 @@ export function resolveChips(
   }
   if (state.chatFocus === "sidebar") {
     return [
-      { key: "↑↓", label: "select", shed: 2 },
+      { key: "↑↓", label: "select", shed: 3 },
       { key: "enter", label: "open" },
+      { key: "shift+↑↓", label: "move", shed: 2 },
       { key: "tab", label: "next pane", shed: 1 },
       { key: "esc", label: "back to editor" },
       {

--- a/src/tui/components/sidebar.test.tsx
+++ b/src/tui/components/sidebar.test.tsx
@@ -349,3 +349,40 @@ describe("Sidebar", () => {
     expect(strip(lastFrame() ?? "")).toContain("…");
   });
 });
+
+describe("Sidebar session drag feedback", () => {
+  it("paints ↕ on the row in hand and the chevron on the slot under the pointer", () => {
+    const { lastFrame } = render(
+      <Sidebar
+        width={30}
+        sessions={SESSIONS}
+        sessionsCursor={1}
+        sessionDrag={{ sessionId: "ghijkl5678", from: 1, over: 0 }}
+        currentSessionId={null}
+        tasks={[]}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={true}
+      />,
+    );
+    const text = strip(lastFrame() ?? "");
+    expect(text).toMatch(/↕ [^\n]*another conversa/);
+    expect(text).toMatch(/▸ [^\n]*first ever messa/);
+  });
+
+  it("paints no drag marks when nothing is dragged", () => {
+    const { lastFrame } = render(
+      <Sidebar
+        width={30}
+        sessions={SESSIONS}
+        sessionsCursor={1}
+        currentSessionId={null}
+        tasks={[]}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={true}
+      />,
+    );
+    expect(strip(lastFrame() ?? "")).not.toContain("↕");
+  });
+});

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -608,7 +608,7 @@ function SessionRow({
       <Text>{" ".repeat(ROW_MARGIN_COLUMNS)}</Text>
       <Box flexShrink={0} width={Math.max(0, groundWidth - CLOSE_COLUMNS)}>
         <Text
-          color={drag === "target" ? theme.colors.accent : theme.colors.railForeground}
+          color={drag === "target" ? theme.colors.railAccent : theme.colors.railForeground}
           bold={selected || current || drag !== null}
           underline={drag === "target"}
           wrap="truncate"

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -8,6 +8,7 @@ import {
 import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { MOUSE_LAYER_BASE } from "../mouse/mouse-registry.js";
 import { computeRowWindow } from "../row-window.js";
+import { SessionRailRow, type SidebarDragState } from "../session-rail/index.js";
 import type { TaskSummaryRow } from "../tasks/tasks-panel-state.js";
 import { theme } from "../theme/theme.js";
 import type { SessionPickerEntry } from "../tui-state.js";
@@ -21,6 +22,8 @@ export interface SidebarProps {
   width: number;
   sessions: readonly SessionPickerEntry[];
   sessionsCursor: number;
+  /** A session row mid-drag: paints `↕` on it and a marker on the slot it is over. */
+  sessionDrag?: SidebarDragState | null;
   currentSessionId: string | null;
   tasks: readonly TaskSummaryRow[];
   tasksCursor: number;
@@ -98,6 +101,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
     tasksCursor,
     activeSection,
     focused,
+    sessionDrag = null,
     sessionId = null,
     maxSessionRows = DEFAULT_MAX_SESSION_ROWS,
     maxTaskRows = DEFAULT_MAX_TASK_ROWS,
@@ -153,6 +157,7 @@ export function Sidebar(props: SidebarProps): ReactElement {
       <SessionsList
         sessions={sessions}
         cursor={sessionsCursor}
+        drag={sessionDrag}
         focused={sessionsActive}
         currentSessionId={currentSessionId}
         maxRows={maxSessionRows}
@@ -480,6 +485,7 @@ function runningCount(tasks: readonly TaskSummaryRow[]): number {
 interface SessionsListProps {
   sessions: readonly SessionPickerEntry[];
   cursor: number;
+  drag: SidebarDragState | null;
   focused: boolean;
   currentSessionId: string | null;
   maxRows: number;
@@ -490,6 +496,7 @@ interface SessionsListProps {
 function SessionsList({
   sessions,
   cursor,
+  drag,
   focused,
   currentSessionId,
   maxRows,
@@ -507,36 +514,45 @@ function SessionsList({
   const visible = sessions.slice(window.start, window.start + window.count);
   const visibleCursor =
     Math.max(0, Math.min(cursor, sessions.length - 1)) - window.start;
+  const dragRole = (entry: SessionPickerEntry, row: number): DragRole => {
+    if (!drag) return null;
+    if (entry.sessionId === drag.sessionId) return "source";
+    return row === drag.over ? "target" : null;
+  };
   return (
     <Box flexDirection="column">
       {visible.map((entry, idx) => (
-        <SidebarRow
+        <SessionRailRow
           key={entry.sessionId}
-          section="sessions"
+          sessionId={entry.sessionId}
           row={window.start + idx}
           selected={focused && idx === visibleCursor}
-          onActivate={(mouse) =>
-            mouse.callbacks.onSessionSwitchRequested?.(entry.sessionId)
-          }
+          windowStart={window.start}
+          windowEnd={window.start + window.count - 1}
         >
           <SessionRow
             entry={entry}
             selected={focused && idx === visibleCursor}
             current={entry.sessionId === currentSessionId}
+            drag={dragRole(entry, window.start + idx)}
             previewWidth={previewWidth}
             inner={inner}
           />
-        </SidebarRow>
+        </SessionRailRow>
       ))}
       <MoreRow hidden={window.hiddenAfter} inner={inner} />
     </Box>
   );
 }
 
+/** The row being dragged, the slot it hovers, or neither. */
+type DragRole = "source" | "target" | null;
+
 interface SessionRowProps {
   entry: SessionPickerEntry;
   selected: boolean;
   current: boolean;
+  drag: DragRole;
   previewWidth: number;
   inner: number;
 }
@@ -545,6 +561,7 @@ function SessionRow({
   entry,
   selected,
   current,
+  drag,
   previewWidth,
   inner,
 }: SessionRowProps): ReactElement {
@@ -552,7 +569,17 @@ function SessionRow({
   // the dot is "this is the thread you are in". The ground answers the
   // first one too, but only in colour — and a colour is nothing under
   // NO_COLOR or in a pipe, so the glyph stays.
-  const chevron = selected ? theme.glyphs.chevronRight : " ";
+  //
+  // A drag borrows the chevron cell: `↕` on the row in hand, and the
+  // chevron in the accent colour on the slot it would drop into — the
+  // 90s list-widget feedback, in glyph and colour only, so no row is
+  // added or resized while the pointer is held.
+  const chevron =
+    drag === "source"
+      ? DRAG_HANDLE
+      : drag === "target" || selected
+        ? theme.glyphs.chevronRight
+        : " ";
   const marker = current ? theme.glyphs.assistantMarker : " ";
   // The ground runs almost the full width of the rail with one column of
   // air either side, so a selected row reads as a row in a list rather
@@ -581,10 +608,11 @@ function SessionRow({
       <Text>{" ".repeat(ROW_MARGIN_COLUMNS)}</Text>
       <Box flexShrink={0} width={Math.max(0, groundWidth - CLOSE_COLUMNS)}>
         <Text
-          color={theme.colors.railForeground}
-          bold={selected || current}
+          color={drag === "target" ? theme.colors.accent : theme.colors.railForeground}
+          bold={selected || current || drag !== null}
+          underline={drag === "target"}
           wrap="truncate"
-          {...(selected ? { inverse: true } : {})}
+          {...(selected || drag === "source" ? { inverse: true } : {})}
         >
           {ground}
         </Text>
@@ -601,6 +629,8 @@ function SessionRow({
 
 /** Air either side of a rail list row's ground. */
 const ROW_MARGIN_COLUMNS = 1;
+/** Painted in the chevron cell of the row being dragged. */
+const DRAG_HANDLE = "↕";
 /** Cells the close affordance occupies inside the ground: `[x]` + a pad. */
 const CLOSE_COLUMNS = 4;
 

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -151,6 +151,10 @@ function mountApp(): {
   seedSessions: () => void;
   /** Session ids the app asked the host to delete. */
   deleted: string[];
+  /** Session ids the app asked the host to switch to. */
+  switched: string[];
+  /** `[sessionId, toIndex]` pairs the app asked the host to reorder. */
+  moves: Array<[string, number]>;
   /** Clicks the Tasks header's `+ new` chip delivered to the host. */
   taskNews: number[];
   /** Provider ids `/model` asked the orchestrator to ensure a catalog for. */
@@ -160,6 +164,8 @@ function mountApp(): {
   const bus = makeTuiEventBus();
   const mouse = makeMouseSource();
   const deleted: string[] = [];
+  const switched: string[] = [];
+  const moves: Array<[string, number]> = [];
   const copied: string[] = [];
   const taskNews: number[] = [];
   const modelEnsures: Array<string | null> = [];
@@ -177,6 +183,9 @@ function mountApp(): {
       callbacks={{
         ...noopCallbacks(),
         onSessionDeleteConfirmed: (sessionId) => deleted.push(sessionId),
+        onSessionSwitchRequested: (sessionId) => switched.push(sessionId),
+        onSessionMoveRequested: (sessionId, toIndex) =>
+          moves.push([sessionId, toIndex]),
         onTaskNewRequested: () => taskNews.push(taskNews.length),
         onProvidersInlineModelsEnsureRequested: (providerId) =>
           modelEnsures.push(providerId),
@@ -190,6 +199,8 @@ function mountApp(): {
     mouse,
     stdin,
     deleted,
+    switched,
+    moves,
     taskNews,
     modelEnsures,
     copied,
@@ -634,6 +645,90 @@ describe("TuiApp mouse", () => {
     // The quit chord must not have been armed by that Ctrl+C.
     expect(app.frame()).not.toContain("press again to quit");
     app.unmount();
+  });
+
+  /**
+   * The rail's session rows: click-to-select, click-again-to-open, and
+   * the drag that reorders them. All three ride one press, so the
+   * gesture is arbitrated on release — pinned here end to end.
+   */
+  describe("session rows", () => {
+    const rowLine = (app: ReturnType<typeof mountApp>, needle: string): string =>
+      app
+        .frame()
+        .split("\n")
+        .find((line) => line.includes(needle)) ?? "";
+
+    const seedRail = async (app: ReturnType<typeof mountApp>): Promise<void> => {
+      await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
+      app.seedSessions();
+      // The rail truncates previews to its width, so rows are found by a prefix.
+      await waitUntil(() => app.frame().includes("first th"), "the rail rows");
+      await delay(150);
+    };
+
+    /** Press+release on the row until it is the selected one. */
+    const clickRowUntilSelected = async (
+      app: ReturnType<typeof mountApp>,
+      needle: string,
+    ): Promise<void> => {
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        const at = locate(app.frame(), needle);
+        app.mouse.emit(click(at.x + 2, at.y));
+        await delay(30);
+        app.mouse.emit(release(at.x + 2, at.y));
+        await delay(50);
+        if (rowLine(app, needle).includes("[x]")) return;
+      }
+      throw new Error(`the ${needle} row never became selected`);
+    };
+
+    it("drags a row above another and asks the host to move it there", async () => {
+      const app = mountApp();
+      await seedRail(app);
+      // Press on the second row and hold; retry until the press has
+      // landed on a registered target (it selects the row).
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        const at = locate(app.frame(), "second th");
+        app.mouse.emit(click(at.x + 2, at.y));
+        await delay(50);
+        if (rowLine(app, "second th").includes("[x]")) break;
+        app.mouse.emit(release(at.x + 2, at.y));
+        await delay(30);
+      }
+      expect(rowLine(app, "second th")).toContain("[x]");
+      const target = locate(app.frame(), "first th");
+      app.mouse.emit(drag(target.x + 2, target.y));
+      await waitUntil(
+        () => rowLine(app, "second th").includes("↕"),
+        "the drag handle on the row in hand",
+      );
+      expect(rowLine(app, "first th")).toContain("▸");
+      app.mouse.emit(release(target.x + 2, target.y));
+      await waitUntil(() => app.moves.length > 0, "the move request");
+      expect(app.moves).toEqual([["s-2", 0]]);
+      // Dropping is not opening.
+      expect(app.switched).toEqual([]);
+      await waitUntil(() => !app.frame().includes("↕"), "the drag feedback to clear");
+      app.unmount();
+    });
+
+    it("opens a row on the second click, and only then", async () => {
+      const app = mountApp();
+      await seedRail(app);
+      await clickRowUntilSelected(app, "first th");
+      // The click that selected the row must not have opened it.
+      expect(app.switched).toEqual([]);
+      const at = locate(app.frame(), "first th");
+      app.mouse.emit(click(at.x + 2, at.y));
+      await delay(30);
+      app.mouse.emit(release(at.x + 2, at.y));
+      await waitUntil(() => app.switched.length > 0, "the switch request");
+      await delay(100);
+      expect(app.switched).toEqual(["s-1"]);
+      expect(app.moves).toEqual([]);
+      app.unmount();
+    });
   });
 
   it("moves a panel cursor with the wheel", async () => {

--- a/src/tui/rail-session-list.test.ts
+++ b/src/tui/rail-session-list.test.ts
@@ -249,6 +249,24 @@ describe("rail session list — manual order", () => {
     expect(rail().map((e) => e.sessionId)).toEqual(["s-1", "s-3", "s-2"]);
   });
 
+  it("gives an imported thread the slot its own date earns", () => {
+    // The operator arranged the rail this year; an import has just
+    // written a transcript from four years ago. It belongs beside the
+    // old rows, not above the ones the operator arranged.
+    const now = Date.now();
+    const stored = [
+      { ...spokenTo("s-2", "second"), updatedAt: now - 1_000 },
+      { ...spokenTo("s-1", "first"), updatedAt: now - 2_000 },
+      {
+        ...spokenTo("s-imported", "a transcript from four years ago"),
+        updatedAt: now - 4 * 365 * 24 * 3_600_000,
+      },
+    ];
+    const { orchestrator, rail } = harness(stored, false, ["s-2", "s-1"]);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-2", "s-1", "s-imported"]);
+  });
+
   it("puts threads the order has never seen on top", () => {
     const stored = [
       spokenTo("s-new", "started after the arranging"),

--- a/src/tui/rail-session-list.test.ts
+++ b/src/tui/rail-session-list.test.ts
@@ -78,13 +78,27 @@ function stubRuntime(
   } as unknown as AgentRuntime;
 }
 
-function harness(stored: ReturnType<typeof blank>[], settleTurns = false) {
+function harness(
+  stored: ReturnType<typeof blank>[],
+  settleTurns = false,
+  order: string[] = [],
+) {
   const bus = makeTuiEventBus();
   const actions: TuiAction[] = [];
   bus.subscribe((a) => actions.push(a));
+  // The rail's manual order, held in memory instead of the developer's
+  // config.json; `written` is every snapshot the orchestrator persisted.
+  const written: string[][] = [];
   const orchestrator = new ChatOrchestrator(stubRuntime(stored, settleTurns), bus, {
     maxSteps: 5,
     llamaUrl: "http://127.0.0.1:8080", readGateFacts: cloudGateFacts,
+    sessionRailOrder: {
+      read: () => order,
+      write: (next) => {
+        order = [...next];
+        written.push([...next]);
+      },
+    },
   });
   const rail = (): readonly SessionPickerEntry[] => {
     for (let i = actions.length - 1; i >= 0; i -= 1) {
@@ -100,7 +114,7 @@ function harness(stored: ReturnType<typeof blank>[], settleTurns = false) {
     }
     return [];
   };
-  return { orchestrator, rail, picker, actions };
+  return { orchestrator, rail, picker, actions, written };
 }
 
 describe("rail session list", () => {
@@ -220,5 +234,67 @@ describe("rail session list — steering", () => {
     orchestrator.newSession();
     orchestrator.steerMessage("opening line");
     expect(rail()[0]?.preview).toBe("opening line");
+  });
+});
+
+describe("rail session list — manual order", () => {
+  it("follows tui.sessionRail.order once the operator has arranged the rail", () => {
+    const stored = [
+      spokenTo("s-3", "third"),
+      spokenTo("s-2", "second"),
+      spokenTo("s-1", "first"),
+    ];
+    const { orchestrator, rail } = harness(stored, false, ["s-1", "s-3", "s-2"]);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-1", "s-3", "s-2"]);
+  });
+
+  it("puts threads the order has never seen on top", () => {
+    const stored = [
+      spokenTo("s-new", "started after the arranging"),
+      spokenTo("s-2", "second"),
+      spokenTo("s-1", "first"),
+    ];
+    const { orchestrator, rail } = harness(stored, false, ["s-1", "s-2"]);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-new", "s-1", "s-2"]);
+  });
+
+  it("keeps the first-prompt stand-in on top of an arranged list", () => {
+    const stored = [spokenTo("s-2", "second"), spokenTo("s-1", "first")];
+    const { orchestrator, rail } = harness(stored, false, ["s-1", "s-2"]);
+    orchestrator.newSession();
+    orchestrator.sendMessage("brand new thread");
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-new-1", "s-1", "s-2"]);
+  });
+
+  it("moveSession snapshots the displayed list with the row on its new slot, then re-emits", () => {
+    const stored = [
+      spokenTo("s-3", "third"),
+      spokenTo("s-2", "second"),
+      spokenTo("s-1", "first"),
+    ];
+    const { orchestrator, rail, written } = harness(stored);
+    orchestrator.refreshRecentSessions();
+    // Recency until touched: nothing has been written yet.
+    expect(written).toEqual([]);
+    orchestrator.moveSession("s-1", 0);
+    expect(written).toEqual([["s-1", "s-3", "s-2"]]);
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-1", "s-3", "s-2"]);
+    orchestrator.moveSession("s-3", 2);
+    expect(written.at(-1)).toEqual(["s-1", "s-2", "s-3"]);
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-1", "s-2", "s-3"]);
+  });
+
+  it("writes nothing for a move that changes nothing or names no row", () => {
+    const stored = [spokenTo("s-2", "second"), spokenTo("s-1", "first")];
+    const { orchestrator, written, actions } = harness(stored);
+    orchestrator.refreshRecentSessions();
+    const emitted = actions.length;
+    orchestrator.moveSession("s-2", 0);
+    orchestrator.moveSession("s-2", -4);
+    orchestrator.moveSession("s-ghost", 1);
+    expect(written).toEqual([]);
+    expect(actions.length).toBe(emitted);
   });
 });

--- a/src/tui/reduce-sidebar-actions.test.ts
+++ b/src/tui/reduce-sidebar-actions.test.ts
@@ -232,3 +232,80 @@ describe("reduce sidebar + chat scroll actions", () => {
     expect(tooFarUp.sidebarTasksCursor).toBe(0);
   });
 });
+
+describe("reduce sidebar drag actions", () => {
+  const seeded = () =>
+    reduceTuiState(
+      { ...createInitialTuiState(SESSION), chatFocus: "sidebar" as const },
+      {
+        type: "recent_sessions_updated",
+        sessions: [
+          entry({ sessionId: "a" }),
+          entry({ sessionId: "b" }),
+          entry({ sessionId: "c" }),
+        ],
+      },
+    );
+
+  it("starts with the pressed row as both origin and slot", () => {
+    const next = reduceTuiState(seeded(), {
+      type: "sidebar_drag_started",
+      sessionId: "b",
+      row: 1,
+    });
+    expect(next.sidebarDrag).toEqual({ sessionId: "b", from: 1, over: 1 });
+    // The list itself is untouched until the host re-emits it.
+    expect(next.recentSessions.map((e) => e.sessionId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("moves the slot under the pointer, clamped to the list", () => {
+    const started = reduceTuiState(seeded(), {
+      type: "sidebar_drag_started",
+      sessionId: "b",
+      row: 1,
+    });
+    const over = reduceTuiState(started, { type: "sidebar_drag_moved", row: 0 });
+    expect(over.sidebarDrag).toEqual({ sessionId: "b", from: 1, over: 0 });
+    const past = reduceTuiState(over, { type: "sidebar_drag_moved", row: 9 });
+    expect(past.sidebarDrag?.over).toBe(2);
+    // Same slot again: the same state object, so nothing repaints.
+    expect(reduceTuiState(past, { type: "sidebar_drag_moved", row: 9 })).toBe(past);
+  });
+
+  it("ignores a move with no drag in flight", () => {
+    const state = seeded();
+    expect(reduceTuiState(state, { type: "sidebar_drag_moved", row: 0 })).toBe(state);
+  });
+
+  it("ends on release", () => {
+    const started = reduceTuiState(seeded(), {
+      type: "sidebar_drag_started",
+      sessionId: "b",
+      row: 1,
+    });
+    expect(reduceTuiState(started, { type: "sidebar_drag_ended" }).sidebarDrag).toBeNull();
+  });
+
+  it("is cleared by a list refresh and by focus leaving the rail", () => {
+    const started = reduceTuiState(seeded(), {
+      type: "sidebar_drag_started",
+      sessionId: "b",
+      row: 1,
+    });
+    const refreshed = reduceTuiState(started, {
+      type: "recent_sessions_updated",
+      sessions: [entry({ sessionId: "b" }), entry({ sessionId: "a" })],
+    });
+    expect(refreshed.sidebarDrag).toBeNull();
+    const unfocused = reduceTuiState(started, {
+      type: "chat_focus_set",
+      focus: "editor",
+    });
+    expect(unfocused.sidebarDrag).toBeNull();
+    const stillFocused = reduceTuiState(started, {
+      type: "chat_focus_set",
+      focus: "sidebar",
+    });
+    expect(stillFocused.sidebarDrag).not.toBeNull();
+  });
+});

--- a/src/tui/reduce-ui-actions.ts
+++ b/src/tui/reduce-ui-actions.ts
@@ -290,10 +290,13 @@ export function reduceUiAction(
       };
     case "recent_sessions_updated": {
       const max = Math.max(0, action.sessions.length - 1);
+      // A refreshed list is a different list: the row a drag started
+      // on may have moved or gone, so the drag feedback ends with it.
       return {
         ...state,
         recentSessions: action.sessions,
         sidebarCursor: Math.min(state.sidebarCursor, max),
+        sidebarDrag: null,
       };
     }
     case "chat_focus_toggled":
@@ -302,7 +305,11 @@ export function reduceUiAction(
         chatFocus: state.chatFocus === "editor" ? "sidebar" : "editor",
       };
     case "chat_focus_set":
-      return { ...state, chatFocus: action.focus };
+      return {
+        ...state,
+        chatFocus: action.focus,
+        sidebarDrag: action.focus === "sidebar" ? state.sidebarDrag : null,
+      };
     case "sidebar_collapse_toggled": {
       const collapsed = !state.sidebarCollapsed;
       // Folding the rail away takes its focus stop with it, so the
@@ -420,6 +427,7 @@ export function reduceUiAction(
         chatFocus: "editor",
         sidebarSection: "sessions",
         sidebarCursor: 0,
+        sidebarDrag: null,
         sidebarTasksCursor: 0,
         queuedMessages: [],
       };

--- a/src/tui/session-rail/handle-session-move-key.test.ts
+++ b/src/tui/session-rail/handle-session-move-key.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Key } from "ink";
+
+import { handleAppKey } from "../app-key-bindings.js";
+import {
+  createInitialTuiState,
+  type SessionPickerEntry,
+  type TuiSessionInfo,
+  type TuiState,
+} from "../tui-state.js";
+
+function key(overrides: Partial<Key> = {}): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageDown: false,
+    pageUp: false,
+    home: false,
+    end: false,
+    return: false,
+    escape: false,
+    ctrl: false,
+    shift: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    meta: false,
+    super: false,
+    hyper: false,
+    capsLock: false,
+    numLock: false,
+    ...overrides,
+  } as Key;
+}
+
+function session(): TuiSessionInfo {
+  return {
+    sessionId: "s-1",
+    workingDir: "/tmp/w",
+    llamaUrl: "http://127.0.0.1:8080",
+    browserChannel: "chromium",
+    browserHeadless: true,
+    approvalLevel: 5,
+    maxSteps: 8,
+    skillCount: 0,
+  };
+}
+
+function entry(sessionId: string): SessionPickerEntry {
+  return {
+    sessionId,
+    workingDir: "/tmp/w",
+    turnCount: 1,
+    stepCount: 1,
+    updatedAt: 0,
+    preview: sessionId,
+  };
+}
+
+/** Rail focused on Sessions with three rows and the cursor on `cursor`. */
+function railState(cursor: number, section: "sessions" | "tasks" = "sessions"): TuiState {
+  return {
+    ...createInitialTuiState(session()),
+    chatFocus: "sidebar",
+    sidebarSection: section,
+    sidebarCursor: cursor,
+    recentSessions: [entry("s-1"), entry("s-2"), entry("s-3")],
+  };
+}
+
+function ctx(state: TuiState) {
+  return {
+    state,
+    dispatch: vi.fn(),
+    callbacks: {
+      onApprovalDecision: vi.fn(),
+      onAbort: vi.fn(),
+      onQuit: vi.fn(),
+      onSessionMoveRequested: vi.fn(),
+      onSessionSwitchRequested: vi.fn(),
+    },
+    ctrlCArmed: false,
+    setCtrlCArmed: vi.fn(),
+    sidebarVisible: true,
+  };
+}
+
+describe("rail session move keys", () => {
+  it("Shift+↑ moves the selected row up and takes the cursor with it", () => {
+    const c = ctx(railState(1));
+    expect(handleAppKey("", key({ upArrow: true, shift: true }), c)).toBe(true);
+    expect(c.callbacks.onSessionMoveRequested).toHaveBeenCalledWith("s-2", 0);
+    expect(c.dispatch).toHaveBeenCalledWith({ type: "sidebar_cursor_set", row: 0 });
+    // Not a plain cursor move: the chord must not ALSO walk the list.
+    expect(c.dispatch).not.toHaveBeenCalledWith({
+      type: "sidebar_cursor_moved",
+      delta: -1,
+    });
+  });
+
+  it("Shift+↓ moves the selected row down", () => {
+    const c = ctx(railState(1));
+    expect(handleAppKey("", key({ downArrow: true, shift: true }), c)).toBe(true);
+    expect(c.callbacks.onSessionMoveRequested).toHaveBeenCalledWith("s-2", 2);
+    expect(c.dispatch).toHaveBeenCalledWith({ type: "sidebar_cursor_set", row: 2 });
+  });
+
+  it("accepts Meta+↑/↓ as the same chord", () => {
+    const c = ctx(railState(2));
+    expect(handleAppKey("", key({ upArrow: true, meta: true }), c)).toBe(true);
+    expect(c.callbacks.onSessionMoveRequested).toHaveBeenCalledWith("s-3", 1);
+  });
+
+  it("does nothing on the top row for Shift+↑, and on the last for Shift+↓", () => {
+    const top = ctx(railState(0));
+    expect(handleAppKey("", key({ upArrow: true, shift: true }), top)).toBe(true);
+    expect(top.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
+    expect(top.dispatch).not.toHaveBeenCalled();
+    const bottom = ctx(railState(2));
+    expect(handleAppKey("", key({ downArrow: true, shift: true }), bottom)).toBe(true);
+    expect(bottom.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
+    expect(bottom.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("leaves a plain ↑ alone", () => {
+    const c = ctx(railState(1));
+    expect(handleAppKey("", key({ upArrow: true }), c)).toBe(true);
+    expect(c.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
+    expect(c.dispatch).toHaveBeenCalledWith({ type: "sidebar_cursor_moved", delta: -1 });
+  });
+
+  it("is not a move on the Tasks pane", () => {
+    const c = ctx(railState(1, "tasks"));
+    handleAppKey("", key({ upArrow: true, shift: true }), c);
+    expect(c.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
+  });
+
+  it("still swallows letters while the rail has focus", () => {
+    const c = ctx(railState(1));
+    expect(handleAppKey("q", key(), c)).toBe(true);
+    expect(c.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
+    expect(c.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/tui/session-rail/handle-session-move-key.ts
+++ b/src/tui/session-rail/handle-session-move-key.ts
@@ -1,0 +1,49 @@
+import type { Key } from "ink";
+
+import type { TuiAction } from "../tui-action.js";
+import type { TuiState } from "../tui-state.js";
+
+export interface SessionMoveKeyContext {
+  state: TuiState;
+  dispatch: (action: TuiAction) => void;
+  callbacks: {
+    onSessionMoveRequested?: (sessionId: string, toIndex: number) => void;
+  };
+}
+
+/**
+ * Shift+↑ / Shift+↓ with the rail's Sessions pane focused: move the
+ * selected row one slot and keep the cursor on it. Meta+↑/↓ is accepted
+ * as an alias for terminals that hand Shift+arrow to their own scroll
+ * or selection.
+ *
+ * Returns `true` when the chord was consumed, `false` when it was not
+ * a move chord at all — a plain arrow, or a chord on the Tasks pane —
+ * so the caller's own ↑/↓ handling runs instead. A move that would
+ * leave the list (Shift+↑ on the top row) is consumed and does nothing:
+ * the operator was clearly talking to the rail, and letting the chord
+ * fall through to a cursor move would be a surprise.
+ *
+ * Ink reports the chord as `upArrow: true, shift: true` — `\x1b[1;2A`
+ * carries the xterm modifier 2, which `parse-keypress` maps to `shift`.
+ */
+export function handleSessionMoveKey(
+  key: Key,
+  ctx: SessionMoveKeyContext,
+): boolean {
+  if (!key.upArrow && !key.downArrow) return false;
+  if (!key.shift && !key.meta) return false;
+  if (key.ctrl) return false;
+  const { state } = ctx;
+  if (state.sidebarSection !== "sessions") return false;
+  const from = state.sidebarCursor;
+  const entry = state.recentSessions[from];
+  if (!entry) return true;
+  const to = from + (key.upArrow ? -1 : 1);
+  if (to < 0 || to >= state.recentSessions.length) return true;
+  ctx.callbacks.onSessionMoveRequested?.(entry.sessionId, to);
+  // After the callback: the orchestrator's refresh re-emits the list,
+  // and the cursor must end on the moved row, not on where it was.
+  ctx.dispatch({ type: "sidebar_cursor_set", row: to });
+  return true;
+}

--- a/src/tui/session-rail/index.ts
+++ b/src/tui/session-rail/index.ts
@@ -1,0 +1,22 @@
+export type { SessionRailAction, SidebarDragState } from "./session-rail-actions.js";
+export { reduceSessionRailAction } from "./session-rail-reducer.js";
+export {
+  applySessionRailOrder,
+  computeMovedOrder,
+  moveSessionInOrder,
+  pruneSessionRailOrder,
+} from "./session-rail-order.js";
+export {
+  persistSessionRailOrder,
+  readSessionRailOrder,
+} from "./persist-session-rail.js";
+export {
+  SessionRailOrchestrator,
+  configSessionRailOrderStore,
+  type SessionRailOrderStore,
+} from "./session-rail-orchestrator.js";
+export {
+  handleSessionMoveKey,
+  type SessionMoveKeyContext,
+} from "./handle-session-move-key.js";
+export { SessionRailRow, type SessionRailRowProps } from "./session-rail-row.js";

--- a/src/tui/session-rail/index.ts
+++ b/src/tui/session-rail/index.ts
@@ -5,6 +5,7 @@ export {
   computeMovedOrder,
   moveSessionInOrder,
   pruneSessionRailOrder,
+  type RailRow,
 } from "./session-rail-order.js";
 export {
   persistSessionRailOrder,

--- a/src/tui/session-rail/persist-session-rail.test.ts
+++ b/src/tui/session-rail/persist-session-rail.test.ts
@@ -1,0 +1,48 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getConfig, resetConfigCache } from "../../config/index.js";
+import {
+  persistSessionRailOrder,
+  readSessionRailOrder,
+} from "./persist-session-rail.js";
+
+const STATE_DIR_ENV = "ATOMIC_AGENT_STATE_DIR";
+
+describe("persistSessionRailOrder", () => {
+  let stateDir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "session-rail-persist-"));
+    mkdirSync(stateDir, { recursive: true });
+    originalEnv = process.env[STATE_DIR_ENV];
+    process.env[STATE_DIR_ENV] = stateDir;
+    resetConfigCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[STATE_DIR_ENV];
+    else process.env[STATE_DIR_ENV] = originalEnv;
+    resetConfigCache();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("writes the order to config.json and getConfig() picks it up", () => {
+    expect(readSessionRailOrder()).toEqual([]);
+    persistSessionRailOrder(["s-b", "s-a"]);
+    const onDisk = JSON.parse(readFileSync(getConfig().paths.userConfigFile, "utf8"));
+    expect(onDisk.tui.sessionRail.order).toEqual(["s-b", "s-a"]);
+    expect(readSessionRailOrder()).toEqual(["s-b", "s-a"]);
+  });
+
+  it("replaces the previous order and leaves the rest of tui alone", () => {
+    persistSessionRailOrder(["s-a"]);
+    persistSessionRailOrder(["s-b", "s-a"]);
+    expect(getConfig().tui.sessionRail.order).toEqual(["s-b", "s-a"]);
+    expect(getConfig().tui.theme).toBe("auto");
+    expect(getConfig().tui.mouse).toBe(true);
+  });
+});

--- a/src/tui/session-rail/persist-session-rail.ts
+++ b/src/tui/session-rail/persist-session-rail.ts
@@ -1,0 +1,30 @@
+import {
+  ensureUserConfigFileSync,
+  getConfig,
+  parseUserConfigFile,
+  resetConfigCache,
+  writeUserConfigFileSync,
+} from "../../config/index.js";
+
+/**
+ * Persist the rail's manual session order into `tui.sessionRail.order`,
+ * then invalidate the config cache so the next `getConfig()` sees it.
+ * Same read → merge → validate → write → reset shape as the other
+ * `persist-*` helpers. Only the orchestrator calls this, from the
+ * move callback — never the reducer or a render path.
+ */
+export function persistSessionRailOrder(order: readonly string[]): void {
+  const path = getConfig().paths.userConfigFile;
+  const prev = ensureUserConfigFileSync(path);
+  const draft = {
+    ...prev,
+    tui: { ...prev.tui, sessionRail: { order: [...order] } },
+  };
+  writeUserConfigFileSync(path, parseUserConfigFile(draft));
+  resetConfigCache();
+}
+
+/** The persisted order, `[]` while the operator has never arranged the rail. */
+export function readSessionRailOrder(): readonly string[] {
+  return getConfig().tui.sessionRail.order;
+}

--- a/src/tui/session-rail/session-rail-actions.ts
+++ b/src/tui/session-rail/session-rail-actions.ts
@@ -1,0 +1,26 @@
+/**
+ * Reducer actions for the rail's row-drag feedback. The mouse layer
+ * emits them while a session row is being dragged; the reducer folds
+ * them into `state.sidebarDrag` so `SessionRow` can paint the dragged
+ * row and the slot it is over. The actual reorder is NOT an action —
+ * it goes through `onSessionMoveRequested` to the orchestrator, which
+ * persists the order and re-emits the list.
+ */
+export type SessionRailAction =
+  /** The pointer left the row it pressed on: the drag is now real. */
+  | { type: "sidebar_drag_started"; sessionId: string; row: number }
+  /** The pointer is over another row (absolute index into the list). */
+  | { type: "sidebar_drag_moved"; row: number }
+  /** Button up, or the gesture was abandoned. */
+  | { type: "sidebar_drag_ended" };
+
+/**
+ * A row drag in flight. `from` is where the row sat when the drag began,
+ * `over` the slot under the pointer right now — both absolute indices
+ * into `recentSessions`, not into the rendered window.
+ */
+export interface SidebarDragState {
+  sessionId: string;
+  from: number;
+  over: number;
+}

--- a/src/tui/session-rail/session-rail-orchestrator.ts
+++ b/src/tui/session-rail/session-rail-orchestrator.ts
@@ -1,0 +1,59 @@
+import type { SessionPickerEntry } from "../tui-state.js";
+import {
+  persistSessionRailOrder,
+  readSessionRailOrder,
+} from "./persist-session-rail.js";
+import {
+  applySessionRailOrder,
+  computeMovedOrder,
+} from "./session-rail-order.js";
+
+/**
+ * Where the manual order lives. Injectable so orchestrator tests stay
+ * hermetic — the default reads and writes the user's `config.json`.
+ */
+export interface SessionRailOrderStore {
+  read(): readonly string[];
+  write(order: readonly string[]): void;
+}
+
+export const configSessionRailOrderStore: SessionRailOrderStore = {
+  read: readSessionRailOrder,
+  write: persistSessionRailOrder,
+};
+
+/**
+ * The rail's order, owned by the chat orchestrator.
+ *
+ * `arrange` is the one hook in `railSessions()`: it applies the stored
+ * order and remembers what was emitted, so a later `moveSession` can
+ * compute the new order against exactly the list the operator saw —
+ * the row indices the keyboard and the mouse hand over are indices
+ * into THAT list, pending stand-ins included. The first move persists
+ * the whole displayed list, which is the "snapshot on first touch"
+ * that turns a recency-sorted rail into a manual one.
+ */
+export class SessionRailOrchestrator {
+  private lastRail: readonly SessionPickerEntry[] = [];
+
+  constructor(
+    private readonly store: SessionRailOrderStore,
+    private readonly refresh: () => void,
+  ) {}
+
+  /** Apply the remembered order to the list about to be emitted. */
+  arrange(entries: readonly SessionPickerEntry[]): SessionPickerEntry[] {
+    const arranged = applySessionRailOrder(entries, this.store.read());
+    this.lastRail = arranged;
+    return arranged;
+  }
+
+  /** Drop `sessionId` on slot `toIndex` of the displayed list, persist, re-emit. */
+  moveSession(sessionId: string, toIndex: number): void {
+    const displayed = this.lastRail.map((entry) => entry.sessionId);
+    const next = computeMovedOrder(displayed, sessionId, toIndex);
+    if (!next) return;
+    this.store.write(next);
+    this.refresh();
+  }
+}

--- a/src/tui/session-rail/session-rail-order.test.ts
+++ b/src/tui/session-rail/session-rail-order.test.ts
@@ -7,7 +7,16 @@ import {
   pruneSessionRailOrder,
 } from "./session-rail-order.js";
 
-const row = (sessionId: string) => ({ sessionId });
+/**
+ * A rail row. `updatedAt` defaults to a descending stamp derived from
+ * the id's trailing digit, so `row("s-3")` is newer than `row("s-1")`
+ * and the fixtures below read the way the store hands them over: newest
+ * first. Pass a stamp explicitly where the date is the point.
+ */
+const row = (sessionId: string, updatedAt?: number) => ({
+  sessionId,
+  updatedAt: updatedAt ?? Number(sessionId.replace(/\D/g, "") || 0) * 1000,
+});
 const ids = (rows: readonly { sessionId: string }[]) => rows.map((r) => r.sessionId);
 
 describe("applySessionRailOrder", () => {
@@ -22,12 +31,49 @@ describe("applySessionRailOrder", () => {
     expect(ids(arranged)).toEqual(["s-1", "s-3", "s-2"]);
   });
 
-  it("puts sessions the order has never seen on top, newest first", () => {
-    // s-5 and s-4 were started after the operator arranged the list;
-    // the store lists them first because they are the most recent.
+  it("puts sessions the order has never seen where their date earns it", () => {
+    // s-5 and s-4 were started after the operator arranged the list, so
+    // they are newer than every arranged row and land on top of it.
     const entries = [row("s-5"), row("s-1"), row("s-4"), row("s-2"), row("s-3")];
     const arranged = applySessionRailOrder(entries, ["s-1", "s-3", "s-2"]);
     expect(ids(arranged)).toEqual(["s-5", "s-4", "s-1", "s-3", "s-2"]);
+  });
+
+  it("drops an old import in among the rows of its own age, not on top", () => {
+    // The arranged rail holds this year's work; the import has just
+    // written a transcript from four years ago. It belongs at the
+    // bottom, beside the other old rows — not above today's thread.
+    const arrangedRows = [
+      row("s-now", 4_000),
+      row("s-mid", 3_000),
+      row("s-old", 1_000),
+    ];
+    const imported = row("s-import", 2_000);
+    const arranged = applySessionRailOrder(
+      [imported, ...arrangedRows],
+      ["s-now", "s-mid", "s-old"],
+    );
+    expect(ids(arranged)).toEqual(["s-now", "s-mid", "s-import", "s-old"]);
+  });
+
+  it("keeps a hand-arranged list from throwing a newcomer to the top", () => {
+    // The operator dragged the oldest thread to the top, so the list is
+    // in no date order at all. A newcomer older than two of the three
+    // rows still sits below both of them.
+    const entries = [
+      row("s-import", 2_000),
+      row("s-old", 1_000),
+      row("s-now", 4_000),
+      row("s-mid", 3_000),
+    ];
+    const arranged = applySessionRailOrder(entries, ["s-old", "s-now", "s-mid"]);
+    expect(ids(arranged)).toEqual(["s-old", "s-now", "s-mid", "s-import"]);
+  });
+
+  it("keeps several newcomers in their own recency order", () => {
+    const entries = [row("s-a", 5_000), row("s-b", 1_500), row("s-keep", 2_000)];
+    const arranged = applySessionRailOrder(entries, ["s-keep"]);
+    expect(ids(arranged)).toEqual(["s-a", "s-keep", "s-b"]);
   });
 
   it("ignores ids in the order that have no row", () => {

--- a/src/tui/session-rail/session-rail-order.test.ts
+++ b/src/tui/session-rail/session-rail-order.test.ts
@@ -70,6 +70,14 @@ describe("applySessionRailOrder", () => {
     expect(ids(arranged)).toEqual(["s-old", "s-now", "s-mid", "s-import"]);
   });
 
+  it("keeps newcomers of the same age in the order they arrived", () => {
+    // A batch of imports written in one pass shares a timestamp; the
+    // list must not come out reversed.
+    const entries = [row("s-a", 2_000), row("s-b", 2_000), row("s-c", 2_000)];
+    const arranged = applySessionRailOrder(entries, ["s-keep"]);
+    expect(ids(arranged)).toEqual(["s-a", "s-b", "s-c"]);
+  });
+
   it("keeps several newcomers in their own recency order", () => {
     const entries = [row("s-a", 5_000), row("s-b", 1_500), row("s-keep", 2_000)];
     const arranged = applySessionRailOrder(entries, ["s-keep"]);

--- a/src/tui/session-rail/session-rail-order.test.ts
+++ b/src/tui/session-rail/session-rail-order.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applySessionRailOrder,
+  computeMovedOrder,
+  moveSessionInOrder,
+  pruneSessionRailOrder,
+} from "./session-rail-order.js";
+
+const row = (sessionId: string) => ({ sessionId });
+const ids = (rows: readonly { sessionId: string }[]) => rows.map((r) => r.sessionId);
+
+describe("applySessionRailOrder", () => {
+  it("keeps the recency order while nothing has been arranged", () => {
+    const entries = [row("s-3"), row("s-2"), row("s-1")];
+    expect(ids(applySessionRailOrder(entries, []))).toEqual(["s-3", "s-2", "s-1"]);
+  });
+
+  it("follows the manual order", () => {
+    const entries = [row("s-3"), row("s-2"), row("s-1")];
+    const arranged = applySessionRailOrder(entries, ["s-1", "s-3", "s-2"]);
+    expect(ids(arranged)).toEqual(["s-1", "s-3", "s-2"]);
+  });
+
+  it("puts sessions the order has never seen on top, newest first", () => {
+    // s-5 and s-4 were started after the operator arranged the list;
+    // the store lists them first because they are the most recent.
+    const entries = [row("s-5"), row("s-1"), row("s-4"), row("s-2"), row("s-3")];
+    const arranged = applySessionRailOrder(entries, ["s-1", "s-3", "s-2"]);
+    expect(ids(arranged)).toEqual(["s-5", "s-4", "s-1", "s-3", "s-2"]);
+  });
+
+  it("ignores ids in the order that have no row", () => {
+    const entries = [row("s-2"), row("s-1")];
+    const arranged = applySessionRailOrder(entries, ["s-gone", "s-1", "s-2"]);
+    expect(ids(arranged)).toEqual(["s-1", "s-2"]);
+  });
+
+  it("does not mutate its input", () => {
+    const entries = [row("s-2"), row("s-1")];
+    applySessionRailOrder(entries, ["s-1", "s-2"]);
+    expect(ids(entries)).toEqual(["s-2", "s-1"]);
+  });
+});
+
+describe("moveSessionInOrder", () => {
+  it("moves a row up", () => {
+    expect(moveSessionInOrder(["a", "b", "c"], 2, 0)).toEqual(["c", "a", "b"]);
+  });
+
+  it("moves a row down", () => {
+    expect(moveSessionInOrder(["a", "b", "c"], 0, 2)).toEqual(["b", "c", "a"]);
+  });
+
+  it("clamps both ends", () => {
+    expect(moveSessionInOrder(["a", "b", "c"], 0, 99)).toEqual(["b", "c", "a"]);
+    expect(moveSessionInOrder(["a", "b", "c"], 2, -5)).toEqual(["c", "a", "b"]);
+  });
+
+  it("is a no-op when source and target coincide", () => {
+    const input = ["a", "b", "c"];
+    expect(moveSessionInOrder(input, 1, 1)).toEqual(input);
+    expect(moveSessionInOrder(input, 0, -1)).toEqual(input);
+    expect(moveSessionInOrder([], 0, 1)).toEqual([]);
+  });
+});
+
+describe("computeMovedOrder", () => {
+  it("returns the snapshot with the row in its new slot", () => {
+    expect(computeMovedOrder(["a", "b", "c"], "c", 0)).toEqual(["c", "a", "b"]);
+  });
+
+  it("returns null for an unknown id or a move that changes nothing", () => {
+    expect(computeMovedOrder(["a", "b"], "zzz", 0)).toBeNull();
+    expect(computeMovedOrder(["a", "b"], "a", 0)).toBeNull();
+    expect(computeMovedOrder(["a", "b"], "b", 5)).toBeNull();
+  });
+});
+
+describe("pruneSessionRailOrder", () => {
+  it("drops ids that are no longer live, keeping the order", () => {
+    expect(pruneSessionRailOrder(["b", "gone", "a"], ["a", "b", "new"])).toEqual([
+      "b",
+      "a",
+    ]);
+  });
+});

--- a/src/tui/session-rail/session-rail-order.ts
+++ b/src/tui/session-rail/session-rail-order.ts
@@ -44,7 +44,7 @@ export function applySessionRailOrder<T extends RailRow>(
 }
 
 /** What the rail needs of a row to arrange it: an identity and a date. */
-interface RailRow {
+export interface RailRow {
   sessionId: string;
   updatedAt: number;
 }

--- a/src/tui/session-rail/session-rail-order.ts
+++ b/src/tui/session-rail/session-rail-order.ts
@@ -4,9 +4,11 @@
  * The list is recency-sorted until the operator touches it. The first
  * move snapshots the displayed ids as a manual order (persisted under
  * `tui.sessionRail.order`); from then on ids in that order keep it, and
- * ids the order has never seen — a thread started afterwards — go to
- * the TOP, still by recency among themselves, so a new conversation
- * lands where a recency-sorted rail would have put it anyway.
+ * ids the order has never seen take the slot their date earns them —
+ * as many rows down as there are rows newer than they are. A thread
+ * started now is the newest thing there is, so it lands on top; a
+ * four-year-old transcript that an import has just written lands beside
+ * the other four-year-old rows rather than above today's work.
  */
 
 /**
@@ -17,7 +19,7 @@
  * entry are ignored — a deleted thread leaves a stale id behind until
  * the next write prunes it.
  */
-export function applySessionRailOrder<T extends { sessionId: string }>(
+export function applySessionRailOrder<T extends RailRow>(
   entries: readonly T[],
   order: readonly string[],
 ): T[] {
@@ -27,14 +29,48 @@ export function applySessionRailOrder<T extends { sessionId: string }>(
     if (!rank.has(id)) rank.set(id, index);
   });
   const unknown: T[] = [];
-  const known: T[] = [];
+  const arranged: T[] = [];
   for (const entry of entries) {
-    (rank.has(entry.sessionId) ? known : unknown).push(entry);
+    (rank.has(entry.sessionId) ? arranged : unknown).push(entry);
   }
-  known.sort(
+  arranged.sort(
     (a, b) => (rank.get(a.sessionId) ?? 0) - (rank.get(b.sessionId) ?? 0),
   );
-  return [...unknown, ...known];
+  // Newest first, so a run of new rows keeps its own recency order as
+  // each one is placed.
+  unknown.sort((a, b) => b.updatedAt - a.updatedAt);
+  for (const row of unknown) insertByDate(arranged, row);
+  return arranged;
+}
+
+/** What the rail needs of a row to arrange it: an identity and a date. */
+interface RailRow {
+  sessionId: string;
+  updatedAt: number;
+}
+
+/**
+ * Put `row` directly below the last row that is newer than it, so it
+ * ends up under everything newer and above everything older.
+ *
+ * Scanning from the bottom for the last newer row — rather than from
+ * the top for the first older one — is what keeps this honest on a
+ * hand-arranged rail, which is in no date order at all. "Before the
+ * first older row" would throw a four-year-old import to the top the
+ * moment the operator had dragged an old thread up there. This rule
+ * holds the one property that matters either way: nothing newer ever
+ * ends up below it. A thread created now has nothing newer above it,
+ * so it still lands on top.
+ */
+function insertByDate<T extends RailRow>(rows: T[], row: T): void {
+  let at = 0;
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    if ((rows[i]?.updatedAt ?? 0) > row.updatedAt) {
+      at = i + 1;
+      break;
+    }
+  }
+  rows.splice(at, 0, row);
 }
 
 /**

--- a/src/tui/session-rail/session-rail-order.ts
+++ b/src/tui/session-rail/session-rail-order.ts
@@ -39,7 +39,11 @@ export function applySessionRailOrder<T extends RailRow>(
   // Newest first, so a run of new rows keeps its own recency order as
   // each one is placed.
   unknown.sort((a, b) => b.updatedAt - a.updatedAt);
-  for (const row of unknown) insertByDate(arranged, row);
+  const placed = new Set<T>();
+  for (const row of unknown) {
+    insertByDate(arranged, row, placed);
+    placed.add(row);
+  }
   return arranged;
 }
 
@@ -61,11 +65,29 @@ export interface RailRow {
  * holds the one property that matters either way: nothing newer ever
  * ends up below it. A thread created now has nothing newer above it,
  * so it still lands on top.
+ *
+ * A row of exactly the same age counts as above it only when this pass
+ * placed it. Both readings of a tie are wanted and they point opposite
+ * ways: against the rows the operator arranged, "as new as the newest"
+ * takes the top slot, because a session minted this second shares a
+ * millisecond with the one before it; against the other newcomers of
+ * this pass — a batch of imports written in one go, all stamped alike —
+ * the arrival order has to survive, or the batch comes out reversed.
+ * Knowing which rows this pass placed is what separates the two.
  */
-function insertByDate<T extends RailRow>(rows: T[], row: T): void {
+function insertByDate<T extends RailRow>(
+  rows: T[],
+  row: T,
+  placed: ReadonlySet<T>,
+): void {
   let at = 0;
   for (let i = rows.length - 1; i >= 0; i -= 1) {
-    if ((rows[i]?.updatedAt ?? 0) > row.updatedAt) {
+    const other = rows[i];
+    if (!other) continue;
+    const above =
+      other.updatedAt > row.updatedAt ||
+      (other.updatedAt === row.updatedAt && placed.has(other));
+    if (above) {
       at = i + 1;
       break;
     }

--- a/src/tui/session-rail/session-rail-order.ts
+++ b/src/tui/session-rail/session-rail-order.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure order arithmetic for the rail's Sessions list.
+ *
+ * The list is recency-sorted until the operator touches it. The first
+ * move snapshots the displayed ids as a manual order (persisted under
+ * `tui.sessionRail.order`); from then on ids in that order keep it, and
+ * ids the order has never seen — a thread started afterwards — go to
+ * the TOP, still by recency among themselves, so a new conversation
+ * lands where a recency-sorted rail would have put it anyway.
+ */
+
+/**
+ * Arrange `entries` by `order`. An empty order is "no opinion": the
+ * incoming (recency) order stands. Otherwise ids named by `order` form
+ * a block sorted by their position in it, and everything else sits
+ * above that block in its incoming order. Ids in `order` that have no
+ * entry are ignored — a deleted thread leaves a stale id behind until
+ * the next write prunes it.
+ */
+export function applySessionRailOrder<T extends { sessionId: string }>(
+  entries: readonly T[],
+  order: readonly string[],
+): T[] {
+  if (order.length === 0) return [...entries];
+  const rank = new Map<string, number>();
+  order.forEach((id, index) => {
+    if (!rank.has(id)) rank.set(id, index);
+  });
+  const unknown: T[] = [];
+  const known: T[] = [];
+  for (const entry of entries) {
+    (rank.has(entry.sessionId) ? known : unknown).push(entry);
+  }
+  known.sort(
+    (a, b) => (rank.get(a.sessionId) ?? 0) - (rank.get(b.sessionId) ?? 0),
+  );
+  return [...unknown, ...known];
+}
+
+/**
+ * Move the id at `from` so it lands at index `to`. Both indices are
+ * clamped to the list; `from === to` (after clamping) or an empty list
+ * returns a copy unchanged. Never mutates its input.
+ */
+export function moveSessionInOrder(
+  ids: readonly string[],
+  from: number,
+  to: number,
+): string[] {
+  const next = [...ids];
+  if (next.length === 0) return next;
+  const max = next.length - 1;
+  const source = Math.min(max, Math.max(0, from));
+  const target = Math.min(max, Math.max(0, to));
+  if (source === target) return next;
+  const [moved] = next.splice(source, 1);
+  if (moved === undefined) return next;
+  next.splice(target, 0, moved);
+  return next;
+}
+
+/**
+ * The order the rail should persist after `sessionId`, displayed in
+ * `displayedIds`, is dropped on `toIndex`. `null` when the id is not on
+ * the list or the move changes nothing — the caller then writes nothing.
+ */
+export function computeMovedOrder(
+  displayedIds: readonly string[],
+  sessionId: string,
+  toIndex: number,
+): string[] | null {
+  const from = displayedIds.indexOf(sessionId);
+  if (from < 0) return null;
+  const next = moveSessionInOrder(displayedIds, from, toIndex);
+  return next.every((id, index) => id === displayedIds[index]) ? null : next;
+}
+
+/** Drop ids from `order` that no longer name a live session. */
+export function pruneSessionRailOrder(
+  order: readonly string[],
+  liveIds: readonly string[],
+): string[] {
+  const live = new Set(liveIds);
+  return order.filter((id) => live.has(id));
+}

--- a/src/tui/session-rail/session-rail-reducer.ts
+++ b/src/tui/session-rail/session-rail-reducer.ts
@@ -1,0 +1,45 @@
+import type { TuiState } from "../tui-state.js";
+import type { SessionRailAction } from "./session-rail-actions.js";
+
+const DRAG_ACTIONS = new Set<string>([
+  "sidebar_drag_started",
+  "sidebar_drag_moved",
+  "sidebar_drag_ended",
+]);
+
+function isSessionRailAction(action: { type: string }): action is SessionRailAction {
+  return DRAG_ACTIONS.has(action.type);
+}
+
+/**
+ * Reducer slice for `state.sidebarDrag`. Returns the next state when
+ * the action is one of the drag actions, `null` otherwise so the root
+ * reducer falls through. The slice never touches the session list or
+ * the cursor: while a row is dragged the list stays as it is and only
+ * the paint changes, so an abandoned drag leaves nothing to undo.
+ */
+export function reduceSessionRailAction(
+  state: TuiState,
+  action: { type: string },
+): TuiState | null {
+  if (!isSessionRailAction(action)) return null;
+  switch (action.type) {
+    case "sidebar_drag_started": {
+      const max = Math.max(0, state.recentSessions.length - 1);
+      const row = Math.min(max, Math.max(0, action.row));
+      return {
+        ...state,
+        sidebarDrag: { sessionId: action.sessionId, from: row, over: row },
+      };
+    }
+    case "sidebar_drag_moved": {
+      if (!state.sidebarDrag) return state;
+      const max = Math.max(0, state.recentSessions.length - 1);
+      const over = Math.min(max, Math.max(0, action.row));
+      if (over === state.sidebarDrag.over) return state;
+      return { ...state, sidebarDrag: { ...state.sidebarDrag, over } };
+    }
+    case "sidebar_drag_ended":
+      return state.sidebarDrag ? { ...state, sidebarDrag: null } : state;
+  }
+}

--- a/src/tui/session-rail/session-rail-row.tsx
+++ b/src/tui/session-rail/session-rail-row.tsx
@@ -1,0 +1,104 @@
+import { Box } from "ink";
+import { useRef, type ReactElement, type ReactNode } from "react";
+
+import { useMouseCommands, useMouseTarget } from "../mouse/mouse-context.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
+
+export interface SessionRailRowProps {
+  sessionId: string;
+  /** Absolute index into the session list, not the visible window. */
+  row: number;
+  selected: boolean;
+  /** First and last absolute rows currently painted — a drag cannot leave them. */
+  windowStart: number;
+  windowEnd: number;
+  children: ReactNode;
+}
+
+interface Gesture {
+  /** Whether the row was already the selected one when the press landed. */
+  selectedAtPress: boolean;
+  /** The pointer has left the pressed row at least once. */
+  moved: boolean;
+  /** The slot under the pointer, absolute. */
+  over: number;
+}
+
+/**
+ * A session row that can be clicked and dragged.
+ *
+ * The click contract of every rail row is "first click selects, the
+ * second activates". A drag has to start from the same press, so the
+ * gesture is arbitrated on release rather than on press: the press
+ * selects (if the row was not selected) and captures the pointer; held
+ * motion onto another row turns the press into a drag and paints the
+ * feedback; the release either drops the row (`onSessionMoveRequested`)
+ * or — if the pointer never left the row AND the row was already
+ * selected before the press — activates it. A press on an unselected
+ * row therefore still selects it, and an already-selected row still
+ * opens on the next click, exactly once.
+ *
+ * Rows are one line tall, so the row under the pointer is this row's
+ * index plus the hit's local Y — the registry keeps routing to the
+ * captured target with out-of-range local coordinates while the
+ * pointer wanders. The result is clamped to the painted window: rows
+ * above or below it are not on screen, and a drop there would land on
+ * a slot the operator cannot see.
+ */
+export function SessionRailRow({
+  sessionId,
+  row,
+  selected,
+  windowStart,
+  windowEnd,
+  children,
+}: SessionRailRowProps): ReactElement {
+  const mouse = useMouseCommands();
+  const gesture = useRef<Gesture | null>(null);
+  const ref = useMouseTarget(
+    (hit) => {
+      if (!mouse) return false;
+      if (isPrimaryPress(hit.event)) {
+        gesture.current = { selectedAtPress: selected, moved: false, over: row };
+        if (!selected) {
+          mouse.dispatch({ type: "chat_focus_set", focus: "sidebar" });
+          mouse.dispatch({ type: "sidebar_section_focused", section: "sessions" });
+          mouse.dispatch({ type: "sidebar_cursor_set", row });
+        }
+        mouse.registry.capturePointer(ref);
+        return true;
+      }
+      const current = gesture.current;
+      if (!current) return false;
+      if (hit.event.kind === "motion" && hit.event.button === "left") {
+        const over = Math.min(windowEnd, Math.max(windowStart, row + hit.localY));
+        if (over === current.over) return true;
+        if (!current.moved) {
+          current.moved = true;
+          mouse.dispatch({ type: "sidebar_drag_started", sessionId, row });
+        }
+        current.over = over;
+        mouse.dispatch({ type: "sidebar_drag_moved", row: over });
+        return true;
+      }
+      if (hit.event.kind === "release") {
+        gesture.current = null;
+        mouse.registry.releasePointer();
+        if (current.moved) {
+          mouse.dispatch({ type: "sidebar_drag_ended" });
+          mouse.dispatch({ type: "sidebar_cursor_set", row: current.over });
+          if (current.over !== row) {
+            mouse.callbacks.onSessionMoveRequested?.(sessionId, current.over);
+          }
+        } else if (current.selectedAtPress) {
+          mouse.callbacks.onSessionSwitchRequested?.(sessionId);
+        }
+        return true;
+      }
+      return false;
+    },
+    { enabled: mouse !== null },
+  );
+  if (!mouse) return <>{children}</>;
+  return <Box ref={ref}>{children}</Box>;
+}

--- a/src/tui/tui-action.ts
+++ b/src/tui/tui-action.ts
@@ -7,6 +7,7 @@ import type { ComposerSwitchAction } from "./composer-switch/composer-switch-act
 import type { ContextMenuState } from "./context-menu/context-menu-state.js";
 import type { LocalModelsAction } from "./local-models/local-models-actions.js";
 import type { TasksAction } from "./tasks/tasks-actions.js";
+import type { SessionRailAction } from "./session-rail/session-rail-actions.js";
 import type { SkillsAction } from "./skills/skills-actions.js";
 import type { MemoryAction } from "./memory/memory-actions.js";
 import type { McpAction } from "./mcp/mcp-actions.js";
@@ -307,6 +308,7 @@ export type TuiAction =
   | ComposerSwitchAction
   | LocalModelsAction
   | TasksAction
+  | SessionRailAction
   | SkillsAction
   | MemoryAction
   | McpAction

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -237,6 +237,12 @@ export interface TuiAppCallbacks {
   onSessionPickerRequested?(): void;
   /** Ask the orchestrator to swap to an existing persisted session. */
   onSessionSwitchRequested?(sessionId: string): void;
+  /**
+   * Put a rail session on another slot (Shift+↑/↓ or a row drag).
+   * `toIndex` indexes the list as displayed; the host persists the
+   * resulting order and re-emits `recent_sessions_updated`.
+   */
+  onSessionMoveRequested?(sessionId: string, toIndex: number): void;
   /** Ask the orchestrator to start a fresh session. */
   onSessionNewRequested?(): void;
   /** Ask the orchestrator to dump the current user profile into the chat log. */
@@ -1828,6 +1834,7 @@ export function TuiApp({
             maxTaskRows={sidebarRows.tasks}
             sessions={state.recentSessions}
             sessionsCursor={state.sidebarCursor}
+            sessionDrag={state.sidebarDrag}
             currentSessionId={state.session.sessionId}
             tasks={selectSidebarTasks(state.tasksPanel.rows)}
             runningTaskCount={countRunningTasks(state.tasksPanel.rows)}

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -439,6 +439,8 @@ export async function tuiCommand(args: string[]): Promise<number> {
         },
         onSessionPickerRequested: () => orchestrator.openSessionPicker(),
         onSessionSwitchRequested: (id) => orchestrator.switchSession(id),
+        onSessionMoveRequested: (id, toIndex) =>
+          orchestrator.moveSession(id, toIndex),
         onSessionNewRequested: () => orchestrator.newSession(),
         onSessionDeleteConfirmed: (sessionId) =>
           orchestrator.deleteSession(sessionId),

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -10,6 +10,7 @@ import type { ContextMenuState } from "./context-menu/context-menu-state.js";
 import type { ApprovalRequest } from "../approval/approval-gate.js";
 import type { WhileBusySubmitMode } from "../config/index.js";
 import type { OnboardingUiState } from "./onboarding/onboarding-state.js";
+import type { SidebarDragState } from "./session-rail/session-rail-actions.js";
 import type {
   LatestResult,
   LoadedSkillBody,
@@ -594,6 +595,14 @@ export interface TuiState {
    */
   sidebarCursor: number;
   /**
+   * A session row being dragged to a new slot, or `null`. Paint-only
+   * feedback (`↕` on the dragged row, a marker on the slot under the
+   * pointer); the reorder itself reaches the orchestrator through
+   * `onSessionMoveRequested` on release. Cleared by the release, by a
+   * list refresh, and by focus leaving the rail.
+   */
+  sidebarDrag: SidebarDragState | null;
+  /**
    * Highlighted row in the sidebar's tasks list. Bounded by the number
    * of rows produced by `selectSidebarTasks` at render time; the
    * reducer clamps against the global `tasksPanel.rows` cap (5) since
@@ -806,6 +815,7 @@ export function createInitialTuiState(
     sidebarSection: "sessions",
     sidebarCollapsed: false,
     sidebarCursor: 0,
+    sidebarDrag: null,
     sidebarTasksCursor: 0,
     chatScrollOffset: 0,
     queuedMessages: [],


### PR DESCRIPTION
## What

The rail's Sessions list was strictly recency-sorted; the operator could not put a thread where they wanted it. Now a session row can be moved:

- **Keyboard** — with the rail focused, `Shift+↑` / `Shift+↓` (Alt/Meta+arrow as an alias for terminals that keep Shift+arrows to themselves) moves the selected row one slot; the cursor follows. At the top or bottom edge the chord is consumed and does nothing, so it never degrades into a plain cursor move. The rail's hint strip shows `[shift+↑↓] move`.
- **Mouse** — press a row and drag: the row in hand shows `↕` and stays inverse, the slot under the pointer gets the chevron in the rail accent, release drops it. A press that never moves keeps the old contract exactly (first click selects, a second click on the selected row opens it, once) — the gesture is arbitrated on release, so a drag and a click start from the same press. Pointer capture keeps a drag that wanders off the rail alive; the drop index is clamped to the painted window.
- **Remembered** — the first move snapshots the list as displayed into `tui.sessionRail.order` (config v52) and persists every later move. From then on ids in the order keep it. An empty order means "recency", i.e. today's behaviour until you touch the list. The modal session picker reads the same list and follows the same order.
- **A thread the order has never seen takes the slot its date earns**: directly below the last row that is newer than it. A conversation started now is newer than everything and still lands on top; a four-year-old transcript that an import has just written lands beside the other old rows instead of above today's work. The scan runs from the bottom rather than the top because a hand-arranged rail is in no date order — "before the first older row" would throw an old import back to the top the moment an old thread had been dragged up there. Rows of the same age keep the order they arrived in, so a batch of imports written in one pass is not handed back reversed.

New module `src/tui/session-rail/`: pure order arithmetic (`applySessionRailOrder`, `moveSessionInOrder`, `computeMovedOrder`, `pruneSessionRailOrder`), the config persist helper, a `SessionRailOrchestrator` that owns the "list as displayed" and turns a drop into a persisted order, the drag reducer slice (`sidebarDrag`), the key binding, and the drag-aware `SessionRailRow`. `railSessions()` in the chat orchestrator gained one `arrange(...)` call; the big files got only the wiring lines.

## Why

The list is the operator's working set. A desktop list widget lets you arrange it and remembers the arrangement; this brings that to the rail without changing what a fresh install shows.

## How it was verified

- `npm run lint` clean
- `npx vitest run src/tui/session-rail src/tui/reduce-sidebar-actions.test.ts src/tui/reduce-session-actions.test.ts src/tui/app-key-bindings.test.ts src/tui/session-delete-keys.test.ts src/tui/rail-session-list.test.ts src/tui/mouse src/tui/components/sidebar.test.tsx src/tui/components/sidebar-fit.test.tsx src/tui/chat-orchestrator*.test.ts src/config` — 35 files / 580 tests green (order module, reducer, Shift+arrow binding incl. the edge and the letter-swallow, config v51→v52 inheritance, a `mouse-app` drag of `s-2` above `s-1` calling `onSessionMoveRequested("s-2", 0)` plus the two-click switch still opening once, a sidebar render showing `↕`)
- Ink's `parse-keypress` (`fnKeyRe` branch) maps `\x1b[1;2A` to `upArrow + shift`, checked in `node_modules/ink/build/parse-keypress.js`
- Live, in a PTY at 120×36 with six seeded sessions: focused the rail, sent `\x1b[1;2B` twice → `config.json` holds `tui.sessionRail.order = [s-seed-0004, s-seed-0003, s-seed-0005, …]` (the top row moved two slots down); relaunched the TUI against the same state dir → the rail boots in that order.

Notes: `USER_CONFIG_VERSION` is bumped to 52 here; open PRs #354/#360 also claim 52 and #355/#361 claim 53 — whichever lands second renumbers in the RC. The rail still shows at most 25 rows on this branch; #367 lifts that cap and touches the same `railSessions()` lines (a one-line merge).

