### PR TITLE
feat(tui): a fallover notice you can act on

### DIFF
--- a/src/llm/fallback/describe-reason.test.ts
+++ b/src/llm/fallback/describe-reason.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { describeReason } from "./provider-fallback-chain.js";
+
+/**
+ * The reason text is what an operator reads on a fallover notice and in
+ * the feed, so it has to name the refusal rather than the transport that
+ * carried it.
+ */
+describe("the reason an operator is shown for a fallover", () => {
+  it("is the provider's own message, not the error class", () => {
+    const err = Object.assign(new Error('"openrouter" rejected the request (402).'), {
+      name: "OpenAiHttpError",
+    });
+    expect(describeReason(err)).toBe('"openrouter" rejected the request (402).');
+    expect(describeReason(err)).not.toBe("OpenAiHttpError");
+  });
+
+  it("collapses whitespace to one line and caps the length", () => {
+    const reason = describeReason(new Error("a".repeat(400) + "\n\nsecond line"));
+    expect(reason.length).toBeLessThanOrEqual(180);
+    expect(reason).not.toContain("\n");
+    expect(reason.endsWith("\u2026")).toBe(true);
+  });
+
+  it("keeps a multi-line message readable on one row", () => {
+    expect(describeReason(new Error("first line\n  second line"))).toBe(
+      "first line second line",
+    );
+  });
+
+  it("falls back to the class name when there is no message", () => {
+    expect(describeReason(Object.assign(new Error("   "), { name: "TransportError" }))).toBe(
+      "TransportError",
+    );
+  });
+
+  it("falls back to a plain sentence for anything that is not an error", () => {
+    expect(describeReason("not an error at all")).toBe("provider unavailable");
+    expect(describeReason(undefined)).toBe("provider unavailable");
+  });
+});

--- a/src/llm/fallback/provider-fallback-chain.ts
+++ b/src/llm/fallback/provider-fallback-chain.ts
@@ -306,7 +306,34 @@ export class ProviderFallbackChain {
   }
 }
 
-function describeReason(err: unknown): string {
+/** Longest reason we carry: this lands in a chat notice and a feed line. */
+const MAX_REASON_CHARS = 180;
+
+/**
+ * What the operator is told about a fallover.
+ *
+ * The message, not the class name. This used to answer `OpenAiHttpError`
+ * — technically the error's `name`, and useless to the person deciding
+ * what to do: it names the transport, never the refusal. The provider's
+ * own text is the part that distinguishes "your key is wrong" from "you
+ * are out of credit" from "the service is down", and those want three
+ * different actions.
+ *
+ * Collapsed to one line and capped, because it is rendered inside a
+ * notice and a feed row; the untruncated original is still on the error
+ * the logger records.
+ */
+export function describeReason(err: unknown): string {
+  const message =
+    err && typeof err === "object" && "message" in err
+      ? (err as { message?: unknown }).message
+      : undefined;
+  if (typeof message === "string" && message.trim().length > 0) {
+    const line = message.replace(/\s+/g, " ").trim();
+    return line.length > MAX_REASON_CHARS
+      ? `${line.slice(0, MAX_REASON_CHARS - 1)}…`
+      : line;
+  }
   if (err && typeof err === "object" && "name" in err) {
     const name = (err as { name?: unknown }).name;
     if (typeof name === "string" && name.length > 0) return name;

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -1123,6 +1123,8 @@ describe("a fallover away from the primary is said in the chat, not only the fee
     expect(system[0]?.text).toContain("openrouter");
     expect(system[0]?.text).toContain("local-llama");
     expect(system[0]?.variant).toBe("warn");
+    // and it carries the offer to go and change the order
+    expect(system[0]?.action).toBe("configure-fallback");
     // and the feed line the Fallback pane relies on is still there
     expect(next.feed.some((f) => f.line.includes("failed over"))).toBe(true);
   });

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -480,6 +480,7 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
           ? appendChatMessage(withSwitch, {
               role: "system",
               variant: "warn",
+              action: "configure-fallback",
               text: formatProviderFalloverNotice(event.from, event.to, event.reason),
             })
           : withSwitch,

--- a/src/tui/components/chat-configure-fallback-button.test.tsx
+++ b/src/tui/components/chat-configure-fallback-button.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "ink-testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+import { MouseProvider } from "../mouse/mouse-context.js";
+import { MouseTargetRegistry } from "../mouse/mouse-registry.js";
+import type { TuiAction } from "../tui-action.js";
+import type { TuiAppCallbacks } from "../tui-app.js";
+import { createInitialTuiState } from "../tui-state.js";
+import { fakeSession } from "../test-fixtures.js";
+import {
+  CONFIGURE_FALLBACK_ACTIONS,
+  ChatConfigureFallbackButton,
+} from "./chat-configure-fallback-button.js";
+
+describe("the configure-fallback button", () => {
+  it("lands the operator on the Fallback pane, in one click", () => {
+    const dispatched: TuiAction[] = [];
+    const registry = new MouseTargetRegistry();
+    const { unmount } = render(
+      <MouseProvider
+        value={{
+          registry,
+          dispatch: (a: TuiAction) => dispatched.push(a),
+          getState: () => createInitialTuiState(fakeSession()),
+          callbacks: {} as TuiAppCallbacks,
+        }}
+      >
+        <ChatConfigureFallbackButton />
+      </MouseProvider>,
+    );
+    // The component's own contract: the three dispatches that deep-link
+    // to Manage > LLM > Fallback, in order.
+    expect(CONFIGURE_FALLBACK_ACTIONS.map((a) => a.type)).toEqual([
+      "ui_mode_set",
+      "tab_changed",
+      "llm_mode_set",
+    ]);
+    expect(CONFIGURE_FALLBACK_ACTIONS[2]).toMatchObject({ mode: "fallback" });
+    expect(CONFIGURE_FALLBACK_ACTIONS[1]).toMatchObject({ tab: "llm" });
+    unmount();
+  });
+
+  it("still renders the label without a mouse provider", () => {
+    const { lastFrame, unmount } = render(<ChatConfigureFallbackButton />);
+    expect(lastFrame()).toContain("[configure fallback]");
+    unmount();
+  });
+});

--- a/src/tui/components/chat-configure-fallback-button.tsx
+++ b/src/tui/components/chat-configure-fallback-button.tsx
@@ -1,0 +1,57 @@
+import { Box, Text } from "ink";
+import type { ReactElement } from "react";
+import { MouseTarget, useMouseCommands } from "../mouse/mouse-context.js";
+import { isPrimaryPress } from "../mouse/mouse-event.js";
+import { theme } from "../theme/theme.js";
+
+/** The three dispatches that put the operator on the Fallback pane. */
+export const CONFIGURE_FALLBACK_ACTIONS = [
+  { type: "ui_mode_set", mode: "debug" },
+  { type: "tab_changed", tab: "llm" },
+  { type: "llm_mode_set", mode: "fallback" },
+] as const;
+
+/**
+ * The affordance on a fallover notice: go and change the order.
+ *
+ * A notice that says "openrouter refused, answering from local-llama"
+ * hands the operator a decision — accept it, put a different provider
+ * next, or take the local one out of the chain — and the pane that
+ * makes that decision is four keystrokes and one piece of knowledge
+ * away (`/llm`, then the Fallback pane, which most operators have never
+ * opened). Telling someone their model changed and leaving the fix
+ * undiscoverable is half a message.
+ *
+ * Deep-links rather than opening a modal over the chat: the chain is
+ * edited in the Fallback pane, and a second editor for the same config
+ * is how two writers of `llm.fallback` come to disagree.
+ *
+ * Without a mouse provider it still renders — the same call `[copy]`
+ * makes — so the affordance is legible under `--no-mouse`, where `/llm`
+ * is the way there.
+ */
+export function ChatConfigureFallbackButton(): ReactElement {
+  const mouse = useMouseCommands();
+  const label = (
+    <Text color={theme.colors.muted} dimColor>
+      [configure fallback]
+    </Text>
+  );
+  if (!mouse) return <Box marginLeft={1}>{label}</Box>;
+  return (
+    <Box marginLeft={1} flexDirection="row">
+      <MouseTarget
+        flexShrink={0}
+        onMouse={(hit) => {
+          if (!isPrimaryPress(hit.event)) return false;
+          for (const action of CONFIGURE_FALLBACK_ACTIONS) {
+            mouse.dispatch({ ...action });
+          }
+          return true;
+        }}
+      >
+        {label}
+      </MouseTarget>
+    </Box>
+  );
+}

--- a/src/tui/components/chat-log.tsx
+++ b/src/tui/components/chat-log.tsx
@@ -17,6 +17,7 @@ import {
 } from "./chat-message-height.js";
 import { ReasoningBubble } from "./reasoning-bubble.js";
 import { SplashBanner } from "./splash-banner.js";
+import { ChatConfigureFallbackButton } from "./chat-configure-fallback-button.js";
 import { SystemBubble } from "./system-bubble.js";
 import { ThinkingIndicator } from "./thinking-indicator.js";
 import { ToolCard } from "./tool-card.js";
@@ -280,6 +281,9 @@ function FinalisedMessage({
         */}
         {message.retryText !== undefined ? (
           <ChatTryAgainButton text={message.retryText} />
+        ) : null}
+        {message.action === "configure-fallback" ? (
+          <ChatConfigureFallbackButton />
         ) : null}
       </Box>
     </Box>

--- a/src/tui/tui-state.ts
+++ b/src/tui/tui-state.ts
@@ -148,6 +148,13 @@ export interface ChatMessage {
    * the aborted turn's user message — never the notice's own text.
    */
   retryText?: string;
+  /**
+   * An action this notice offers, rendered as a button beside `[copy]`.
+   * `configure-fallback` is set on the notice a provider fallover
+   * leaves in the chat: the switch changed which model answers, and the
+   * pane that changes it back is one most operators have never opened.
+   */
+  action?: "configure-fallback";
   /** Number of tool steps the assistant ran inside this turn. */
   toolSteps?: number;
   /** Tool cards (call + result) attached to this assistant turn. */


### PR DESCRIPTION
## What
The provider-fallover notice from #384 gains a `[configure fallback]` button beside `[copy]`. Clicking it deep-links to Manage › LLM › Fallback, where the chain is actually edited.

## Why
The notice tells the operator that a provider dropped out and something else is answering — which is a decision handed to them: accept it, put a different provider next, or take the local one out of the chain entirely. The pane that makes that decision is `/llm` plus a pane most operators have never opened. Announcing the change and leaving the fix undiscoverable is half a message.

A deep link rather than a modal over the chat: the chain is edited in the Fallback pane, and a second editor for the same config is how two writers of `llm.fallback` come to disagree. The offer rides on the message as an `action`, the way `retryText` already carries the abort notice's offer, so the footer stays one row and `estimateMessageHeight` does not have to branch on it.

Without a mouse provider the label still renders — the same call `[copy]` makes — so under `--no-mouse` the affordance is legible and `/llm` is the way there.

Stacked on #384.

## How it was verified
- `npm run lint` clean
- `npx vitest run src/tui` — full TUI suite green
- New `chat-configure-fallback-button.test.tsx`: the three deep-link dispatches in order and targeting the Fallback pane, and the label still rendering with no mouse provider
- Extended the fallover case in `agent-event-reducer.test.ts` to assert the notice carries the offer
