### PR TITLE
feat(tui): pin sessions — a white ↑ on every row keeps a thread at the top

### DIFF
--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -1543,7 +1543,7 @@ describe("tui.sessionRail (config v52)", () => {
   it("gives a v51 file the recency default — an empty order", () => {
     const parsed = parseUserConfigFile({ version: 51, tui: { theme: "nord" } });
     expect(parsed.version).toBe(USER_CONFIG_VERSION);
-    expect(parsed.tui.sessionRail).toEqual({ order: [] });
+    expect(parsed.tui.sessionRail).toEqual({ order: [], pinned: [] });
     expect(parsed.tui.theme).toBe("nord");
   });
 
@@ -1570,5 +1570,44 @@ describe("tui.sessionRail (config v52)", () => {
         tui: { sessionRail: { order: "s-a" } },
       }),
     ).toThrow(/tui\.sessionRail\.order/);
+  });
+});
+
+describe("tui.sessionRail.pinned (config v53)", () => {
+  it("gives a v52 file nothing pinned and keeps its order", () => {
+    const parsed = parseUserConfigFile({
+      version: 52,
+      tui: { sessionRail: { order: ["s-b", "s-a"] } },
+    });
+    expect(parsed.version).toBe(USER_CONFIG_VERSION);
+    expect(parsed.tui.sessionRail).toEqual({ order: ["s-b", "s-a"], pinned: [] });
+  });
+
+  it("round-trips the pinned block next to the order", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      tui: { sessionRail: { order: ["s-b", "s-a", "s-c"], pinned: ["s-c", "s-a"] } },
+    });
+    expect(parsed.tui.sessionRail).toEqual({
+      order: ["s-b", "s-a", "s-c"],
+      pinned: ["s-c", "s-a"],
+    });
+  });
+
+  it("drops pinned entries that are not ids and dedupes them", () => {
+    const parsed = parseUserConfigFile({
+      version: USER_CONFIG_VERSION,
+      tui: { sessionRail: { pinned: ["s-b", 7, "", null, "s-a", "s-b"] } },
+    });
+    expect(parsed.tui.sessionRail).toEqual({ order: [], pinned: ["s-b", "s-a"] });
+  });
+
+  it("rejects a pinned block that is not a list", () => {
+    expect(() =>
+      parseUserConfigFile({
+        version: USER_CONFIG_VERSION,
+        tui: { sessionRail: { pinned: "s-a" } },
+      }),
+    ).toThrow(/tui\.sessionRail\.pinned/);
   });
 });

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -1701,8 +1701,9 @@ export interface UserConfigFile {
    * `--no-mouse`. Older files are upgraded with `mouse: true`.
    *
    * `sessionRail` (config v52) remembers the operator's own ordering of
-   * the rail's Sessions list — see {@link SessionRailConfig}. Older
-   * files are upgraded with an empty order, which means "by recency".
+   * the rail's Sessions list, and (v53) which threads are pinned to its
+   * top — see {@link SessionRailConfig}. Older files are upgraded with
+   * an empty order, which means "by recency", and nothing pinned.
    */
   tui: {
     theme: string;
@@ -1855,7 +1856,10 @@ export interface UserConfigFile {
 // the rail's Sessions list (`order: string[]`, session ids). Additive: an
 // older file inherits `[]`, which keeps the list sorted by recency until
 // the operator moves a row for the first time.
-export const USER_CONFIG_VERSION = 52;
+// v53: `tui.sessionRail.pinned` (`string[]`, session ids) — the threads
+// the operator pinned to the top of the rail. Additive: an older file
+// inherits `[]`, nothing pinned, and `order` keeps its v52 meaning.
+export const USER_CONFIG_VERSION = 53;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -1996,6 +2000,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   49,
   50,
   51,
+  52,
   USER_CONFIG_VERSION,
 ];
 
@@ -2265,7 +2270,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
     theme: "auto",
     whileBusySubmit: "steer",
     mouse: true,
-    sessionRail: { order: [] },
+    sessionRail: { order: [], pinned: [] },
     onboarding: {
       completedAt: null,
       importOfferedAt: null,
@@ -4396,6 +4401,13 @@ export function parseWhileBusySubmit(
  */
 export interface SessionRailConfig {
   order: string[];
+  /**
+   * Session ids pinned to the top of the rail (config v53). Pinned rows
+   * form a block above everything else; inside the block they follow
+   * `order` like any other row. A pinned id that no longer exists is
+   * ignored on read and dropped on the next write.
+   */
+  pinned: string[];
 }
 
 export interface OnboardingState {
@@ -4414,38 +4426,45 @@ export interface OnboardingState {
  * predates the block.
  */
 /**
- * Parse `tui.sessionRail`. Absent → the recency default. The order is a
- * list of session ids; entries that are not non-empty strings are
- * dropped rather than rejected — a hand-edited or partially written id
- * costs one row its remembered place, not the whole config file — and
- * duplicates keep their first position so the on-disk form stays
- * canonical.
+ * Parse `tui.sessionRail`. Absent → the recency default, nothing pinned.
+ * `order` and `pinned` are lists of session ids; entries that are not
+ * non-empty strings are dropped rather than rejected — a hand-edited or
+ * partially written id costs one row its remembered place, not the
+ * whole config file — and duplicates keep their first position so the
+ * on-disk form stays canonical.
  */
 export function parseSessionRailConfig(raw: unknown): SessionRailConfig {
-  if (raw === undefined || raw === null) return { order: [] };
+  if (raw === undefined || raw === null) return { order: [], pinned: [] };
   if (typeof raw !== "object" || Array.isArray(raw)) {
     throw new ConfigValidationError(
       "tui.sessionRail",
       `expected object, got ${JSON.stringify(raw)}`,
     );
   }
-  const order = (raw as Record<string, unknown>).order;
-  if (order === undefined || order === null) return { order: [] };
-  if (!Array.isArray(order)) {
+  const block = raw as Record<string, unknown>;
+  return {
+    order: parseSessionIdList(block.order, "tui.sessionRail.order"),
+    pinned: parseSessionIdList(block.pinned, "tui.sessionRail.pinned"),
+  };
+}
+
+function parseSessionIdList(raw: unknown, path: string): string[] {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
     throw new ConfigValidationError(
-      "tui.sessionRail.order",
-      `expected string[], got ${JSON.stringify(order)}`,
+      path,
+      `expected string[], got ${JSON.stringify(raw)}`,
     );
   }
   const seen = new Set<string>();
   const result: string[] = [];
-  for (const entry of order) {
+  for (const entry of raw) {
     if (typeof entry !== "string" || entry.length === 0) continue;
     if (seen.has(entry)) continue;
     seen.add(entry);
     result.push(entry);
   }
-  return { order: result };
+  return result;
 }
 
 export function parseOnboardingState(raw: unknown): OnboardingState {

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -512,7 +512,10 @@ export function loadConfig(): AtomicAgentConfig {
       whileBusySubmit: user.tui.whileBusySubmit,
       mouse: user.tui.mouse,
       onboarding: { ...user.tui.onboarding },
-      sessionRail: { order: [...user.tui.sessionRail.order] },
+      sessionRail: {
+        order: [...user.tui.sessionRail.order],
+        pinned: [...user.tui.sessionRail.pinned],
+      },
     },
     analytics: {
       enabled: user.analytics.enabled,

--- a/src/tui/app-key-bindings.ts
+++ b/src/tui/app-key-bindings.ts
@@ -19,7 +19,10 @@ import {
 import type { MenuNode } from "./menu/menu-registry.js";
 import { cycleNavSlot, type NavSlot } from "./section.js";
 import { selectSidebarTasks } from "./sidebar-tasks-selector.js";
-import { handleSessionMoveKey } from "./session-rail/index.js";
+import {
+  handleSessionMoveKey,
+  handleSessionPinKey,
+} from "./session-rail/index.js";
 import type { TuiAction } from "./tui-action.js";
 import type { TuiState } from "./tui-state.js";
 import { isUninstallConfirmed } from "./uninstall/uninstall-state.js";
@@ -73,6 +76,8 @@ export interface AppKeyCallbacks {
   onSessionSwitchRequested?(sessionId: string): void;
   /** Shift+↑/↓ in the rail: put the selected session on slot `toIndex`. */
   onSessionMoveRequested?(sessionId: string, toIndex: number): void;
+  /** `p` in the rail, or a row's `↑`: pin the selected session, or release it. */
+  onSessionPinToggled?(sessionId: string): void;
   /**
    * Optional — called when Enter is pressed on a sidebar Tasks row.
    * The handler is expected to switch to the Tasks debug tab and open
@@ -725,6 +730,10 @@ function handleSidebarKey(
     }
     return true;
   }
+  // `p` is the keyboard twin of the row's `↑`, for the same reason `x`
+  // is the twin of `[x]`: the mark is painted whether or not mouse
+  // reporting is on.
+  if (handleSessionPinKey(input, key, ctx)) return true;
   if (key.return) {
     if (state.sidebarSection === "tasks") {
       const visible = selectSidebarTasks(state.tasksPanel.rows);

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -48,8 +48,8 @@ import { PrivacyOrchestrator } from "./privacy/privacy-orchestrator.js";
 import { IntegrationsOrchestrator } from "./integrations/integrations-orchestrator.js";
 import {
   SessionRailOrchestrator,
-  configSessionRailOrderStore,
-  type SessionRailOrderStore,
+  configSessionRailLayoutStore,
+  type SessionRailLayoutStore,
 } from "./session-rail/index.js";
 import type { TuiEventBus } from "./tui-app.js";
 import { formatAgentErrorForChat } from "./format-agent-error-for-chat.js";
@@ -94,11 +94,12 @@ export interface ChatOrchestratorOptions {
    */
   readGateFacts?: () => LocalTurnGateFacts;
   /**
-   * Where the rail's manual session order is read from and written to.
-   * Injectable for the same reason as `readGateFacts`; the default is
-   * `tui.sessionRail.order` in the user's config file.
+   * Where the rail's layout — manual order and pinned ids — is read
+   * from and written to. Injectable for the same reason as
+   * `readGateFacts`; the default is `tui.sessionRail` in the user's
+   * config file.
    */
-  sessionRailOrder?: SessionRailOrderStore;
+  sessionRailLayout?: SessionRailLayoutStore;
 }
 
 /** Multiline text for the chat transcript (`/memory`); feed still gets `runtime_info` lines. */
@@ -252,7 +253,7 @@ export class ChatOrchestrator {
     // than reimplementing pairing / restart / enable.
     this.integrations = new IntegrationsOrchestrator(runtime, bus, this.telegram);
     this.sessionRail = new SessionRailOrchestrator(
-      options.sessionRailOrder ?? configSessionRailOrderStore,
+      options.sessionRailLayout ?? configSessionRailLayoutStore,
       () => this.refreshRecentSessions(),
     );
     // Tap the bus rather than the runtime handler: what the reducer was

--- a/src/tui/chat-orchestrator.ts
+++ b/src/tui/chat-orchestrator.ts
@@ -255,6 +255,13 @@ export class ChatOrchestrator {
     this.sessionRail = new SessionRailOrchestrator(
       options.sessionRailLayout ?? configSessionRailLayoutStore,
       () => this.refreshRecentSessions(),
+      // A pinned thread must show whatever its age: when it has fallen
+      // out of the recency window `railSessions` reads, the rail fetches
+      // it by id and builds the same row the window would have.
+      (sessionId) => {
+        const state = this.runtime.sessionStore.load(sessionId);
+        return state ? toPickerEntry(state) : null;
+      },
     );
     // Tap the bus rather than the runtime handler: what the reducer was
     // offered is exactly what a switch-back may need to replay, session
@@ -479,6 +486,15 @@ export class ChatOrchestrator {
   }
 
   /**
+   * `p` or the row's `↑` in the rail: pin `sessionId` to the top block,
+   * or release it. A config write only — the session row is untouched,
+   * so a pin never bumps `updatedAt`.
+   */
+  togglePinned(sessionId: string): void {
+    this.sessionRail.togglePinned(sessionId);
+  }
+
+  /**
    * Put the current session on the rail the instant its first prompt is
    * sent, named by that prompt. Called from `runOneTurn`, which is the
    * one funnel every first turn passes through — `sendMessage` and
@@ -497,6 +513,7 @@ export class ChatOrchestrator {
       stepCount: 0,
       updatedAt: Date.now(),
       preview: text,
+      pinned: false,
     });
     this.refreshRecentSessions();
   }
@@ -1345,5 +1362,6 @@ function toPickerEntry(state: SessionState): SessionPickerEntry {
     stepCount: state.stepCount,
     updatedAt: state.updatedAt,
     preview: preview.length > 0 ? preview : "(empty)",
+    pinned: false,
   };
 }

--- a/src/tui/components/hotkey-chips.ts
+++ b/src/tui/components/hotkey-chips.ts
@@ -204,6 +204,7 @@ export function resolveChips(
       { key: "↑↓", label: "select", shed: 3 },
       { key: "enter", label: "open" },
       { key: "shift+↑↓", label: "move", shed: 2 },
+      { key: "p", label: "pin", shed: 3 },
       { key: "tab", label: "next pane", shed: 1 },
       { key: "esc", label: "back to editor" },
       {

--- a/src/tui/components/session-picker.tsx
+++ b/src/tui/components/session-picker.tsx
@@ -104,10 +104,13 @@ function PickerRow({
   const preview = truncate(entry.preview, 48);
   const marker = current ? theme.glyphs.assistantMarker : " ";
   const chevron = selected ? theme.glyphs.chevronRight : " ";
+  // The picker lists the rail's list, pinned block first — the same
+  // `↑` says why those rows are on top.
+  const pin = entry.pinned ? theme.glyphs.pinned : " ";
   return (
     <Box>
       <Text color={selected ? theme.colors.accentSoft : theme.colors.muted} bold={selected}>
-        {chevron} {marker} {idShort}
+        {chevron} {marker} {pin} {idShort}
       </Text>
       <Text color={theme.colors.muted}>
         {"  "}

--- a/src/tui/components/sidebar-fit.test.tsx
+++ b/src/tui/components/sidebar-fit.test.tsx
@@ -26,6 +26,7 @@ const SESSIONS: readonly SessionPickerEntry[] = Array.from(
     stepCount: 1,
     updatedAt: 0,
     preview: `session ${idx}`,
+    pinned: false,
   }),
 );
 

--- a/src/tui/components/sidebar.test.tsx
+++ b/src/tui/components/sidebar.test.tsx
@@ -369,8 +369,57 @@ describe("Sidebar session drag feedback", () => {
       />,
     );
     const text = strip(lastFrame() ?? "");
-    expect(text).toMatch(/↕ [^\n]*another conversa/);
-    expect(text).toMatch(/▸ [^\n]*first ever messa/);
+    // The previews are two columns shorter than they were before the
+    // pin mark took its cells, so match a prefix the rail still fits.
+    expect(text).toMatch(/↕ [^\n]*another conver/);
+    expect(text).toMatch(/▸ [^\n]*first ever mes/);
+  });
+
+  it("paints the pin mark on every session row", () => {
+    const { lastFrame } = render(
+      <Sidebar
+        width={30}
+        sessions={[SESSIONS[0]!, { ...SESSIONS[1]!, pinned: true }]}
+        sessionsCursor={0}
+        currentSessionId={null}
+        tasks={[]}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={true}
+      />,
+    );
+    const lines = strip(lastFrame() ?? "").split("\n");
+    const first = lines.find((line) => line.includes("first ever")) ?? "";
+    const second = lines.find((line) => line.includes("another conv")) ?? "";
+    // Both rows carry it — the mark says "pinned / not pinned", which a
+    // mark that only appeared on the selected row could not.
+    expect(first).toContain("↑");
+    expect(second).toContain("↑");
+    // …at the right edge of the row, past the preview.
+    expect(first.lastIndexOf("↑")).toBeGreaterThan(first.indexOf("first ever"));
+  });
+
+  it("puts pinned rows above the rest exactly as it is handed them", () => {
+    // Ordering is the rail orchestrator's job; the component draws the
+    // list in the order it receives, pins included.
+    const pinned = { ...SESSIONS[1]!, pinned: true };
+    const { lastFrame } = render(
+      <Sidebar
+        width={30}
+        sessions={[pinned, SESSIONS[0]!]}
+        sessionsCursor={0}
+        currentSessionId={null}
+        tasks={[]}
+        tasksCursor={0}
+        activeSection="sessions"
+        focused={true}
+      />,
+    );
+    const lines = strip(lastFrame() ?? "").split("\n");
+    const pinnedRow = lines.findIndex((line) => line.includes("another conv"));
+    const plainRow = lines.findIndex((line) => line.includes("first ever"));
+    expect(pinnedRow).toBeGreaterThan(-1);
+    expect(pinnedRow).toBeLessThan(plainRow);
   });
 
   it("paints no drag marks when nothing is dragged", () => {

--- a/src/tui/components/sidebar.test.tsx
+++ b/src/tui/components/sidebar.test.tsx
@@ -22,6 +22,7 @@ const SESSIONS: readonly SessionPickerEntry[] = [
     stepCount: 5,
     updatedAt: Date.now() - 60_000,
     preview: "first ever message in the session",
+    pinned: false,
   },
   {
     sessionId: "ghijkl5678",
@@ -30,6 +31,7 @@ const SESSIONS: readonly SessionPickerEntry[] = [
     stepCount: 2,
     updatedAt: Date.now() - 600_000,
     preview: "another conversation",
+    pinned: false,
   },
 ];
 
@@ -272,6 +274,7 @@ describe("Sidebar", () => {
       ...SESSIONS[0]!,
       sessionId: `s-${idx}`,
       preview: `session number ${idx}`,
+      pinned: false,
     }));
     const manyTasks = Array.from({ length: 8 }, (_, idx) =>
       taskRow({ id: `t-${idx}`, userMessage: `task number ${idx}` }),

--- a/src/tui/components/sidebar.tsx
+++ b/src/tui/components/sidebar.tsx
@@ -8,7 +8,12 @@ import {
 import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { MOUSE_LAYER_BASE } from "../mouse/mouse-registry.js";
 import { computeRowWindow } from "../row-window.js";
-import { SessionRailRow, type SidebarDragState } from "../session-rail/index.js";
+import {
+  PinSessionButton,
+  PIN_COLUMNS,
+  SessionRailRow,
+  type SidebarDragState,
+} from "../session-rail/index.js";
 import type { TaskSummaryRow } from "../tasks/tasks-panel-state.js";
 import { theme } from "../theme/theme.js";
 import type { SessionPickerEntry } from "../tui-state.js";
@@ -592,21 +597,24 @@ function SessionRow({
   // selected made the mark materialise on top of text the operator was
   // already pointing at: the second click of the ordinary
   // select-then-open gesture landed on `[x]` and asked to delete the
-  // thread instead of opening it.
+  // thread instead of opening it. The pin columns are reserved the same
+  // way, and painted on every row — a pin mark that appeared only under
+  // the pointer could not show which threads are already pinned.
+  const marks = CLOSE_COLUMNS + PIN_COLUMNS;
   const preview = truncate(
     entry.preview,
-    Math.max(1, Math.min(previewWidth, groundWidth - 5 - CLOSE_COLUMNS)),
+    Math.max(1, Math.min(previewWidth, groundWidth - 5 - marks)),
   );
   const label = `${chevron} ${marker} ${preview}`;
   // Every cell width is computed here, so nothing may flex. Yoga
   // shrinks text children by default and Ink re-wraps a squeezed
   // `<Text>` rather than clipping it — the trap
   // `MouseTargetProps.flexShrink` warns about, one row away from here.
-  const ground = ` ${label}`.padEnd(Math.max(0, groundWidth - CLOSE_COLUMNS));
+  const ground = ` ${label}`.padEnd(Math.max(0, groundWidth - marks));
   return (
     <Box width={inner} flexShrink={0}>
       <Text>{" ".repeat(ROW_MARGIN_COLUMNS)}</Text>
-      <Box flexShrink={0} width={Math.max(0, groundWidth - CLOSE_COLUMNS)}>
+      <Box flexShrink={0} width={Math.max(0, groundWidth - marks)}>
         <Text
           color={drag === "target" ? theme.colors.railAccent : theme.colors.railForeground}
           bold={selected || current || drag !== null}
@@ -622,6 +630,11 @@ function SessionRow({
       ) : (
         <Text>{" ".repeat(CLOSE_COLUMNS)}</Text>
       )}
+      <PinSessionButton
+        sessionId={entry.sessionId}
+        pinned={entry.pinned}
+        inverse={selected || drag === "source"}
+      />
       <Text>{" ".repeat(ROW_MARGIN_COLUMNS)}</Text>
     </Box>
   );

--- a/src/tui/components/status-bar.test.tsx
+++ b/src/tui/components/status-bar.test.tsx
@@ -19,6 +19,7 @@ function entry(preview: string): SessionPickerEntry {
     stepCount: 1,
     updatedAt: Date.now(),
     preview,
+    pinned: false,
   };
 }
 

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -215,6 +215,7 @@ function mountApp(): {
             stepCount: 1,
             updatedAt: 2,
             preview: "first thread",
+            pinned: false,
           },
           {
             sessionId: "s-2",
@@ -223,6 +224,7 @@ function mountApp(): {
             stepCount: 1,
             updatedAt: 1,
             preview: "second thread",
+            pinned: false,
           },
         ],
       });

--- a/src/tui/mouse/mouse-app.test.tsx
+++ b/src/tui/mouse/mouse-app.test.tsx
@@ -155,6 +155,7 @@ function mountApp(): {
   switched: string[];
   /** `[sessionId, toIndex]` pairs the app asked the host to reorder. */
   moves: Array<[string, number]>;
+  pins: string[];
   /** Clicks the Tasks header's `+ new` chip delivered to the host. */
   taskNews: number[];
   /** Provider ids `/model` asked the orchestrator to ensure a catalog for. */
@@ -166,6 +167,7 @@ function mountApp(): {
   const deleted: string[] = [];
   const switched: string[] = [];
   const moves: Array<[string, number]> = [];
+  const pins: string[] = [];
   const copied: string[] = [];
   const taskNews: number[] = [];
   const modelEnsures: Array<string | null> = [];
@@ -184,6 +186,7 @@ function mountApp(): {
         ...noopCallbacks(),
         onSessionDeleteConfirmed: (sessionId) => deleted.push(sessionId),
         onSessionSwitchRequested: (sessionId) => switched.push(sessionId),
+        onSessionPinToggled: (sessionId) => pins.push(sessionId),
         onSessionMoveRequested: (sessionId, toIndex) =>
           moves.push([sessionId, toIndex]),
         onTaskNewRequested: () => taskNews.push(taskNews.length),
@@ -201,6 +204,7 @@ function mountApp(): {
     deleted,
     switched,
     moves,
+    pins,
     taskNews,
     modelEnsures,
     copied,
@@ -464,7 +468,9 @@ describe("TuiApp mouse", () => {
     ): Promise<void> => {
       await waitUntil(() => app.frame().includes("R U N"), "the Run screen");
       app.seedSessions();
-      await waitUntil(() => app.frame().includes("first thread"), "the rail rows");
+      // A prefix, not the whole preview: the rail truncates previews to
+      // its width, and the pin mark takes two of those columns.
+      await waitUntil(() => app.frame().includes("first th"), "the rail rows");
       app.stdin.write("\t");
       await waitUntil(() => app.frame().includes("[x]"), "the selected row");
       await clickUntil(
@@ -712,6 +718,29 @@ describe("TuiApp mouse", () => {
       // Dropping is not opening.
       expect(app.switched).toEqual([]);
       await waitUntil(() => !app.frame().includes("↕"), "the drag feedback to clear");
+      app.unmount();
+    });
+
+    it("pins a row when its ↑ is clicked, without opening it", async () => {
+      const app = mountApp();
+      await seedRail(app);
+      // The arrow sits at the right edge of every row, so it is
+      // reachable without selecting the row first.
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        const line = rowLine(app, "second th");
+        const at = locate(app.frame(), "second th");
+        const arrow = line.lastIndexOf("↑");
+        expect(arrow).toBeGreaterThan(-1);
+        app.mouse.emit(click(arrow, at.y));
+        await delay(30);
+        app.mouse.emit(release(arrow, at.y));
+        await delay(50);
+        if (app.pins.length > 0) break;
+      }
+      expect(app.pins).toEqual(["s-2"]);
+      // A pin is not an open and not a move.
+      expect(app.switched).toEqual([]);
+      expect(app.moves).toEqual([]);
       app.unmount();
     });
 

--- a/src/tui/rail-session-list.test.ts
+++ b/src/tui/rail-session-list.test.ts
@@ -82,21 +82,26 @@ function harness(
   stored: ReturnType<typeof blank>[],
   settleTurns = false,
   order: string[] = [],
+  pinned: string[] = [],
 ) {
   const bus = makeTuiEventBus();
   const actions: TuiAction[] = [];
   bus.subscribe((a) => actions.push(a));
-  // The rail's manual order, held in memory instead of the developer's
-  // config.json; `written` is every snapshot the orchestrator persisted.
+  // The rail's layout, held in memory instead of the developer's
+  // config.json; `written` is every order snapshot the orchestrator
+  // persisted and `pins` every pinned list.
   const written: string[][] = [];
+  const pins: string[][] = [];
   const orchestrator = new ChatOrchestrator(stubRuntime(stored, settleTurns), bus, {
     maxSteps: 5,
     llamaUrl: "http://127.0.0.1:8080", readGateFacts: cloudGateFacts,
-    sessionRailOrder: {
-      read: () => order,
+    sessionRailLayout: {
+      read: () => ({ order, pinned }),
       write: (next) => {
-        order = [...next];
-        written.push([...next]);
+        order = [...next.order];
+        pinned = [...next.pinned];
+        written.push([...next.order]);
+        pins.push([...next.pinned]);
       },
     },
   });
@@ -114,7 +119,7 @@ function harness(
     }
     return [];
   };
-  return { orchestrator, rail, picker, actions, written };
+  return { orchestrator, rail, picker, actions, written, pins };
 }
 
 describe("rail session list", () => {

--- a/src/tui/rail-session-list.test.ts
+++ b/src/tui/rail-session-list.test.ts
@@ -303,3 +303,98 @@ describe("rail session list — manual order", () => {
     expect(actions.length).toBe(emitted);
   });
 });
+
+describe("rail session list — pinned block", () => {
+  it("keeps pinned threads on top whatever their recency, in the manual order", () => {
+    const stored = [
+      spokenTo("s-4", "newest"),
+      spokenTo("s-3", "third"),
+      spokenTo("s-2", "second"),
+      spokenTo("s-1", "oldest"),
+    ];
+    const { orchestrator, rail } = harness(stored, false, ["s-1", "s-3"], ["s-3", "s-1"]);
+    orchestrator.refreshRecentSessions();
+    const rows = rail();
+    expect(rows.map((e) => e.sessionId)).toEqual(["s-1", "s-3", "s-4", "s-2"]);
+    expect(rows.map((e) => e.pinned)).toEqual([true, true, false, false]);
+  });
+
+  it("loads a pinned thread that has fallen out of the recency window", () => {
+    // 30 real threads, the rail shows 25 — the oldest one is pinned and
+    // must still be on the list, built from its first prompt.
+    const stored = Array.from({ length: 30 }, (_, i) =>
+      spokenTo(`s-real-${i}`, `thread ${i}`),
+    );
+    const { orchestrator, rail } = harness(stored, false, [], ["s-real-29"]);
+    orchestrator.refreshRecentSessions();
+    const rows = rail();
+    expect(rows).toHaveLength(26);
+    expect(rows[0]).toMatchObject({
+      sessionId: "s-real-29",
+      preview: "thread 29",
+      pinned: true,
+    });
+  });
+
+  it("shows nothing for a pinned id that no longer exists, and prunes it on the next write", () => {
+    const stored = [spokenTo("s-2", "second"), spokenTo("s-1", "first")];
+    const { orchestrator, rail, pins } = harness(stored, false, [], ["s-gone"]);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-2", "s-1"]);
+    orchestrator.togglePinned("s-1");
+    expect(pins.at(-1)).toEqual(["s-1"]);
+  });
+
+  it("togglePinned appends to the block, then releases to the top of the rest", () => {
+    const stored = [
+      spokenTo("s-3", "third"),
+      spokenTo("s-2", "second"),
+      spokenTo("s-1", "first"),
+    ];
+    const { orchestrator, rail, written, pins } = harness(stored, false, [], ["s-2"]);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-2", "s-3", "s-1"]);
+    orchestrator.togglePinned("s-1");
+    expect(pins.at(-1)).toEqual(["s-2", "s-1"]);
+    expect(written.at(-1)).toEqual(["s-2", "s-1", "s-3"]);
+    expect(rail().map((e) => [e.sessionId, e.pinned])).toEqual([
+      ["s-2", true],
+      ["s-1", true],
+      ["s-3", false],
+    ]);
+    orchestrator.togglePinned("s-2");
+    expect(pins.at(-1)).toEqual(["s-1"]);
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-1", "s-2", "s-3"]);
+    expect(rail()[1]?.pinned).toBe(false);
+  });
+
+  it("a drop inside the block pins, a drop below it unpins", () => {
+    const stored = [
+      spokenTo("s-3", "third"),
+      spokenTo("s-2", "second"),
+      spokenTo("s-1", "first"),
+    ];
+    const { orchestrator, rail, pins } = harness(stored, false, [], ["s-1"]);
+    orchestrator.refreshRecentSessions();
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-1", "s-3", "s-2"]);
+    // Drag s-2 onto the pinned row: it joins the block.
+    orchestrator.moveSession("s-2", 0);
+    expect(pins.at(-1)).toEqual(["s-2", "s-1"]);
+    expect(rail().map((e) => e.pinned)).toEqual([true, true, false]);
+    // Drag s-1 below the block: it leaves it.
+    orchestrator.moveSession("s-1", 2);
+    expect(pins.at(-1)).toEqual(["s-2"]);
+    expect(rail().map((e) => e.sessionId)).toEqual(["s-2", "s-3", "s-1"]);
+  });
+
+  it("pinning writes the config only — the session store is not touched", () => {
+    const stored = [spokenTo("s-2", "second"), spokenTo("s-1", "first")];
+    const before = stored.map((s) => ({ ...s }));
+    const { orchestrator, rail } = harness(stored);
+    orchestrator.refreshRecentSessions();
+    const updatedAt = rail().map((e) => e.updatedAt);
+    orchestrator.togglePinned("s-1");
+    expect(stored).toEqual(before);
+    expect(rail().map((e) => e.updatedAt)).toEqual([updatedAt[1], updatedAt[0]]);
+  });
+});

--- a/src/tui/reduce-session-actions.test.ts
+++ b/src/tui/reduce-session-actions.test.ts
@@ -15,6 +15,7 @@ function entry(overrides: Partial<SessionPickerEntry> = {}): SessionPickerEntry 
     stepCount: 0,
     updatedAt: Date.now(),
     preview: "(empty)",
+    pinned: false,
     ...overrides,
   };
 }

--- a/src/tui/reduce-sidebar-actions.test.ts
+++ b/src/tui/reduce-sidebar-actions.test.ts
@@ -21,6 +21,7 @@ function entry(overrides: Partial<SessionPickerEntry>): SessionPickerEntry {
     stepCount: 0,
     updatedAt: 0,
     preview: "",
+    pinned: false,
     ...overrides,
   };
 }

--- a/src/tui/session-rail/handle-session-move-key.test.ts
+++ b/src/tui/session-rail/handle-session-move-key.test.ts
@@ -48,7 +48,7 @@ function session(): TuiSessionInfo {
   };
 }
 
-function entry(sessionId: string): SessionPickerEntry {
+function entry(sessionId: string, pinned = false): SessionPickerEntry {
   return {
     sessionId,
     workingDir: "/tmp/w",
@@ -56,17 +56,22 @@ function entry(sessionId: string): SessionPickerEntry {
     stepCount: 1,
     updatedAt: 0,
     preview: sessionId,
+    pinned,
   };
 }
 
 /** Rail focused on Sessions with three rows and the cursor on `cursor`. */
-function railState(cursor: number, section: "sessions" | "tasks" = "sessions"): TuiState {
+function railState(
+  cursor: number,
+  section: "sessions" | "tasks" = "sessions",
+  rows: SessionPickerEntry[] = [entry("s-1"), entry("s-2"), entry("s-3")],
+): TuiState {
   return {
     ...createInitialTuiState(session()),
     chatFocus: "sidebar",
     sidebarSection: section,
     sidebarCursor: cursor,
-    recentSessions: [entry("s-1"), entry("s-2"), entry("s-3")],
+    recentSessions: rows,
   };
 }
 
@@ -122,6 +127,24 @@ describe("rail session move keys", () => {
     expect(handleAppKey("", key({ downArrow: true, shift: true }), bottom)).toBe(true);
     expect(bottom.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
     expect(bottom.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("stops at the edge of the pinned block instead of crossing it", () => {
+    // s-1 is pinned, s-2 and s-3 are not. Shift+↓ on the last pinned row
+    // and Shift+↑ on the first unpinned row would both cross the edge —
+    // that is a pin change, which only `p` may make.
+    const rows = [entry("s-1", true), entry("s-2"), entry("s-3")];
+    const lastPinned = ctx(railState(0, "sessions", rows));
+    expect(handleAppKey("", key({ downArrow: true, shift: true }), lastPinned)).toBe(true);
+    expect(lastPinned.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
+    expect(lastPinned.dispatch).not.toHaveBeenCalled();
+    const firstUnpinned = ctx(railState(1, "sessions", rows));
+    expect(handleAppKey("", key({ upArrow: true, shift: true }), firstUnpinned)).toBe(true);
+    expect(firstUnpinned.callbacks.onSessionMoveRequested).not.toHaveBeenCalled();
+    // Inside the unpinned half the move still works.
+    const inside = ctx(railState(1, "sessions", rows));
+    expect(handleAppKey("", key({ downArrow: true, shift: true }), inside)).toBe(true);
+    expect(inside.callbacks.onSessionMoveRequested).toHaveBeenCalledWith("s-2", 2);
   });
 
   it("leaves a plain ↑ alone", () => {

--- a/src/tui/session-rail/handle-session-move-key.ts
+++ b/src/tui/session-rail/handle-session-move-key.ts
@@ -22,7 +22,10 @@ export interface SessionMoveKeyContext {
  * so the caller's own ↑/↓ handling runs instead. A move that would
  * leave the list (Shift+↑ on the top row) is consumed and does nothing:
  * the operator was clearly talking to the rail, and letting the chord
- * fall through to a cursor move would be a surprise.
+ * fall through to a cursor move would be a surprise. The same goes for
+ * a move that would cross the pinned block's edge: a keyboard move
+ * never pins or unpins — that is what `p` is for — so the chord stops
+ * at the boundary.
  *
  * Ink reports the chord as `upArrow: true, shift: true` — `\x1b[1;2A`
  * carries the xterm modifier 2, which `parse-keypress` maps to `shift`.
@@ -40,7 +43,8 @@ export function handleSessionMoveKey(
   const entry = state.recentSessions[from];
   if (!entry) return true;
   const to = from + (key.upArrow ? -1 : 1);
-  if (to < 0 || to >= state.recentSessions.length) return true;
+  const target = state.recentSessions[to];
+  if (!target || target.pinned !== entry.pinned) return true;
   ctx.callbacks.onSessionMoveRequested?.(entry.sessionId, to);
   // After the callback: the orchestrator's refresh re-emits the list,
   // and the cursor must end on the moved row, not on where it was.

--- a/src/tui/session-rail/handle-session-pin-key.test.ts
+++ b/src/tui/session-rail/handle-session-pin-key.test.ts
@@ -99,6 +99,25 @@ describe("rail session pin key", () => {
     expect(c.callbacks.onSessionPinToggled).toHaveBeenCalledWith("s-1");
   });
 
+  it("takes the cursor to the row's new slot so a second `p` undoes the first", () => {
+    // s-2 is pinned, so the block is one row long and an unpinned s-1
+    // pinned now lands right after it, at index 1.
+    const rows = [entry("s-2", true), entry("s-1")];
+    const c = ctx(railState(1, "sessions", rows));
+    expect(handleAppKey("p", key(), c)).toBe(true);
+    expect(c.callbacks.onSessionPinToggled).toHaveBeenCalledWith("s-1");
+    expect(c.dispatch).toHaveBeenCalledWith({ type: "sidebar_cursor_set", row: 1 });
+  });
+
+  it("follows a released row to the head of the unpinned half", () => {
+    // Two pinned rows; releasing the first leaves a one-row block, so
+    // the row it is released to is index 1.
+    const rows = [entry("s-1", true), entry("s-2", true), entry("s-3")];
+    const c = ctx(railState(0, "sessions", rows));
+    expect(handleAppKey("p", key(), c)).toBe(true);
+    expect(c.dispatch).toHaveBeenCalledWith({ type: "sidebar_cursor_set", row: 1 });
+  });
+
   it("works on an already-pinned row — the same key releases it", () => {
     const c = ctx(railState(1));
     expect(handleAppKey("p", key(), c)).toBe(true);

--- a/src/tui/session-rail/handle-session-pin-key.test.ts
+++ b/src/tui/session-rail/handle-session-pin-key.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Key } from "ink";
+
+import { handleAppKey } from "../app-key-bindings.js";
+import {
+  createInitialTuiState,
+  type SessionPickerEntry,
+  type TuiSessionInfo,
+  type TuiState,
+} from "../tui-state.js";
+
+function key(overrides: Partial<Key> = {}): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageDown: false,
+    pageUp: false,
+    home: false,
+    end: false,
+    return: false,
+    escape: false,
+    ctrl: false,
+    shift: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    meta: false,
+    super: false,
+    hyper: false,
+    capsLock: false,
+    numLock: false,
+    ...overrides,
+  } as Key;
+}
+
+function session(): TuiSessionInfo {
+  return {
+    sessionId: "s-1",
+    workingDir: "/tmp/w",
+    llamaUrl: "http://127.0.0.1:8080",
+    browserChannel: "chromium",
+    browserHeadless: true,
+    approvalLevel: 5,
+    maxSteps: 8,
+    skillCount: 0,
+  };
+}
+
+function entry(sessionId: string, pinned = false): SessionPickerEntry {
+  return {
+    sessionId,
+    workingDir: "/tmp/w",
+    turnCount: 1,
+    stepCount: 1,
+    updatedAt: 0,
+    preview: sessionId,
+    pinned,
+  };
+}
+
+function railState(
+  cursor: number,
+  section: "sessions" | "tasks" = "sessions",
+  rows: SessionPickerEntry[] = [entry("s-1"), entry("s-2", true)],
+): TuiState {
+  return {
+    ...createInitialTuiState(session()),
+    chatFocus: "sidebar",
+    sidebarSection: section,
+    sidebarCursor: cursor,
+    recentSessions: rows,
+  };
+}
+
+function ctx(state: TuiState) {
+  return {
+    state,
+    dispatch: vi.fn(),
+    callbacks: {
+      onApprovalDecision: vi.fn(),
+      onAbort: vi.fn(),
+      onQuit: vi.fn(),
+      onSessionPinToggled: vi.fn(),
+      onSessionSwitchRequested: vi.fn(),
+      onSessionMoveRequested: vi.fn(),
+    },
+    ctrlCArmed: false,
+    setCtrlCArmed: vi.fn(),
+    sidebarVisible: true,
+  };
+}
+
+describe("rail session pin key", () => {
+  it("`p` toggles the pin of the selected row", () => {
+    const c = ctx(railState(0));
+    expect(handleAppKey("p", key(), c)).toBe(true);
+    expect(c.callbacks.onSessionPinToggled).toHaveBeenCalledWith("s-1");
+  });
+
+  it("works on an already-pinned row — the same key releases it", () => {
+    const c = ctx(railState(1));
+    expect(handleAppKey("p", key(), c)).toBe(true);
+    expect(c.callbacks.onSessionPinToggled).toHaveBeenCalledWith("s-2");
+  });
+
+  it("accepts an upper-case P", () => {
+    const c = ctx(railState(0));
+    expect(handleAppKey("P", key({ shift: true }), c)).toBe(true);
+    expect(c.callbacks.onSessionPinToggled).toHaveBeenCalledWith("s-1");
+  });
+
+  it("leaves the Tasks pane alone", () => {
+    const c = ctx(railState(0, "tasks"));
+    // Still consumed — the rail swallows letters so they cannot reach
+    // the composer — but no pin is toggled.
+    expect(handleAppKey("p", key(), c)).toBe(true);
+    expect(c.callbacks.onSessionPinToggled).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on ctrl+p or meta+p", () => {
+    const withCtrl = ctx(railState(0));
+    handleAppKey("p", key({ ctrl: true }), withCtrl);
+    expect(withCtrl.callbacks.onSessionPinToggled).not.toHaveBeenCalled();
+    const withMeta = ctx(railState(0));
+    handleAppKey("p", key({ meta: true }), withMeta);
+    expect(withMeta.callbacks.onSessionPinToggled).not.toHaveBeenCalled();
+  });
+
+  it("still swallows other letters instead of pinning", () => {
+    const c = ctx(railState(0));
+    expect(handleAppKey("q", key(), c)).toBe(true);
+    expect(c.callbacks.onSessionPinToggled).not.toHaveBeenCalled();
+  });
+});

--- a/src/tui/session-rail/handle-session-pin-key.ts
+++ b/src/tui/session-rail/handle-session-pin-key.ts
@@ -1,9 +1,12 @@
 import type { Key } from "ink";
 
+import type { TuiAction } from "../tui-action.js";
 import type { TuiState } from "../tui-state.js";
+import { pinnedBlockLength } from "./session-rail-pin.js";
 
 export interface SessionPinKeyContext {
   state: TuiState;
+  dispatch: (action: TuiAction) => void;
   callbacks: {
     onSessionPinToggled?: (sessionId: string) => void;
   };
@@ -19,6 +22,12 @@ export interface SessionPinKeyContext {
  * operators in front of a control they can see and cannot reach — the
  * same reason `x` exists beside the close mark.
  *
+ * The cursor follows the row, as it does for a move: pinning lifts the
+ * thread to the end of the top block and unpinning drops it at the head
+ * of the rest, and a cursor left on the old slot would put the next `p`
+ * on a different thread — pressing it twice would pin two rows instead
+ * of undoing the first.
+ *
  * Returns `true` when the key was consumed. A `p` on the Tasks pane is
  * not consumed here; the caller's own letter-swallow deals with it.
  */
@@ -32,6 +41,18 @@ export function handleSessionPinKey(
   const { state } = ctx;
   if (state.sidebarSection !== "sessions") return false;
   const entry = state.recentSessions[state.sidebarCursor];
-  if (entry) ctx.callbacks.onSessionPinToggled?.(entry.sessionId);
+  if (!entry) return true;
+  ctx.callbacks.onSessionPinToggled?.(entry.sessionId);
+  // Where the row lands: the block grows by one and takes it last when
+  // pinning, and the row leaves the block and heads the rest when it is
+  // released — the two slots `togglePinned` moves it to.
+  const block = pinnedBlockLength(
+    state.recentSessions.map((row) => row.sessionId),
+    state.recentSessions.filter((row) => row.pinned).map((row) => row.sessionId),
+  );
+  ctx.dispatch({
+    type: "sidebar_cursor_set",
+    row: entry.pinned ? Math.max(0, block - 1) : block,
+  });
   return true;
 }

--- a/src/tui/session-rail/handle-session-pin-key.ts
+++ b/src/tui/session-rail/handle-session-pin-key.ts
@@ -1,0 +1,37 @@
+import type { Key } from "ink";
+
+import type { TuiState } from "../tui-state.js";
+
+export interface SessionPinKeyContext {
+  state: TuiState;
+  callbacks: {
+    onSessionPinToggled?: (sessionId: string) => void;
+  };
+}
+
+/**
+ * `p` with the rail's Sessions pane focused: pin the selected thread to
+ * the top block, or release it.
+ *
+ * The keyboard twin of the row's `↑`. The mark is painted whether or
+ * not mouse reporting is on, so leaving the toggle to the pointer would
+ * strand `/mouse off`, terminals without reporting, and keyboard-first
+ * operators in front of a control they can see and cannot reach — the
+ * same reason `x` exists beside the close mark.
+ *
+ * Returns `true` when the key was consumed. A `p` on the Tasks pane is
+ * not consumed here; the caller's own letter-swallow deals with it.
+ */
+export function handleSessionPinKey(
+  input: string,
+  key: Key,
+  ctx: SessionPinKeyContext,
+): boolean {
+  if (key.ctrl || key.meta) return false;
+  if (input.toLowerCase() !== "p") return false;
+  const { state } = ctx;
+  if (state.sidebarSection !== "sessions") return false;
+  const entry = state.recentSessions[state.sidebarCursor];
+  if (entry) ctx.callbacks.onSessionPinToggled?.(entry.sessionId);
+  return true;
+}

--- a/src/tui/session-rail/index.ts
+++ b/src/tui/session-rail/index.ts
@@ -7,13 +7,14 @@ export {
   pruneSessionRailOrder,
 } from "./session-rail-order.js";
 export {
-  persistSessionRailOrder,
-  readSessionRailOrder,
+  persistSessionRailLayout,
+  readSessionRailLayout,
+  type SessionRailLayout,
 } from "./persist-session-rail.js";
 export {
   SessionRailOrchestrator,
-  configSessionRailOrderStore,
-  type SessionRailOrderStore,
+  configSessionRailLayoutStore,
+  type SessionRailLayoutStore,
 } from "./session-rail-orchestrator.js";
 export {
   handleSessionMoveKey,

--- a/src/tui/session-rail/index.ts
+++ b/src/tui/session-rail/index.ts
@@ -7,9 +7,15 @@ export {
   pruneSessionRailOrder,
 } from "./session-rail-order.js";
 export {
+  arrangeSessionRail,
+  computeDroppedLayout,
+  pinnedBlockLength,
+  togglePinned,
+  type SessionRailLayout,
+} from "./session-rail-pin.js";
+export {
   persistSessionRailLayout,
   readSessionRailLayout,
-  type SessionRailLayout,
 } from "./persist-session-rail.js";
 export {
   SessionRailOrchestrator,

--- a/src/tui/session-rail/index.ts
+++ b/src/tui/session-rail/index.ts
@@ -26,4 +26,13 @@ export {
   handleSessionMoveKey,
   type SessionMoveKeyContext,
 } from "./handle-session-move-key.js";
+export {
+  handleSessionPinKey,
+  type SessionPinKeyContext,
+} from "./handle-session-pin-key.js";
+export {
+  PinSessionButton,
+  PIN_COLUMNS,
+  type PinSessionButtonProps,
+} from "./pin-session-button.js";
 export { SessionRailRow, type SessionRailRowProps } from "./session-rail-row.js";

--- a/src/tui/session-rail/persist-session-rail.test.ts
+++ b/src/tui/session-rail/persist-session-rail.test.ts
@@ -5,13 +5,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { getConfig, resetConfigCache } from "../../config/index.js";
 import {
-  persistSessionRailOrder,
-  readSessionRailOrder,
+  persistSessionRailLayout,
+  readSessionRailLayout,
 } from "./persist-session-rail.js";
 
 const STATE_DIR_ENV = "ATOMIC_AGENT_STATE_DIR";
 
-describe("persistSessionRailOrder", () => {
+describe("persistSessionRailLayout", () => {
   let stateDir: string;
   let originalEnv: string | undefined;
 
@@ -30,18 +30,18 @@ describe("persistSessionRailOrder", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
-  it("writes the order to config.json and getConfig() picks it up", () => {
-    expect(readSessionRailOrder()).toEqual([]);
-    persistSessionRailOrder(["s-b", "s-a"]);
+  it("writes order and pinned to config.json and getConfig() picks them up", () => {
+    expect(readSessionRailLayout()).toEqual({ order: [], pinned: [] });
+    persistSessionRailLayout({ order: ["s-b", "s-a"], pinned: ["s-a"] });
     const onDisk = JSON.parse(readFileSync(getConfig().paths.userConfigFile, "utf8"));
-    expect(onDisk.tui.sessionRail.order).toEqual(["s-b", "s-a"]);
-    expect(readSessionRailOrder()).toEqual(["s-b", "s-a"]);
+    expect(onDisk.tui.sessionRail).toEqual({ order: ["s-b", "s-a"], pinned: ["s-a"] });
+    expect(readSessionRailLayout()).toEqual({ order: ["s-b", "s-a"], pinned: ["s-a"] });
   });
 
-  it("replaces the previous order and leaves the rest of tui alone", () => {
-    persistSessionRailOrder(["s-a"]);
-    persistSessionRailOrder(["s-b", "s-a"]);
-    expect(getConfig().tui.sessionRail.order).toEqual(["s-b", "s-a"]);
+  it("replaces the previous layout and leaves the rest of tui alone", () => {
+    persistSessionRailLayout({ order: ["s-a"], pinned: ["s-a"] });
+    persistSessionRailLayout({ order: ["s-b", "s-a"], pinned: [] });
+    expect(getConfig().tui.sessionRail).toEqual({ order: ["s-b", "s-a"], pinned: [] });
     expect(getConfig().tui.theme).toBe("auto");
     expect(getConfig().tui.mouse).toBe(true);
   });

--- a/src/tui/session-rail/persist-session-rail.ts
+++ b/src/tui/session-rail/persist-session-rail.ts
@@ -5,16 +5,7 @@ import {
   resetConfigCache,
   writeUserConfigFileSync,
 } from "../../config/index.js";
-
-/**
- * What the rail remembers between runs: the manual order and the
- * pinned ids. One value, because a pin rewrites both — pinning moves
- * the row into the block, and the block is ordered by `order`.
- */
-export interface SessionRailLayout {
-  readonly order: readonly string[];
-  readonly pinned: readonly string[];
-}
+import type { SessionRailLayout } from "./session-rail-pin.js";
 
 /**
  * Persist the rail's layout into `tui.sessionRail`, then invalidate the

--- a/src/tui/session-rail/persist-session-rail.ts
+++ b/src/tui/session-rail/persist-session-rail.ts
@@ -7,24 +7,38 @@ import {
 } from "../../config/index.js";
 
 /**
- * Persist the rail's manual session order into `tui.sessionRail.order`,
- * then invalidate the config cache so the next `getConfig()` sees it.
- * Same read → merge → validate → write → reset shape as the other
- * `persist-*` helpers. Only the orchestrator calls this, from the
- * move callback — never the reducer or a render path.
+ * What the rail remembers between runs: the manual order and the
+ * pinned ids. One value, because a pin rewrites both — pinning moves
+ * the row into the block, and the block is ordered by `order`.
  */
-export function persistSessionRailOrder(order: readonly string[]): void {
+export interface SessionRailLayout {
+  readonly order: readonly string[];
+  readonly pinned: readonly string[];
+}
+
+/**
+ * Persist the rail's layout into `tui.sessionRail`, then invalidate the
+ * config cache so the next `getConfig()` sees it. Same read → merge →
+ * validate → write → reset shape as the other `persist-*` helpers.
+ * Only the orchestrator calls this, from the move and pin callbacks —
+ * never the reducer or a render path.
+ */
+export function persistSessionRailLayout(layout: SessionRailLayout): void {
   const path = getConfig().paths.userConfigFile;
   const prev = ensureUserConfigFileSync(path);
   const draft = {
     ...prev,
-    tui: { ...prev.tui, sessionRail: { order: [...order] } },
+    tui: {
+      ...prev.tui,
+      sessionRail: { order: [...layout.order], pinned: [...layout.pinned] },
+    },
   };
   writeUserConfigFileSync(path, parseUserConfigFile(draft));
   resetConfigCache();
 }
 
-/** The persisted order, `[]` while the operator has never arranged the rail. */
-export function readSessionRailOrder(): readonly string[] {
-  return getConfig().tui.sessionRail.order;
+/** The persisted layout: `[]`/`[]` while the operator has never touched the rail. */
+export function readSessionRailLayout(): SessionRailLayout {
+  const { order, pinned } = getConfig().tui.sessionRail;
+  return { order, pinned };
 }

--- a/src/tui/session-rail/pin-session-button.tsx
+++ b/src/tui/session-rail/pin-session-button.tsx
@@ -1,0 +1,59 @@
+import { Text } from "ink";
+import type { ReactElement } from "react";
+
+import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { MOUSE_LAYER_BASE } from "../mouse/mouse-registry.js";
+import { theme } from "../theme/theme.js";
+
+/** Cells the pin affordance occupies inside a row's ground: `↑` + a pad. */
+export const PIN_COLUMNS = 2;
+
+export interface PinSessionButtonProps {
+  sessionId: string;
+  pinned: boolean;
+  /** The row carries inverse video (selected, or the one being dragged). */
+  inverse: boolean;
+}
+
+/**
+ * The `↑` at the right edge of every session row: click it to pin the
+ * thread to the top of the rail, click it again to release it.
+ *
+ * Unlike the `[x]`, this one is painted on EVERY row rather than only
+ * the selected one. Pinning is not destructive — the worst a mis-click
+ * does is move a row, and the next click puts it back — and a mark that
+ * only appears under the pointer cannot show which threads are already
+ * pinned, which is half of what this control is for. Bright and bold
+ * when pinned, dim when not, so the block reads at a glance.
+ */
+export function PinSessionButton({
+  sessionId,
+  pinned,
+  inverse,
+}: PinSessionButtonProps): ReactElement {
+  const mouse = useMouseCommands();
+  const glyph = (
+    <Text
+      color={pinned ? theme.colors.railForeground : theme.colors.railMuted}
+      bold={pinned}
+      {...(inverse ? { inverse: true } : {})}
+    >
+      {`${theme.glyphs.pinned} `}
+    </Text>
+  );
+  if (!mouse) return glyph;
+  return (
+    <MouseTarget
+      layer={MOUSE_LAYER_BASE}
+      flexShrink={0}
+      onMouse={(hit) => {
+        if (!isPrimaryPress(hit.event)) return false;
+        mouse.callbacks.onSessionPinToggled?.(sessionId);
+        return true;
+      }}
+    >
+      {glyph}
+    </MouseTarget>
+  );
+}

--- a/src/tui/session-rail/session-rail-orchestrator.ts
+++ b/src/tui/session-rail/session-rail-orchestrator.ts
@@ -1,7 +1,8 @@
 import type { SessionPickerEntry } from "../tui-state.js";
 import {
-  persistSessionRailOrder,
-  readSessionRailOrder,
+  persistSessionRailLayout,
+  readSessionRailLayout,
+  type SessionRailLayout,
 } from "./persist-session-rail.js";
 import {
   applySessionRailOrder,
@@ -9,17 +10,18 @@ import {
 } from "./session-rail-order.js";
 
 /**
- * Where the manual order lives. Injectable so orchestrator tests stay
- * hermetic — the default reads and writes the user's `config.json`.
+ * Where the layout (manual order + pinned ids) lives. Injectable so
+ * orchestrator tests stay hermetic — the default reads and writes the
+ * user's `config.json`.
  */
-export interface SessionRailOrderStore {
-  read(): readonly string[];
-  write(order: readonly string[]): void;
+export interface SessionRailLayoutStore {
+  read(): SessionRailLayout;
+  write(layout: SessionRailLayout): void;
 }
 
-export const configSessionRailOrderStore: SessionRailOrderStore = {
-  read: readSessionRailOrder,
-  write: persistSessionRailOrder,
+export const configSessionRailLayoutStore: SessionRailLayoutStore = {
+  read: readSessionRailLayout,
+  write: persistSessionRailLayout,
 };
 
 /**
@@ -37,13 +39,13 @@ export class SessionRailOrchestrator {
   private lastRail: readonly SessionPickerEntry[] = [];
 
   constructor(
-    private readonly store: SessionRailOrderStore,
+    private readonly store: SessionRailLayoutStore,
     private readonly refresh: () => void,
   ) {}
 
   /** Apply the remembered order to the list about to be emitted. */
   arrange(entries: readonly SessionPickerEntry[]): SessionPickerEntry[] {
-    const arranged = applySessionRailOrder(entries, this.store.read());
+    const arranged = applySessionRailOrder(entries, this.store.read().order);
     this.lastRail = arranged;
     return arranged;
   }
@@ -53,7 +55,7 @@ export class SessionRailOrchestrator {
     const displayed = this.lastRail.map((entry) => entry.sessionId);
     const next = computeMovedOrder(displayed, sessionId, toIndex);
     if (!next) return;
-    this.store.write(next);
+    this.store.write({ order: next, pinned: this.store.read().pinned });
     this.refresh();
   }
 }

--- a/src/tui/session-rail/session-rail-orchestrator.ts
+++ b/src/tui/session-rail/session-rail-orchestrator.ts
@@ -2,12 +2,13 @@ import type { SessionPickerEntry } from "../tui-state.js";
 import {
   persistSessionRailLayout,
   readSessionRailLayout,
-  type SessionRailLayout,
 } from "./persist-session-rail.js";
 import {
-  applySessionRailOrder,
-  computeMovedOrder,
-} from "./session-rail-order.js";
+  arrangeSessionRail,
+  computeDroppedLayout,
+  togglePinned,
+  type SessionRailLayout,
+} from "./session-rail-pin.js";
 
 /**
  * Where the layout (manual order + pinned ids) lives. Injectable so
@@ -25,15 +26,28 @@ export const configSessionRailLayoutStore: SessionRailLayoutStore = {
 };
 
 /**
- * The rail's order, owned by the chat orchestrator.
+ * Build the row for a session the incoming list does not carry, or
+ * `null` when it no longer exists. Injected so tests never touch a
+ * session store.
+ */
+export type SessionRailEntryLoader = (sessionId: string) => SessionPickerEntry | null;
+
+/**
+ * The rail's layout, owned by the chat orchestrator.
  *
  * `arrange` is the one hook in `railSessions()`: it applies the stored
- * order and remembers what was emitted, so a later `moveSession` can
- * compute the new order against exactly the list the operator saw —
- * the row indices the keyboard and the mouse hand over are indices
- * into THAT list, pending stand-ins included. The first move persists
- * the whole displayed list, which is the "snapshot on first touch"
- * that turns a recency-sorted rail into a manual one.
+ * layout and remembers what was emitted, so a later `moveSession` or
+ * `togglePinned` can compute the new layout against exactly the list
+ * the operator saw — the row indices the keyboard and the mouse hand
+ * over are indices into THAT list, pending stand-ins included. The
+ * first move or pin persists the whole displayed list, which is the
+ * "snapshot on first touch" that turns a recency-sorted rail into a
+ * manual one.
+ *
+ * A pinned id the incoming list lacks — a thread older than the
+ * recency window — is fetched through `loadEntry` before arranging, so
+ * a pin is never lost to age. A pin on a deleted session loads nothing
+ * and is pruned on the next write.
  */
 export class SessionRailOrchestrator {
   private lastRail: readonly SessionPickerEntry[] = [];
@@ -41,21 +55,54 @@ export class SessionRailOrchestrator {
   constructor(
     private readonly store: SessionRailLayoutStore,
     private readonly refresh: () => void,
+    private readonly loadEntry: SessionRailEntryLoader = () => null,
   ) {}
 
-  /** Apply the remembered order to the list about to be emitted. */
+  /** Apply the remembered layout to the list about to be emitted. */
   arrange(entries: readonly SessionPickerEntry[]): SessionPickerEntry[] {
-    const arranged = applySessionRailOrder(entries, this.store.read().order);
+    const layout = this.store.read();
+    const pinned = new Set(layout.pinned);
+    const present = new Set(entries.map((entry) => entry.sessionId));
+    const missing: SessionPickerEntry[] = [];
+    for (const id of layout.pinned) {
+      if (present.has(id)) continue;
+      const loaded = this.loadEntry(id);
+      if (loaded) missing.push(loaded);
+    }
+    const arranged = arrangeSessionRail([...entries, ...missing], layout).map(
+      (entry) => ({ ...entry, pinned: pinned.has(entry.sessionId) }),
+    );
     this.lastRail = arranged;
     return arranged;
   }
 
-  /** Drop `sessionId` on slot `toIndex` of the displayed list, persist, re-emit. */
+  /**
+   * Drop `sessionId` on slot `toIndex` of the displayed list, persist,
+   * re-emit. The slot decides the pin: inside the pinned block pins,
+   * below it unpins — the keyboard never asks for a crossing move, so
+   * this is the drag's rule.
+   */
   moveSession(sessionId: string, toIndex: number): void {
-    const displayed = this.lastRail.map((entry) => entry.sessionId);
-    const next = computeMovedOrder(displayed, sessionId, toIndex);
+    const next = computeDroppedLayout(
+      this.store.read(),
+      this.displayedIds(),
+      sessionId,
+      toIndex,
+    );
     if (!next) return;
-    this.store.write({ order: next, pinned: this.store.read().pinned });
+    this.store.write(next);
     this.refresh();
+  }
+
+  /** Pin `sessionId` to the end of the block, or release it to the top of the rest. */
+  togglePinned(sessionId: string): void {
+    const next = togglePinned(this.store.read(), this.displayedIds(), sessionId);
+    if (!next) return;
+    this.store.write(next);
+    this.refresh();
+  }
+
+  private displayedIds(): string[] {
+    return this.lastRail.map((entry) => entry.sessionId);
   }
 }

--- a/src/tui/session-rail/session-rail-pin.test.ts
+++ b/src/tui/session-rail/session-rail-pin.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  arrangeSessionRail,
+  computeDroppedLayout,
+  pinnedBlockLength,
+  togglePinned,
+} from "./session-rail-pin.js";
+
+const row = (sessionId: string) => ({ sessionId });
+const ids = (rows: readonly { sessionId: string }[]) => rows.map((r) => r.sessionId);
+
+describe("arrangeSessionRail", () => {
+  it("puts the pinned block on top, ordered by `order`, above the unpinned half", () => {
+    // Recency says s-5 first; the pins say s-1 and s-3 come first, s-3 ahead.
+    const entries = [row("s-5"), row("s-4"), row("s-3"), row("s-2"), row("s-1")];
+    const arranged = arrangeSessionRail(entries, {
+      order: ["s-3", "s-1", "s-2", "s-4"],
+      pinned: ["s-1", "s-3"],
+    });
+    expect(ids(arranged)).toEqual(["s-3", "s-1", "s-5", "s-2", "s-4"]);
+  });
+
+  it("keeps recency below the pins while nothing has been arranged", () => {
+    const entries = [row("s-3"), row("s-2"), row("s-1")];
+    const arranged = arrangeSessionRail(entries, { order: [], pinned: ["s-1"] });
+    expect(ids(arranged)).toEqual(["s-1", "s-3", "s-2"]);
+  });
+
+  it("puts pinned ids the order has never seen at the end of the block", () => {
+    const entries = [row("s-3"), row("s-2"), row("s-1")];
+    const arranged = arrangeSessionRail(entries, {
+      order: ["s-1"],
+      pinned: ["s-1", "s-3", "s-2"],
+    });
+    expect(ids(arranged)).toEqual(["s-1", "s-3", "s-2"]);
+  });
+
+  it("ignores pinned ids that have no entry", () => {
+    const entries = [row("s-2"), row("s-1")];
+    const arranged = arrangeSessionRail(entries, { order: [], pinned: ["s-gone"] });
+    expect(ids(arranged)).toEqual(["s-2", "s-1"]);
+  });
+
+  it("is the plain manual order when nothing is pinned", () => {
+    const entries = [row("s-3"), row("s-2"), row("s-1")];
+    const arranged = arrangeSessionRail(entries, { order: ["s-1", "s-3"], pinned: [] });
+    expect(ids(arranged)).toEqual(["s-2", "s-1", "s-3"]);
+  });
+});
+
+describe("pinnedBlockLength", () => {
+  it("counts the displayed ids that are pinned", () => {
+    expect(pinnedBlockLength(["a", "b", "c"], ["a", "b", "zzz"])).toBe(2);
+    expect(pinnedBlockLength(["a", "b"], [])).toBe(0);
+  });
+});
+
+describe("togglePinned", () => {
+  it("pin appends the row to the end of the pinned block", () => {
+    const displayed = ["p-1", "p-2", "u-1", "u-2", "u-3"];
+    const next = togglePinned({ order: displayed, pinned: ["p-1", "p-2"] }, displayed, "u-2");
+    expect(next).toEqual({
+      order: ["p-1", "p-2", "u-2", "u-1", "u-3"],
+      pinned: ["p-1", "p-2", "u-2"],
+    });
+  });
+
+  it("the first pin on an unarranged rail snapshots the displayed list", () => {
+    const displayed = ["s-3", "s-2", "s-1"];
+    const next = togglePinned({ order: [], pinned: [] }, displayed, "s-1");
+    expect(next).toEqual({ order: ["s-1", "s-3", "s-2"], pinned: ["s-1"] });
+    expect(ids(arrangeSessionRail(displayed.map(row), next!))).toEqual(next!.order);
+  });
+
+  it("unpin drops the row at the top of the unpinned half", () => {
+    const displayed = ["p-1", "p-2", "p-3", "u-1", "u-2"];
+    const next = togglePinned(
+      { order: displayed, pinned: ["p-1", "p-2", "p-3"] },
+      displayed,
+      "p-1",
+    );
+    expect(next).toEqual({
+      order: ["p-2", "p-3", "p-1", "u-1", "u-2"],
+      pinned: ["p-2", "p-3"],
+    });
+  });
+
+  it("unpinning the only pin leaves the row on top and the block empty", () => {
+    const displayed = ["p-1", "u-1"];
+    const next = togglePinned({ order: displayed, pinned: ["p-1"] }, displayed, "p-1");
+    expect(next).toEqual({ order: ["p-1", "u-1"], pinned: [] });
+  });
+
+  it("prunes a pinned id that is no longer displayed", () => {
+    const displayed = ["p-1", "u-1"];
+    const next = togglePinned({ order: displayed, pinned: ["p-1", "gone"] }, displayed, "u-1");
+    expect(next?.pinned).toEqual(["p-1", "u-1"]);
+  });
+
+  it("returns null for an id that is not on the list", () => {
+    expect(togglePinned({ order: [], pinned: [] }, ["a"], "zzz")).toBeNull();
+  });
+
+  it("does not mutate its input", () => {
+    const displayed = ["a", "b"];
+    const layout = { order: ["a", "b"], pinned: ["a"] };
+    togglePinned(layout, displayed, "b");
+    expect(displayed).toEqual(["a", "b"]);
+    expect(layout).toEqual({ order: ["a", "b"], pinned: ["a"] });
+  });
+});
+
+describe("computeDroppedLayout", () => {
+  const displayed = ["p-1", "p-2", "u-1", "u-2"];
+  const layout = { order: displayed, pinned: ["p-1", "p-2"] };
+
+  it("a drop inside the pinned block pins the row", () => {
+    expect(computeDroppedLayout(layout, displayed, "u-2", 1)).toEqual({
+      order: ["p-1", "u-2", "p-2", "u-1"],
+      pinned: ["p-1", "u-2", "p-2"],
+    });
+  });
+
+  it("a drop below the block unpins the row", () => {
+    expect(computeDroppedLayout(layout, displayed, "p-1", 2)).toEqual({
+      order: ["p-2", "u-1", "p-1", "u-2"],
+      pinned: ["p-2"],
+    });
+  });
+
+  it("a move inside one half keeps its pin state", () => {
+    expect(computeDroppedLayout(layout, displayed, "p-2", 0)).toEqual({
+      order: ["p-2", "p-1", "u-1", "u-2"],
+      pinned: ["p-2", "p-1"],
+    });
+    expect(computeDroppedLayout(layout, displayed, "u-1", 3)).toEqual({
+      order: ["p-1", "p-2", "u-2", "u-1"],
+      pinned: ["p-1", "p-2"],
+    });
+  });
+
+  it("never pins when nothing is pinned", () => {
+    const flat = computeDroppedLayout({ order: [], pinned: [] }, ["a", "b", "c"], "c", 0);
+    expect(flat).toEqual({ order: ["c", "a", "b"], pinned: [] });
+  });
+
+  it("returns null for an unknown id or a drop that changes nothing", () => {
+    expect(computeDroppedLayout(layout, displayed, "zzz", 0)).toBeNull();
+    expect(computeDroppedLayout(layout, displayed, "p-1", 0)).toBeNull();
+    expect(computeDroppedLayout(layout, displayed, "u-2", 9)).toBeNull();
+  });
+});

--- a/src/tui/session-rail/session-rail-pin.ts
+++ b/src/tui/session-rail/session-rail-pin.ts
@@ -10,7 +10,11 @@
  * touch" a move does.
  */
 
-import { applySessionRailOrder, moveSessionInOrder } from "./session-rail-order.js";
+import {
+  applySessionRailOrder,
+  moveSessionInOrder,
+  type RailRow,
+} from "./session-rail-order.js";
 
 /** What the rail remembers between runs: the manual order and the pinned ids. */
 export interface SessionRailLayout {
@@ -37,7 +41,7 @@ export function pinnedBlockLength(
  * over the rest, so an unarranged rail still reads by recency below
  * its pins.
  */
-export function arrangeSessionRail<T extends { sessionId: string }>(
+export function arrangeSessionRail<T extends RailRow>(
   entries: readonly T[],
   layout: SessionRailLayout,
 ): T[] {

--- a/src/tui/session-rail/session-rail-pin.ts
+++ b/src/tui/session-rail/session-rail-pin.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure pin arithmetic for the rail's Sessions list.
+ *
+ * Pinned sessions form a block at the TOP of the rail. Inside the block
+ * the rows follow the same manual `order` as everything else, so one
+ * list in the config describes both halves; `pinned` only says which
+ * ids belong to the block. Pinning appends to the block, unpinning puts
+ * the row at the top of the unpinned half, and both are expressed by
+ * rewriting `order` from the ids as displayed — the same "snapshot on
+ * touch" a move does.
+ */
+
+import { applySessionRailOrder, moveSessionInOrder } from "./session-rail-order.js";
+
+/** What the rail remembers between runs: the manual order and the pinned ids. */
+export interface SessionRailLayout {
+  readonly order: readonly string[];
+  readonly pinned: readonly string[];
+}
+
+/** How many of `displayedIds` are pinned — the block always sits at 0..n-1. */
+export function pinnedBlockLength(
+  displayedIds: readonly string[],
+  pinned: readonly string[],
+): number {
+  const set = new Set(pinned);
+  let count = 0;
+  for (const id of displayedIds) if (set.has(id)) count += 1;
+  return count;
+}
+
+/**
+ * Arrange `entries` into the pinned block followed by the unpinned
+ * list. The block holds every pinned id that has an entry, sorted by
+ * its position in `order`; pinned ids `order` has never seen go last
+ * in their incoming order. The unpinned half is `applySessionRailOrder`
+ * over the rest, so an unarranged rail still reads by recency below
+ * its pins.
+ */
+export function arrangeSessionRail<T extends { sessionId: string }>(
+  entries: readonly T[],
+  layout: SessionRailLayout,
+): T[] {
+  const pinnedSet = new Set(layout.pinned);
+  if (pinnedSet.size === 0) return applySessionRailOrder(entries, layout.order);
+  const rank = new Map<string, number>();
+  layout.order.forEach((id, index) => {
+    if (!rank.has(id)) rank.set(id, index);
+  });
+  const ranked: T[] = [];
+  const unranked: T[] = [];
+  const rest: T[] = [];
+  for (const entry of entries) {
+    if (!pinnedSet.has(entry.sessionId)) rest.push(entry);
+    else if (rank.has(entry.sessionId)) ranked.push(entry);
+    else unranked.push(entry);
+  }
+  ranked.sort(
+    (a, b) => (rank.get(a.sessionId) ?? 0) - (rank.get(b.sessionId) ?? 0),
+  );
+  return [...ranked, ...unranked, ...applySessionRailOrder(rest, layout.order)];
+}
+
+/**
+ * Flip the pin of `sessionId`, displayed in `displayedIds`. Pinning
+ * appends the row to the block; unpinning drops it at the top of the
+ * unpinned half. `null` when the id is not on the list.
+ *
+ * `pinned` is rewritten from the displayed ids too: a pinned id that is
+ * not on screen is dropped. The orchestrator loads every live pinned
+ * session before displaying the list, so the only ids that can be
+ * missing here are deleted ones — this is where a stale pin is pruned.
+ */
+export function togglePinned(
+  layout: SessionRailLayout,
+  displayedIds: readonly string[],
+  sessionId: string,
+): SessionRailLayout | null {
+  const from = displayedIds.indexOf(sessionId);
+  if (from < 0) return null;
+  const pinnedSet = new Set(layout.pinned);
+  const block = pinnedBlockLength(displayedIds, layout.pinned);
+  const wasPinned = pinnedSet.has(sessionId);
+  // `moveSessionInOrder` removes first, then inserts: after removing a
+  // pinned row the block ends at `block - 2`, so `block - 1` is the top
+  // of the unpinned half; after removing an unpinned row the block is
+  // intact and `block` is the slot right after it.
+  const order = moveSessionInOrder(displayedIds, from, wasPinned ? block - 1 : block);
+  if (wasPinned) pinnedSet.delete(sessionId);
+  else pinnedSet.add(sessionId);
+  return { order, pinned: order.filter((id) => pinnedSet.has(id)) };
+}
+
+/**
+ * The layout after `sessionId` is dropped on slot `toIndex` of the
+ * displayed list — the desktop rule: the slot decides the pin. A drop
+ * inside the pinned block (an index below its length) pins the row, a
+ * drop below the block unpins it. `null` when the id is not on the
+ * list or nothing would change, so the caller writes nothing.
+ */
+export function computeDroppedLayout(
+  layout: SessionRailLayout,
+  displayedIds: readonly string[],
+  sessionId: string,
+  toIndex: number,
+): SessionRailLayout | null {
+  const from = displayedIds.indexOf(sessionId);
+  if (from < 0) return null;
+  const max = displayedIds.length - 1;
+  const to = Math.min(max, Math.max(0, toIndex));
+  const block = pinnedBlockLength(displayedIds, layout.pinned);
+  const pinnedSet = new Set(layout.pinned);
+  const wasPinned = pinnedSet.has(sessionId);
+  const shouldPin = to < block;
+  const order = moveSessionInOrder(displayedIds, from, to);
+  const sameOrder = order.every((id, index) => id === displayedIds[index]);
+  if (sameOrder && shouldPin === wasPinned) return null;
+  if (shouldPin) pinnedSet.add(sessionId);
+  else pinnedSet.delete(sessionId);
+  return { order, pinned: order.filter((id) => pinnedSet.has(id)) };
+}

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -159,6 +159,8 @@ export interface TuiGlyphs {
   readonly menuCursor: string;
   /** Hamburger, for the rail's menu button. */
   readonly menuGlyph: string;
+  /** Pins a session row to the top of the rail; sits at the row's right edge. */
+  readonly pinned: string;
   /** Folds the rail away; sits in its top-right corner. */
   readonly railCollapse: string;
   /** Reopens the folded rail; sits at the head of the status bar. */
@@ -207,6 +209,7 @@ const GLYPHS: TuiGlyphs = {
   chevronRight: "▸",
   menuCursor: "▶",
   menuGlyph: "☰",
+  pinned: "↑",
   railCollapse: "«",
   railRestore: "»",
   dotSeparator: "·",

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -243,6 +243,11 @@ export interface TuiAppCallbacks {
    * resulting order and re-emits `recent_sessions_updated`.
    */
   onSessionMoveRequested?(sessionId: string, toIndex: number): void;
+  /**
+   * `p` on the focused rail row, or a click on a row's `↑`: pin that
+   * session to the top block of the rail, or release it.
+   */
+  onSessionPinToggled?(sessionId: string): void;
   /** Ask the orchestrator to start a fresh session. */
   onSessionNewRequested?(): void;
   /** Ask the orchestrator to dump the current user profile into the chat log. */

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -439,6 +439,7 @@ export async function tuiCommand(args: string[]): Promise<number> {
         },
         onSessionPickerRequested: () => orchestrator.openSessionPicker(),
         onSessionSwitchRequested: (id) => orchestrator.switchSession(id),
+        onSessionPinToggled: (id) => orchestrator.togglePinned(id),
         onSessionMoveRequested: (id, toIndex) =>
           orchestrator.moveSession(id, toIndex),
         onSessionNewRequested: () => orchestrator.newSession(),

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -294,6 +294,12 @@ export interface SessionPickerEntry {
   updatedAt: number;
   /** First user message snippet (trimmed) or "(empty)" for blank sessions. */
   preview: string;
+  /**
+   * Pinned to the top of the rail (`tui.sessionRail.pinned`). Stamped by
+   * the rail orchestrator when it arranges the list; `false` everywhere
+   * an entry is built.
+   */
+  pinned: boolean;
 }
 
 /**


### PR DESCRIPTION
## What

Stacked on #369 (`feat/session-rail-reorder`) — please merge that first; this branch is based on it and will be retargeted to `main` once it lands.

Threads can now be pinned to the top of the rail:

- **An up arrow at the right edge of every session row.** Bright and bold when the thread is pinned, dim when it is not. Clicking it pins the row; clicking again releases it. Unlike the `[x]`, the mark is on every row rather than only the selected one — pinning is not destructive, and a mark that only appears under the pointer cannot answer the other half of the question the control exists for: which threads are already pinned. Its two columns are reserved on every row, like the close mark's four, so nothing materialises under a pointer mid-gesture.
- **`p` on the focused row does the same**, for the same reason `x` exists beside the close mark: the mark is painted whether or not mouse reporting is on. The cursor follows the row to its new slot, so pressing `p` twice undoes the first press instead of pinning a second thread.
- **The pinned block sits at the top of the rail**, manually ordered like the rest: pinning appends to the block, releasing drops the row at the head of the unpinned half, and Shift+↑/↓ moves stop at the block's edge — a keyboard move never pins or unpins. A **drag** decides by where it lands: dropped inside the block it pins, dropped below it releases, which is what a desktop list does.
- **A pin outlives the recency window.** When a pinned thread has fallen out of the list `railSessions()` reads, the rail fetches it by id and builds the same row; a pin on a deleted session is pruned on the next write.
- **Remembered** in `tui.sessionRail.pinned` (config v53), beside the v52 `order`. Pinning writes config only — the session row is untouched, so a pin never bumps `updatedAt`.
- The modal picker lists the same arranged list, so pinned rows carry the mark there too.

## Why

The rail is the operator's working set, and a handful of threads are the ones they come back to daily. Recency buries those under whatever ran last; a pin is how every desktop list has solved that.

## How it was verified

- `npm run lint` clean
- `npx vitest run src/tui/session-rail src/tui/reduce-sidebar-actions.test.ts src/tui/reduce-session-actions.test.ts src/tui/app-key-bindings.test.ts src/tui/session-delete-keys.test.ts src/tui/rail-session-list.test.ts src/tui/components/sidebar.test.tsx src/tui/components/sidebar-fit.test.tsx src/tui/chat-orchestrator.test.ts src/config src/tui/mouse/mouse-app.test.tsx` — 26 files / 484 tests green. New: the pin arithmetic (append, release, block edge, drag across the boundary, pruning), `p` (including the cursor follow, upper-case `P`, Tasks pane untouched, other letters still swallowed), a `mouse-app` click on a row's arrow that pins without opening or moving the row, sidebar renders for the mark on every row, config v52→v53 inheritance.
- Live, in a PTY at 120×36 with six seeded threads: `p` pinned the selected row, which moved to the top with the cursor still on it, and `p` again released it — `tui.sessionRail.pinned` in `config.json` followed both. Frame colours checked against the palette: a pinned unselected row's arrow renders `#eef1f6` (`railForeground`) bold, an unpinned row's `#b9c8ea` (`railMuted`).

Two width assertions written against the wider preview moved with the two reserved columns (`sidebar.test.tsx`, and the delete tests in `mouse-app.test.tsx` now match a preview prefix, as the neighbouring row tests already did).

Note: this bumps `USER_CONFIG_VERSION` to 53, which #355/#361 also claim — the RC renumbers whichever lands second.
