### PR TITLE
fix(tui): stop the full-frame repaint that makes the UI blink

### DIFF
--- a/src/tui/components/thinking-indicator.test.tsx
+++ b/src/tui/components/thinking-indicator.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "ink-testing-library";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createInitialTuiState,
   type TuiSessionInfo,
@@ -32,6 +32,10 @@ function makeState(overrides: Partial<TuiState>): TuiState {
     ...overrides,
   };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("ThinkingIndicator", () => {
   it("renders nothing when the agent is idle", () => {
@@ -95,6 +99,18 @@ describe("ThinkingIndicator", () => {
     const text = strip(lastFrame() ?? "");
     expect(text).toMatch(/thinking · \d+s/);
     expect(text).not.toContain("reply");
+  });
+
+  it("re-reads the clock once a second, not four times", () => {
+    // The label is whole seconds, so a 250 ms tick spent three of every
+    // four wake-ups re-rendering the whole app to produce the identical
+    // string. Every one of those was a repaint the operator could see.
+    const spy = vi.spyOn(globalThis, "setInterval");
+    render(<ThinkingIndicator state={makeState({})} />);
+    const delays = spy.mock.calls.map(([, delay]) => delay);
+
+    expect(delays).toContain(1000);
+    expect(delays).not.toContain(250);
   });
 
   it("formats minutes for elapsed durations over 60s", () => {

--- a/src/tui/components/thinking-indicator.tsx
+++ b/src/tui/components/thinking-indicator.tsx
@@ -113,6 +113,12 @@ function formatPhase(phase: Phase, elapsed: string): string {
   }
 }
 
+/**
+ * How often the elapsed-time label re-reads the clock. Matches the
+ * resolution of what it renders: whole seconds.
+ */
+const ELAPSED_TICK_MS = 1000;
+
 function useElapsedSinceStart(
   startedAt: number | null,
   active: boolean,
@@ -120,7 +126,12 @@ function useElapsedSinceStart(
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (!active || startedAt === null) return;
-    const handle = setInterval(() => setNow(Date.now()), 250);
+    // One tick per second, because `formatElapsed` renders whole
+    // seconds and nothing finer. The old 250 ms interval re-rendered
+    // the whole app four times a second to produce the same string
+    // three times out of four — free repaints on a surface whose
+    // repaints the operator can see.
+    const handle = setInterval(() => setNow(Date.now()), ELAPSED_TICK_MS);
     return () => clearInterval(handle);
   }, [active, startedAt]);
   if (startedAt === null) return 0;

--- a/src/tui/ink-render-options.test.ts
+++ b/src/tui/ink-render-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildInkRenderOptions } from "./ink-render-options.js";
+
+const streams = {
+  stdin: {} as NodeJS.ReadStream,
+  stdout: {} as NodeJS.WriteStream,
+  stderr: {} as NodeJS.WriteStream,
+};
+
+describe("buildInkRenderOptions", () => {
+  it("renders incrementally", () => {
+    // The whole point of the option: Ink's default rewrites every line
+    // of the frame on every state change, and while a turn runs that is
+    // a full-screen erase several times a second — visible as blinking
+    // on any terminal without synchronized output. Losing this flag
+    // silently brings the blink back, so it is pinned here.
+    const options = buildInkRenderOptions({ ...streams, kittyKeyboard: false });
+    expect(options.incrementalRendering).toBe(true);
+  });
+
+  it("keeps Ctrl+C for the app", () => {
+    const options = buildInkRenderOptions({ ...streams, kittyKeyboard: false });
+    expect(options.exitOnCtrlC).toBe(false);
+  });
+
+  it("enables the kitty protocol only when the terminal answered", () => {
+    expect(
+      buildInkRenderOptions({ ...streams, kittyKeyboard: false }).kittyKeyboard,
+    ).toBeUndefined();
+    expect(
+      buildInkRenderOptions({ ...streams, kittyKeyboard: true }).kittyKeyboard,
+    ).toEqual({
+      mode: "enabled",
+      flags: ["disambiguateEscapeCodes"],
+    });
+  });
+
+  it("passes the streams through untouched", () => {
+    const options = buildInkRenderOptions({ ...streams, kittyKeyboard: true });
+    expect(options.stdin).toBe(streams.stdin);
+    expect(options.stdout).toBe(streams.stdout);
+    expect(options.stderr).toBe(streams.stderr);
+  });
+});

--- a/src/tui/ink-render-options.ts
+++ b/src/tui/ink-render-options.ts
@@ -1,0 +1,73 @@
+/**
+ * The options the TUI hands Ink's `render()`.
+ *
+ * Split out of `tui-command.ts` so the choices below are assertable: that
+ * file pulls in the whole runtime (and `node:sea`, which vitest cannot
+ * load), so anything asserted about it there has to be asserted by
+ * reading source text. Here it is a pure function returning a plain
+ * object.
+ */
+import type { RenderOptions } from "ink";
+
+export interface InkRenderOptionsInput {
+  readonly stdin: NodeJS.ReadStream;
+  readonly stdout: NodeJS.WriteStream;
+  readonly stderr: NodeJS.WriteStream;
+  /**
+   * Whether the terminal answered the kitty-keyboard query. Enables the
+   * protocol only when we know it is understood.
+   */
+  readonly kittyKeyboard: boolean;
+}
+
+export function buildInkRenderOptions(
+  input: InkRenderOptionsInput,
+): RenderOptions {
+  return {
+    stdin: input.stdin,
+    stdout: input.stdout,
+    stderr: input.stderr,
+    exitOnCtrlC: false,
+    // Repaint only the lines that changed.
+    //
+    // Ink's default rewrites the entire frame on every state change:
+    // erase every line, print every line, for a screenful of rows. While
+    // a turn is running the spinner alone asks for that eight times a
+    // second — measured over a PTY, ~9.3 KB and a full-screen erase per
+    // frame, 4.3 MB across a one-minute turn. On a terminal that
+    // implements DEC 2026 synchronized output the erase is hidden; on one
+    // that does not (Apple Terminal among them) it is painted, and the UI
+    // visibly blinks. With incremental rendering an unchanged line is
+    // skipped instead of rewritten, so a spinner tick costs the spinner's
+    // line.
+    //
+    // Ink marks the mode experimental, so the frame it produces was
+    // checked rather than assumed: driven over a PTY into a pyte grid and
+    // compared character for character against the default renderer
+    // across startup, streaming, the Esc menu, a popup, the composer and
+    // a resize. The two ways an incremental renderer can desynchronise
+    // from the screen are both already covered — Ink re-syncs its line
+    // cache through `log.clear()`/`log.sync()` on the console-passthrough
+    // and shrink-resize paths, and this app writes its own escape
+    // sequences (alt screen, mouse tracking) only outside a rendered
+    // block.
+    incrementalRendering: true,
+    // `disambiguateEscapeCodes` alone: it is what makes Shift+Enter a
+    // distinct keystroke (`ESC [ 13 ; 2 u`). `reportAllKeysAsEscapeCodes`
+    // would reroute ordinary typing through CSI u as well, putting the
+    // paste and text-insert paths at risk for nothing.
+    //
+    // `mode: "enabled"` rather than `"auto"`: Ink's own probe and the
+    // App's reader both see the terminal's reply, so auto can type
+    // `[?1u` into the composer before the first render. The caller
+    // already asked, on a stdin nobody else was reading.
+    ...(input.kittyKeyboard
+      ? {
+          kittyKeyboard: {
+            mode: "enabled" as const,
+            flags: ["disambiguateEscapeCodes" as const],
+          },
+        }
+      : {}),
+  };
+}

--- a/src/tui/ink-render-options.ts
+++ b/src/tui/ink-render-options.ts
@@ -1,11 +1,16 @@
 /**
  * The options the TUI hands Ink's `render()`.
  *
- * Split out of `tui-command.ts` so the choices below are assertable: that
- * file pulls in the whole runtime (and `node:sea`, which vitest cannot
- * load), so anything asserted about it there has to be asserted by
- * reading source text. Here it is a pure function returning a plain
- * object.
+ * Split out of `tui-command.ts` so each choice below can be asserted
+ * without booting the runtime: here it is a pure function returning a
+ * plain object.
+ *
+ * That is a convenience, not the only way to see these options. The
+ * options actually handed to `render()` are asserted end-to-end in
+ * `tui-command.mouse.test.ts`, which boots `tuiCommand` with `node:sea`
+ * stubbed and Ink's `render` intercepted. Keep that assertion: a unit
+ * test of this function says nothing about whether the call site still
+ * calls it.
  */
 import type { RenderOptions } from "ink";
 
@@ -32,9 +37,10 @@ export function buildInkRenderOptions(
     //
     // Ink's default rewrites the entire frame on every state change:
     // erase every line, print every line, for a screenful of rows. While
-    // a turn is running the spinner alone asks for that eight times a
-    // second — measured over a PTY, ~9.3 KB and a full-screen erase per
-    // frame, 4.3 MB across a one-minute turn. On a terminal that
+    // a turn is running the spinner alone asks for that eight to ten
+    // times a second — measured over a PTY at 110x34, a median 5.5 KB
+    // and a full-screen erase per frame, ~3.4 MB a minute. With this on,
+    // the median frame is 237 bytes. On a terminal that
     // implements DEC 2026 synchronized output the erase is hidden; on one
     // that does not (Apple Terminal among them) it is painted, and the UI
     // visibly blinks. With incremental rendering an unchanged line is
@@ -43,14 +49,27 @@ export function buildInkRenderOptions(
     //
     // Ink marks the mode experimental, so the frame it produces was
     // checked rather than assumed: driven over a PTY into a pyte grid and
-    // compared character for character against the default renderer
-    // across startup, streaming, the Esc menu, a popup, the composer and
-    // a resize. The two ways an incremental renderer can desynchronise
-    // from the screen are both already covered — Ink re-syncs its line
-    // cache through `log.clear()`/`log.sync()` on the console-passthrough
-    // and shrink-resize paths, and this app writes its own escape
-    // sequences (alt screen, mouse tracking) only outside a rendered
-    // block.
+    // compared character for character against the default renderer, at
+    // 110x34, 80x24 and 40x16, across startup, the composer, a turn in
+    // flight, the Esc menu and its submenus, every Manage tab, the
+    // session and model pickers, the update modal, a mouse drag and
+    // wheel, a chat log scrolled past the viewport, resizes that grow and
+    // shrink in each dimension separately, and teardown — where the last
+    // bytes on the wire (ESU, cursor, mouse, alt screen) are identical
+    // byte for byte.
+    //
+    // The two ways an incremental renderer can desynchronise from the
+    // screen are both covered — Ink re-syncs its line cache through
+    // `log.clear()`/`log.sync()` on the console-passthrough, width-shrink
+    // and clear-terminal paths (a height shrink reaches the last of those
+    // via `shouldClearTerminalForFrame`), and this app writes its own
+    // escape sequences (alt screen, mouse tracking) only outside a
+    // rendered block.
+    //
+    // Not covered, because the harness cannot reach a provider: assistant
+    // text streaming into the transcript, and the approval modal. The
+    // closest reachable stand-ins — slash-command output overflowing the
+    // viewport, and the update modal — were driven and matched.
     incrementalRendering: true,
     // `disambiguateEscapeCodes` alone: it is what makes Shift+Enter a
     // distinct keystroke (`ESC [ 13 ; 2 u`). `reportAllKeysAsEscapeCodes`

--- a/src/tui/ink-render-options.ts
+++ b/src/tui/ink-render-options.ts
@@ -36,27 +36,51 @@ export function buildInkRenderOptions(
     // Repaint only the lines that changed.
     //
     // Ink's default rewrites the entire frame on every state change:
-    // erase every line, print every line, for a screenful of rows. While
-    // a turn is running the spinner alone asks for that eight to ten
-    // times a second — measured over a PTY at 110x34, a median 5.5 KB
-    // and a full-screen erase per frame, ~3.4 MB a minute. With this on,
-    // the median frame is 237 bytes. On a terminal that
-    // implements DEC 2026 synchronized output the erase is hidden; on one
-    // that does not (Apple Terminal among them) it is painted, and the UI
-    // visibly blinks. With incremental rendering an unchanged line is
-    // skipped instead of rewritten, so a spinner tick costs the spinner's
-    // line.
+    // erase every line, print every line, for a screenful of rows. A
+    // running turn asks for that about ten times a second whether or not
+    // the model is saying anything — the spinner and the elapsed label
+    // are enough on their own.
+    //
+    // Measured over a PTY against a build of current main, 30 s of a turn
+    // streaming text into the transcript:
+    //
+    //           110x34                      80x24
+    //           before      after           before      after
+    //   bytes   1,578,957   402,572         1,592,102   161,860
+    //   CSI K       9,724     1,825             9,648     1,074
+    //   cur-up      9,438       391             9,246       396
+    //   updates       286       391               402       396
+    //   frame       5,497       237             3,971       154   (median)
+    //
+    // The repaint *rate* is what it always was — this changes what a
+    // repaint costs, not how often one happens. The median frame drops
+    // 23x; the total drops less (4x at 110x34, 10x at 80x24) because
+    // arriving text genuinely dirties many lines at once, and a frame
+    // where everything changed costs what it always did.
+    //
+    // On a terminal that implements DEC 2026 synchronized output the
+    // erase is hidden; on one that does not (Apple Terminal among them)
+    // it is painted, and the UI visibly blinks. With incremental
+    // rendering an unchanged line is skipped instead of rewritten, so a
+    // spinner tick costs the spinner's line.
     //
     // Ink marks the mode experimental, so the frame it produces was
     // checked rather than assumed: driven over a PTY into a pyte grid and
     // compared character for character against the default renderer, at
-    // 110x34, 80x24 and 40x16, across startup, the composer, a turn in
-    // flight, the Esc menu and its submenus, every Manage tab, the
-    // session and model pickers, the update modal, a mouse drag and
-    // wheel, a chat log scrolled past the viewport, resizes that grow and
-    // shrink in each dimension separately, and teardown — where the last
-    // bytes on the wire (ESU, cursor, mouse, alt screen) are identical
-    // byte for byte.
+    // 110x34, 80x24 and 40x16, across startup, the composer, a turn
+    // streaming text into the transcript, the Esc menu and its submenus,
+    // every Manage tab, the session and model pickers, the update modal,
+    // a mouse drag and wheel, a transcript scrolled past the viewport,
+    // resizes that grow and shrink in each dimension separately, and
+    // teardown — where the last bytes on the wire (ESU, cursor, mouse,
+    // alt screen) are identical byte for byte.
+    //
+    // The transcript is the surface with the most to lose here, since it
+    // is the one that grows and scrolls while deltas arrive, so it was
+    // driven against a stub that emits a fixed number of deltas and then
+    // holds the socket open: the screen settles on the same final state
+    // in both runs, and the two grids match exactly — mid-stream, after a
+    // scroll up, after a scroll back, and after an abort.
     //
     // The two ways an incremental renderer can desynchronise from the
     // screen are both covered — Ink re-syncs its line cache through
@@ -66,10 +90,9 @@ export function buildInkRenderOptions(
     // escape sequences (alt screen, mouse tracking) only outside a
     // rendered block.
     //
-    // Not covered, because the harness cannot reach a provider: assistant
-    // text streaming into the transcript, and the approval modal. The
-    // closest reachable stand-ins — slash-command output overflowing the
-    // viewport, and the update modal — were driven and matched.
+    // Not covered: the approval modal, which needs a model that asks for
+    // a tool. The update modal, which is the same overlay machinery, was
+    // driven and matched.
     incrementalRendering: true,
     // `disambiguateEscapeCodes` alone: it is what makes Shift+Enter a
     // distinct keystroke (`ESC [ 13 ; 2 u`). `reportAllKeysAsEscapeCodes`

--- a/src/tui/synchronized-output.test.ts
+++ b/src/tui/synchronized-output.test.ts
@@ -24,9 +24,13 @@ function fakeStdout(isTTY: boolean): NodeJS.WriteStream & { writes: string[] } {
 /**
  * What an incremental repaint of a single line looks like on the wire:
  * move the cursor onto the line, write it, erase to end of line. The last
- * line of a fullscreen frame carries no trailing newline, and on a short
- * terminal the whole thing fits under 64 bytes - the shape the old
- * length-or-newline test let through unbracketed.
+ * line of a fullscreen frame carries no trailing newline.
+ *
+ * Constructed, not captured: no real repaint this small has been
+ * observed (see the note on `looksLikeFrame` — the smallest measured was
+ * 189 bytes, at the smallest window the TUI renders in). It pins the
+ * predicate, which is "erases a line, therefore repainting", against the
+ * length of any particular frame.
  */
 const LINE_REPAINT = "\u001B[2A\u001B[E\u001B[Gthinking \u00B7 3s\u001B[K";
 
@@ -130,6 +134,8 @@ describe("looksLikeFrame", () => {
     // Short, and no newline - but it erases a line, so it is a repaint,
     // and a repaint has to reach the terminal inside one synchronized
     // update or it is exactly the tearing this module exists to stop.
+    // Nothing this short has been seen on the wire; this pins the
+    // predicate, not a reproduction.
     expect(LINE_REPAINT.length).toBeLessThan(64);
     expect(LINE_REPAINT).not.toContain("\n");
     expect(looksLikeFrame(LINE_REPAINT)).toBe(true);

--- a/src/tui/synchronized-output.test.ts
+++ b/src/tui/synchronized-output.test.ts
@@ -21,6 +21,15 @@ function fakeStdout(isTTY: boolean): NodeJS.WriteStream & { writes: string[] } {
   return stream as unknown as NodeJS.WriteStream & { writes: string[] };
 }
 
+/**
+ * What an incremental repaint of a single line looks like on the wire:
+ * move the cursor onto the line, write it, erase to end of line. The last
+ * line of a fullscreen frame carries no trailing newline, and on a short
+ * terminal the whole thing fits under 64 bytes - the shape the old
+ * length-or-newline test let through unbracketed.
+ */
+const LINE_REPAINT = "\u001B[2A\u001B[E\u001B[Gthinking \u00B7 3s\u001B[K";
+
 const FRAME = "\u001B[H\u001B[2Kline one\nline two\nline three\n";
 
 describe("enableSynchronizedOutput", () => {
@@ -33,6 +42,15 @@ describe("enableSynchronizedOutput", () => {
     controller.restore();
 
     expect(stdout.writes[0]).toBe(`${BSU}${FRAME}${ESU}`);
+  });
+
+  it("brackets a short incremental line repaint too", () => {
+    const stdout = fakeStdout(true);
+    const controller = enableSynchronizedOutput({ stdout, env: {} });
+    stdout.write(LINE_REPAINT);
+    controller.restore();
+
+    expect(stdout.writes[0]).toBe(`${BSU}${LINE_REPAINT}${ESU}`);
   });
 
   it("leaves short control sequences alone", () => {
@@ -106,6 +124,15 @@ describe("looksLikeFrame", () => {
   it("counts anything with a newline, or anything long", () => {
     expect(looksLikeFrame("a\nb")).toBe(true);
     expect(looksLikeFrame("x".repeat(65))).toBe(true);
+  });
+
+  it("counts a short single-line incremental repaint", () => {
+    // Short, and no newline - but it erases a line, so it is a repaint,
+    // and a repaint has to reach the terminal inside one synchronized
+    // update or it is exactly the tearing this module exists to stop.
+    expect(LINE_REPAINT.length).toBeLessThan(64);
+    expect(LINE_REPAINT).not.toContain("\n");
+    expect(looksLikeFrame(LINE_REPAINT)).toBe(true);
   });
 
   it("does not count a bare mode toggle", () => {

--- a/src/tui/synchronized-output.ts
+++ b/src/tui/synchronized-output.ts
@@ -66,15 +66,29 @@ const ERASE_IN_LINE = /\u001B\[[0-2]?K/;
  * only Ink's frames. A full frame is many bytes and contains a newline;
  * a mode toggle is neither.
  *
- * Incremental rendering makes a third clause worth having. A repaint
- * that rewrites one line of a fullscreen frame carries no newline —
- * cursor moves, the line, `CSI K` — and its size is dominated by one
- * cursor-move per skipped row. On a normal terminal that still clears
- * 64 bytes (measured: at 110x34 and 80x24 no bracketed update came out
- * under 64 bytes), but on a short one — a dozen rows, a one-word label
- * — it does not, and a repaint that slips through unbracketed is
- * exactly the tearing this module exists to stop. So: anything that
- * erases a line is repainting, whatever its length.
+ * Incremental rendering makes a third clause worth having, as a
+ * backstop rather than as a fix for anything observed. A repaint that
+ * rewrites one line of a fullscreen frame carries no newline — cursor
+ * moves, the line, `CSI K` — so only its length keeps it bracketed, and
+ * its length is incidental: one cursor-move per skipped row plus
+ * whatever the changed line happens to contain.
+ *
+ * Measured, that length has never come close to the bar. Driving the
+ * TUI over a PTY at 110x34, 80x24 and 40x16 — the last is the smallest
+ * window the TUI will render in at all; below it the screen is
+ * `terminal too small`, and no frame is written — the smallest chunk
+ * this `write` bracketed was 189 bytes, and across every scenario
+ * (startup, menus, submenus, the Manage tabs, both pickers, the update
+ * modal, mouse drag and wheel, resizes in both dimensions, teardown)
+ * not one chunk was caught by this clause that the length test had not
+ * already caught. So it is insurance against a shape the app does not
+ * currently produce, not a repair.
+ *
+ * It is close to free: `||` short-circuits, so the regex only ever runs
+ * on chunks of 64 bytes or fewer with no newline in them — never on a
+ * frame. And the predicate is the honest one: something that erases a
+ * line is repainting, and a repaint that slips through unbracketed is
+ * exactly the tearing this module exists to stop.
  */
 export function looksLikeFrame(chunk: string): boolean {
   return (

--- a/src/tui/synchronized-output.ts
+++ b/src/tui/synchronized-output.ts
@@ -48,16 +48,38 @@ export interface SynchronizedOutputOptions {
 }
 
 /**
+ * Erase-in-line: `CSI K`, `CSI 0 K`, `CSI 1 K`, `CSI 2 K`.
+ *
+ * The one sequence that only ever appears when something is repainting
+ * text. Ink terminates every line it rewrites with `CSI K`, and its
+ * whole-block clears use `CSI 2 K`; no mode toggle, cursor nudge or
+ * mouse/kitty setup sequence contains either.
+ */
+const ERASE_IN_LINE = /\u001B\[[0-2]?K/;
+
+/**
  * True when `chunk` is worth bracketing.
  *
  * Wrapping a lone escape sequence in a synchronized update is not wrong,
  * but it is two extra sequences spent rendering nothing — and this
  * `write` sees every cursor nudge and mode toggle the app makes, not
- * only Ink's frames. A frame is many bytes and contains a newline; a
- * mode toggle is neither.
+ * only Ink's frames. A full frame is many bytes and contains a newline;
+ * a mode toggle is neither.
+ *
+ * Incremental rendering makes a third clause worth having. A repaint
+ * that rewrites one line of a fullscreen frame carries no newline —
+ * cursor moves, the line, `CSI K` — and its size is dominated by one
+ * cursor-move per skipped row. On a normal terminal that still clears
+ * 64 bytes (measured: at 110x34 and 80x24 no bracketed update came out
+ * under 64 bytes), but on a short one — a dozen rows, a one-word label
+ * — it does not, and a repaint that slips through unbracketed is
+ * exactly the tearing this module exists to stop. So: anything that
+ * erases a line is repainting, whatever its length.
  */
 export function looksLikeFrame(chunk: string): boolean {
-  return chunk.length > 64 || chunk.includes("\n");
+  return (
+    chunk.length > 64 || chunk.includes("\n") || ERASE_IN_LINE.test(chunk)
+  );
 }
 
 /**

--- a/src/tui/tui-command.mouse.test.ts
+++ b/src/tui/tui-command.mouse.test.ts
@@ -135,6 +135,8 @@ interface Booted {
    * exactly as the tracker does on an unclaimed drag.
    */
   readonly selectionDragIntent: () => void;
+  /** The second argument `tuiCommand` handed Ink's `render()`. */
+  readonly renderOptions: Record<string, unknown>;
   readonly seen: TuiMouseEvent[];
   /** Every bus action emitted after mount — system messages included. */
   readonly actions: TuiAction[];
@@ -154,10 +156,17 @@ async function bootTui(args: string[] = []): Promise<Booted> {
     releaseExit = resolve;
   });
   let props: Record<string, unknown> | null = null;
-  inkRender.mockImplementation((element: { props: Record<string, unknown> }) => {
-    props = element.props;
-    return { waitUntilExit: () => exited, clear: () => {} };
-  });
+  let renderOptions: Record<string, unknown> = {};
+  inkRender.mockImplementation(
+    (
+      element: { props: Record<string, unknown> },
+      options: Record<string, unknown>,
+    ) => {
+      props = element.props;
+      renderOptions = options;
+      return { waitUntilExit: () => exited, clear: () => {} };
+    },
+  );
 
   const { tuiCommand } = await import("./tui-command.js");
   const finished = tuiCommand(["--skip-llama-setup", ...args]);
@@ -189,6 +198,7 @@ async function bootTui(args: string[] = []): Promise<Booted> {
 
   return {
     mouse: captured.mouse,
+    renderOptions,
     setMouseEnabled,
     selectionDragIntent,
     seen,
@@ -239,6 +249,22 @@ describe("tuiCommand mouse wiring", () => {
     });
     resetConfigCache();
   }
+
+  it("hands Ink the render options it was built with", async () => {
+    // `ink-render-options.test.ts` asserts what `buildInkRenderOptions`
+    // returns; nothing there asserts that the returned object is what
+    // reaches `render()`. Delete the call at the call site and every
+    // test in that file still passes, with the renderer silently back on
+    // full-frame repaints. This closes that gap: it reads the options
+    // off the intercepted `render` call, in the process that made it.
+    writeMouseConfig(false);
+    const app = await bootTui();
+    expect(app.renderOptions).toMatchObject({
+      incrementalRendering: true,
+      exitOnCtrlC: false,
+    });
+    await app.stop();
+  });
 
   it("hands TuiApp a mouse source even when mouse support starts off", async () => {
     writeMouseConfig(false);

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -19,6 +19,7 @@ import type { MetricSample, MetricSink } from "../tracing/metrics-collector.js";
 import { isKnownLocalModelId } from "../local-llm/index.js";
 import { registerSession } from "../local-llm/session-registry.js";
 import { enterAltScreen } from "./alt-screen.js";
+import { buildInkRenderOptions } from "./ink-render-options.js";
 import { enableSynchronizedOutput } from "./synchronized-output.js";
 import { legacyConhostStartupHint } from "./legacy-conhost.js";
 import { ChatOrchestrator } from "./chat-orchestrator.js";
@@ -712,29 +713,12 @@ export async function tuiCommand(args: string[]): Promise<number> {
       // above is what decides whether anything is ever emitted.
       mouse: mouseSource,
     }),
-    {
+    buildInkRenderOptions({
       stdin: mouseStdin.stdin,
       stdout: process.stdout,
       stderr: process.stderr,
-      exitOnCtrlC: false,
-      // `disambiguateEscapeCodes` alone: it is what makes Shift+Enter a
-      // distinct keystroke (`ESC [ 13 ; 2 u`). `reportAllKeysAsEscapeCodes`
-      // would reroute ordinary typing through CSI u as well, putting the
-      // paste and text-insert paths at risk for nothing.
-      //
-      // `mode: "enabled"` rather than `"auto"`: Ink's own probe and the
-      // App's reader both see the terminal's reply, so auto can type
-      // `[?1u` into the composer before the first render. We already
-      // asked, above, on a stdin nobody else was reading.
-      ...(kittyKeyboard
-        ? {
-            kittyKeyboard: {
-              mode: "enabled" as const,
-              flags: ["disambiguateEscapeCodes" as const],
-            },
-          }
-        : {}),
-    },
+      kittyKeyboard,
+    }),
   );
 
   orchestrator.start();


### PR DESCRIPTION
## What

The TUI repaints the entire frame on every state change: erase every line, print every line, for a
screenful of rows. Ink 7 can rewrite only the lines that changed. This turns that on.

Measured over a PTY, thirty seconds of a turn streaming text into the transcript:

| | 110x34 before | 110x34 after | 80x24 before | 80x24 after |
|---|---|---|---|---|
| bytes | 1,578,957 | 402,572 | 1,592,102 | 161,860 |
| erase-in-line | 9,724 | 1,825 | 9,648 | 1,074 |
| cursor-up | 9,438 | 391 | 9,246 | 396 |
| median frame | 5,497 B | 237 B | 3,971 B | 154 B |

Read that median honestly. The repaint *rate* does not change — about ten updates a second either
way, driven by the spinner and the elapsed tick, not by the model. What changes is how much of each
frame is dirty. A frame where only the spinner moved costs 237 bytes instead of 5.5 KB, but arriving
text genuinely dirties many lines at once, and a fully dirty frame still costs what it always did
(branch mean 1,003 B against a 237 B median at 110x34; max 4,583 B, about one full frame). So the
total saving over a streaming turn is 4x at 110x34 and 10x at 80x24, while an idle or
spinner-only stretch is closer to 20x.

Two smaller changes ride along:

- `ThinkingIndicator`'s elapsed label re-read the clock every 250 ms while rendering whole seconds,
  so three of every four of those re-renders produced the same string. It ticks once a second now.
- `looksLikeFrame()` decides which writes get bracketed in a synchronized update. Its
  size-and-newline test was written for full frames; an incremental single-line repaint carries no
  newline, and its length is incidental. Anything containing an erase-in-line sequence is now
  treated as a repaint whatever its length. This is a backstop, not a repair: the smallest chunk
  actually observed was 189 bytes, and no chunk was ever caught by the new clause that the length
  test had not already caught. `||` short-circuits, so the regex never runs on a frame.

The render options moved into `buildInkRenderOptions()` so each choice is assertable without booting
the runtime; `tui-command.mouse.test.ts` separately asserts that the options actually reach
`render()`, because a unit test of the builder says nothing about whether the call site still calls
it.

## Why

The blinking is the symptom operators report. It is not a terminal problem: the app is writing a
full-screen erase about ten times a second and asking the terminal to hide it behind DEC 2026
synchronized output. Terminals that implement 2026 hide it; Apple Terminal, among others, paints it.

## How it was verified

Ink marks incremental rendering experimental, so the frame it produces was checked rather than
assumed. Both builds were driven over a PTY into a pyte grid and compared character for character,
normalising only the session id, the elapsed label, the spinner phase and the rotating composer
placeholder.

- at 110x34, 80x24 and 40x16 (the smallest window the TUI renders in at all): startup, the composer,
  a turn in flight, a **streaming transcript mid-stream, scrolled up, scrolled back and aborted**,
  the Esc menu and its submenus, the menu opened by a mouse click, every Manage tab, the session and
  model pickers, the update banner and its modal, a mouse drag and wheel, a chat log scrolled past
  the viewport, resizes that grow and shrink in each dimension separately, and teardown
- every checkpoint identical. Teardown writes the same final 220 bytes byte for byte (ESU, cursor
  show, mouse disable, alt-screen exit)
- a baseline-against-baseline run was compared first as a noise floor
- `ATOMIC_AGENT_NO_SYNC_OUTPUT=1` and a piped stdout both behave as before
- `npm run lint` clean; `npx vitest run src/tui` — 256 files / 2794 tests green (baseline noise: `local-models-orchestrator-auto-update` raises the usual sandbox `EACCES` spawning llama-server)
- each new test was mutation-checked: turning the flag off, restoring the 250 ms tick, and dropping the erase clause each kill their own test and only their own

Not covered: the approval modal, which needs a model that asks for a tool. The update modal is the
same overlay machinery and matches. That limit is written down at the flag rather than left implied.
