### PR TITLE
fix(tui): say in the chat when the primary provider drops out

### DIFF
--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -1104,3 +1104,55 @@ describe("update banner state", () => {
     expect(reduceTuiState(running, offer)).toBe(running);
   });
 });
+
+describe("a fallover away from the primary is said in the chat, not only the feed", () => {
+  const away = {
+    type: "provider_switched" as const,
+    direction: "away" as const,
+    from: "openrouter",
+    to: "local-llama",
+    reason: '"openrouter" rejected the request (402).',
+  };
+
+  it("posts one system message naming the cause and what answers now", () => {
+    const next = apply(createInitialTuiState(fakeSession()), [
+      { type: "agent_event", event: away },
+    ]);
+    const system = next.messages.filter((m) => m.role === "system");
+    expect(system).toHaveLength(1);
+    expect(system[0]?.text).toContain("openrouter");
+    expect(system[0]?.text).toContain("local-llama");
+    expect(system[0]?.variant).toBe("warn");
+    // and the feed line the Fallback pane relies on is still there
+    expect(next.feed.some((f) => f.line.includes("failed over"))).toBe(true);
+  });
+
+  it("does not repeat itself when the chain re-announces the same switch", () => {
+    const s = apply(createInitialTuiState(fakeSession()), [
+      { type: "agent_event", event: away },
+      { type: "agent_event", event: away },
+    ]);
+    expect(s.messages.filter((m) => m.role === "system")).toHaveLength(1);
+  });
+
+  it("says nothing in the chat when the primary recovers", () => {
+    const first = apply(createInitialTuiState(fakeSession()), [
+      { type: "agent_event", event: away },
+    ]);
+    const before = first.messages.length;
+    const s = apply(first, [
+      {
+        type: "agent_event",
+        event: {
+          type: "provider_switched",
+          direction: "back",
+          from: "local-llama",
+          to: "openrouter",
+          reason: "probe ok",
+        },
+      },
+    ]);
+    expect(s.messages).toHaveLength(before);
+    expect(s.feed.some((f) => f.line.includes("recovered primary"))).toBe(true);
+  });
+});

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -5,6 +5,7 @@ import {
 } from "./context-usage-from-prompt.js";
 import { formatBackgroundApprovalNotice } from "./detached-turns.js";
 import { formatAgentErrorForChat } from "./format-agent-error-for-chat.js";
+import { formatProviderFalloverNotice } from "./format-provider-fallover.js";
 import { formatFeedLine } from "./format-event.js";
 import {
   appendChatMessage,
@@ -449,19 +450,39 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         event.direction === "away"
           ? `» failed over ${event.from} -> ${event.to} (${event.reason})`
           : `» recovered primary ${event.to} (probe ok)`;
-      return appendFeed(
-        {
-          ...state,
-          fallbackPanel: {
-            ...state.fallbackPanel,
-            lastSwitch: {
-              direction: event.direction,
-              from: event.from,
-              to: event.to,
-              reason: event.reason,
-            },
+      const prev = state.fallbackPanel.lastSwitch;
+      // Say it in the chat too, once per transition. A fallover changes
+      // which model answers and what it costs, and the feed lives in a
+      // tab the operator is not looking at while they work. Repeats of
+      // the same switch stay in the feed: the chain re-announces on
+      // every probe, and one notice per transition is the signal.
+      const announce =
+        event.direction === "away" &&
+        !(
+          prev?.direction === "away" &&
+          prev.from === event.from &&
+          prev.to === event.to
+        );
+      const withSwitch = {
+        ...state,
+        fallbackPanel: {
+          ...state.fallbackPanel,
+          lastSwitch: {
+            direction: event.direction,
+            from: event.from,
+            to: event.to,
+            reason: event.reason,
           },
         },
+      };
+      return appendFeed(
+        announce
+          ? appendChatMessage(withSwitch, {
+              role: "system",
+              variant: "warn",
+              text: formatProviderFalloverNotice(event.from, event.to, event.reason),
+            })
+          : withSwitch,
         {
           kind: "runtime_info",
           stepIndex: null,

--- a/src/tui/format-provider-fallover.test.ts
+++ b/src/tui/format-provider-fallover.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyFalloverReason,
+  formatProviderFalloverNotice,
+} from "./format-provider-fallover.js";
+
+describe("classifyFalloverReason", () => {
+  it.each([
+    '"openrouter" rejected the request (402).',
+    "This request requires more credits, or fewer max_tokens",
+    "quota exceeded for this month",
+  ])("reads %j as a billing refusal", (reason) => {
+    expect(classifyFalloverReason(reason)).toBe("billing");
+  });
+
+  it.each(['provider rejected the request (401).', "403 Forbidden", "invalid api key"])(
+    "reads %j as an auth refusal",
+    (reason) => {
+      expect(classifyFalloverReason(reason)).toBe("auth");
+    },
+  );
+
+  it.each(["socket hang up", "503 Service Unavailable", "timed out after 300000ms"])(
+    "leaves %j as transient",
+    (reason) => {
+      expect(classifyFalloverReason(reason)).toBe("other");
+    },
+  );
+});
+
+describe("formatProviderFalloverNotice", () => {
+  it("names both providers and the reason", () => {
+    const text = formatProviderFalloverNotice("openrouter", "local-llama", "socket hang up");
+    expect(text).toContain("openrouter");
+    expect(text).toContain("local-llama");
+    expect(text).toContain("socket hang up");
+  });
+
+  it("says a credit refusal will not clear by itself, and how to act", () => {
+    const text = formatProviderFalloverNotice(
+      "openrouter",
+      "local-llama",
+      '"openrouter" rejected the request (402).',
+    );
+    expect(text).toMatch(/will not clear by itself/);
+    expect(text).toContain("maxOutputTokens");
+    expect(text).toContain("every answer comes from local-llama");
+  });
+
+  it("points an auth refusal at the key file", () => {
+    const text = formatProviderFalloverNotice("openrouter", "local-llama", "401 unauthorized");
+    expect(text).toMatch(/will not clear by itself/);
+    expect(text).toContain(".env");
+  });
+
+  it("keeps a transient failure short — the chain's own probe handles it", () => {
+    const text = formatProviderFalloverNotice("openrouter", "local-llama", "503");
+    expect(text).toMatch(/until openrouter recovers/);
+    expect(text).not.toMatch(/will not clear by itself/);
+  });
+});

--- a/src/tui/format-provider-fallover.ts
+++ b/src/tui/format-provider-fallover.ts
@@ -1,0 +1,49 @@
+/**
+ * The chat-surface announcement for a fallover away from the primary
+ * provider.
+ *
+ * A fallover changes which model is answering, what it costs, and how
+ * good the answers are — and the chain is designed to make it seamless,
+ * which is exactly why it needs saying. Until now the only trace of it
+ * was a feed line in Observe › Feed: an operator working in the chat saw
+ * their cloud model quietly replaced by a local one and no reason for it
+ * anywhere they were looking. A billing or credential refusal never
+ * heals on its own, so silence there costs a whole session.
+ *
+ * Recovery stays a feed line: going back to the provider the operator
+ * chose restores what they already expect, and a chat bubble for it
+ * would be noise.
+ */
+export function formatProviderFalloverNotice(
+  from: string,
+  to: string,
+  reason: string,
+): string {
+  const cause = classifyFalloverReason(reason);
+  return [
+    `Switched from ${from} to ${to}: ${reason}`,
+    cause === "billing"
+      ? `${from} is refusing requests over credit or quota, which will not clear by itself — top it up, or lower that provider's maxOutputTokens so a request fits. Until then every answer comes from ${to}.`
+      : cause === "auth"
+        ? `${from} refused the credentials, which will not clear by itself — check the API key in <stateDir>/.env. Until then every answer comes from ${to}.`
+        : `Answers come from ${to} until ${from} recovers.`,
+  ].join("\n");
+}
+
+export type FalloverCause = "billing" | "auth" | "other";
+
+/**
+ * What kind of failure this was, from the reason text the chain carries.
+ *
+ * Only two kinds earn extra words: the ones an operator has to act on
+ * rather than wait out. A 402 or a quota message means the account is
+ * out of room; a 401/403 means the key is wrong. Everything else — a
+ * timeout, a 5xx, a rate limit — is transient by nature and the chain's
+ * own recovery probe is the right answer to it.
+ */
+export function classifyFalloverReason(reason: string): FalloverCause {
+  const text = reason.toLowerCase();
+  if (/\b402\b|credit|quota|insufficient|billing|payment/.test(text)) return "billing";
+  if (/\b401\b|\b403\b|unauthor|forbidden|invalid api key|api key/.test(text)) return "auth";
+  return "other";
+}


### PR DESCRIPTION
## What
When the fallback chain moves away from the primary provider, the chat now says so once: which provider dropped out, what replaced it, and why. Repeats of the same transition stay in the feed (the chain re-announces on every probe), and recovery stays a feed line — going back to the provider the operator chose restores what they already expect.

A refusal for **credit** (402, quota, "insufficient") or **credentials** (401/403, invalid key) gets one extra sentence, because those never clear on their own and the operator has to act: top up or lower that provider's `maxOutputTokens`, or fix the key in `<stateDir>/.env`. Timeouts and 5xx keep the short form.

## Why
A fallover is built to be seamless, and that is exactly why it needs announcing — it silently changes which model answers, what it costs and how good the answers are.

From a real session: OpenRouter began refusing every request with HTTP 402 (the account could not cover the reservation). The chain did its job and fell over to the local llama-server, so the operator kept getting answers — from a 27B local model instead of the cloud one they had configured — for an hour, with no indication anywhere in the chat. They reported it as "the model stopped working" and "nothing works", and the only way to find the cause was reading the trace and pinning the chain to cloud-only to force the error to surface. The feed line existed the whole time, in a tab nobody looks at while working.

Silence is the wrong default for a change of this size, and it is worst precisely for the failures that will not fix themselves.

## How it was verified
- `npm run lint` clean
- `npx vitest run src/tui` — full TUI suite green
- New `format-provider-fallover.test.ts`: 402 / quota / "insufficient" classify as billing, 401 / 403 / invalid key as auth, socket hang-up / 503 / timeout stay transient; the billing text names `maxOutputTokens` and the auth text names `.env`; a transient reason never claims the failure is permanent
- New cases in `agent-event-reducer.test.ts`: one warn-variant system message on the first switch away, the Fallback pane's feed line still emitted, no second message when the same switch re-announces, and nothing added to the chat on recovery
