### PR TITLE
feat(skills): verify-work — run what you just wrote before reporting it done

### DIFF
--- a/src/skills/verify-work-starter.test.ts
+++ b/src/skills/verify-work-starter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  listStarterSkillNames,
+  resolveStarterSkillsSourceDir,
+} from "./seed-starter-skills.js";
+
+/**
+ * The `verify-work` starter exists to stop a turn reporting unrun code as
+ * done. These cases pin the parts an agent actually keys off — the
+ * frontmatter it is selected by, and the instructions that make the check
+ * concrete — so a later edit cannot quietly soften it into advice.
+ */
+describe("the verify-work starter skill", () => {
+  const dir = resolveStarterSkillsSourceDir();
+  if (dir === null) throw new Error("starter-skills tree not found");
+  const body = readFileSync(join(dir, "verify-work", "SKILL.md"), "utf8");
+
+  it("ships in the bundled starter pack", async () => {
+    expect(await listStarterSkillNames()).toContain("verify-work");
+  });
+
+  it("is selected when work is about to be reported as done", () => {
+    expect(body).toContain("name: verify-work");
+    expect(body).toMatch(/description:.*(done|working|fixed)/);
+  });
+
+  it("declares the tools the checks need", () => {
+    expect(body).toContain("os.shell.run");
+  });
+
+  it("states the rule as a prohibition, not a suggestion", () => {
+    expect(body).toMatch(/Never report code as working, done, or fixed/);
+    expect(body).toMatch(/"Should work" is not a verdict/);
+  });
+
+  it("tells the agent to read the project's own runner before guessing one", () => {
+    expect(body).toMatch(/package\.json/);
+    expect(body).toMatch(/do not guess a runner/);
+  });
+
+  it("covers the visual case, where a loading page can still be broken", () => {
+    expect(body).toMatch(/console/i);
+    expect(body).toMatch(/screenshot/i);
+    expect(body).toMatch(/blank/i);
+  });
+
+  it("bounds the retry loop and forbids weakening the check to pass it", () => {
+    expect(body).toMatch(/three/i);
+    expect(body).toMatch(/[Nn]ever delete or weaken a test/);
+  });
+
+  it("requires an honest answer when a check cannot run", () => {
+    expect(body).toMatch(/could not run/);
+  });
+});

--- a/starter-skills/README.md
+++ b/starter-skills/README.md
@@ -19,6 +19,7 @@ the global skills dir — it will be replaced on the next boot. Use a distinct
 | `wttr-weather/` | Weather lookup via `wttr.in` | none |
 | `currency/` | Exchange rates & conversion via the Frankfurter API | none |
 | `skill-creator/` | Author or edit `SKILL.md` files | none |
+| `verify-work/` | Run what you just wrote and prove it works before reporting | none |
 | `github/` | GitHub repos / issues / PRs / Actions via the `gh` CLI | `gh` installed + `gh auth login` |
 | `apple-calendar/` | Read Calendar via `icalBuddy`, create events via AppleScript | macOS + `brew install ical-buddy` + Calendar permission |
 | `obsidian/` | Read / search / write notes in an Obsidian vault | `OBSIDIAN_VAULT_PATH` env var (default `~/Documents/Obsidian Vault`) |

--- a/starter-skills/verify-work/SKILL.md
+++ b/starter-skills/verify-work/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: verify-work
+description: Prove that code, a script or a page you just produced actually runs — execute it, read the real output, and fix what breaks before reporting. Use after writing or changing anything executable, and whenever you are about to say something is done, working, or fixed.
+version: 1.0.0
+requires_tools:
+  - os.shell.run
+  - os.fs.read
+dangerous: false
+---
+
+# verify-work
+
+Writing a file is not evidence. Running it is.
+
+The failure this skill exists to prevent: a turn writes source files and a
+test file, replies "done, tests included", and never executes a single one
+of them. The operator finds out later that nothing ran. If you wrote it,
+run it — and if you cannot run it, say so plainly instead of implying you
+did.
+
+## The rule
+
+**Never report code as working, done, or fixed unless a command you ran in
+this turn proves it.** Quote the command and the part of its output that
+carries the verdict — an exit code, a passing count, a rendered element.
+"Should work" is not a verdict.
+
+If verification is impossible here (no runtime installed, needs a device,
+needs a credential you must not use), say which check you could not run and
+why, in one sentence. That is an honest result. Silence is not.
+
+## Pick the smallest command that could fail
+
+Verify in this order and stop at the first that applies.
+
+1. **The project's own test command.** Read `package.json` / `Makefile` /
+   `pyproject.toml` first — do not guess a runner.
+   `npm test` · `npm run <script>` · `pytest -q` · `cargo test` · `go test ./...`
+2. **The file you just wrote.** `node path/to/file.mjs` ·
+   `python3 path/to/file.py` · `bash path/to/script.sh`
+3. **The entry point, once.** A CLI: `--help` plus one real invocation with
+   real arguments. A server: start it, hit one endpoint, stop it.
+4. **A syntax floor**, only when nothing above can run:
+   `node --check file.js` · `python3 -m py_compile file.py` · `tsc --noEmit`
+
+Run it from the directory the project expects. Capture stderr, not just
+stdout — a script that prints nothing and exits 1 has failed.
+
+## Web pages and anything visual
+
+A page that loads is not a page that works. Use the browser tools:
+
+1. Open the file or serve it, then `browser.*` to navigate to it.
+2. **Read the console.** An uncaught exception on load is a failure even
+   when the page looks fine. Report it and fix it.
+3. Screenshot and actually look: is the thing the operator asked for on
+   screen, or is the canvas blank, the layout collapsed, the sprite absent?
+4. Exercise one interaction — a click, a key, a submit — and confirm the
+   state changed.
+
+For a canvas or game, a blank frame is the usual failure and it is invisible
+from the source alone. Check a second frame after input, not just the first
+paint.
+
+## When it fails
+
+Fix and re-run, up to **three** attempts on the same defect. Each attempt
+must change something you can name. If the third fails, stop and report:
+the command, the error, what you tried, and what you believe is wrong.
+Three failed attempts on one error means the diagnosis is wrong, and a
+fourth guess is a worse use of the operator's time than a clear question.
+
+Never delete or weaken a test to make a run pass, never comment out the
+failing assertion, and never lower a check to reach green. If a test is
+genuinely wrong, say so explicitly and explain why before touching it.
+
+## What to report
+
+Two or three lines:
+
+- the command you ran, verbatim;
+- its verdict — exit code, `12 passed`, `no console errors`, the screenshot;
+- anything you could not verify, named.
+
+Do not paste whole logs. Paste the failing lines when it failed.


### PR DESCRIPTION
## What
A new bundled starter skill, `verify-work`, that makes the agent run what it just wrote and read the real output before calling it done.

It states the rule as a prohibition — never report code as working, done or fixed unless a command run in that turn proves it, and quote the command and its verdict — then gives the order to try: the project's own test command (read from `package.json` / `Makefile` / `pyproject.toml`, not guessed), then the file just written, then the entry point once, then a syntax floor when nothing else can run. It covers the visual case separately, because a page that loads is not a page that works: read the console, screenshot and actually look, exercise one interaction, and check a second frame — a blank canvas is the usual failure and is invisible from the source.

It bounds the loop at three attempts on one defect, each changing something nameable, then stop and report. And it forbids the shortcut that turns red green: deleting the test, commenting out the assertion, lowering the check.

## Why
Observed, not hypothetical. In a real session the agent wrote `src/solvers/hcaptcha.js`, `src/solvers/base.js` and `tests/test-altcha.mjs`, then replied — 18 tool calls, and not one shell invocation after the scaffolding step. The test file it authored was never executed. The operator's report was that "the output didn't work really well", which is what unverified work feels like from the outside.

This is a procedure gap rather than a capability gap: `os.shell.run` and the browser tools were always available, nothing instructed the agent to reach for them at the end of a build, and nothing made an unrun test feel like an unfinished turn. A starter skill is the right vehicle — it is seeded into every install on boot and costs nothing until the situation matches.

Deliberately not included: a bundled test framework or a runner of our own. The projects being built already have runners, and the failure was never a missing one.

## How it was verified
- `npm run lint` clean
- `npx vitest run src/skills` — 18 files / 116 tests green
- New `verify-work-starter.test.ts` pins the parts an agent actually keys off: that it ships in the bundled pack, that its description triggers on "done / working / fixed", that it declares `os.shell.run`, and that the load-bearing sentences survive an edit — the prohibition, "do not guess a runner", the console/screenshot/blank checks, the three-attempt bound, the ban on weakening a test, and the requirement to say what could not be verified
