### PR TITLE
fix(tui): the provider-outage readout ticks, names the failure, and keeps the route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,11 +180,18 @@ two app restarts and a fresh session — with nothing on screen to say the link 
    - given up — the row stays `provider unreachable — <reason>` until a turn actually succeeds.
    The reason is humanised in the TUI only (`terminated` / `socket hang up` / `other side closed` →
    `connection dropped mid-reply`, `fetch failed` → `no connection`); the runtime classifier keeps
-   the raw wording, which is what the logs and the trace are matched on. The readout shrinks before
-   anything in the route statement and opens Manage › LLM when clicked, so a narrow terminal
-   degrades to the whole route plus a truncated warning rather than to a warning alone. The context
-   readout is not touched: it is driven by `prompt_built` / `llm_completed`, and a parked turn
-   produces neither.
+   the raw wording, which is what the logs and the trace are matched on.
+   **The row fits in this order:** the readout's head — the state and its numbers — never shrinks,
+   because the counter is what says the wait is progressing rather than hung; its reason grows into
+   whatever the route leaves over (`flexGrow` from a zero basis, not `flexShrink`: Yoga leaves an
+   item at full width rather than shrink it by more than it has to give, and a shrinking reason
+   clipped the route off the row); and the while-a-turn-runs Enter hint is dropped outright while an
+   outage is live, since it is repeated verbatim in the hint strip under the composer and its ~19
+   columns are what let both statements be read at all. The context and mode chips keep their
+   `flexShrink={0}` — "at 60 the right-hand readout must survive intact" still holds. Clicking the
+   readout opens Manage › LLM. Below roughly 130 composer columns the route cannot be shown as well;
+   the readout's numbers win that trade. The context readout is not touched: it is driven by
+   `prompt_built` / `llm_completed`, and a parked turn produces neither.
 
 ### No-progress loop detection
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,13 @@ two app restarts and a fresh session — with nothing on screen to say the link 
      entry, assistant text, half-parsed tool calls) — otherwise the retry's reasoning is spliced
      onto the tail of the attempt whose socket died.
    - given up — the row stays `provider unreachable — <reason>` until a turn actually succeeds.
+   **A live wait belongs to a running turn and ends with it.** `turn_finished` clears a `parked` or
+   `retrying` outage whichever way the turn ended — Esc during the backoff (the feed line says
+   "· Esc stops") and a turn stopped at its step ceiling included. Left standing it counted a wait
+   nothing was waiting for, and the next turn's first `step_started` read it as the parked step
+   going back on the wire: a healthy turn labelled `retrying provider (attempt 1)`, with that
+   step's streamed reply wiped at every step boundary. Only `givenUp` survives the end of a turn,
+   because it is past tense on purpose.
    The reason is humanised in the TUI only (`terminated` / `socket hang up` / `other side closed` →
    `connection dropped mid-reply`, `fetch failed` → `no connection`); the runtime classifier keeps
    the raw wording, which is what the logs and the trace are matched on.
@@ -185,12 +192,19 @@ two app restarts and a fresh session — with nothing on screen to say the link 
    because the counter is what says the wait is progressing rather than hung; its reason grows into
    whatever the route leaves over (`flexGrow` from a zero basis, not `flexShrink`: Yoga leaves an
    item at full width rather than shrink it by more than it has to give, and a shrinking reason
-   clipped the route off the row); and the while-a-turn-runs Enter hint is dropped outright while an
-   outage is live, since it is repeated verbatim in the hint strip under the composer and its ~19
-   columns are what let both statements be read at all. The context and mode chips keep their
-   `flexShrink={0}` — "at 60 the right-hand readout must survive intact" still holds. Clicking the
-   readout opens Manage › LLM. Below roughly 130 composer columns the route cannot be shown as well;
-   the readout's numbers win that trade. The context readout is not touched: it is driven by
+   clipped the route off the row); and the while-a-turn-runs Enter hint is dropped outright while a
+   wait is live, since its ~19 columns are what let both statements be read at all. That drop is
+   only safe because the hint strip's `⏎` chip is **essential** (`hotkey-chips.ts`): at `shed: 3` it
+   was itself dropped at every width up to 112 columns as soon as the composer held a draft, which
+   is exactly the state the hint is written for, and the two disappearances together left nothing
+   on screen saying what Enter would do. A `givenUp` badge does not take the hint with it — it is
+   past tense, twenty columns wide and has no counter to protect. The context and mode chips keep
+   their `flexShrink={0}` — "at 60 the right-hand readout must survive intact" still holds. Clicking
+   the readout opens Manage › LLM (verified under a PTY, not only in unit tests: the readout is a
+   Box, and Ink cannot nest one inside a `<Text>`). Measured against a bar carrying its real
+   right-hand group, the ladder is: the head is whole from about 90 bar columns, the model name
+   joins it around 119, the route is whole around 140 and the reason around 190. The readout's
+   numbers win every trade below those. The context readout is not touched: it is driven by
    `prompt_built` / `llm_completed`, and a parked turn produces neither.
 
 ### No-progress loop detection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,11 +165,26 @@ two app restarts and a fresh session — with nothing on screen to say the link 
    `cancelled`, not `failed`.
 5. **The budget resets after a recovery**, so a second outage later in a long task gets its own; the
    task's wall-clock ceiling is what bounds the total.
-6. **The UI says it once, then keeps it live.** One feed line per outage (not per retry — the
-   backoff fires every few seconds at first), the composer meta-row carries `waiting for provider
-   14s/300s — <reason>`, and when the wait runs out the row stays as `provider unreachable —
-   <reason>` until a turn actually succeeds. The context readout is not touched: it is driven by
-   `prompt_built` / `llm_completed`, and a parked turn produces neither.
+6. **The UI says it once, then keeps it live — and *live* means moving.** One feed line per outage
+   (not per retry — the backoff fires every few seconds at first), and the composer meta-row carries
+   the state in three wordings:
+   - parked in the backoff — `waiting for provider 14s/300s — <reason>`, counted off the clock
+     (`sinceTs`) on a one-second tick and clipped at the budget, not off the last event: the loop
+     emits nothing for up to 30s at a time and a row that only repainted on an event stood frozen.
+   - retrying — `retrying provider (attempt 2) — 8s`. A `step_started` while an outage is live *is*
+     the parked step going back on the wire; `provider_recovered` only lands once that step has
+     finished, so a step that streams for minutes has no other event to say it is alive. The same
+     transition drops what the dead attempt left streaming for that step index (trailing reasoning
+     entry, assistant text, half-parsed tool calls) — otherwise the retry's reasoning is spliced
+     onto the tail of the attempt whose socket died.
+   - given up — the row stays `provider unreachable — <reason>` until a turn actually succeeds.
+   The reason is humanised in the TUI only (`terminated` / `socket hang up` / `other side closed` →
+   `connection dropped mid-reply`, `fetch failed` → `no connection`); the runtime classifier keeps
+   the raw wording, which is what the logs and the trace are matched on. The readout shrinks before
+   anything in the route statement and opens Manage › LLM when clicked, so a narrow terminal
+   degrades to the whole route plus a truncated warning rather than to a warning alone. The context
+   readout is not touched: it is driven by `prompt_built` / `llm_completed`, and a parked turn
+   produces neither.
 
 ### No-progress loop detection
 

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -870,15 +870,127 @@ describe("provider outage", () => {
     } as never,
   });
 
+  const step = (stepIndex: number): TuiAction => ({
+    type: "agent_event",
+    event: { type: "step_started", stepIndex },
+  });
+
+  const reasoningDelta = (stepIndex: number, text: string): TuiAction => ({
+    type: "agent_event",
+    event: {
+      type: "llm_event",
+      event: { type: "reasoning_delta", stepIndex, text },
+    } as never,
+  });
+
   it("shows the outage and says how long it will keep trying", () => {
     const next = reduceTuiState(createInitialTuiState(fakeSession()), waiting());
     expect(next.providerOutage).toMatchObject({
       reason: "fetch failed",
       attempt: 1,
+      phase: "parked",
       givenUp: false,
     });
+    expect(next.providerOutage?.sinceTs).toBeGreaterThan(0);
     expect(next.feed.at(-1)?.line).toContain("provider not answering");
     expect(next.feed.at(-1)?.line).toContain("retrying in 2s");
+  });
+
+  it("flips to `retrying` when the parked step goes back on the wire", () => {
+    // The loop emits nothing between the backoff and
+    // `provider_recovered`, which only lands once the replayed step has
+    // *finished*. `step_started` during an outage is the one event that
+    // says the retry is live, and without it a step that streams for
+    // minutes leaves the row counting a wait that is already over.
+    const parked = apply(createInitialTuiState(fakeSession()), [
+      step(4),
+      waiting(),
+    ]);
+    expect(parked.providerOutage).toMatchObject({ phase: "parked" });
+    const retrying = reduceTuiState(parked, step(4));
+    expect(retrying.providerOutage).toMatchObject({
+      phase: "retrying",
+      attempt: 1,
+      // The wait total is not rewritten — the next `provider_waiting`
+      // owns it, and the readout counts the retry off `sinceTs`.
+      waitedMs: 0,
+    });
+    expect(retrying.providerOutage?.sinceTs).toBeGreaterThanOrEqual(
+      parked.providerOutage?.sinceTs ?? 0,
+    );
+  });
+
+  it("drops the dead attempt's reasoning instead of splicing the retry onto it", () => {
+    // `appendReasoningDelta` merges into the trailing entry whenever the
+    // step index matches, so the retry's thinking used to be welded onto
+    // the tail of the attempt whose socket died — the model's reasoning
+    // shown twice, joined mid-sentence.
+    const next = apply(createInitialTuiState(fakeSession()), [
+      step(2),
+      reasoningDelta(2, "first attempt thinking"),
+      waiting({ reason: "terminated" }),
+      step(2),
+      reasoningDelta(2, "retry thinking"),
+    ]);
+    expect(next.reasoning).toHaveLength(1);
+    expect(next.reasoning[0]?.text).toBe("retry thinking");
+  });
+
+  it("clears the dead attempt's streamed reply and half-parsed tool calls", () => {
+    const parked: TuiState = {
+      ...apply(createInitialTuiState(fakeSession()), [step(1), waiting()]),
+      streamingAssistantText: "half a sentence before the socket",
+      streamingToolCalls: [
+        {
+          id: "call_1",
+          stepIndex: 1,
+          tool: "os.fs.read",
+          args: {},
+          startedAt: Date.now(),
+        },
+      ],
+    };
+    const retrying = reduceTuiState(parked, step(1));
+    expect(retrying.streamingAssistantText).toBeNull();
+    expect(retrying.streamingToolCalls).toEqual([]);
+  });
+
+  it("leaves an ordinary step start completely alone", () => {
+    // The retry branch hangs off `step_started`, which every turn fires
+    // for every step. With no outage live it must change nothing.
+    const before = apply(createInitialTuiState(fakeSession()), [
+      step(0),
+      reasoningDelta(0, "thinking"),
+    ]);
+    const after = reduceTuiState(
+      { ...before, streamingAssistantText: "partial" },
+      step(0),
+    );
+    expect(after.providerOutage).toBeNull();
+    expect(after.reasoning).toHaveLength(1);
+    expect(after.reasoning[0]?.text).toBe("thinking");
+    expect(after.streamingAssistantText).toBe("partial");
+  });
+
+  it("does not turn a given-up outage back into a live wait", () => {
+    // The badge is past tense and sticky until a turn actually
+    // succeeds; the next turn's first step must not restart a countdown.
+    const dead = apply(createInitialTuiState(fakeSession()), [
+      waiting(),
+      {
+        type: "agent_event",
+        event: {
+          type: "loop_failed",
+          error: new Error("fetch failed"),
+          category: "transport",
+        },
+      },
+    ]);
+    const next = reduceTuiState(dead, step(0));
+    expect(next.providerOutage).toMatchObject({
+      givenUp: true,
+      phase: "parked",
+    });
   });
 
   it("does not repeat the feed line on every retry", () => {

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -993,6 +993,84 @@ describe("provider outage", () => {
     });
   });
 
+  const turnFinished = (reason: string): TuiAction => ({
+    type: "agent_event",
+    event: {
+      type: "turn_finished",
+      turnIndex: 0,
+      reason,
+      stepCount: 1,
+      durationMs: 20,
+    } as never,
+  });
+
+  it.each(["cancelled", "max_steps"])(
+    "takes a live wait down with the turn that ended %s",
+    (reason) => {
+      // `waiting` and `retrying` are claims about a turn that is on the
+      // wire. Esc during the backoff is the ending the loop's own feed
+      // line advertises ("· Esc stops"), and it used to leave the
+      // readout standing and counting — measured live at 19s and
+      // climbing, fourteen seconds after the loop was dead.
+      const ended = apply(createInitialTuiState(fakeSession()), [
+        step(0),
+        waiting(),
+        turnFinished(reason),
+      ]);
+      expect(ended.providerOutage).toBeNull();
+    },
+  );
+
+  it("does not read the next turn's first step as the parked one", () => {
+    const ended = apply(createInitialTuiState(fakeSession()), [
+      step(0),
+      waiting(),
+      turnFinished("cancelled"),
+    ]);
+    const fresh = apply(ended, [
+      { type: "agent_event", event: { type: "turn_started" } as never },
+      step(0),
+    ]);
+    expect(fresh.providerOutage).toBeNull();
+  });
+
+  it("keeps the given-up badge across an aborted turn", () => {
+    // Sticky on purpose: the next message fails the same way until the
+    // link is back, and a state that clears itself between attempts is
+    // how eight identical failures read as eight separate surprises.
+    const dead = apply(createInitialTuiState(fakeSession()), [
+      waiting(),
+      {
+        type: "agent_event",
+        event: {
+          type: "loop_failed",
+          error: new Error("fetch failed"),
+          category: "transport",
+        },
+      },
+      turnFinished("failed"),
+    ]);
+    expect(dead.providerOutage).toMatchObject({ givenUp: true });
+    expect(reduceTuiState(dead, turnFinished("cancelled")).providerOutage)
+      .toMatchObject({ givenUp: true });
+  });
+
+  it("clears the given-up badge once a turn reaches the model", () => {
+    const dead = apply(createInitialTuiState(fakeSession()), [
+      waiting(),
+      {
+        type: "agent_event",
+        event: {
+          type: "loop_failed",
+          error: new Error("fetch failed"),
+          category: "transport",
+        },
+      },
+      turnFinished("failed"),
+    ]);
+    expect(reduceTuiState(dead, turnFinished("reply")).providerOutage).toBeNull();
+  });
+
   it("does not repeat the feed line on every retry", () => {
     // The backoff fires every few seconds at first; the meta-row carries
     // the live numbers, so a wall of identical lines would only bury the

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -376,16 +376,35 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         currentTurnToolSteps: 0,
         runStartedAt: Date.now(),
       };
-    case "turn_finished":
-      // A turn that reached the model clears the outage: the link is
-      // demonstrably answering again. A failed one leaves it standing.
+    case "turn_finished": {
+      // `waiting` and `retrying` are claims about a turn that is still
+      // on the wire, so the end of the turn ends them — whichever way it
+      // ended. It used to clear only on `reply` / `finish`, which left a
+      // live outage standing after the two endings that reach it most
+      // often: Esc during the backoff (the feed line the loop prints
+      // says "· Esc stops") and a turn stopped at its step ceiling. The
+      // row then counted a wait that nothing was waiting for — measured
+      // at 19s and climbing, fourteen seconds after the loop was dead —
+      // and the next turn's first `step_started` read it as the parked
+      // step going back on the wire: a brand-new healthy turn labelled
+      // `retrying provider (attempt 1)`, with that step's streamed reply
+      // wiped at every step boundary for as long as it ran.
+      //
+      // `givenUp` is the one that survives, and survives on purpose: it
+      // is past tense, it is what stops nine identical failures reading
+      // as nine separate surprises, and `loop_failed` has already set it
+      // by the time this event lands. It survives until a turn actually
+      // reaches the model — at which point the link is demonstrably
+      // answering again and the badge would be the lie instead.
+      const reachedTheModel =
+        event.reason === "reply" || event.reason === "finish";
+      const keepBadge = !reachedTheModel && Boolean(state.providerOutage?.givenUp);
       return finishTurn(
-        event.reason === "reply" || event.reason === "finish"
-          ? { ...state, providerOutage: null }
-          : state,
+        keepBadge ? state : { ...state, providerOutage: null },
         event.reason,
         event.stepCount,
       );
+    }
     case "step_started":
       // `retryProviderOutage` is a no-op unless an outage is live, so an
       // ordinary step start goes through here exactly as it always did.

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -22,6 +22,10 @@ import {
   startNewRun,
   upsertReasoning,
 } from "./reducer-helpers.js";
+import {
+  parkProviderOutage,
+  retryProviderOutage,
+} from "./provider-outage-state.js";
 import { reduceUiAction } from "./reduce-ui-actions.js";
 import { reduceComposerSwitchAction } from "./composer-switch/composer-switch-reducer.js";
 import { selectComposerBackend } from "./composer-switch/composer-switch-rows.js";
@@ -383,17 +387,22 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         event.stepCount,
       );
     case "step_started":
-      return {
-        ...appendFeed(state, {
-          kind: "step_started",
-          stepIndex: event.stepIndex,
-          line: formatFeedLine({ type: "step_started", stepIndex: event.stepIndex }),
-          color: "blue",
-        }),
-        status: "running",
-        currentStep: event.stepIndex,
-        stepStartedAt: Date.now(),
-      };
+      // `retryProviderOutage` is a no-op unless an outage is live, so an
+      // ordinary step start goes through here exactly as it always did.
+      return retryProviderOutage(
+        {
+          ...appendFeed(state, {
+            kind: "step_started",
+            stepIndex: event.stepIndex,
+            line: formatFeedLine({ type: "step_started", stepIndex: event.stepIndex }),
+            color: "blue",
+          }),
+          status: "running",
+          currentStep: event.stepIndex,
+          stepStartedAt: Date.now(),
+        },
+        event.stepIndex,
+      );
     case "step_finished":
       return {
         ...appendFeed(state, {
@@ -550,16 +559,12 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
       )}s, waited ${Math.round(event.waitedMs / 1000)}s of ${Math.round(
         event.maxWaitMs / 1000,
       )}s · Esc stops`;
-      const next: TuiState = {
-        ...state,
-        providerOutage: {
-          reason: event.reason,
-          waitedMs: event.waitedMs,
-          maxWaitMs: event.maxWaitMs,
-          attempt: event.attempt,
-          givenUp: false,
-        },
-      };
+      const next: TuiState = parkProviderOutage(state, {
+        reason: event.reason,
+        waitedMs: event.waitedMs,
+        maxWaitMs: event.maxWaitMs,
+        attempt: event.attempt,
+      });
       // One feed line per outage, not per retry: the backoff fires every
       // few seconds at the start and the meta-row carries the live
       // numbers. A wall of identical lines would bury the work above it.

--- a/src/tui/components/hotkey-chips.ts
+++ b/src/tui/components/hotkey-chips.ts
@@ -141,16 +141,28 @@ export function resolveChips(
     const steering = state.whileBusyMode === "steer";
     const chips: HotkeyChip[] = [
       { key: SCROLL_KEY, label: "scroll", shed: 1 },
-      { key: "⏎", label: steering ? "steer" : "queue message", shed: 3 },
+      // Essential, and the only chip in this list that is: the composer
+      // stays live through a turn, so Enter is a key the operator can
+      // press at any moment with a half-written message in the buffer,
+      // and it either steers into the running turn or parks the message
+      // behind it. Nothing else on screen says which — and while the
+      // provider is down the meta row above drops its own copy of this
+      // hint to make room for the outage numbers, so this is then the
+      // last statement of it anywhere. At `shed: 3` it was not: it went
+      // at every width up to 112 columns the moment a draft lengthened
+      // the Esc chip to `abort, draft kept`, which is exactly the state
+      // it is written for. `ctrl+t` keeps its rank — the mode is worth
+      // less than what the key does right now.
+      { key: "⏎", label: steering ? "steer" : "queue message" },
       {
         key: "ctrl+t",
         label: steering ? "queue mode" : "steer mode",
-        shed: 4,
+        shed: 3,
       },
       { key: "esc", label: hasDraft ? "abort, draft kept" : "abort" },
       ...(composerSelectionActive(state)
         ? [
-            { key: "ctrl+x", label: "cut", shed: 5 },
+            { key: "ctrl+x", label: "cut", shed: 4 },
             { key: "ctrl+c", label: "copy" },
           ]
         : [

--- a/src/tui/components/hotkey-hint.test.tsx
+++ b/src/tui/components/hotkey-hint.test.tsx
@@ -361,6 +361,28 @@ describe("HotkeyHint queue affordances", () => {
     expect(out.split("\n").filter((l) => l.trim().length > 0)).toHaveLength(1);
   });
 
+  it.each([54, 70, 79, 100])(
+    "keeps the Enter chip on a %i-column row with a draft in the buffer",
+    (columns) => {
+      // The one chip in the running strip with no shed rank. A draft
+      // lengthens the Esc chip to `abort, draft kept`, and at `shed: 3`
+      // that was enough to drop `[⏎] steer` at every width up to 112 —
+      // in the one state the chip exists for, and the one state where
+      // the meta row above has dropped its own copy of the hint to make
+      // room for the provider-outage numbers. `ctrl+t` may still go.
+      const out = renderHint(
+        chatState({
+          status: "running",
+          inputValue: "a message the operator is part-way through",
+        }),
+        columns,
+      );
+      expect(out).toMatch(/\[⏎\]\s*steer/);
+      expect(out).toContain("abort, draft kept");
+      expect(out.split("\n").filter((l) => l.trim().length > 0)).toHaveLength(1);
+    },
+  );
+
   it("gives an armed ctrl+c the whole row", () => {
     const { lastFrame, unmount } = render(
       <HotkeyHint state={chatState({ status: "running" })} ctrlCArmed />,

--- a/src/tui/components/prompt-meta-bar.test.tsx
+++ b/src/tui/components/prompt-meta-bar.test.tsx
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { Box, render as inkRender } from "ink";
+import { Box, Text, render as inkRender } from "ink";
 import { render } from "ink-testing-library";
 import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
@@ -215,7 +215,10 @@ const ROUTE = {
   model: "qwen3-30b-a3b-instruct",
 };
 
-function renderMetaBarAt(columns: number, leftSlot: ReactElement | null): string[] {
+function renderMetaBarAt(
+  columns: number,
+  leftSlot: ReactElement | null,
+): string[] {
   const stdout = new SizedStdout(columns);
   const instance = inkRender(
     <PromptMetaBar
@@ -241,7 +244,9 @@ function renderMetaBarAt(columns: number, leftSlot: ReactElement | null): string
   return frame.split("\n").map((line) => line.replace(/\s+$/, ""));
 }
 
-const OUTAGE_LINE = "waiting for provider 42s/300s — connection dropped mid-reply";
+const OUTAGE_HEAD = "waiting for provider 42s/300s";
+const OUTAGE_TAIL = " — connection dropped mid-reply";
+const OUTAGE_LINE = `${OUTAGE_HEAD}${OUTAGE_TAIL}`;
 
 /**
  * The readout used to sit in a `flexShrink={0}` slot, so it took the
@@ -252,27 +257,56 @@ const OUTAGE_LINE = "waiting for provider 42s/300s — connection dropped mid-re
  */
 describe("the meta bar while the provider is down", () => {
   const readout = (
-    <ProviderOutageReadout text={OUTAGE_LINE} givenUp={false} />
+    <ProviderOutageReadout
+      head={OUTAGE_HEAD}
+      tail={OUTAGE_TAIL}
+      givenUp={false}
+    />
   );
 
   it.each([80, 100, 110, 160])("keeps the route at %i columns", (columns) => {
     const frame = renderMetaBarAt(columns, readout).join("\n");
     // Backend word, provider and model all still on the row. Below ~110
-    // the last two lose a character each to Yoga's rounding — the row
-    // simply needs more columns than the terminal has — but the route
-    // reads as a route, which is the whole point.
+    // the last two lose characters — the row simply needs more columns
+    // than the terminal has — but the route reads as a route.
     expect(frame).toContain("custom");
     expect(frame).toContain("llama.c");
     expect(frame).toContain("qwen3-30b");
-    // Something of the readout survives too — a truncated warning is
-    // still a warning, and it is the click target for the LLM pane.
-    expect(frame).toContain("waiting for provider");
   });
 
-  it.each([110, 160])("carries both statements whole at %i columns", (columns) => {
-    const frame = renderMetaBarAt(columns, readout).join("\n");
+  it.each([80, 100, 110, 160])(
+    "keeps the readout's numbers at %i columns",
+    (columns) => {
+      // `waiting` alone says the link is down, which the colour already
+      // said; the counter is what says the wait is still progressing
+      // rather than hung. It is in the head, which does not shrink.
+      const frame = renderMetaBarAt(columns, readout).join("\n");
+      expect(frame).toContain(OUTAGE_HEAD);
+    },
+  );
+
+  it("gives the reason the columns nothing else wants", () => {
+    // The tail grows from nothing into the leftovers, so it appears
+    // exactly when the row can afford it and never at the route's
+    // expense.
+    expect(renderMetaBarAt(160, readout).join("\n")).toContain(OUTAGE_LINE);
+    expect(renderMetaBarAt(80, readout).join("\n")).not.toContain(
+      "connection dropped",
+    );
+  });
+
+  it("carries both statements whole at 160 columns", () => {
+    const frame = renderMetaBarAt(160, readout).join("\n");
     expect(frame).toContain(OUTAGE_LINE);
     expect(frame).toContain("custom · llama.cpp · qwen3-30b-a3b-instruct");
+  });
+
+  it("does not open a gap between the reason and the route", () => {
+    // The tail is capped at its own text: growing past it would leave a
+    // run of blanks in front of the separator.
+    expect(renderMetaBarAt(160, readout).join("\n")).toContain(
+      "mid-reply · ● custom",
+    );
   });
 
   it.each([80, 100, 110, 160])("stays one row tall at %i columns", (columns) => {
@@ -284,15 +318,15 @@ describe("the meta bar while the provider is down", () => {
     for (const line of lines) expect(line.length).toBeLessThanOrEqual(columns);
   });
 
-  it("spends the columns it loses on itself, not on the route", () => {
-    // 80 is 30 columns short of what the full row wants. The readout
-    // gives up 29 of them; the route gives up two characters.
-    const tail = (lines: string[]): string =>
-      lines.join("\n").split("waiting for provider")[1] ?? "";
-    const lost =
-      tail(renderMetaBarAt(160, readout)).length -
-      tail(renderMetaBarAt(80, readout)).length;
-    expect(lost).toBeGreaterThanOrEqual(25);
+  it("leaves a short composer notice next to the route", () => {
+    // The other slot: it shrinks the ordinary way and must not be padded
+    // out to some readout-sized floor.
+    const notice = (
+      <Text wrap="truncate">saved</Text>
+    );
+    expect(renderMetaBarAt(160, notice).join("\n")).toContain(
+      "saved · ● custom",
+    );
   });
 
   it("opens the LLM pane when the readout is clicked", async () => {
@@ -310,7 +344,11 @@ describe("the meta bar while the provider is down", () => {
         <Box width={100}>
           <PromptMetaBar
             leftSlot={
-              <ProviderOutageReadout text={OUTAGE_LINE} givenUp={false} />
+              <ProviderOutageReadout
+                head={OUTAGE_HEAD}
+                tail={OUTAGE_TAIL}
+                givenUp={false}
+              />
             }
             backend={ROUTE.backend}
             provider={ROUTE.provider}
@@ -323,7 +361,7 @@ describe("the meta bar while the provider is down", () => {
       </MouseProvider>,
     );
     await new Promise((resolve) => setTimeout(resolve, 120));
-    const { x, y } = locate(lastFrame() ?? "", "waiting for provider");
+    const { x, y } = locate(lastFrame() ?? "", OUTAGE_HEAD);
     expect(registry.dispatch(click(x, y))).toBe(true);
     expect(actions).toContainEqual({ type: "tab_changed", tab: "llm" });
     unmount();

--- a/src/tui/components/prompt-meta-bar.test.tsx
+++ b/src/tui/components/prompt-meta-bar.test.tsx
@@ -10,7 +10,7 @@ import { MouseTargetRegistry } from "../mouse/mouse-registry.js";
 import type { TuiAction } from "../tui-action.js";
 import type { TuiAppCallbacks } from "../tui-app.js";
 import type { TuiState } from "../tui-state.js";
-import { PromptMetaBar } from "./prompt-meta-bar.js";
+import { META_SLOT_SHRINK, PromptMetaBar } from "./prompt-meta-bar.js";
 import { PromptShell } from "./prompt-shell.js";
 import { ProviderOutageReadout } from "./provider-outage-readout.js";
 
@@ -215,6 +215,23 @@ const ROUTE = {
   model: "qwen3-30b-a3b-instruct",
 };
 
+/**
+ * The bar's right-hand group, at the width `tui-app` really gives it:
+ * the context readout and the mode chip, both `flexShrink={0}`, are
+ * about fifty columns the left half never sees. Rendering the row
+ * without them was measuring a bar with fifty columns of slack in it —
+ * so nothing on the left ever had to shrink, and every assertion below
+ * about *which* half gives way passed by having no pressure to resolve.
+ * (Measured: with these two null, making the readout's head shrinkable
+ * changed no frame at any width in this file.)
+ */
+const RIGHT_GROUP = (
+  <>
+    <Text>{"context [==      ] 1/20 tasks ·  6.2k/32.8k"}</Text>
+    <Text>{" default "}</Text>
+  </>
+);
+
 function renderMetaBarAt(
   columns: number,
   leftSlot: ReactElement | null,
@@ -227,7 +244,7 @@ function renderMetaBarAt(
       provider={ROUTE.provider}
       model={ROUTE.model}
       rightSlot={null}
-      contextSlot={null}
+      contextSlot={RIGHT_GROUP}
       modeSlot={null}
     />,
     {
@@ -250,10 +267,15 @@ const OUTAGE_LINE = `${OUTAGE_HEAD}${OUTAGE_TAIL}`;
 
 /**
  * The readout used to sit in a `flexShrink={0}` slot, so it took the
- * left end of the bar outright: at 160 columns the route was gone, and
- * at 110 the readout itself was cut away and the row carried nothing at
- * all. Both halves are checked at every width — the provider is exactly
- * what an operator looks left for when the link is down.
+ * left end of the bar outright and the whole route statement was pushed
+ * off it — the provider gone from exactly the place someone looks when
+ * the link is down. Both halves are checked at each width.
+ *
+ * `columns` here is the **composer's inner width**, not the terminal's:
+ * the rail and the frame take about forty columns, so a 160-column
+ * terminal renders this bar at 119. Every number below is a bar width,
+ * and the ladder they describe is the one measured live under a PTY
+ * against a provider that kills the socket mid-stream.
  */
 describe("the meta bar while the provider is down", () => {
   const readout = (
@@ -264,39 +286,73 @@ describe("the meta bar while the provider is down", () => {
     />
   );
 
-  it.each([80, 100, 110, 160])("keeps the route at %i columns", (columns) => {
-    const frame = renderMetaBarAt(columns, readout).join("\n");
-    // Backend word, provider and model all still on the row. Below ~110
-    // the last two lose characters — the row simply needs more columns
-    // than the terminal has — but the route reads as a route.
-    expect(frame).toContain("custom");
-    expect(frame).toContain("llama.c");
-    expect(frame).toContain("qwen3-30b");
+  it.each([119, 130, 160, 200])(
+    "keeps the route legible at %i columns",
+    (columns) => {
+      // The backend word whole, and enough of the provider and the model
+      // to name them.
+      const frame = renderMetaBarAt(columns, readout).join("\n");
+      expect(frame).toContain("● custom");
+      expect(frame).toContain("llam");
+      expect(frame).toContain("qwen3-30b");
+    },
+  );
+
+  it.each([90, 110])(
+    "still names the backend at %i columns, where the model cannot fit",
+    (columns) => {
+      // The readout's numbers win this trade — the head is whole at both
+      // — but the row is not empty the way it was: the backend word is
+      // still there, which is what says *which* link is down.
+      const frame = renderMetaBarAt(columns, readout).join("\n");
+      expect(frame).toContain("● c");
+    },
+  );
+
+  it.each([140, 160, 200])("carries the route whole at %i columns", (columns) => {
+    expect(renderMetaBarAt(columns, readout).join("\n")).toContain(
+      "● custom · llama.cpp · qwen3-30b-a3b-instruct",
+    );
   });
 
-  it.each([80, 100, 110, 160])(
+  it.each([90, 110, 119, 130, 160])(
     "keeps the readout's numbers at %i columns",
     (columns) => {
       // `waiting` alone says the link is down, which the colour already
       // said; the counter is what says the wait is still progressing
-      // rather than hung. It is in the head, which does not shrink.
+      // rather than hung. It is in the head, which does not shrink — and
+      // this is the assertion that says so, so it has to run on a row
+      // that is actually under pressure. It is: at 110 the model name is
+      // already losing characters to keep this whole.
       const frame = renderMetaBarAt(columns, readout).join("\n");
       expect(frame).toContain(OUTAGE_HEAD);
     },
   );
 
+  it("degrades to the head alone before it gives up the head", () => {
+    // 75 columns is past what the row can carry: the head is clipped by
+    // the bar's own `overflow="hidden"` rather than by any shrink, and
+    // what survives is still the front of the state word. Recorded
+    // rather than wished away — "never shrinks" is a shrink-order claim,
+    // not a promise about a row narrower than one statement.
+    const frame = renderMetaBarAt(75, readout).join("\n");
+    expect(frame).toContain("waiting for provide");
+    expect(frame).not.toContain("custom");
+  });
+
   it("gives the reason the columns nothing else wants", () => {
     // The tail grows from nothing into the leftovers, so it appears
     // exactly when the row can afford it and never at the route's
-    // expense.
-    expect(renderMetaBarAt(160, readout).join("\n")).toContain(OUTAGE_LINE);
-    expect(renderMetaBarAt(80, readout).join("\n")).not.toContain(
+    // expense: not at 119, where the route is still losing characters,
+    // and whole once the route is whole with room to spare.
+    expect(renderMetaBarAt(200, readout).join("\n")).toContain(OUTAGE_LINE);
+    expect(renderMetaBarAt(119, readout).join("\n")).not.toContain(
       "connection dropped",
     );
   });
 
-  it("carries both statements whole at 160 columns", () => {
-    const frame = renderMetaBarAt(160, readout).join("\n");
+  it("carries both statements whole at 200 columns", () => {
+    const frame = renderMetaBarAt(200, readout).join("\n");
     expect(frame).toContain(OUTAGE_LINE);
     expect(frame).toContain("custom · llama.cpp · qwen3-30b-a3b-instruct");
   });
@@ -304,19 +360,46 @@ describe("the meta bar while the provider is down", () => {
   it("does not open a gap between the reason and the route", () => {
     // The tail is capped at its own text: growing past it would leave a
     // run of blanks in front of the separator.
-    expect(renderMetaBarAt(160, readout).join("\n")).toContain(
+    expect(renderMetaBarAt(200, readout).join("\n")).toContain(
       "mid-reply · ● custom",
     );
   });
 
-  it.each([80, 100, 110, 160])("stays one row tall at %i columns", (columns) => {
-    // Ink wraps rather than clips, and a second line here would push the
-    // composer's bottom border down.
-    const lines = renderMetaBarAt(columns, readout);
-    // `paddingY={1}` — one blank, the row, one blank.
-    expect(lines).toHaveLength(3);
-    for (const line of lines) expect(line.length).toBeLessThanOrEqual(columns);
-  });
+  it.each([75, 90, 110, 119, 130, 160, 200])(
+    "stays one row tall at %i columns",
+    (columns) => {
+      // Ink wraps rather than clips, and a second line here would push
+      // the composer's bottom border down.
+      const lines = renderMetaBarAt(columns, readout);
+      // `paddingY={1}` — one blank, the row, one blank.
+      expect(lines).toHaveLength(3);
+      for (const line of lines) expect(line.length).toBeLessThanOrEqual(columns);
+    },
+  );
+
+  it.each([75, 90, 110, 119, 130, 160, 200])(
+    "stays one row tall through the other two phases at %i columns",
+    (columns) => {
+      // A retry carries no reason at all, and a given-up badge is a
+      // different head with a different colour; neither may wrap either.
+      for (const slot of [
+        <ProviderOutageReadout
+          head="retrying provider (attempt 2) — 8s"
+          tail={null}
+          givenUp={false}
+        />,
+        <ProviderOutageReadout
+          head="provider unreachable"
+          tail=" — no connection"
+          givenUp
+        />,
+      ]) {
+        const lines = renderMetaBarAt(columns, slot);
+        expect(lines).toHaveLength(3);
+        for (const line of lines) expect(line.length).toBeLessThanOrEqual(columns);
+      }
+    },
+  );
 
   it("leaves a short composer notice next to the route", () => {
     // The other slot: it shrinks the ordinary way and must not be padded
@@ -327,6 +410,24 @@ describe("the meta bar while the provider is down", () => {
     expect(renderMetaBarAt(160, notice).join("\n")).toContain(
       "saved · ● custom",
     );
+  });
+
+  it("makes a long composer notice yield to the route", () => {
+    // `META_SLOT_SHRINK`, the reason the slot is no longer `flexShrink={0}`:
+    // a notice that kept its own width took the left end of the bar and
+    // pushed the route off it, which is the same failure the outage
+    // readout had. The notice gives up characters; the model name still
+    // reads.
+    const notice = (
+      <Box flexShrink={META_SLOT_SHRINK} minWidth={0}>
+        <Text wrap="truncate">
+          saved settings to ~/.atomic-agent/config.json
+        </Text>
+      </Box>
+    );
+    const frame = renderMetaBarAt(110, notice).join("\n");
+    expect(frame).toContain("qwen3-30b");
+    expect(frame).not.toContain("config.json");
   });
 
   it("opens the LLM pane when the readout is clicked", async () => {

--- a/src/tui/components/prompt-meta-bar.test.tsx
+++ b/src/tui/components/prompt-meta-bar.test.tsx
@@ -1,12 +1,18 @@
+import { EventEmitter } from "node:events";
+import { Box, render as inkRender } from "ink";
 import { render } from "ink-testing-library";
 import type { ReactElement } from "react";
 import { describe, expect, it } from "vitest";
+import type { ComposerBackendMeta } from "../composer-switch/composer-switch-rows.js";
 import { MouseProvider } from "../mouse/mouse-context.js";
 import type { TuiMouseEvent } from "../mouse/mouse-event.js";
 import { MouseTargetRegistry } from "../mouse/mouse-registry.js";
+import type { TuiAction } from "../tui-action.js";
 import type { TuiAppCallbacks } from "../tui-app.js";
 import type { TuiState } from "../tui-state.js";
+import { PromptMetaBar } from "./prompt-meta-bar.js";
 import { PromptShell } from "./prompt-shell.js";
+import { ProviderOutageReadout } from "./provider-outage-readout.js";
 
 function strip(value: string): string {
   return value
@@ -184,5 +190,142 @@ describe("the model label", () => {
     expect(renderModel("vendor/an-extremely-long-single-model-name")).toContain(
       "vendor/an-extremely-long-single…",
     );
+  });
+});
+
+/**
+ * ink-testing-library pins its stdout at 100 columns, and the row's
+ * whole job here is to degrade well at widths on either side of that.
+ * Its Stdout is a dozen lines; this is the same thing with the width as
+ * a parameter.
+ */
+class SizedStdout extends EventEmitter {
+  _lastFrame: string | undefined;
+  constructor(readonly columns: number) {
+    super();
+  }
+  write = (frame: string): void => {
+    this._lastFrame = frame;
+  };
+}
+
+const ROUTE = {
+  backend: { kind: "custom", status: "healthy" } as ComposerBackendMeta,
+  provider: "llama.cpp",
+  model: "qwen3-30b-a3b-instruct",
+};
+
+function renderMetaBarAt(columns: number, leftSlot: ReactElement | null): string[] {
+  const stdout = new SizedStdout(columns);
+  const instance = inkRender(
+    <PromptMetaBar
+      leftSlot={leftSlot}
+      backend={ROUTE.backend}
+      provider={ROUTE.provider}
+      model={ROUTE.model}
+      rightSlot={null}
+      contextSlot={null}
+      modeSlot={null}
+    />,
+    {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      // Ink batches its writes behind log-update otherwise, and the
+      // frame is still empty when a synchronous test reads it.
+      debug: true,
+      patchConsole: false,
+      exitOnCtrlC: false,
+    },
+  );
+  const frame = strip(stdout._lastFrame ?? "");
+  instance.unmount();
+  return frame.split("\n").map((line) => line.replace(/\s+$/, ""));
+}
+
+const OUTAGE_LINE = "waiting for provider 42s/300s — connection dropped mid-reply";
+
+/**
+ * The readout used to sit in a `flexShrink={0}` slot, so it took the
+ * left end of the bar outright: at 160 columns the route was gone, and
+ * at 110 the readout itself was cut away and the row carried nothing at
+ * all. Both halves are checked at every width — the provider is exactly
+ * what an operator looks left for when the link is down.
+ */
+describe("the meta bar while the provider is down", () => {
+  const readout = (
+    <ProviderOutageReadout text={OUTAGE_LINE} givenUp={false} />
+  );
+
+  it.each([80, 100, 110, 160])("keeps the route at %i columns", (columns) => {
+    const frame = renderMetaBarAt(columns, readout).join("\n");
+    // Backend word, provider and model all still on the row. Below ~110
+    // the last two lose a character each to Yoga's rounding — the row
+    // simply needs more columns than the terminal has — but the route
+    // reads as a route, which is the whole point.
+    expect(frame).toContain("custom");
+    expect(frame).toContain("llama.c");
+    expect(frame).toContain("qwen3-30b");
+    // Something of the readout survives too — a truncated warning is
+    // still a warning, and it is the click target for the LLM pane.
+    expect(frame).toContain("waiting for provider");
+  });
+
+  it.each([110, 160])("carries both statements whole at %i columns", (columns) => {
+    const frame = renderMetaBarAt(columns, readout).join("\n");
+    expect(frame).toContain(OUTAGE_LINE);
+    expect(frame).toContain("custom · llama.cpp · qwen3-30b-a3b-instruct");
+  });
+
+  it.each([80, 100, 110, 160])("stays one row tall at %i columns", (columns) => {
+    // Ink wraps rather than clips, and a second line here would push the
+    // composer's bottom border down.
+    const lines = renderMetaBarAt(columns, readout);
+    // `paddingY={1}` — one blank, the row, one blank.
+    expect(lines).toHaveLength(3);
+    for (const line of lines) expect(line.length).toBeLessThanOrEqual(columns);
+  });
+
+  it("spends the columns it loses on itself, not on the route", () => {
+    // 80 is 30 columns short of what the full row wants. The readout
+    // gives up 29 of them; the route gives up two characters.
+    const tail = (lines: string[]): string =>
+      lines.join("\n").split("waiting for provider")[1] ?? "";
+    const lost =
+      tail(renderMetaBarAt(160, readout)).length -
+      tail(renderMetaBarAt(80, readout)).length;
+    expect(lost).toBeGreaterThanOrEqual(25);
+  });
+
+  it("opens the LLM pane when the readout is clicked", async () => {
+    // Where the route the outage is about is configured — the same deep
+    // link the `download model` slot uses.
+    const actions: TuiAction[] = [];
+    const registry = new MouseTargetRegistry();
+    const { lastFrame, unmount } = render(
+      <MouseProvider
+        registry={registry}
+        dispatch={(action) => actions.push(action)}
+        callbacks={noopCallbacks}
+        getState={() => ({}) as TuiState}
+      >
+        <Box width={100}>
+          <PromptMetaBar
+            leftSlot={
+              <ProviderOutageReadout text={OUTAGE_LINE} givenUp={false} />
+            }
+            backend={ROUTE.backend}
+            provider={ROUTE.provider}
+            model={ROUTE.model}
+            rightSlot={null}
+            contextSlot={null}
+            modeSlot={null}
+          />
+        </Box>
+      </MouseProvider>,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    const { x, y } = locate(lastFrame() ?? "", "waiting for provider");
+    expect(registry.dispatch(click(x, y))).toBe(true);
+    expect(actions).toContainEqual({ type: "tab_changed", tab: "llm" });
+    unmount();
   });
 });

--- a/src/tui/components/prompt-meta-bar.tsx
+++ b/src/tui/components/prompt-meta-bar.tsx
@@ -77,8 +77,10 @@ export interface PromptMetaBarProps {
 const MODEL_LABEL_MAX_LEN = 32;
 
 /**
- * How eagerly the chat-surface slot gives up columns, against the route
- * controls' own factors (model 3, provider 1, backend 0).
+ * How eagerly a chat-surface slot gives up columns, against the route
+ * controls' own factors (model 3, provider 1, backend 0). Exported
+ * because the slot carries it: the slot goes straight into this row, so
+ * it owns its own shrink order.
  *
  * It used to be `0` — the slot never shrank, so a provider-outage
  * readout took the left end of the bar outright and pushed the entire
@@ -88,12 +90,16 @@ const MODEL_LABEL_MAX_LEN = 32;
  *
  * An order of magnitude above the route's factors rather than a
  * hairline above them, because Yoga shrinks *proportionally*: at 4 the
- * model would still give up a quarter of every lost column. The
- * intended degradation is the whole route plus a truncated readout, and
- * a factor this size is what expresses "this one goes first" in a
- * layout engine that has no such notion.
+ * model would still give up a quarter of every lost column.
+ *
+ * The outage readout does not use it. Yoga leaves an item at full width
+ * rather than shrink it by more than it has to give (measured: composer
+ * width 119, a 31-column reason with this factor gave up nothing and
+ * the route was clipped off the row), so the readout's reason grows
+ * into the leftovers from a basis of zero instead. Growth Yoga resolves
+ * reliably; large shrinks it does not.
  */
-const SLOT_SHRINK = 40;
+export const META_SLOT_SHRINK = 40;
 
 /**
  * Separator `runModeModelSummary` puts between the two fusion legs.
@@ -129,9 +135,12 @@ export function PromptMetaBar({
       {/*
         The meta group is the only thing allowed to give up columns: at
         60 the right-hand readout must survive intact, because a
-        half-drawn chip is worse than a truncated model name.
+        half-drawn chip is worse than a truncated model name. It also
+        takes the row's slack (`flexGrow`) rather than leaving it between
+        the two groups, so a slot that fills the leftovers — the outage
+        reason — has leftovers to fill.
       */}
-      <Box flexShrink={1} minWidth={0} overflow="hidden">
+      <Box flexGrow={1} flexShrink={1} minWidth={0} overflow="hidden">
         <MetaLeft
           leftSlot={leftSlot}
           backend={backend}
@@ -174,15 +183,18 @@ interface MetaLeftProps {
  *
  * That costs the free truncation the single `<Text wrap="truncate">`
  * used to give the whole group, so the row has to fit by shrinking: the
- * slot and its separator go first (`SLOT_SHRINK`), then the route labels
- * in the order `ComposerMetaControls` sets. Every `<Text>` in here is
- * `truncate` for the same reason — one that wrapped would take the
- * composer's bottom border down a line with it.
+ * slot goes first (`META_SLOT_SHRINK`, or its own arrangement — see the
+ * outage readout), then the route labels in the order
+ * `ComposerMetaControls` sets. Every `<Text>` in here is `truncate` for
+ * the same reason — one that wrapped would take the composer's bottom
+ * border down a line with it.
  *
  * The slot is rendered as it arrives, not wrapped in a `<Text>` of this
  * file's own: it can be a click target, and a click target is a Box,
  * which Ink cannot nest inside a `<Text>`. Callers hand over an element
- * that truncates itself.
+ * that truncates itself — and may hand over more than one box, which is
+ * how the outage readout keeps a rigid head next to a reason that gives
+ * way.
  */
 function MetaLeft({
   leftSlot,
@@ -198,36 +210,36 @@ function MetaLeft({
   const cleanModel = model ? formatModel(model) : null;
   const hasRoute = Boolean(backend || provider || cleanModel || needsModelDownload);
   return (
-    <Box flexDirection="row" flexShrink={1} minWidth={0}>
-      {leftSlot ? (
-        <Box
-          flexDirection="row"
-          flexShrink={SLOT_SHRINK}
-          minWidth={0}
-          // The belt to the caller's braces. The slot is rendered as it
-          // arrives — it can be a click target, and a click target is a
-          // Box, which Ink cannot nest inside a `<Text>` — so this file
-          // can no longer impose `wrap="truncate"` on it. A slot that
-          // forgot to truncate itself would wrap, and a wrapped meta bar
-          // takes the composer's bottom border down a line with it. One
-          // row, clipped.
-          height={1}
-          overflow="hidden"
-        >
-          {leftSlot}
-          {hasRoute ? (
-            // Inside the shrinking group but not shrinking itself: the
-            // three cells it costs are what keep a truncated readout
-            // from running into the route, and a separator that gave up
-            // columns of its own turned into a second ellipsis sitting
-            // next to the readout's.
-            <Box flexShrink={0}>
-              <Text color={theme.colors.railMuted} wrap="truncate">
-                {" "}
-                {theme.glyphs.dotSeparator}{" "}
-              </Text>
-            </Box>
-          ) : null}
+    <Box
+      flexDirection="row"
+      flexGrow={1}
+      flexShrink={1}
+      minWidth={0}
+      // One row, clipped. Ink wraps rather than clips, and a second line
+      // here would take the composer's bottom border down with it. The
+      // slot is rendered as it arrives — it can be a click target, and a
+      // click target is a Box, which Ink cannot nest inside a `<Text>` —
+      // so this file can no longer impose `wrap="truncate"` on it, and
+      // this is the belt to the caller's braces.
+      height={1}
+      overflow="hidden"
+    >
+      {/*
+        Straight into the row, not inside a group box of its own. Yoga
+        only honours `flexShrink={0}` for the direct items of the line it
+        is shrinking: nested one level down, the outage readout's rigid
+        head was squeezed anyway and lost the very counter it exists to
+        protect (measured at composer width 119). Flat, the head sits
+        next to the backend word as another unshrinkable item and the
+        reason after it is what gives way.
+      */}
+      {leftSlot}
+      {leftSlot && hasRoute ? (
+        <Box flexShrink={0}>
+          <Text color={theme.colors.railMuted} wrap="truncate">
+            {" "}
+            {theme.glyphs.dotSeparator}{" "}
+          </Text>
         </Box>
       ) : null}
       <ComposerMetaControls

--- a/src/tui/components/prompt-meta-bar.tsx
+++ b/src/tui/components/prompt-meta-bar.tsx
@@ -77,6 +77,25 @@ export interface PromptMetaBarProps {
 const MODEL_LABEL_MAX_LEN = 32;
 
 /**
+ * How eagerly the chat-surface slot gives up columns, against the route
+ * controls' own factors (model 3, provider 1, backend 0).
+ *
+ * It used to be `0` — the slot never shrank, so a provider-outage
+ * readout took the left end of the bar outright and pushed the entire
+ * route statement off it. At 110 columns the row said nothing at all:
+ * the readout itself was cut away and the provider, the one thing an
+ * operator looks left for when the link is down, had gone with it.
+ *
+ * An order of magnitude above the route's factors rather than a
+ * hairline above them, because Yoga shrinks *proportionally*: at 4 the
+ * model would still give up a quarter of every lost column. The
+ * intended degradation is the whole route plus a truncated readout, and
+ * a factor this size is what expresses "this one goes first" in a
+ * layout engine that has no such notion.
+ */
+const SLOT_SHRINK = 40;
+
+/**
  * Separator `runModeModelSummary` puts between the two fusion legs.
  * Matched here rather than imported as a run-mode concept: this file
  * only needs to know that a label can be a pair, so that it can spend
@@ -155,10 +174,15 @@ interface MetaLeftProps {
  *
  * That costs the free truncation the single `<Text wrap="truncate">`
  * used to give the whole group, so the row has to fit by shrinking: the
- * notice and its separator never give a column, and the route labels
- * truncate in the order `ComposerMetaControls` sets. Every `<Text>` in
- * here is `truncate` for the same reason — one that wrapped would take
- * the composer's bottom border down a line with it.
+ * slot and its separator go first (`SLOT_SHRINK`), then the route labels
+ * in the order `ComposerMetaControls` sets. Every `<Text>` in here is
+ * `truncate` for the same reason — one that wrapped would take the
+ * composer's bottom border down a line with it.
+ *
+ * The slot is rendered as it arrives, not wrapped in a `<Text>` of this
+ * file's own: it can be a click target, and a click target is a Box,
+ * which Ink cannot nest inside a `<Text>`. Callers hand over an element
+ * that truncates itself.
  */
 function MetaLeft({
   leftSlot,
@@ -176,16 +200,34 @@ function MetaLeft({
   return (
     <Box flexDirection="row" flexShrink={1} minWidth={0}>
       {leftSlot ? (
-        <Box flexShrink={0}>
-          <Text wrap="truncate">{leftSlot}</Text>
-        </Box>
-      ) : null}
-      {leftSlot && hasRoute ? (
-        <Box flexShrink={0}>
-          <Text color={theme.colors.railMuted} wrap="truncate">
-            {" "}
-            {theme.glyphs.dotSeparator}{" "}
-          </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={SLOT_SHRINK}
+          minWidth={0}
+          // The belt to the caller's braces. The slot is rendered as it
+          // arrives — it can be a click target, and a click target is a
+          // Box, which Ink cannot nest inside a `<Text>` — so this file
+          // can no longer impose `wrap="truncate"` on it. A slot that
+          // forgot to truncate itself would wrap, and a wrapped meta bar
+          // takes the composer's bottom border down a line with it. One
+          // row, clipped.
+          height={1}
+          overflow="hidden"
+        >
+          {leftSlot}
+          {hasRoute ? (
+            // Inside the shrinking group but not shrinking itself: the
+            // three cells it costs are what keep a truncated readout
+            // from running into the route, and a separator that gave up
+            // columns of its own turned into a second ellipsis sitting
+            // next to the readout's.
+            <Box flexShrink={0}>
+              <Text color={theme.colors.railMuted} wrap="truncate">
+                {" "}
+                {theme.glyphs.dotSeparator}{" "}
+              </Text>
+            </Box>
+          ) : null}
         </Box>
       ) : null}
       <ComposerMetaControls

--- a/src/tui/components/prompt-meta-bar.tsx
+++ b/src/tui/components/prompt-meta-bar.tsx
@@ -225,13 +225,15 @@ function MetaLeft({
       overflow="hidden"
     >
       {/*
-        Straight into the row, not inside a group box of its own. Yoga
-        only honours `flexShrink={0}` for the direct items of the line it
-        is shrinking: nested one level down, the outage readout's rigid
-        head was squeezed anyway and lost the very counter it exists to
-        protect (measured at composer width 119). Flat, the head sits
-        next to the backend word as another unshrinkable item and the
-        reason after it is what gives way.
+        Straight into the row, not inside a group box of its own. A
+        rigid item can only defend its columns on the line that is doing
+        the shrinking: nested one level down, the outage readout's
+        `flexShrink={0}` head sat inside a group that had itself shrunk
+        below the width of its children, and the `overflow="hidden"`
+        below clipped the very counter the head exists to protect
+        (measured at bar width 100 — see `prompt-meta-bar.test.tsx`).
+        Flat, the head sits next to the backend word as another
+        unshrinkable item and the reason after it is what gives way.
       */}
       {leftSlot}
       {leftSlot && hasRoute ? (

--- a/src/tui/components/provider-outage-readout.tsx
+++ b/src/tui/components/provider-outage-readout.tsx
@@ -1,0 +1,65 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+
+import { openLocalModelsPane } from "../composer-switch/composer-switch-activate.js";
+import { useMouseCommands, useMouseTarget } from "../mouse/mouse-context.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { theme } from "../theme/theme.js";
+
+export interface ProviderOutageReadoutProps {
+  /** Already-formatted line from `formatProviderOutage`. */
+  text: string;
+  /** The wait budget ran out — the sticky, past-tense half. */
+  givenUp: boolean;
+  /** See `ComposerMetaControlsProps.mouseLayer`. */
+  mouseLayer?: number;
+}
+
+/**
+ * The meta bar's provider-outage line, as a button.
+ *
+ * Clicking it lands in Manage › LLM — the pane that owns the route the
+ * outage is about, where the URL can be checked and the backend
+ * switched. The same deep link the `download model` slot uses, for the
+ * same reason: the row states a problem, so the one gesture it invites
+ * should reach the place the problem is fixed.
+ *
+ * `useMouseTarget` on a Box rather than the `MouseTarget` wrapper, and
+ * a Box rather than a bare `<Text>`: a click target *is* a Box, and Ink
+ * cannot nest one inside a `<Text>` — it renders in unit tests and
+ * crashes in a real terminal. The Box therefore has to be handed to the
+ * meta bar as a self-contained element, which is why `MetaLeft` no
+ * longer wraps its slot in a `<Text>` of its own.
+ *
+ * `railWarn` while the wait is live, `railError` once it has run out —
+ * both rail tokens, because this lands on the rail's ground and the
+ * page-side `warn` / `error` pair is picked to be read on the terminal's
+ * own background (`theme-contrast.test.ts` holds the rail set to AA
+ * against `railBackground`). A live wait is not an error yet: the whole
+ * point of the park is that it usually comes back.
+ */
+export function ProviderOutageReadout({
+  text,
+  givenUp,
+  mouseLayer,
+}: ProviderOutageReadoutProps): ReactElement {
+  const mouse = useMouseCommands();
+  const ref = useMouseTarget(
+    (hit) => {
+      if (!mouse || !isPrimaryPress(hit.event)) return false;
+      openLocalModelsPane(mouse.dispatch);
+      return true;
+    },
+    mouseLayer === undefined ? {} : { layer: mouseLayer },
+  );
+  return (
+    <Box ref={ref} flexShrink={1} minWidth={0}>
+      <Text
+        color={givenUp ? theme.colors.railError : theme.colors.railWarn}
+        wrap="truncate"
+      >
+        {text}
+      </Text>
+    </Box>
+  );
+}

--- a/src/tui/components/provider-outage-readout.tsx
+++ b/src/tui/components/provider-outage-readout.tsx
@@ -7,8 +7,10 @@ import { isPrimaryPress } from "../mouse/mouse-event.js";
 import { theme } from "../theme/theme.js";
 
 export interface ProviderOutageReadoutProps {
-  /** Already-formatted line from `formatProviderOutage`. */
-  text: string;
+  /** The state and its numbers, from `formatProviderOutageParts`. */
+  head: string;
+  /** The reason, or `null`. The half that gives up columns. */
+  tail: string | null;
   /** The wait budget ran out — the sticky, past-tense half. */
   givenUp: boolean;
   /** See `ComposerMetaControlsProps.mouseLayer`. */
@@ -31,6 +33,21 @@ export interface ProviderOutageReadoutProps {
  * meta bar as a self-contained element, which is why `MetaLeft` no
  * longer wraps its slot in a `<Text>` of its own.
  *
+ * **Two boxes, not one, and both go straight into the meta bar's row.**
+ * The head — `waiting for provider 12s/300s` — cannot shrink; the reason
+ * after it shrinks harder than anything in the route. That ordering is
+ * the point: the counter is what tells an operator the wait is
+ * progressing rather than hung, and it used to be the first thing to go
+ * because the row shrank the readout as one blob.
+ *
+ * Two things were tried first and do not work, both measured at
+ * composer width 119: a `minWidth` floor on a single readout box (Yoga
+ * declined to shrink it at all and clipped the route off the row), and
+ * this same head/tail pair nested inside a shrinking group box (the
+ * head was squeezed anyway — `flexShrink={0}` is only honoured for the
+ * direct items of the line being shrunk). Hence the fragment: these two
+ * boxes are siblings of the backend word, not children of a slot.
+ *
  * `railWarn` while the wait is live, `railError` once it has run out —
  * both rail tokens, because this lands on the rail's ground and the
  * page-side `warn` / `error` pair is picked to be read on the terminal's
@@ -39,7 +56,8 @@ export interface ProviderOutageReadoutProps {
  * point of the park is that it usually comes back.
  */
 export function ProviderOutageReadout({
-  text,
+  head,
+  tail,
   givenUp,
   mouseLayer,
 }: ProviderOutageReadoutProps): ReactElement {
@@ -52,14 +70,42 @@ export function ProviderOutageReadout({
     },
     mouseLayer === undefined ? {} : { layer: mouseLayer },
   );
+  const color = givenUp ? theme.colors.railError : theme.colors.railWarn;
   return (
-    <Box ref={ref} flexShrink={1} minWidth={0}>
-      <Text
-        color={givenUp ? theme.colors.railError : theme.colors.railWarn}
-        wrap="truncate"
-      >
-        {text}
-      </Text>
-    </Box>
+    <>
+      {/*
+        The click target rides the head, which is the half that is always
+        on screen — a target on a reason that has been truncated to
+        nothing is a target nobody can hit.
+      */}
+      <Box ref={ref} flexShrink={0}>
+        <Text color={color} wrap="truncate">
+          {head}
+        </Text>
+      </Box>
+      {tail === null ? null : (
+        <Box
+          // Grows into whatever the head, the separator and the route
+          // leave over, from a basis of zero — never shrinks. Yoga does
+          // not resolve a shrink whose share exceeds the item's own
+          // width: at composer width 119 a `flexShrink` tail simply
+          // refused to give up its 31 columns and the route was clipped
+          // off the row instead. Growing from nothing asks the same
+          // question the other way round, and asks it in the direction
+          // Yoga answers reliably — the reason appears only once
+          // everything else on the row is already whole. `maxWidth`
+          // stops it growing past its own text and opening a gap
+          // before the separator.
+          flexGrow={1}
+          flexBasis={0}
+          minWidth={0}
+          maxWidth={tail.length}
+        >
+          <Text color={color} wrap="truncate">
+            {tail}
+          </Text>
+        </Box>
+      )}
+    </>
   );
 }

--- a/src/tui/components/provider-outage-readout.tsx
+++ b/src/tui/components/provider-outage-readout.tsx
@@ -40,13 +40,20 @@ export interface ProviderOutageReadoutProps {
  * progressing rather than hung, and it used to be the first thing to go
  * because the row shrank the readout as one blob.
  *
- * Two things were tried first and do not work, both measured at
- * composer width 119: a `minWidth` floor on a single readout box (Yoga
- * declined to shrink it at all and clipped the route off the row), and
- * this same head/tail pair nested inside a shrinking group box (the
- * head was squeezed anyway — `flexShrink={0}` is only honoured for the
- * direct items of the line being shrunk). Hence the fragment: these two
- * boxes are siblings of the backend word, not children of a slot.
+ * Two things were tried first and do not work, both re-measured against
+ * a bar carrying its real right-hand group (`prompt-meta-bar.test.tsx`):
+ * a `minWidth` floor on a single readout box — the floor held the
+ * readout at its full 60 columns and the route was clipped off the row
+ * instead (bar width 100) — and this same head/tail pair nested inside
+ * one shrinking group box, where the head came out as `waiting for
+ * provid…` despite its `flexShrink={0}` (bar width 100). The second is
+ * worth stating precisely, because the obvious reading of it is wrong:
+ * Yoga does honour the nested `flexShrink={0}`, it just honours it
+ * *inside* a group that has itself already shrunk below the width of
+ * its two unshrinkable children — and `MetaLeft`'s `overflow="hidden"`
+ * then clips them. A rigid item can only defend its columns on the line
+ * that is doing the shrinking. Hence the fragment: these two boxes are
+ * siblings of the backend word, not children of a slot.
  *
  * `railWarn` while the wait is live, `railError` once it has run out —
  * both rail tokens, because this lands on the rail's ground and the

--- a/src/tui/format-provider-outage.test.ts
+++ b/src/tui/format-provider-outage.test.ts
@@ -1,58 +1,139 @@
 import { describe, expect, it } from "vitest";
 
 import { formatProviderOutage } from "./format-provider-outage.js";
+import type { TuiState } from "./tui-state.js";
+
+type Outage = NonNullable<TuiState["providerOutage"]>;
+
+const NOW = 1_700_000_000_000;
+
+function outage(over: Partial<Outage> = {}): Outage {
+  return {
+    reason: "connection refused by 127.0.0.1:8080",
+    waitedMs: 0,
+    maxWaitMs: 300_000,
+    attempt: 1,
+    phase: "parked",
+    sinceTs: NOW,
+    givenUp: false,
+    ...over,
+  };
+}
 
 describe("formatProviderOutage", () => {
   it("counts the wait against its budget while the turn is parked", () => {
     expect(
-      formatProviderOutage({
-        reason: "fetch failed",
-        waitedMs: 14_000,
-        maxWaitMs: 300_000,
-        attempt: 3,
-        givenUp: false,
-      }),
-    ).toBe("waiting for provider 14s/300s — fetch failed");
+      formatProviderOutage(outage({ waitedMs: 14_000 }), NOW),
+    ).toBe(
+      "waiting for provider 14s/300s — connection refused by 127.0.0.1:8080",
+    );
+  });
+
+  it("ticks between events instead of standing still", () => {
+    // `waitedMs` only moves when the loop emits another
+    // `provider_waiting`, and the backoff reaches 30s between them. The
+    // counter is read off the clock, so the row moves every second the
+    // caller repaints it.
+    const parked = outage({ waitedMs: 14_000 });
+    expect(formatProviderOutage(parked, NOW + 6_000)).toBe(
+      "waiting for provider 20s/300s — connection refused by 127.0.0.1:8080",
+    );
+  });
+
+  it("never counts past the budget it promised", () => {
+    // The loop clips the last sleep to end exactly at `maxWaitMs`; a
+    // counter that ran on through it would advertise a wait that is not
+    // coming.
+    expect(
+      formatProviderOutage(
+        outage({ waitedMs: 290_000, maxWaitMs: 300_000 }),
+        NOW + 60_000,
+      ),
+    ).toContain("300s/300s");
+  });
+
+  it("says a retry is running, and for how long", () => {
+    // The gap this closes: `provider_recovered` only lands once the
+    // replayed step has finished, so a step that streams for two minutes
+    // used to leave the row reading `waiting for provider 8s/300s` the
+    // whole time — a live retry and a hung one looked identical.
+    expect(
+      formatProviderOutage(
+        outage({ phase: "retrying", attempt: 2, waitedMs: 6_000 }),
+        NOW + 8_000,
+      ),
+    ).toBe("retrying provider (attempt 2) — 8s");
   });
 
   it("switches wording once the wait has run out", () => {
     // Different question for the operator: nothing to wait for any
     // more, so the line says the state of the link, not a countdown.
     expect(
-      formatProviderOutage({
-        reason: "fetch failed",
-        waitedMs: 300_000,
-        maxWaitMs: 300_000,
-        attempt: 9,
-        givenUp: true,
-      }),
-    ).toBe("provider unreachable — fetch failed");
+      formatProviderOutage(
+        outage({
+          reason: "fetch failed",
+          waitedMs: 300_000,
+          attempt: 9,
+          givenUp: true,
+        }),
+        NOW,
+      ),
+    ).toBe("provider unreachable — no connection");
+  });
+
+  it("says what undici's bare `terminated` actually means", () => {
+    // The word reached the composer verbatim from the runtime
+    // classifier and told an operator nothing. The classifier keeps it —
+    // logs and the trace are matched on it — and only the readout is
+    // rewritten.
+    expect(formatProviderOutage(outage({ reason: "terminated" }), NOW)).toBe(
+      "waiting for provider 0s/300s — connection dropped mid-reply",
+    );
+  });
+
+  it.each(["socket hang up", "other side closed"])(
+    "reads %s the same way — the socket died carrying the reply",
+    (reason) => {
+      expect(formatProviderOutage(outage({ reason }), NOW)).toContain(
+        "connection dropped mid-reply",
+      );
+    },
+  );
+
+  it("keeps a stack tail from hiding the phrase", () => {
+    expect(
+      formatProviderOutage(
+        outage({ reason: "socket hang up\n  at Socket.onClose" }),
+        NOW,
+      ),
+    ).toBe("waiting for provider 0s/300s — connection dropped mid-reply");
   });
 
   it("keeps the line short enough for the meta bar", () => {
     // It shares a row with the route, the context readout and the mode
     // chip; a wrapped meta bar costs the composer a line.
-    const line = formatProviderOutage({
-      reason:
-        "Can't reach \"aimlapi\" — no response from api.aimlapi.com after three attempts, check the provider URL or your connection",
-      waitedMs: 4_000,
-      maxWaitMs: 300_000,
-      attempt: 2,
-      givenUp: false,
-    });
+    const line = formatProviderOutage(
+      outage({
+        reason:
+          "Can't reach \"aimlapi\" — no response from api.aimlapi.com after three attempts, check the provider URL or your connection",
+        waitedMs: 4_000,
+        attempt: 2,
+      }),
+      NOW,
+    );
     expect(line.length).toBeLessThanOrEqual(80);
     expect(line.endsWith("…")).toBe(true);
   });
 
-  it("flattens a multi-line reason", () => {
+  it("flattens a multi-line reason it has no rewrite for", () => {
     expect(
-      formatProviderOutage({
-        reason: "socket hang up\n  at Socket.onClose",
-        waitedMs: 0,
-        maxWaitMs: 60_000,
-        attempt: 1,
-        givenUp: false,
-      }),
-    ).toBe("waiting for provider 0s/60s — socket hang up at Socket.onClose");
+      formatProviderOutage(
+        outage({
+          reason: "ECONNRESET\n  at TLSSocket.onError",
+          maxWaitMs: 60_000,
+        }),
+        NOW,
+      ),
+    ).toBe("waiting for provider 0s/60s — ECONNRESET at TLSSocket.onError");
   });
 });

--- a/src/tui/format-provider-outage.test.ts
+++ b/src/tui/format-provider-outage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { formatProviderOutage } from "./format-provider-outage.js";
+import {
+  formatProviderOutage,
+  formatProviderOutageParts,
+} from "./format-provider-outage.js";
 import type { TuiState } from "./tui-state.js";
 
 type Outage = NonNullable<TuiState["providerOutage"]>;
@@ -123,6 +126,41 @@ describe("formatProviderOutage", () => {
     );
     expect(line.length).toBeLessThanOrEqual(80);
     expect(line.endsWith("…")).toBe(true);
+  });
+
+  it("splits the line where it is allowed to give up columns", () => {
+    // The head is what the meta bar refuses to shrink, so the counter
+    // survives a narrow row; the reason grows back in when there is
+    // room for it.
+    expect(
+      formatProviderOutageParts(
+        outage({ reason: "terminated", waitedMs: 12_000 }),
+        NOW,
+      ),
+    ).toEqual({
+      head: "waiting for provider 12s/300s",
+      tail: " — connection dropped mid-reply",
+    });
+  });
+
+  it("gives the retrying phase no tail at all", () => {
+    // It carries no reason — the attempt and its clock are the whole
+    // line, and there is nothing here that may be dropped.
+    expect(
+      formatProviderOutageParts(
+        outage({ phase: "retrying", attempt: 2 }),
+        NOW + 8_000,
+      ),
+    ).toEqual({ head: "retrying provider (attempt 2) — 8s", tail: null });
+  });
+
+  it("keeps the given-up state readable down to two words", () => {
+    expect(
+      formatProviderOutageParts(
+        outage({ reason: "fetch failed", givenUp: true }),
+        NOW,
+      ),
+    ).toEqual({ head: "provider unreachable", tail: " — no connection" });
   });
 
   it("flattens a multi-line reason it has no rewrite for", () => {

--- a/src/tui/format-provider-outage.ts
+++ b/src/tui/format-provider-outage.ts
@@ -25,6 +25,28 @@ const HUMANISED_REASONS: ReadonlyArray<readonly [RegExp, string]> = [
 ];
 
 /**
+ * The readout split where it is allowed to give up columns.
+ *
+ * `head` is the state and its numbers — `waiting for provider 12s/300s`
+ * — and never shrinks. `tail` is the reason, and goes first. The first
+ * word alone is not enough to leave standing: `waiting` says the link
+ * is down, which the colour already said, while the counter is the part
+ * that says the wait is still progressing rather than hung. The reason
+ * is the one part the feed line above already carries in full.
+ *
+ * A rigid head rather than a `minWidth` floor on the whole readout,
+ * because Yoga does not reliably clamp-and-redistribute: measured at
+ * composer width 119 a floored readout refused to shrink at all and
+ * clipped the route off the row instead. Two boxes — one that cannot
+ * shrink, one that shrinks hardest — need no clamping.
+ */
+export interface ProviderOutageParts {
+  readonly head: string;
+  /** `null` for the retrying phase, which carries no reason. */
+  readonly tail: string | null;
+}
+
+/**
  * The composer's provider-outage readout.
  *
  * Three states, because they ask for different things from the operator:
@@ -52,19 +74,35 @@ export function formatProviderOutage(
   outage: NonNullable<TuiState["providerOutage"]>,
   now: number = Date.now(),
 ): string {
+  const { head, tail } = formatProviderOutageParts(outage, now);
+  return tail === null ? head : `${head}${tail}`;
+}
+
+/** The same line, split at the point it is allowed to give up columns. */
+export function formatProviderOutageParts(
+  outage: NonNullable<TuiState["providerOutage"]>,
+  now: number = Date.now(),
+): ProviderOutageParts {
   if (outage.givenUp) {
-    return `provider unreachable — ${describeReason(outage.reason)}`;
+    return {
+      head: "provider unreachable",
+      tail: ` — ${describeReason(outage.reason)}`,
+    };
   }
   const inPhaseMs = Math.max(0, now - outage.sinceTs);
   if (outage.phase === "retrying") {
-    return `retrying provider (attempt ${outage.attempt}) — ${seconds(inPhaseMs)}s`;
+    return {
+      head: `retrying provider (attempt ${outage.attempt}) — ${seconds(inPhaseMs)}s`,
+      tail: null,
+    };
   }
   // Clamped: the loop never sleeps past the budget, so a counter that
   // ran through it would be promising a wait that is not coming.
   const waited = Math.min(outage.waitedMs + inPhaseMs, outage.maxWaitMs);
-  return `waiting for provider ${seconds(waited)}s/${seconds(
-    outage.maxWaitMs,
-  )}s — ${describeReason(outage.reason)}`;
+  return {
+    head: `waiting for provider ${seconds(waited)}s/${seconds(outage.maxWaitMs)}s`,
+    tail: ` — ${describeReason(outage.reason)}`,
+  };
 }
 
 function seconds(ms: number): number {

--- a/src/tui/format-provider-outage.ts
+++ b/src/tui/format-provider-outage.ts
@@ -4,15 +4,45 @@ import type { TuiState } from "./tui-state.js";
 const REASON_MAX_LEN = 48;
 
 /**
+ * Transport messages rewritten for someone who is not reading a stack
+ * trace. Presentation only — the runtime classifier
+ * (`src/llm/reliability/network-error.ts`) keeps the raw wording,
+ * because that is what the logs, the trace and the failure category are
+ * matched on.
+ *
+ * The three mid-stream drops are the same set `MID_STREAM_DROP_MESSAGES`
+ * recognises, and for the same argued reason: each can only come from a
+ * socket that was already carrying a request when it died, so "dropped
+ * mid-reply" is a claim about what happened rather than a guess.
+ * `fetch failed` is deliberately *not* in that set — undici throws it
+ * for a connection that never opened — so it gets the other sentence.
+ */
+const HUMANISED_REASONS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/^terminated\b/i, "connection dropped mid-reply"],
+  [/^socket hang up\b/i, "connection dropped mid-reply"],
+  [/^other side closed\b/i, "connection dropped mid-reply"],
+  [/^fetch failed\b/i, "no connection"],
+];
+
+/**
  * The composer's provider-outage readout.
  *
- * Two states, because they ask for different things from the operator:
- * while the turn is parked there is nothing to do but wait (or press
- * Esc), and the useful facts are how long it has waited and how long it
- * will keep trying. Once the wait has run out, the useful fact is that
- * every message from here on will fail the same way until the link is
- * back — which is exactly what nine identical one-second failures in a
- * row failed to say.
+ * Three states, because they ask for different things from the operator:
+ *
+ * - **parked** — the backoff sleep. Nothing to do but wait (or press
+ *   Esc), so the row carries how long it has waited and how long it will
+ *   keep trying, counted live off `sinceTs` rather than off the last
+ *   event, which stood still for whole minutes at a time.
+ * - **retrying** — the parked step is back on the wire and may stream
+ *   for minutes before anything else is emitted. The row says which
+ *   attempt is running and how long it has been running: the one fact
+ *   that separates a working retry from a hung one.
+ * - **given up** — the wait ran out. Every message from here on will
+ *   fail the same way until the link is back, which is exactly what nine
+ *   identical one-second failures in a row failed to say.
+ *
+ * `now` is a parameter so the caller's render tick drives the counter
+ * and the wording is testable without faking the clock.
  *
  * Kept short and reason-first: this shares a row with the route, the
  * context readout and the mode chip, and a wrapped meta bar would cost
@@ -20,18 +50,36 @@ const REASON_MAX_LEN = 48;
  */
 export function formatProviderOutage(
   outage: NonNullable<TuiState["providerOutage"]>,
+  now: number = Date.now(),
 ): string {
-  const reason = shortenReason(outage.reason);
   if (outage.givenUp) {
-    return `provider unreachable — ${reason}`;
+    return `provider unreachable — ${describeReason(outage.reason)}`;
   }
-  const waited = Math.round(outage.waitedMs / 1000);
-  const budget = Math.round(outage.maxWaitMs / 1000);
-  return `waiting for provider ${waited}s/${budget}s — ${reason}`;
+  const inPhaseMs = Math.max(0, now - outage.sinceTs);
+  if (outage.phase === "retrying") {
+    return `retrying provider (attempt ${outage.attempt}) — ${seconds(inPhaseMs)}s`;
+  }
+  // Clamped: the loop never sleeps past the budget, so a counter that
+  // ran through it would be promising a wait that is not coming.
+  const waited = Math.min(outage.waitedMs + inPhaseMs, outage.maxWaitMs);
+  return `waiting for provider ${seconds(waited)}s/${seconds(
+    outage.maxWaitMs,
+  )}s — ${describeReason(outage.reason)}`;
 }
 
-function shortenReason(raw: string): string {
+function seconds(ms: number): number {
+  return Math.round(ms / 1000);
+}
+
+function describeReason(raw: string): string {
   const flat = raw.trim().replace(/\s+/g, " ");
+  for (const [pattern, text] of HUMANISED_REASONS) {
+    if (pattern.test(flat)) return text;
+  }
+  return shortenReason(flat);
+}
+
+function shortenReason(flat: string): string {
   if (flat.length <= REASON_MAX_LEN) return flat;
   return `${flat.slice(0, REASON_MAX_LEN - 1)}…`;
 }

--- a/src/tui/provider-outage-composer.test.tsx
+++ b/src/tui/provider-outage-composer.test.tsx
@@ -1,0 +1,157 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it } from "vitest";
+
+import { makeTuiEventBus, TuiApp, type TuiAppCallbacks } from "./tui-app.js";
+import type { TuiSessionInfo } from "./tui-state.js";
+
+/**
+ * What the composer says while the provider is down, driven through the
+ * real event bus rather than the reducer alone: the meta row and the
+ * hint strip make one statement between them, and only a mounted app
+ * shows whether the two halves still add up.
+ */
+const SESSION: TuiSessionInfo = {
+  sessionId: "s1",
+  workingDir: "/tmp/outage",
+  llamaUrl: "http://127.0.0.1:8080",
+  browserChannel: "chrome",
+  browserHeadless: false,
+  approvalLevel: 5,
+  maxSteps: 10,
+  skillCount: 0,
+};
+
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 60));
+const strip = (value: string): string =>
+  value.replace(new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g"), "");
+
+function callbacks(): TuiAppCallbacks {
+  return {
+    onApprovalDecision: () => {},
+    onAbort: () => {},
+    onQuit: () => {},
+    onMessageSubmitted: () => {},
+  };
+}
+
+function mount() {
+  const bus = makeTuiEventBus();
+  const app = render(
+    <TuiApp session={SESSION} bus={bus} callbacks={callbacks()} />,
+  );
+  const emit = (event: unknown): void => {
+    bus.emitAgentEvent(event as never);
+  };
+  return { emit, ...app, frame: () => strip(app.lastFrame() ?? "") };
+}
+
+const WAITING = {
+  type: "provider_waiting",
+  attempt: 1,
+  waitedMs: 0,
+  maxWaitMs: 300_000,
+  nextRetryMs: 2_000,
+  reason: "terminated",
+};
+
+/** The meta row's Enter-routing hint — not the hint strip's chip. */
+const META_HINT = "⏎ steer (ctrl+t)";
+
+describe("the composer while the provider is down", () => {
+  it("trades the meta row's Enter hint for the outage numbers", async () => {
+    // The ~19 columns the hint costs are what let the readout and the
+    // route both be read. Nothing is lost because the strip below keeps
+    // its own `⏎` chip — which is why that chip is essential.
+    const app = mount();
+    app.emit({ type: "step_started", stepIndex: 0 });
+    await settle();
+    expect(app.frame()).toContain(META_HINT);
+    app.emit(WAITING);
+    await settle();
+    const frame = app.frame();
+    expect(frame).toContain("waiting for provider");
+    expect(frame).not.toContain(META_HINT);
+    expect(frame).toMatch(/\[⏎\]\s*steer/);
+    app.unmount();
+  });
+
+  it("takes the readout down with the turn when Esc stops the wait", async () => {
+    // The feed line the loop prints during a backoff ends "· Esc stops",
+    // so this is the ending an operator reaches on purpose. The readout
+    // used to survive it and go on counting — measured live at 19s and
+    // climbing, fourteen seconds after the loop was dead.
+    const app = mount();
+    app.emit({ type: "step_started", stepIndex: 0 });
+    app.emit(WAITING);
+    await settle();
+    expect(app.frame()).toContain("waiting for provider");
+    app.emit({
+      type: "turn_finished",
+      turnIndex: 0,
+      reason: "cancelled",
+      stepCount: 1,
+      durationMs: 20,
+    });
+    await settle();
+    expect(app.frame()).not.toContain("waiting for provider");
+    app.unmount();
+  });
+
+  it("does not label the next turn a retry of the abandoned one", async () => {
+    // A stale outage turned the next turn's first `step_started` into
+    // "the parked step going back on the wire": a brand-new healthy turn
+    // reading `retrying provider (attempt 1)`, counting up, with its
+    // streamed reply wiped at every step boundary.
+    const app = mount();
+    app.emit({ type: "step_started", stepIndex: 0 });
+    app.emit(WAITING);
+    app.emit({
+      type: "turn_finished",
+      turnIndex: 0,
+      reason: "cancelled",
+      stepCount: 1,
+      durationMs: 20,
+    });
+    await settle();
+    app.emit({ type: "turn_started" });
+    app.emit({ type: "step_started", stepIndex: 0 });
+    await settle();
+    const frame = app.frame();
+    expect(frame).not.toContain("retrying provider");
+    // …and the hint the healthy turn is entitled to is back on the row.
+    expect(frame).toContain(META_HINT);
+    app.unmount();
+  });
+
+  it("keeps the given-up badge, and the Enter hint alongside it", async () => {
+    // The badge is past tense and sticky until a turn actually succeeds:
+    // it is what stops nine identical failures reading as nine separate
+    // surprises. It has no counter to protect and 20 columns of width,
+    // so the turn running underneath it keeps its Enter hint.
+    const app = mount();
+    app.emit({ type: "step_started", stepIndex: 0 });
+    app.emit(WAITING);
+    app.emit({
+      type: "loop_failed",
+      error: new Error("terminated"),
+      category: "transport",
+    });
+    app.emit({
+      type: "turn_finished",
+      turnIndex: 0,
+      reason: "failed",
+      stepCount: 1,
+      durationMs: 20,
+    });
+    await settle();
+    expect(app.frame()).toContain("provider unreachable");
+    app.emit({ type: "turn_started" });
+    app.emit({ type: "step_started", stepIndex: 0 });
+    await settle();
+    const frame = app.frame();
+    expect(frame).toContain("provider unreachable");
+    expect(frame).toContain(META_HINT);
+    app.unmount();
+  });
+});

--- a/src/tui/provider-outage-state.ts
+++ b/src/tui/provider-outage-state.ts
@@ -1,0 +1,77 @@
+import type { TuiState } from "./tui-state.js";
+
+/**
+ * The two state transitions of a provider outage that the agent loop
+ * does not spell out for us.
+ *
+ * The loop emits `provider_waiting` once per backoff and
+ * `provider_recovered` only after the replayed step has *finished* —
+ * which, when the step streams for minutes, leaves a multi-minute gap
+ * with no event in it at all. The composer used to sit in that gap
+ * showing the wait counter frozen at whatever the last `provider_waiting`
+ * carried, so a retry that was making progress looked exactly like a
+ * hung one. `step_started` is the event that closes the gap: while an
+ * outage is live it can only mean the parked step is being replayed.
+ */
+
+type ProviderOutage = NonNullable<TuiState["providerOutage"]>;
+
+/** Park the turn: the backoff sleep has begun. */
+export function parkProviderOutage(
+  state: TuiState,
+  event: {
+    reason: string;
+    waitedMs: number;
+    maxWaitMs: number;
+    attempt: number;
+  },
+  now: number = Date.now(),
+): TuiState {
+  const outage: ProviderOutage = {
+    reason: event.reason,
+    waitedMs: event.waitedMs,
+    maxWaitMs: event.maxWaitMs,
+    attempt: event.attempt,
+    phase: "parked",
+    sinceTs: now,
+    givenUp: false,
+  };
+  return { ...state, providerOutage: outage };
+}
+
+/**
+ * A step started while an outage is live: that is the parked step going
+ * back on the wire.
+ *
+ * Besides flipping the phase this wipes what the dead attempt left
+ * streaming for the same step. `appendReasoningDelta` merges into the
+ * trailing reasoning entry whenever the step index matches, so without
+ * this the retry's thinking is spliced onto the tail of the attempt
+ * whose socket died and the operator reads the model's reasoning twice,
+ * welded together mid-sentence. Same for the assistant text and the
+ * half-parsed tool calls: the retry re-streams both from the beginning.
+ *
+ * A `givenUp` outage is left alone — it is a sticky post-mortem badge,
+ * not a live wait, and the next turn's first step must not turn it back
+ * into a countdown.
+ */
+export function retryProviderOutage(
+  state: TuiState,
+  stepIndex: number,
+  now: number = Date.now(),
+): TuiState {
+  const outage = state.providerOutage;
+  if (!outage || outage.givenUp) return state;
+  const last = state.reasoning.at(-1);
+  const reasoning =
+    last && last.stepIndex === stepIndex
+      ? state.reasoning.slice(0, -1)
+      : state.reasoning;
+  return {
+    ...state,
+    providerOutage: { ...outage, phase: "retrying", sinceTs: now },
+    reasoning,
+    streamingAssistantText: null,
+    streamingToolCalls: [],
+  };
+}

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -88,6 +88,8 @@ import { TasksCancelModal } from "./components/tasks-cancel-modal.js";
 import { UpdateModal } from "./components/update-modal.js";
 import { UpdateIndicator } from "./components/update-indicator.js";
 import { UpdateRestartPrompt } from "./components/update-restart-prompt.js";
+import { ProviderOutageReadout } from "./components/provider-outage-readout.js";
+import { useElapsed } from "./hooks/use-elapsed.js";
 import { useTerminalSize } from "./hooks/use-terminal-size.js";
 import {
   computeSidebarRowBudget,
@@ -1603,12 +1605,32 @@ export function TuiApp({
   // slot rather than taking a row of its own so the meta-bar keeps its
   // shape — `contextSlot` and `modeSlot` are separate props at the far
   // end and are not touched by it.
-  const promptLeftSlot = state.providerOutage ? (
-    <Text color={theme.colors.railError}>
-      {formatProviderOutage(state.providerOutage)}
-    </Text>
+  //
+  // The counter has to move on its own: between the backoff's
+  // `provider_waiting` and the retry's `provider_recovered` the loop
+  // emits nothing for as long as the replayed step streams, and a row
+  // that only repainted on an event stood frozen through it. One tick a
+  // second, armed only while an outage is actually live and still
+  // waiting — a `givenUp` badge is past tense and has nothing to count.
+  const outage = state.providerOutage;
+  const outageTickFrom = outage && !outage.givenUp ? outage.sinceTs : null;
+  const outageElapsedMs = useElapsed(outageTickFrom, 1000);
+  const promptLeftSlot = outage ? (
+    <ProviderOutageReadout
+      text={formatProviderOutage(
+        outage,
+        outageTickFrom === null
+          ? undefined
+          : outageTickFrom + (outageElapsedMs ?? 0),
+      )}
+      givenUp={outage.givenUp}
+      mouseLayer={MOUSE_LAYER_PANEL}
+    />
   ) : state.composerNotice ? (
-    <Text color={theme.colors.railSuccess}>{state.composerNotice}</Text>
+    // Truncates itself: `MetaLeft` hands its slot straight to the row.
+    <Text color={theme.colors.railSuccess} wrap="truncate">
+      {state.composerNotice}
+    </Text>
   ) : null;
   // While a turn is running the meta-row gains a second job: the operator
   // needs to know what Enter will do to the message they are typing.

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -1652,17 +1652,27 @@ export function TuiApp({
   // the context window, which never changes and never told anyone
   // anything. The chip below reports how much of it is in use instead.
   //
-  // Dropped outright while the link is down, not shrunk. It is the one
-  // thing on the row that is duplicated verbatim two lines below it, in
-  // the hint strip under the composer (`[⏎] steer · [ctrl+t] queue mode
-  // · [esc] abort`), so nothing is lost — and it is the ~19 columns that
-  // decide whether the outage readout and the route can both be read at
-  // the widths people actually run. This does NOT reopen the pinned "at
-  // 60 the right-hand readout must survive intact" decision: that
-  // argument is about a half-drawn context or mode chip, and both of
-  // those keep their `flexShrink={0}` and their place on the row.
+  // Dropped outright while a wait is live, not shrunk. It is the one
+  // thing on the row that is duplicated two lines below it, in the hint
+  // strip under the composer, so nothing is lost — and it is the ~19
+  // columns that decide whether the outage readout and the route can
+  // both be read at the widths people actually run. What makes "nothing
+  // is lost" true rather than hopeful is that the strip's `⏎` chip is
+  // essential (`hotkey-chips.ts`): it used to carry `shed: 3` and was
+  // dropped at every width up to 112 columns as soon as the composer
+  // held a draft — which is precisely the state this hint exists for.
+  // This does NOT reopen the pinned "at 60 the right-hand readout must
+  // survive intact" decision: that argument is about a half-drawn
+  // context or mode chip, and both of those keep their `flexShrink={0}`
+  // and their place on the row.
+  //
+  // A `givenUp` badge does not take the hint with it. It is past tense
+  // and 20 columns wide, it has no counter to protect, and the turn
+  // running underneath it is an ordinary turn whose Enter the operator
+  // still has to aim.
+  const outageIsLive = Boolean(outage && !outage.givenUp);
   const promptRightSlot =
-    state.status === "running" && !outage ? (
+    state.status === "running" && !outageIsLive ? (
       <Text>
         <Text color={theme.colors.railAccent} bold>
           {"\u23ce"} {state.whileBusyMode}

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -1,5 +1,5 @@
 import { ContextChip } from "./components/context-chip.js";
-import { formatProviderOutage } from "./format-provider-outage.js";
+import { formatProviderOutageParts } from "./format-provider-outage.js";
 import type { ApprovalLevel } from "../approval/approval-level.js";
 import {
   codingModeLook,
@@ -88,6 +88,7 @@ import { TasksCancelModal } from "./components/tasks-cancel-modal.js";
 import { UpdateModal } from "./components/update-modal.js";
 import { UpdateIndicator } from "./components/update-indicator.js";
 import { UpdateRestartPrompt } from "./components/update-restart-prompt.js";
+import { META_SLOT_SHRINK } from "./components/prompt-meta-bar.js";
 import { ProviderOutageReadout } from "./components/provider-outage-readout.js";
 import { useElapsed } from "./hooks/use-elapsed.js";
 import { useTerminalSize } from "./hooks/use-terminal-size.js";
@@ -1615,22 +1616,31 @@ export function TuiApp({
   const outage = state.providerOutage;
   const outageTickFrom = outage && !outage.givenUp ? outage.sinceTs : null;
   const outageElapsedMs = useElapsed(outageTickFrom, 1000);
-  const promptLeftSlot = outage ? (
-    <ProviderOutageReadout
-      text={formatProviderOutage(
+  const outageParts = outage
+    ? formatProviderOutageParts(
         outage,
         outageTickFrom === null
           ? undefined
           : outageTickFrom + (outageElapsedMs ?? 0),
-      )}
+      )
+    : null;
+  const promptLeftSlot = outage && outageParts ? (
+    <ProviderOutageReadout
+      head={outageParts.head}
+      tail={outageParts.tail}
       givenUp={outage.givenUp}
       mouseLayer={MOUSE_LAYER_PANEL}
     />
   ) : state.composerNotice ? (
-    // Truncates itself: `MetaLeft` hands its slot straight to the row.
-    <Text color={theme.colors.railSuccess} wrap="truncate">
-      {state.composerNotice}
-    </Text>
+    // A Box that truncates itself: `MetaLeft` hands its slot straight
+    // into the row, so the slot owns both its wrapping and its shrink
+    // order. The notice yields before the route for the same reason the
+    // outage reason does — the route is what the row is for.
+    <Box flexShrink={META_SLOT_SHRINK} minWidth={0}>
+      <Text color={theme.colors.railSuccess} wrap="truncate">
+        {state.composerNotice}
+      </Text>
+    </Box>
   ) : null;
   // While a turn is running the meta-row gains a second job: the operator
   // needs to know what Enter will do to the message they are typing.
@@ -1641,8 +1651,18 @@ export function TuiApp({
   // What used to live here when idle was `ctx <window>` — the *size* of
   // the context window, which never changes and never told anyone
   // anything. The chip below reports how much of it is in use instead.
+  //
+  // Dropped outright while the link is down, not shrunk. It is the one
+  // thing on the row that is duplicated verbatim two lines below it, in
+  // the hint strip under the composer (`[⏎] steer · [ctrl+t] queue mode
+  // · [esc] abort`), so nothing is lost — and it is the ~19 columns that
+  // decide whether the outage readout and the route can both be read at
+  // the widths people actually run. This does NOT reopen the pinned "at
+  // 60 the right-hand readout must survive intact" decision: that
+  // argument is about a half-drawn context or mode chip, and both of
+  // those keep their `flexShrink={0}` and their place on the row.
   const promptRightSlot =
-    state.status === "running" ? (
+    state.status === "running" && !outage ? (
       <Text>
         <Text color={theme.colors.railAccent} bold>
           {"\u23ce"} {state.whileBusyMode}

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -375,6 +375,22 @@ export interface TuiState {
     maxWaitMs: number;
     /** Retry attempts made so far. */
     attempt: number;
+    /**
+     * Which half of the retry cycle the turn is in.
+     *
+     * `parked` is the backoff sleep — nothing is on the wire and the
+     * only useful facts are how long it has waited and how long it may.
+     * `retrying` is the replayed step, which can stream for minutes; a
+     * row that still counted the *wait* through it read as frozen, and
+     * the operator had no way to tell a live retry from a dead one.
+     */
+    phase: "parked" | "retrying";
+    /**
+     * Wall clock when `phase` was entered. The readout counts from here
+     * on a one-second tick rather than from `waitedMs`, which only moves
+     * when the loop emits another event.
+     */
+    sinceTs: number;
     /** `true` once the wait budget ran out and the turn failed. */
     givenUp: boolean;
   } | null;


### PR DESCRIPTION
## What

A local model streamed a reply for twenty minutes and the socket died mid-body. The agent loop did
the right thing — parked the turn, retried the same step — and the composer said this, for the next
several minutes, without moving:

```
waiting for provider 0s/300s — terminated
```

Three separate problems in one row.

**The counter was frozen.** `waitedMs` only advances when the loop emits another `provider_waiting`,
and between the backoff and the retry's `provider_recovered` the loop emits nothing at all — for as
long as the replayed step streams. Measured live, that row changed twice in a twenty-six second
window. It now counts off a `sinceTs` stamped when the phase was entered, on a one-second tick, and
changed thirteen times over the same window.

**A live retry looked exactly like a hung one.** `providerOutage` gains a `phase`. `step_started`
arriving while an outage is live can only mean the parked step went back on the wire, so the row
switches to `retrying provider (attempt 2) — 8s`. That is the one fact separating a retry that is
working from one that is not, and nothing on screen carried it before.

**`terminated` is not a sentence.** It is undici's word for a socket dying mid-body. The row now
says `connection dropped mid-reply`, and `fetch failed` becomes `no connection`. Presentation only —
the runtime classifier keeps the raw wording, because the logs, the trace and the failure category
are matched on it. The three mid-stream drops rewritten here are exactly the set
`MID_STREAM_DROP_MESSAGES` already recognises, so the claim is about what happened rather than a
guess.

Two more things, both visible in the same row:

**The route came back.** The readout used to take the whole left group, so `● custom · llama.cpp ·
<model>` disappeared exactly when someone wants to know which provider is down. The readout is now a
rigid head (`waiting for provider 12s/300s`, never shrinks) plus a reason that gives up columns
before the route does. The `⏎ steer (ctrl+t)` hint is dropped outright while the link is down — it
is duplicated verbatim in the hint strip two lines below, and it is the ~19 columns that decide
whether both statements fit. This does not reopen the pinned "at 60 the right-hand readout must
survive intact" decision: that argument is about a half-drawn context or mode chip, and both keep
their `flexShrink={0}` and their place.

**The retry's reasoning is no longer spliced onto the dead attempt's.** `appendReasoningDelta` merges
into the trailing reasoning entry whenever the step index matches, so the replayed step's thinking
was welded onto the tail of the attempt whose socket died and the operator read the model's
reasoning twice, joined mid-sentence. The retry now clears what the dead attempt left streaming for
that step.

## Why

Everything above is what an operator sees when a local model server drops a connection, which on a
long turn is routine. The loop's behaviour was already right; only the reporting was wrong, and it
was wrong in the direction of looking hung.

## What still does not fit

The row fills in stages as the terminal gets wider. Measured against a bar carrying its real
right-hand group: the readout's head is whole from about 90 bar columns, the model name joins it
around 119, the route is whole around 140, and the reason around 190. Below those the readout's
numbers win the trade. Live, at four terminal widths, against `origin/main`:

| terminal | before | after |
|---|---|---|
| 110 | left half **empty for the whole outage** | `waiting for pro…` — no route |
| 120 | `waiti…` — five characters | `waiting for provider 0s…` — no route |
| 160 | `waiting for provider 0s/300s — terminated`, **route gone**, counter frozen | `waiting for provider 14s/300s · ● custom · llama.… · fake-r…`, ticking |
| 200 | both, but frozen at `0s` and reading `terminated` | both, ticking, with a distinct retrying phase |

So a narrow terminal gains a live readout rather than the route; 160 is where the route was lost
and is where it comes back.

One known limitation, reported rather than fixed: after a laptop suspend the parked row shows the
full budget for a single repaint before the next event corrects it. Fixing that means carrying
`nextRetryMs` in state.

## Two bugs found while verifying this, fixed here

**A live wait outlived its own turn.** `turn_finished` cleared the outage only on `reply` or
`finish`, so a `parked` or `retrying` state survived the two endings that reach it most often: Esc
during the backoff — the ending the loop's own feed line advertises — and a turn stopped at its step
ceiling. Before the counter ticked this was cosmetic. With a ticking counter it is a row that lies:
measured under a PTY, Esc at 5.2 s and the row went on counting to 19s/300s for fourteen seconds
after the loop was dead, and then the next message's first step was read as the parked step going
back on the wire — a brand-new healthy turn labelled `retrying provider (attempt 1)`, with its
streamed reply wiped at every step boundary. A live wait now ends with its turn whichever way the
turn ended. Only `givenUp` survives, on purpose.

**The hint strip did not actually carry the Enter hint.** Dropping `⏎ steer (ctrl+t)` from the meta
row rests on it being repeated two lines below. It was not, where it mattered: the strip sheds chips
by rank, `⏎` carried rank 3, and a draft in the composer lengthens the Esc chip to `abort, draft
kept`, which pushed `⏎` off at every chat width up to 112 columns. So on a 110-column terminal an
operator mid-message would have had nothing anywhere saying what Enter would do. `⏎` is now the one
essential chip in the running strip; `ctrl+t` takes rank 3.

## How it was verified

- `npm run lint` clean
- `npx vitest run src/tui src/agent/agent-loop.test.ts` — 257 files / 2891 tests green (baseline on main: 256 / 2860) (baseline noise: `local-models-orchestrator-auto-update` raises the usual sandbox `EACCES` spawning llama-server)
- live (PTY + pyte, a stub provider killing the socket mid-body, at 110 / 120 / 160 / 200 columns): the counter advancing across consecutive samples, the retrying phase appearing with its own attempt number and elapsed count, the route present at 160 and above, and zero frames anywhere mixing two attempts' reasoning
- AGENTS.md invariant 6 under "Waiting out a provider outage" is updated to describe the ticking counter and the retry phase. The context readout is still untouched by a parked turn, as that section requires.
- every new assertion was mutation-checked: eleven deliberate breakages of the production code. Two survived the first battery — the readout harness was passing empty right-hand slots, so nothing on the row was ever under width pressure — and the harness was rebuilt against the real bar before both mutants died
- the click target was exercised in a real terminal, not only in unit tests: clicking the readout opens Manage › LLM, and clicking the route words beside it still opens their own pickers
