### PR TITLE
fix(llm): stop capping cloud completions at the llama-server output budget

### DIFF
--- a/src/llm/provider/cloud-subcall.test.ts
+++ b/src/llm/provider/cloud-subcall.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildCloudSubcallRequest } from "./cloud-subcall.js";
+import { buildCloudSubcallRequest, CLOUD_SUBCALL_MAX_TOKENS } from "./cloud-subcall.js";
 
 describe("buildCloudSubcallRequest", () => {
   it("exposes the synthetic emit function with tool_choice 'auto'", () => {
@@ -16,5 +16,26 @@ describe("buildCloudSubcallRequest", () => {
     expect(req.tools).toHaveLength(1);
     expect(req.toolChoice).toBe("auto");
     expect(req.parallelToolCalls).toBe(false);
+  });
+});
+
+describe("the sub-call's own output bound", () => {
+  it("bounds a structured sub-call even though the main path sends no cap", () => {
+    const req = buildCloudSubcallRequest({
+      prompt: "p",
+      emitFunctionName: "emit",
+      argsSchema: { type: "object" },
+    });
+    expect(req.maxTokens).toBe(CLOUD_SUBCALL_MAX_TOKENS);
+  });
+
+  it("lets the caller override it", () => {
+    const req = buildCloudSubcallRequest({
+      prompt: "p",
+      emitFunctionName: "emit",
+      argsSchema: { type: "object" },
+      maxTokens: 64,
+    });
+    expect(req.maxTokens).toBe(64);
   });
 });

--- a/src/llm/provider/cloud-subcall.ts
+++ b/src/llm/provider/cloud-subcall.ts
@@ -19,6 +19,18 @@ import type { ToolCallTransport } from "./completion-types.js";
  * (`extractCloudSubcallText` in `reflection-runner.ts` is the canonical
  * example) so the sub-call still extracts useful output.
  */
+/**
+ * Output bound for a structured sub-call when the caller names none.
+ *
+ * These emit one small JSON object against a schema (a handful of memory
+ * notes, a vote, a rewritten query), so a few thousand tokens is
+ * generous. It is set explicitly here rather than inherited from a
+ * global default: the main completion path deliberately sends no
+ * `max_tokens` at all (see `openai-build-body.ts`), and a cold-path
+ * sub-runner is exactly the place that should stay bounded regardless.
+ */
+export const CLOUD_SUBCALL_MAX_TOKENS = 2048;
+
 export function buildCloudSubcallRequest(params: {
   prompt: string;
   emitFunctionName: string;
@@ -30,7 +42,7 @@ export function buildCloudSubcallRequest(params: {
   return {
     prompt: params.prompt,
     sessionId: params.sessionId,
-    maxTokens: params.maxTokens,
+    maxTokens: params.maxTokens ?? CLOUD_SUBCALL_MAX_TOKENS,
     tools: [
       {
         type: "function",

--- a/src/llm/provider/openai/openai-build-body.test.ts
+++ b/src/llm/provider/openai/openai-build-body.test.ts
@@ -172,3 +172,41 @@ describe("buildOpenAiChatBody", () => {
     expect("parallel_tool_calls" in body).toBe(false);
   });
 });
+
+describe("buildOpenAiChatBody — the output bound", () => {
+  const request = { prompt: "hi", sessionId: "s-1" };
+
+  it("sends no max_tokens when nobody asked for one", () => {
+    const body = buildOpenAiChatBody(request, "gpt-test", false);
+    // The cap used to default to `localModels.completionMaxTokens` (8192),
+    // a llama-server decode budget that has nothing to do with a cloud
+    // model — and it killed any turn whose reply ran long, mid-JSON,
+    // with "model response truncated at 8192 tokens".
+    expect("max_tokens" in body).toBe(false);
+  });
+
+  it("honours a cap the caller set", () => {
+    const body = buildOpenAiChatBody({ ...request, maxTokens: 512 }, "gpt-test", false);
+    expect(body.max_tokens).toBe(512);
+  });
+
+  it("lets a provider entry pin one through extraBody", () => {
+    const body = buildOpenAiChatBody(request, "gpt-test", false, { max_tokens: 64_000 });
+    expect(body.max_tokens).toBe(64_000);
+  });
+
+  it("still lets the caller's cap lose to an explicit passthrough", () => {
+    // `max_tokens` is deliberately not reserved: an operator who pins a
+    // ceiling for a provider that requires one gets the last word.
+    const body = buildOpenAiChatBody({ ...request, maxTokens: 512 }, "gpt-test", false, {
+      max_tokens: 4096,
+    });
+    expect(body.max_tokens).toBe(4096);
+  });
+
+  it("keeps the fields the caller owns unconditionally", () => {
+    const body = buildOpenAiChatBody(request, "gpt-test", true, { model: "hijack" });
+    expect(body.model).toBe("gpt-test");
+    expect(body.stream).toBe(true);
+  });
+});

--- a/src/llm/provider/openai/openai-build-body.ts
+++ b/src/llm/provider/openai/openai-build-body.ts
@@ -1,4 +1,3 @@
-import { getConfig } from "../../../config/index.js";
 import type { CompletionRequest } from "../completion-types.js";
 import { filterCloudCompletionRequest } from "./sampling-filter.js";
 
@@ -21,9 +20,26 @@ export function buildOpenAiChatBody(
     model: defaultChatModel,
     messages: [{ role: "user", content: filtered.prompt }],
     temperature: filtered.temperature ?? 0.2,
-    max_tokens: filtered.maxTokens ?? getConfig().localModels.completionMaxTokens,
     stream,
   };
+  // `max_tokens` only when somebody actually asked for a bound.
+  //
+  // It used to default to `localModels.completionMaxTokens` — the
+  // llama-server `n_predict` knob, 8192 — which is the wrong number for
+  // a cloud model twice over: it is sized for a local runner's decode
+  // budget, and it silently capped every cloud completion at a fraction
+  // of what the model can emit. A turn that legitimately writes a long
+  // file (a whole page, a large refactor) hit that wall mid-JSON, the
+  // provider reported `finish_reason: "length"`, and the turn died with
+  // "model response truncated at 8192 tokens" — a limit nobody chose and
+  // nothing in the UI named.
+  //
+  // Omitted, the server applies the model's own default, which is what
+  // an operator picking a cloud model expects. A provider that requires
+  // the field, or a deployment that wants a hard ceiling, sets it
+  // through the entry's `extraBody` — `max_tokens` is deliberately not
+  // in `RESERVED_BODY_KEYS`, so that passthrough wins.
+  if (typeof filtered.maxTokens === "number") body.max_tokens = filtered.maxTokens;
   if (filtered.stop) body.stop = filtered.stop;
   if (typeof filtered.seed === "number") body.seed = filtered.seed;
   if (filtered.tools && filtered.tools.length > 0) {


### PR DESCRIPTION
## What
Cloud completions no longer inherit the llama-server output budget.

`buildOpenAiChatBody` sent `max_tokens: localModels.completionMaxTokens` on every request. That knob is the local runner's `n_predict` decode budget and defaults to **8192** — it has nothing to do with a cloud model's output window, and nothing in the UI presents it as a limit on one. Now `max_tokens` is sent only when a bound was actually requested: the caller's value, or the provider entry's `extraBody` (which already takes precedence, since `max_tokens` is deliberately not in `RESERVED_BODY_KEYS`). Omitted, the server applies the model's own default.

Structured cloud sub-calls (reflection, link-gen, votes, the query rewriter, distillation) now carry an explicit `CLOUD_SUBCALL_MAX_TOKENS = 2048` instead of inheriting the removed default, so the cold paths that emit one small schema-bound JSON object stay bounded.

The llama-server path is untouched — it still needs its `n_predict`.

## Why
This is the whole failure mode behind a turn dying instantly with **"turn failed — model response truncated at 8192 tokens"** on a long generation (asking for a complete web page, say).

The chain: output passes 8192 → the provider returns `finish_reason: "length"` → `openai-normalise-response.ts` sets `truncated: true` → `detectModelFailure` classifies it `truncated` → `step-executor.ts` throws `ModelError` before the parser ever runs, deliberately, because re-running the same prompt would just hit the same wall. Correct reasoning about a wall that should not have been there: the model was stopped at a limit sized for a different runtime, and the operator never chose 8192 for their cloud model.

Note this is only half the story, and the other half already has a PR. #359 makes a length-truncated completion recoverable instead of terminal. The two are complementary: #359 stops a real ceiling from killing a turn, this stops a fake ceiling from being hit in the first place. Neither subsumes the other.

Immediate workaround for anyone on a release build: set `extraBody: { "max_tokens": 32000 }` on the provider entry in `config.json`.

## How it was verified
- `npm run lint` clean
- `npx vitest run src/llm src/agent src/memory/reflection` — 90 files / 1201 tests green
- `npx vitest run src/llm/provider` — 43 files / 422 tests green
- New `openai-build-body.test.ts`: no `max_tokens` by default, the caller's value honoured, an `extraBody` pin wins over the caller's, and the reserved fields still cannot be hijacked. New cases in `cloud-subcall.test.ts` for the sub-call bound and its override. All of them fail before the change (the default test sees 8192).
