### PR TITLE
fix(agent): recover from an unparseable tool call instead of ending the turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,44 @@ two app restarts and a fresh session — with nothing on screen to say the link 
    <reason>` until a turn actually succeeds. The context readout is not touched: it is driven by
    `prompt_built` / `llm_completed`, and a parked turn produces neither.
 
+### An unparseable completion is retried, not fatal
+
+A completion the runtime cannot read as tool calls used to end the turn. The step executor's own
+one-shot repair (`buildToolCallRepairPrompt`, capped at `REPAIR_MAX_TOKENS`) is not enough on its
+own: the cap exists to stop a reasoning model re-deliberating for minutes, but it also means a
+repair that must re-emit a large argument — a file body on `os.fs.write` — cannot fit, truncates,
+and fails the parse a second time. What the operator got was `Turn failed [grammar]: tool call
+"os.fs.write" arguments are not a valid JSON object`, a session with `lastError` set, nothing in the
+transcript, and a turn that only restarted when they noticed the silence and typed "try again".
+
+[src/agent/parse-failure-recovery.ts](src/agent/parse-failure-recovery.ts) lets the loop spend
+ordinary steps on it instead. Locked invariants (pinned by
+[src/agent/parse-failure-recovery.test.ts](src/agent/parse-failure-recovery.test.ts),
+[src/agent/agent-loop.test.ts](src/agent/agent-loop.test.ts) and
+[src/tui/agent-event-reducer.test.ts](src/tui/agent-event-reducer.test.ts)):
+
+1. **Only a body our parser rejected recovers.** `ToolCallParseError`, or a `GrammarError` whose
+   cause is not a `LlamaServerError`. A llama-server 400/413/422 wears the same `GrammarError`
+   shape and is the server refusing the request — re-prompting reproduces it, so it fails at once.
+2. **`PARSE_RECOVERY_BUDGET` (2) per turn, and the step is counted.** Unlike the outage park this
+   is a *new* step at the next index, not a replay: the model consumed an inference and the budget
+   must be visible in `stepsTaken`. `legMadeProgress` stays false, so a leg made entirely of
+   rejected completions still stops at its boundary as `no_progress`.
+3. **The retry carries a `### notice`, not the capped repair prompt.** `composeParseFailureNotice`
+   names the rejection, states that nothing ran, and points at oversized arguments as the likely
+   cause. It composes with whatever the step already owed the model (loop detector, steering)
+   rather than overwriting that slot, and the rejection comes first.
+4. **A failed turn leaves a row in the transcript.** `formatTurnFailedRecord` is recorded as an
+   `assistant_reply` turn — recorded only, with no `assistant_reply` event, because every surface
+   already prints its own line from `loop_failed` and a second copy would arrive as a message from
+   the agent. Without the row, the next turn is built from a history in which the attempt never
+   happened and the model repeats it verbatim.
+5. **The feed and the trace both say it.** One `parse_failure_recovered` line per recovery
+   (`» the model's output could not be read as a tool call (<reason>) — trying again (n/2)`),
+   because the recovering step produces neither a tool call nor text and would otherwise be a gap
+   on screen — and a `parse_failure_recovered` trace row carrying step, attempt/budget and reason,
+   because a post-mortem reading `<stateDir>/traces/<sessionId>.ndjson` needs the same answer.
+
 ### No-progress loop detection
 
 The runtime guards against "stuck" turns where the model re-emits the same tool call (same args, same result) without making progress. The detector is [src/agent/loop-detector.ts](src/agent/loop-detector.ts) `ToolLoopTracker` — **one instance per turn**, owned by `AgentLoop.runTurn`, threaded into `executeStep` → `executeBatch` via `BatchExecutionContext.tracker`. Ported from OpenClaw 2026.6.5; the design goal is **graceful termination, never a hard failure**.

--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -8,6 +8,8 @@ import { buildDefaultToolRegistry } from "../tools/index.js";
 import { osFsReadTool } from "../tools/os/fs-read.js";
 import { SlotManager } from "../llm/slot-manager.js";
 import { TransportError } from "../llm/reliability/llm-failures.js";
+import { LlamaServerError } from "../llm/llama-server-client.js";
+import { PARSE_RECOVERY_BUDGET } from "./parse-failure-recovery.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import type {
   CompletionResult,
@@ -1643,11 +1645,12 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(stepErrors[0]?.category).toBe("model");
   });
 
-  it("classifies persistent parse failure as GrammarError after one retry", async () => {
+  it("classifies persistent parse failure as GrammarError after the recovery budget", async () => {
     const registry = buildDefaultToolRegistry();
     let llmCalls = 0;
     const stepErrors: Array<{ category: string }> = [];
     const parseRetries: number[] = [];
+    const recoveries: Array<{ attempt: number; budget: number }> = [];
     const loop = new AgentLoop({
       registry,
       slotManager: new SlotManager(2),
@@ -1667,6 +1670,8 @@ describe("AgentLoop end-to-end with mock LLM", () => {
           event.event.type === "parse_retry"
         ) {
           parseRetries.push(event.event.attempt);
+        } else if (event.type === "parse_failure_recovered") {
+          recoveries.push({ attempt: event.attempt, budget: event.budget });
         }
       },
     });
@@ -1678,9 +1683,123 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     });
     expect(result.reason).toBe("failed");
     expect(result.session.status).toBe("failed");
-    expect(llmCalls).toBe(2);
-    expect(parseRetries).toHaveLength(1);
+    // Each step gets the step executor's own one-shot repair (2 calls);
+    // the turn then spends `PARSE_RECOVERY_BUDGET` further steps on a
+    // rebuilt prompt before giving up. A model that cannot emit a valid
+    // call three times running still fails, and still as `grammar`.
+    expect(recoveries).toEqual([
+      { attempt: 1, budget: PARSE_RECOVERY_BUDGET },
+      { attempt: 2, budget: PARSE_RECOVERY_BUDGET },
+    ]);
+    expect(llmCalls).toBe(2 * (PARSE_RECOVERY_BUDGET + 1));
+    expect(parseRetries).toHaveLength(PARSE_RECOVERY_BUDGET + 1);
     expect(stepErrors[0]?.category).toBe("grammar");
+  });
+
+  it("recovers a rejected tool call by spending a step on a corrected one", async () => {
+    const registry = buildDefaultToolRegistry();
+    let llmCalls = 0;
+    const prompts: string[] = [];
+    const recoveries: number[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async (params) => {
+        llmCalls += 1;
+        prompts.push(params.prompt);
+        // The first step and its in-step repair both come back
+        // unparseable — the shape a large `os.fs.write` produces when
+        // the repair's own token cap cannot fit the argument again.
+        return llmCalls <= 2
+          ? makeCompletion('[{"tool":"os.fs.write","args":{"path":"/tmp/x","content":"aaa')
+          : makeCompletion(JSON.stringify({ tool: "reply", args: { text: "done" } }));
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "parse_failure_recovered") recoveries.push(event.attempt);
+      },
+    });
+    const session = createEmptySessionState({ id: "s-parse-recovered", workingDir });
+    const result = await loop.runTurn(session, {
+      userMessage: "write the file",
+      maxSteps: 5,
+      signal: new AbortController().signal,
+    });
+    // The turn answers instead of dying, without the operator noticing
+    // the silence and typing "try again".
+    expect(result.reason).toBe("reply");
+    expect(result.session.status).toBe("pending");
+    expect(recoveries).toEqual([1]);
+    // The step after the rejection is told what was rejected — the
+    // feedback the model had no way to get before.
+    const afterRecovery = prompts[2] ?? "";
+    expect(afterRecovery).toContain("rejected before any tool ran");
+    expect(afterRecovery).toContain("Nothing you attempted has happened yet");
+    const replies = result.session.turns.filter((t) => t.kind === "assistant_reply");
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({ text: "done" });
+  });
+
+  it("leaves the failure in the transcript so the next turn is not blind", async () => {
+    const registry = buildDefaultToolRegistry();
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () =>
+        makeCompletion('[{"tool":"reply","args":{"text":'),
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+    });
+    const session = createEmptySessionState({ id: "s-failure-record", workingDir });
+    const result = await loop.runTurn(session, {
+      userMessage: "go",
+      maxSteps: 3,
+      signal: new AbortController().signal,
+    });
+    expect(result.reason).toBe("failed");
+    const last = result.session.turns[result.session.turns.length - 1];
+    expect(last?.kind).toBe("assistant_reply");
+    expect((last as { text: string }).text).toContain("this turn failed");
+    expect((last as { text: string }).text).toContain("grammar");
+    expect((last as { text: string }).text).toContain("Nothing from it took effect");
+  });
+
+  it("does not recover a request the model server itself rejected", async () => {
+    const registry = buildDefaultToolRegistry();
+    let llmCalls = 0;
+    const recoveries: number[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        llmCalls += 1;
+        throw new LlamaServerError("request too large", 413, "http://x/v1");
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "parse_failure_recovered") recoveries.push(event.attempt);
+      },
+    });
+    const session = createEmptySessionState({ id: "s-413", workingDir });
+    const result = await loop.runTurn(session, {
+      userMessage: "go",
+      maxSteps: 3,
+      signal: new AbortController().signal,
+    });
+    // A 413 wears the same `GrammarError` shape, but re-prompting
+    // reproduces it: the operator gets the diagnosis now, not two
+    // wasted steps later.
+    expect(result.reason).toBe("failed");
+    expect(recoveries).toEqual([]);
+    expect(llmCalls).toBe(1);
   });
 
   it("classifies a missing tool call as ToolExecutionError", async () => {

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -55,6 +55,12 @@ import {
 } from "./loop-detector.js";
 import type { BatchLoopSignal } from "./batch-executor.js";
 import { composeSteerNotice } from "./steer-notice.js";
+import {
+  PARSE_RECOVERY_BUDGET,
+  composeParseFailureNotice,
+  formatTurnFailedRecord,
+  isRecoverableParseFailure,
+} from "./parse-failure-recovery.js";
 import { getConfig } from "../config/index.js";
 import type { AgentMetrics } from "../tracing/agent-metrics.js";
 import type { StructuredLogger } from "../tracing/structured-logger.js";
@@ -471,6 +477,20 @@ export type AgentLoopEvent =
     }
   | {
       /**
+       * The completion for step `stepIndex` could not be parsed into
+       * tool calls, and the turn is spending another step on it instead
+       * of ending: the next prompt carries a `### notice` naming the
+       * rejection. Fired once per recovery; `attempt` counts them within
+       * the turn, `budget` is the ceiling after which the turn fails.
+       */
+      type: "parse_failure_recovered";
+      stepIndex: number;
+      attempt: number;
+      budget: number;
+      reason: string;
+    }
+  | {
+      /**
        * A leg of the task finished and the work is continuing. Fired at
        * every `maxSteps` boundary that does not end the task, so a long
        * job reports itself instead of going quiet for an hour.
@@ -729,6 +749,13 @@ export class AgentLoop {
     let outageAttempts = 0;
     /** Retried a step after an outage and have not yet seen it succeed. */
     let awaitingRecovery = false;
+    /**
+     * Completions this turn that came back unparseable and were spent
+     * another step on. Bounded by `PARSE_RECOVERY_BUDGET`: a model that
+     * cannot emit a valid tool call twice in a row will not manage it on
+     * the third try either, and the operator is owed the failure.
+     */
+    let parseRecoveries = 0;
     // Per-turn no-progress loop tracker (OpenClaw-style). Threaded into
     // `executeStep` so the synchronous batch gate can veto looping calls
     // before they are dispatched; the agent loop consumes the resulting
@@ -1220,6 +1247,51 @@ export class AgentLoop {
           reason = "max_steps";
           break;
         }
+        // The completion came back but could not be read as tool calls,
+        // and the step executor's in-step repair did not rescue it
+        // either. Spend an ordinary step on it rather than ending the
+        // turn: the next prompt is built fresh at the full completion
+        // budget — which the capped repair is not — and carries a
+        // `### notice` naming what was rejected, so the model has
+        // something to correct against. Same replay argument as the
+        // outage park below: a parse failure throws before any tool is
+        // dispatched, so nothing is repeated and no side effect is
+        // duplicated.
+        //
+        // The step is counted. It consumed an inference, and leaving
+        // `legMadeProgress` false means a leg made entirely of rejected
+        // completions still stops at the boundary as `no_progress`.
+        if (
+          !cancelled &&
+          parseRecoveries < PARSE_RECOVERY_BUDGET &&
+          isRecoverableParseFailure(err)
+        ) {
+          parseRecoveries += 1;
+          stepsTaken += 1;
+          // The notice this step was carrying (loop detector, steering,
+          // a trimmed batch) is still owed to the next one.
+          pendingNotice = composeParseFailureNotice(
+            noticeForThisStep,
+            runError.message,
+          );
+          this.deps.onEvent?.({
+            type: "parse_failure_recovered",
+            stepIndex: i,
+            attempt: parseRecoveries,
+            budget: PARSE_RECOVERY_BUDGET,
+            reason: runError.message,
+          });
+          this.deps.logger?.warn("completion could not be parsed; retrying the turn", {
+            sessionId: state.id,
+            stepIndex: i,
+            attempt: parseRecoveries,
+            budget: PARSE_RECOVERY_BUDGET,
+            error: runError.message,
+            category,
+          });
+          runError = null;
+          continue;
+        }
         // The provider is not answering. Park the turn instead of
         // killing it: nothing of this step has been committed (a
         // completion failure throws before any tool is dispatched —
@@ -1319,6 +1391,18 @@ export class AgentLoop {
         // fixing here. `cancelled` and `failed` are both classified
         // terminations; only programming bugs or unclassified errors
         // should ever bubble past this point.
+        //
+        // Leave the failure in the transcript. Without it the next turn
+        // — usually the operator typing "try again" — is built from a
+        // history in which the attempt never happened, and the model
+        // reproduces the same rejected output. Recorded only: every
+        // surface already renders its own line from `loop_failed`, so
+        // emitting an `assistant_reply` event here would post the text
+        // twice.
+        state = recordTurn(
+          state,
+          assistantReplyTurn(formatTurnFailedRecord(category, runError.message)),
+        );
         state = { ...state, status: "failed", lastError: runError.message };
         this.deps.onEvent?.({ type: "loop_completed", reason: "failed" });
         state = incrementTurnCount(state);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -44,6 +44,13 @@ export {
   newlyCoveredCount,
 } from "./read-coverage.js";
 export type { LineRange, ReadObservation } from "./read-coverage.js";
+export {
+  PARSE_RECOVERY_BUDGET,
+  composeParseFailureNotice,
+  formatParseFailureNotice,
+  formatTurnFailedRecord,
+  isRecoverableParseFailure,
+} from "./parse-failure-recovery.js";
 export { classifyTestCommand } from "./test-command-key.js";
 export type { RecognizedTestCommand } from "./test-command-key.js";
 export {

--- a/src/agent/parse-failure-recovery.test.ts
+++ b/src/agent/parse-failure-recovery.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  PARSE_RECOVERY_BUDGET,
+  composeParseFailureNotice,
+  formatParseFailureNotice,
+  formatTurnFailedRecord,
+  isRecoverableParseFailure,
+} from "./parse-failure-recovery.js";
+import {
+  GrammarError,
+  ModelError,
+  TransportError,
+} from "../llm/reliability/llm-failures.js";
+import { LlamaServerError } from "../llm/llama-server-client.js";
+import { ToolCallParseError } from "../llm/grammar/tool-call-grammar.js";
+
+describe("isRecoverableParseFailure", () => {
+  it("accepts a completion body the parser rejected", () => {
+    const cause = new ToolCallParseError(
+      'tool call "os.fs.write" arguments are not a valid JSON object',
+    );
+    expect(
+      isRecoverableParseFailure(new GrammarError(cause.message, "", { cause })),
+    ).toBe(true);
+  });
+
+  it("accepts a bare parser error", () => {
+    expect(
+      isRecoverableParseFailure(new ToolCallParseError("tool-call body is empty")),
+    ).toBe(true);
+  });
+
+  it("refuses a llama-server 4xx wearing the same GrammarError shape", () => {
+    // `toLlmFailure` files a 400/413/422 as `GrammarError` too — but that
+    // is the server rejecting the REQUEST, and another inference
+    // reproduces it exactly. Recovering here would burn the budget and
+    // then hand the operator the same diagnosis two steps later.
+    const cause = new LlamaServerError("request too large", 413, "http://x/v1");
+    expect(
+      isRecoverableParseFailure(new GrammarError(cause.message, "", { cause })),
+    ).toBe(false);
+  });
+
+  it("refuses failures from other categories", () => {
+    expect(
+      isRecoverableParseFailure(new TransportError("down", null, "http://x")),
+    ).toBe(false);
+    expect(
+      isRecoverableParseFailure(new ModelError("truncated", "cut off")),
+    ).toBe(false);
+    expect(isRecoverableParseFailure(new Error("something else"))).toBe(false);
+    expect(isRecoverableParseFailure("not an error")).toBe(false);
+  });
+});
+
+describe("formatParseFailureNotice", () => {
+  it("names the rejection, says nothing ran, and points at oversized arguments", () => {
+    const notice = formatParseFailureNotice(
+      'tool call "os.fs.write" arguments are not a valid JSON object',
+    );
+    expect(notice).toContain('tool call "os.fs.write" arguments are not a valid JSON object');
+    expect(notice).toContain("Nothing you attempted has happened yet");
+    expect(notice).toContain("split the work into several smaller calls");
+  });
+
+  it("clips a reason that quotes a slice of the model's output", () => {
+    // V8 puts a fragment of the offending text into `JSON.parse`
+    // messages, and that fragment is model output whose length the
+    // runtime does not control.
+    const long = `invalid tool-call JSON: Unexpected token 'x', "${"y".repeat(5_000)}" is not valid JSON`;
+    const notice = formatParseFailureNotice(long);
+    expect(notice.length).toBeLessThan(1_000);
+    expect(notice).toContain("…");
+  });
+
+  it("collapses newlines so the notice stays one block", () => {
+    expect(formatParseFailureNotice("line one\n\nline two")).toContain(
+      "line one line two",
+    );
+  });
+});
+
+describe("composeParseFailureNotice", () => {
+  it("is the whole notice when nothing else is pending", () => {
+    const out = composeParseFailureNotice(undefined, "bad json");
+    expect(out).toBe(formatParseFailureNotice("bad json"));
+  });
+
+  it("keeps what the step already owed the model, rejection first", () => {
+    const out = composeParseFailureNotice("The user sent a new message", "bad json");
+    expect(out).toContain("bad json");
+    expect(out).toContain("The user sent a new message");
+    expect(out.indexOf("bad json")).toBeLessThan(
+      out.indexOf("The user sent a new message"),
+    );
+  });
+
+  it("treats an empty existing notice as none", () => {
+    expect(composeParseFailureNotice("", "bad json")).toBe(
+      formatParseFailureNotice("bad json"),
+    );
+  });
+});
+
+describe("formatTurnFailedRecord", () => {
+  it("reads as the turn's own account of why it produced nothing", () => {
+    const row = formatTurnFailedRecord("grammar", 'tool call "os.fs.write" arguments are not a valid JSON object');
+    expect(row).toContain("grammar");
+    expect(row).toContain("os.fs.write");
+    expect(row).toContain("Nothing from it took effect");
+  });
+
+  it("clips a runaway message", () => {
+    expect(formatTurnFailedRecord("grammar", "z".repeat(5_000)).length).toBeLessThan(
+      500,
+    );
+  });
+});
+
+describe("PARSE_RECOVERY_BUDGET", () => {
+  it("is bounded", () => {
+    expect(PARSE_RECOVERY_BUDGET).toBeGreaterThan(0);
+    expect(PARSE_RECOVERY_BUDGET).toBeLessThanOrEqual(3);
+  });
+});

--- a/src/agent/parse-failure-recovery.ts
+++ b/src/agent/parse-failure-recovery.ts
@@ -1,0 +1,108 @@
+/**
+ * Recovery from a completion the runtime could not turn into tool calls.
+ *
+ * The step executor already gives such a completion one in-step repair:
+ * the same request replayed with a `### tool-call-repair` block and a
+ * hard `REPAIR_MAX_TOKENS` cap. That cap is the point — it stops a
+ * reasoning model burning its whole budget re-deliberating — but it also
+ * means a repair that has to re-emit a large argument (a file body on
+ * `os.fs.write`) cannot fit, so the repair truncates and the step ends
+ * as `GrammarError`.
+ *
+ * Today that ends the turn: the loop records `lastError`, the surfaces
+ * print `Turn failed [grammar]: …`, and nothing else happens until the
+ * operator notices the silence and types "try again". This module lets
+ * the loop spend one or two ordinary steps instead — a fresh prompt at
+ * the full completion budget, with a `### notice` saying what was
+ * rejected. Same seam the loop detector and mid-turn steering use.
+ *
+ * Only a body OUR parser rejected qualifies. A `GrammarError` that wraps
+ * a llama-server 4xx is the server refusing the request itself; another
+ * inference reproduces it exactly.
+ */
+
+import { GrammarError, LlamaServerError, ToolCallParseError } from "../llm/index.js";
+
+/**
+ * Recoveries allowed per turn. Two, not one: the first is usually enough
+ * for a transient serialization slip, and a model that needs a second is
+ * often one that split an oversized write after being told to. A third
+ * is a model that cannot emit valid JSON at all — spending the whole leg
+ * proving it just delays the failure the operator has to read anyway.
+ */
+export const PARSE_RECOVERY_BUDGET = 2;
+
+/**
+ * Cap on the rejection reason quoted into the notice. Parser messages
+ * are short by construction, but `JSON.parse` failures on V8 quote a
+ * slice of the offending text, and that slice is model output whose
+ * length we do not control.
+ */
+const MAX_REASON_CHARS = 300;
+
+/**
+ * Is this failure a completion body the runtime could not parse into
+ * tool calls — as opposed to the model server rejecting the request?
+ */
+export function isRecoverableParseFailure(err: unknown): boolean {
+  if (err instanceof ToolCallParseError) return true;
+  if (!(err instanceof GrammarError)) return false;
+  // `toLlmFailure` files a llama-server 400/413/422 as `GrammarError`
+  // too: the server is telling us THIS request was malformed or too
+  // large. Re-prompting cannot change that, and the turn should fail
+  // with the diagnosis instead of burning two more steps.
+  return !(err.cause instanceof LlamaServerError);
+}
+
+/**
+ * The `### notice` block for the step that follows a rejected
+ * completion. Says what was rejected, that nothing ran, and what to do
+ * differently — including the one fix that actually resolves the common
+ * case, which is an argument too large to re-emit in one call.
+ */
+export function formatParseFailureNotice(reason: string): string {
+  return [
+    `Your previous output was rejected before any tool ran: ${clip(reason)}`,
+    "Nothing you attempted has happened yet — no file was written, no command ran.",
+    "Emit the call again. Every tool call's arguments must be one valid JSON object, complete and correctly escaped.",
+    "If the arguments were large (a long file body, a big patch), that is the likely cause: split the work into several smaller calls instead of one oversized one.",
+  ].join("\n");
+}
+
+/**
+ * Fold the notice into whatever the step already owed the model. The
+ * loop detector and `composeSteerNotice` share this slot, and the
+ * rejection comes first: it explains why the step is being taken again
+ * at all, which is context for the instruction that follows.
+ */
+export function composeParseFailureNotice(
+  existing: string | undefined,
+  reason: string,
+): string {
+  const block = formatParseFailureNotice(reason);
+  if (existing === undefined || existing.length === 0) return block;
+  return `${block}\n\n${existing}`;
+}
+
+/**
+ * The transcript row a failed turn leaves behind.
+ *
+ * Recorded, never emitted as an `assistant_reply` event: every surface
+ * already prints its own `Turn failed [...]` line from `loop_failed`,
+ * and a second copy would arrive as a message from the agent. What the
+ * row is for is the NEXT turn — without it the model is asked to "try
+ * again" with a transcript in which its own attempt simply never
+ * happened, and it repeats the mistake verbatim.
+ */
+export function formatTurnFailedRecord(
+  category: string,
+  message: string,
+): string {
+  return `(this turn failed before it could answer — ${category}: ${clip(message)}. Nothing from it took effect.)`;
+}
+
+function clip(text: string): string {
+  const flat = text.trim().replace(/\s+/g, " ");
+  if (flat.length <= MAX_REASON_CHARS) return flat;
+  return `${[...flat].slice(0, MAX_REASON_CHARS).join("")}…`;
+}

--- a/src/cli/trace-formatter.test.ts
+++ b/src/cli/trace-formatter.test.ts
@@ -99,3 +99,31 @@ describe("formatTraceChronology loop_detected", () => {
     expect(only).toContain("detector=generic_repeat");
   });
 });
+
+describe("formatTraceChronology parse_failure_recovered", () => {
+  const event: TraceEvent = {
+    type: "parse_failure_recovered",
+    seq: 11,
+    sessionId: "s-1",
+    ts: Date.parse("2026-09-01T10:00:00.000Z"),
+    turnIndex: 0,
+    stepIndex: 2,
+    attempt: 1,
+    budget: 2,
+    reason: 'tool call "os.fs.write" arguments are not a valid JSON object',
+  };
+
+  it("says which step was retried, how far into the budget, and why", () => {
+    // Without this row a post-mortem sees an inference with no tool call
+    // and no text behind it, and nothing saying the step was retried.
+    const line = render([event]);
+    expect(line).toContain("#11 parse_failure_recovered");
+    expect(line).toContain("step=2 attempt=1/2");
+    expect(line).toContain("os.fs.write");
+  });
+
+  it("truncates a reason that quotes the model's own output", () => {
+    const line = render([{ ...event, reason: "x".repeat(400) }]);
+    expect(line.length).toBeLessThan(300);
+  });
+});

--- a/src/cli/trace-formatter.ts
+++ b/src/cli/trace-formatter.ts
@@ -84,6 +84,8 @@ function formatTraceEvent(event: TraceEvent, raw: boolean): string {
       return `${head} steps=${event.stepsTaken}/${event.stepCeiling} elapsed=${Math.round(
         event.elapsedMs / 1000,
       )}s`;
+    case "parse_failure_recovered":
+      return `${head} step=${event.stepIndex} attempt=${event.attempt}/${event.budget} reason=${truncate(event.reason, 120, raw)}`;
     case "provider_waiting":
       return `${head} attempt=${event.attempt} waited=${Math.round(
         event.waitedMs / 1000,

--- a/src/tracing/trace/trace-event.ts
+++ b/src/tracing/trace/trace-event.ts
@@ -30,6 +30,7 @@ export type TraceEvent =
   | TraceTaskContinued
   | TraceProviderWaiting
   | TraceProviderRecovered
+  | TraceParseFailureRecovered
   | TraceLessonDeprecated
   | TraceVoteApplied
   | TraceVoteRejected
@@ -186,6 +187,21 @@ export interface TraceProviderWaiting extends TraceEventBase {
   waitedMs: number;
   maxWaitMs: number;
   nextRetryMs: number;
+  reason: string;
+}
+
+/**
+ * A completion could not be read as tool calls and the turn spent
+ * another step on it instead of ending. This is the row that explains
+ * an inference with no tool call and no text behind it — without it a
+ * post-mortem sees a step that simply did nothing.
+ */
+export interface TraceParseFailureRecovered extends TraceEventBase {
+  type: "parse_failure_recovered";
+  turnIndex: number;
+  stepIndex: number;
+  attempt: number;
+  budget: number;
   reason: string;
 }
 

--- a/src/tracing/trace/trace-recorder.test.ts
+++ b/src/tracing/trace/trace-recorder.test.ts
@@ -31,6 +31,27 @@ describe("createTraceRecorder", () => {
     });
   });
 
+  it("records a parse-failure recovery against the current turn and step", () => {
+    const { events, emit } = collector();
+    const rec = createTraceRecorder({ sessionId: "s-parse", emit, now });
+    rec.onAgentEvent({ type: "turn_started", turnIndex: 3 } as AgentLoopEvent);
+    rec.onAgentEvent({
+      type: "parse_failure_recovered",
+      stepIndex: 2,
+      attempt: 1,
+      budget: 2,
+      reason: 'tool call "os.fs.write" arguments are not a valid JSON object',
+    } as AgentLoopEvent);
+    expect(events.find((e) => e.type === "parse_failure_recovered")).toMatchObject({
+      type: "parse_failure_recovered",
+      sessionId: "s-parse",
+      turnIndex: 3,
+      stepIndex: 2,
+      attempt: 1,
+      budget: 2,
+    });
+  });
+
   it("attaches user_message to the next turn_started", () => {
     const { events, emit } = collector();
     const rec = createTraceRecorder({ sessionId: "s-2", emit, now });

--- a/src/tracing/trace/trace-recorder.ts
+++ b/src/tracing/trace/trace-recorder.ts
@@ -381,6 +381,19 @@ export function createTraceRecorder(
             stepCeiling: event.stepCeiling,
           });
           return;
+        case "parse_failure_recovered":
+          push({
+            type: "parse_failure_recovered",
+            seq: nextSeq(),
+            sessionId,
+            ts: now(),
+            turnIndex: currentTurnIndex,
+            stepIndex: event.stepIndex,
+            attempt: event.attempt,
+            budget: event.budget,
+            reason: event.reason,
+          });
+          return;
         case "provider_waiting":
           push({
             type: "provider_waiting",

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -856,6 +856,47 @@ describe("reduceTuiState", () => {
   });
 });
 
+describe("parse-failure recovery", () => {
+  const recovered = (over: Record<string, unknown> = {}): TuiAction => ({
+    type: "agent_event",
+    event: {
+      type: "parse_failure_recovered",
+      stepIndex: 3,
+      attempt: 1,
+      budget: 2,
+      reason: 'tool call "os.fs.write" arguments are not a valid JSON object',
+      ...over,
+    } as never,
+  });
+
+  it("says the output was rejected and that the turn is trying again", () => {
+    const next = reduceTuiState(createInitialTuiState(fakeSession()), recovered());
+    const line = next.feed.at(-1)?.line ?? "";
+    expect(line).toContain("could not be read as a tool call");
+    expect(line).toContain("os.fs.write");
+    expect(line).toContain("(1/2)");
+  });
+
+  it("clips a reason that quotes the model's own output", () => {
+    const next = reduceTuiState(
+      createInitialTuiState(fakeSession()),
+      recovered({ reason: "x".repeat(500) }),
+    );
+    expect((next.feed.at(-1)?.line ?? "").length).toBeLessThan(250);
+  });
+
+  it("leaves one line per recovery, not one per step", () => {
+    const next = apply(createInitialTuiState(fakeSession()), [
+      recovered(),
+      recovered({ attempt: 2, stepIndex: 4 }),
+    ]);
+    const lines = next.feed.filter((row) =>
+      row.line.includes("could not be read as a tool call"),
+    );
+    expect(lines).toHaveLength(2);
+  });
+});
+
 describe("provider outage", () => {
   const waiting = (over: Record<string, unknown> = {}): TuiAction => ({
     type: "agent_event",

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -596,6 +596,22 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         color: "gray",
       });
     }
+    case "parse_failure_recovered": {
+      // Rendered, unlike `loop_detected`: this step produced no tool
+      // call and no text, so without a line the feed shows a gap the
+      // operator has no way to read. One line per recovery — there are
+      // at most `budget` of them.
+      const reason =
+        event.reason.length > 120
+          ? `${event.reason.slice(0, 120)}…`
+          : event.reason;
+      return appendFeed(state, {
+        kind: "runtime_info",
+        stepIndex: event.stepIndex,
+        line: `» the model's output could not be read as a tool call (${reason}) — trying again (${event.attempt}/${event.budget})`,
+        color: "yellow",
+      });
+    }
     case "loop_detected":
       // Deliberately not rendered: the loop detector's own `### notice`
       // changes what the model does, and the operator sees the effect


### PR DESCRIPTION
## What

A completion the runtime cannot read as tool calls used to end the turn. Reported from a live session: the model emitted an `os.fs.write` whose `function.arguments` were not valid JSON, and the whole turn stopped — `Turn failed [grammar]: tool call "os.fs.write" arguments are not a valid JSON object`, `lastError` set on the session, **nothing in the transcript**, and no further work until the operator noticed the silence and typed "try again".

The step executor does already give such a completion one in-step repair, so it is not true that the model gets no feedback at all. But that repair replays the same request under `REPAIR_MAX_TOKENS` (1024). The cap is deliberate — it stops a reasoning model re-deliberating for minutes — and it is also why the repair cannot rescue this particular failure: re-emitting a large argument does not fit in 1024 tokens, so the repair truncates and fails the parse a second time.

After this change:

- The loop spends up to `PARSE_RECOVERY_BUDGET` (2) **ordinary** steps on a rejected completion. Each retry is a fresh prompt at the full completion budget — which the capped repair is not — carrying a `### notice` that names the rejection, states that nothing ran, and points at oversized arguments as the likely cause. That is the feedback the model had no way to get before.
- Only a body **our parser** rejected qualifies: `ToolCallParseError`, or a `GrammarError` whose cause is not a `LlamaServerError`. A llama-server 400/413/422 wears the same `GrammarError` shape and is the server refusing the request — re-prompting reproduces it exactly, so it still fails at once and the operator gets the diagnosis now rather than two wasted steps later.
- A turn that still fails leaves a row in the transcript (`(this turn failed before it could answer — grammar: … Nothing from it took effect.)`). Recorded only, with no `assistant_reply` event: every surface already prints its own line from `loop_failed`, and a second copy would arrive as a message from the agent.
- The TUI feed gets one line per recovery, and so does the trace (`parse_failure_recovered`, with step, attempt/budget and reason). The recovering step produces neither a tool call nor text, so without them both the live feed and a post-mortem over `<stateDir>/traces/<sessionId>.ndjson` show a step that simply did nothing.

## Why

Two separate costs, both in the report:

**The agent stalls invisibly.** Recovery depended on a human noticing that nothing was happening. A parse failure is exactly the kind a second attempt fixes, and the loop already has the seam for it — `transport` failures park and replay, and PR #359 does the same for a truncated completion. This is the third member of that family.

**The next turn was blind.** The failure branch of `runTurn` set `lastError` and returned without touching `state.turns`, while the `max_steps` branch three lines below records a synthetic `assistant_reply`. So "try again" rebuilt the prompt from a history in which the model's attempt simply never happened — and the model reproduced it verbatim.

The step is counted (`stepsTaken += 1`) and `legMadeProgress` stays false, so a leg made entirely of rejected completions still stops at its boundary as `no_progress`. Unlike the outage park this does **not** decrement `i`: the inference was really spent, and taking the next index avoids the leg-boundary double-run that a replay needs a guard for.

Invariants written up in AGENTS.md § "An unparseable completion is retried, not fatal".

## How it was verified

- `npm run lint` clean
- `npx vitest run src/agent src/tui/agent-event-reducer.test.ts` — 20 files / 382 tests green
- `npx vitest run src/session src/tui src/http src/tasks src/runtime --no-file-parallelism` — 287 files / 3119 tests green (no baseline failures in scope)
- `npx vitest run src/agent src/cli src/tracing src/tui` — 295 files / 3328 tests green
- Every new behaviour test was checked against a defeated build (`isRecoverableParseFailure` forced to `false`, the `recordTurn` removed): the three new `agent-loop` tests flip to failing, so none of them is vacuous.
- New tests: `src/agent/parse-failure-recovery.test.ts` (13), the trace row in `src/cli/trace-formatter.test.ts` and `src/tracing/trace/trace-recorder.test.ts`, plus four in `src/agent/agent-loop.test.ts` (recovers to `reason: "reply"`; the notice reaches the next prompt; the failed turn's last transcript row is the record; a llama-server 413 does **not** recover and costs exactly one call) and three in `src/tui/agent-event-reducer.test.ts`.
- The pinned test "classifies persistent parse failure as GrammarError after one retry" is updated rather than worked around: a persistent failure still ends as `failed`/`grammar`, now after `2 × (PARSE_RECOVERY_BUDGET + 1)` calls.

## Notes for review

- Touches the same `catch` block as #359 (truncated-completion recovery), so one of the two will need a trivial rebase. The behaviours do not overlap: #359 fires only when `completion.truncated` is set, this one only when the body parsed badly without being cut off.
- `IntegrationField`/config untouched; no config version bump.
