### PR TITLE
feat(fusion): the orchestrator plans and reviews, the workers do the work

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -76,6 +76,13 @@ export interface AgentLoopDependencies {
    * gate uses for `approvalRequired`.
    */
   isPlanMode?: () => boolean;
+  /**
+   * Whether the run mode resolves to fusion right now. Read per turn,
+   * for the reason `isPlanMode` is read per call: the operator can flip
+   * the mode between turns and the next turn should honour it. Absent
+   * (embedders, tests) means "not fusion", which gates nothing.
+   */
+  isFusionMode?: () => boolean;
   slotManager: SlotManager;
   grammar: string;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
@@ -838,6 +845,14 @@ export class AgentLoop {
       }
     }
 
+    // Fusion's division of labour is per TURN, not per session: each
+    // turn starts owing a plan and a fan-out before it may write. An
+    // ephemeral turn is a worker's own — the gate is the orchestrator's
+    // and must never close on the hands it is meant to free.
+    const fusionOrchestratorTurn =
+      (this.deps.isFusionMode?.() ?? false) && options.ephemeral !== true;
+    let fusionDelegatedThisTurn = false;
+
     let reason: AgentLoopReason = "max_steps";
     let stepsTaken = 0;
     let runError: Error | null = null;
@@ -1105,6 +1120,15 @@ export class AgentLoop {
             registry: this.deps.registry,
             ...(this.deps.isPlanMode
               ? { isPlanMode: this.deps.isPlanMode }
+              : {}),
+            ...(fusionOrchestratorTurn
+              ? {
+                  isFusionOrchestrator: () => true,
+                  hasDelegated: () => fusionDelegatedThisTurn,
+                  onDelegated: () => {
+                    fusionDelegatedThisTurn = true;
+                  },
+                }
               : {}),
             slotManager: this.deps.slotManager,
             grammar: activeGrammar,

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -1170,3 +1170,92 @@ describe("test-repeat gate (issue #118)", () => {
     ).toBeUndefined();
   });
 });
+
+describe("the fusion orchestrator gate in the executor", () => {
+  const ctrl = new AbortController();
+
+  it("fills a held-back mutation's slot instead of dispatching it", async () => {
+    // The refusal has to arrive as this call's RESULT: the model reads
+    // tool results, not runtime state, and a dropped call would leave it
+    // waiting for an answer that never comes.
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => false,
+      },
+    );
+    expect(run).not.toHaveBeenCalled();
+    expect(out.results[0]?.compressed?.status).toBe("error");
+    expect(out.results[0]?.compressed?.summary).toContain("fusion.delegate");
+  });
+
+  it("dispatches the same call once the turn has delegated", async () => {
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => true,
+      },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves reads alone while the turn is still planning", async () => {
+    const run = vi.fn(async () => okResult("os.fs.read"));
+    const registry = buildRegistry({ "os.fs.read": run }, true);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.read", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => false,
+      },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the turn as delegated when the fan-out comes back", async () => {
+    // However it went: a fan-out whose workers all failed still leaves
+    // the orchestrator holding results it must be able to act on.
+    let delegated = false;
+    const registry = buildRegistry(
+      { "fusion.delegate": async () => okResult("fusion.delegate") },
+      false,
+    );
+    await executeBatch(
+      toBatchInputs([{ tool: "fusion.delegate", args: { tasks: [] } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => delegated,
+        onDelegated: () => {
+          delegated = true;
+        },
+      },
+    );
+    expect(delegated).toBe(true);
+  });
+
+  it("gates nothing when the turn is not the orchestrator's", async () => {
+    // A worker's own turn, and every non-fusion run mode.
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      { ...ctx(ctrl.signal), isFusionOrchestrator: () => false },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -1,4 +1,5 @@
 import { checkPlanMode } from "./plan-mode.js";
+import { checkFusionOrchestrator } from "./fusion-orchestrator-mode.js";
 import type { ToolCallPayload } from "../llm/grammar/tool-call-grammar.js";
 import {
   compressToolResult,
@@ -127,6 +128,17 @@ export interface BatchExecutionContext {
    * the operator flips it mid-session. Absent ⇒ plan mode is off.
    */
   isPlanMode?: () => boolean;
+  /**
+   * True while this turn is the ORCHESTRATOR's turn in fusion mode (not
+   * a worker's, not another run mode). When it is, mutations are held
+   * back until the turn has fanned work out at least once — see
+   * `fusion-orchestrator-mode.ts`.
+   */
+  isFusionOrchestrator?: () => boolean;
+  /** Whether this turn has already completed a `fusion.delegate` call. */
+  hasDelegated?: () => boolean;
+  /** Called once a `fusion.delegate` call comes back, however it went. */
+  onDelegated?: () => void;
   /**
    * Names of skills already present in `SessionState.loadedSkills`. A
    * `skill.view` call targeting one of these is short-circuited with a
@@ -291,6 +303,25 @@ export async function executeBatch(
       });
       continue;
     }
+    // Then fusion's division of labour, for the same reason in the same
+    // order: a mutation held back until the turn has delegated must not
+    // spend a slot in the loop tracker either.
+    const fusion = runFusionOrchestratorGate(input, registry, ctx);
+    if (!fusion.proceed && fusion.vetoResult) {
+      ctx.onCallStarted?.({ batchIndex: input.batchIndex, batchSize });
+      slots[input.batchIndex] = {
+        ...slots[input.batchIndex]!,
+        compressed: fusion.vetoResult,
+        durationMs: 0,
+      };
+      ctx.onCallFinished?.({
+        batchIndex: input.batchIndex,
+        batchSize,
+        result: fusion.vetoResult,
+        durationMs: 0,
+      });
+      continue;
+    }
     const gate = runSyncLoopGate(input, ctx, loopSignals);
     if (!gate.proceed && gate.vetoResult) {
       ctx.onCallStarted?.({ batchIndex: input.batchIndex, batchSize });
@@ -384,6 +415,10 @@ export async function executeBatch(
       compressed,
       durationMs,
     };
+    // A fan-out that came back — whatever the workers made of it — opens
+    // the orchestrator's own write gate for the rest of the turn, so it
+    // can merge what it got and run the parts workers had to hand up.
+    if (input.call.tool === "fusion.delegate") ctx.onDelegated?.();
     // Record the real outcome so the next step's gate sees a completed
     // (args + result) entry. Terminal verbs are not tracked.
     if (ctx.tracker && input.resourceClass !== "terminal") {
@@ -542,6 +577,25 @@ function runPlanModeGate(
 ): { proceed: boolean; vetoResult?: CompressedToolResult } {
   if (!ctx.isPlanMode?.()) return { proceed: true };
   const verdict = checkPlanMode(input.call.tool, registry);
+  if (verdict.allowed) return { proceed: true };
+  return { proceed: false, vetoResult: verdict.refusal! };
+}
+
+/**
+ * Fusion's division of labour. Sits beside the plan-mode gate because it
+ * answers the same kind of question — is this call going to run at all —
+ * and it runs after it: plan mode is the operator's explicit "not yet",
+ * and that outranks a mode's internal shape.
+ */
+function runFusionOrchestratorGate(
+  input: BatchCallInput,
+  registry: ToolRegistry,
+  ctx: BatchExecutionContext,
+): { proceed: boolean; vetoResult?: CompressedToolResult } {
+  if (!ctx.isFusionOrchestrator?.()) return { proceed: true };
+  const verdict = checkFusionOrchestrator(input.call.tool, registry, {
+    delegated: ctx.hasDelegated?.() ?? false,
+  });
   if (verdict.allowed) return { proceed: true };
   return { proceed: false, vetoResult: verdict.refusal! };
 }

--- a/src/agent/fusion-orchestrator-mode.test.ts
+++ b/src/agent/fusion-orchestrator-mode.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkFusionOrchestrator,
+  refusalFor,
+} from "./fusion-orchestrator-mode.js";
+
+/** The two facts the gate reads off a tool: does it exist, does it mutate. */
+function registryWith(
+  tools: Record<string, { readonly: boolean }>,
+): { get: (n: string) => { readonly: boolean }; has: (n: string) => boolean } {
+  return {
+    has: (name) => name in tools,
+    get: (name) => {
+      const tool = tools[name];
+      if (!tool) throw new Error(`unknown tool ${name}`);
+      return tool;
+    },
+  };
+}
+
+const REGISTRY = registryWith({
+  "os.fs.read": { readonly: true },
+  "os.fs.write": { readonly: false },
+  "os.shell.run": { readonly: false },
+  "fusion.delegate": { readonly: false },
+  reply: { readonly: false },
+  finish: { readonly: false },
+});
+
+const BEFORE = { delegated: false };
+const AFTER = { delegated: true };
+
+describe("the fusion orchestrator gate", () => {
+  it("lets the orchestrator read while it is still planning", () => {
+    // Planning *is* reading: a gate that blocked it would leave the
+    // model choosing a split it has no basis for.
+    expect(checkFusionOrchestrator("os.fs.read", REGISTRY, BEFORE).allowed).toBe(
+      true,
+    );
+  });
+
+  it("holds back the first mutation until the turn has delegated", () => {
+    for (const tool of ["os.fs.write", "os.shell.run"]) {
+      const verdict = checkFusionOrchestrator(tool, REGISTRY, BEFORE);
+      expect(verdict.allowed).toBe(false);
+      expect(verdict.refusal?.status).toBe("error");
+      // The exit matters more than the veto: a bare refusal reads as a
+      // broken tool and gets retried.
+      expect(verdict.refusal?.summary).toContain("fusion.delegate");
+      expect(verdict.refusal?.details).toMatchObject({
+        fusion_orchestrator: true,
+        delegated: false,
+      });
+    }
+  });
+
+  it("never gates the fan-out itself", () => {
+    // The one call the refusal points at cannot be the one it blocks.
+    expect(
+      checkFusionOrchestrator("fusion.delegate", REGISTRY, BEFORE).allowed,
+    ).toBe(true);
+  });
+
+  it("never gates the terminal verbs", () => {
+    // Vetoing `reply` would veto the turn's own exit — the mistake
+    // plan mode documents and avoids for the same reason.
+    for (const tool of ["reply", "finish"]) {
+      expect(checkFusionOrchestrator(tool, REGISTRY, BEFORE).allowed).toBe(true);
+    }
+  });
+
+  it("opens up once the workers have reported", () => {
+    // Integration is the orchestrator's own job, and so is anything a
+    // worker had to hand up for approval. Both are writes.
+    for (const tool of ["os.fs.write", "os.shell.run"]) {
+      expect(checkFusionOrchestrator(tool, REGISTRY, AFTER).allowed).toBe(true);
+    }
+  });
+
+  it("passes an unknown tool through untouched", () => {
+    // The executor's unknown-tool path has the better message, and
+    // answering "delegate first" to a typo sends the model hunting for
+    // the wrong problem.
+    expect(
+      checkFusionOrchestrator("os.fs.wirte", REGISTRY, BEFORE).allowed,
+    ).toBe(true);
+  });
+
+  it("names the tool it refused", () => {
+    const refusal = refusalFor("os.fs.write");
+    expect(refusal.tool).toBe("os.fs.write");
+    expect(refusal.summary).toContain("`os.fs.write`");
+  });
+});

--- a/src/agent/fusion-orchestrator-mode.ts
+++ b/src/agent/fusion-orchestrator-mode.ts
@@ -1,0 +1,106 @@
+import type { CompressedToolResult } from "../compressor/result-compressor.js";
+import type { ToolRegistry } from "../tools/tool-registry.js";
+
+/**
+ * Fusion's division of labour, enforced instead of merely asked for.
+ *
+ * In fusion mode the expensive cloud model is the orchestrator and the
+ * local ones are the hands: it decides the approach, splits the work,
+ * writes a self-contained brief per worker, reads what comes back,
+ * integrates it, and sends rework back out. The `### fusion` block has
+ * said so since the mode shipped — and a capable cloud model, handed a
+ * catalog of forty tools, still reads the twelve files itself and never
+ * fans anything out. Advice does not hold against that; the model is
+ * doing what it is good at.
+ *
+ * So the first mutation of a fusion turn is refused until the turn has
+ * delegated at least once. Read the code, plan, then send the doing to
+ * the workers.
+ *
+ * **Why a refusal and not a hidden descriptor.** Removing tools from the
+ * catalog mid-turn rewrites the stable prefix and drops the session's KV
+ * cache (see `effectiveToolDescriptors` in bootstrap). A refusal costs
+ * one tool result and reads as an instruction — the same trade plan mode
+ * makes, and the same one `fusion.delegate` already makes when a worker
+ * calls it.
+ *
+ * **Why it lifts after the first fan-out.** Two things genuinely belong
+ * to the orchestrator afterwards: integration — merging what came back,
+ * which is a write it must be able to make — and anything a worker
+ * handed up because it needed approval, which workers cannot request
+ * (`FUSION_WORKER_APPROVAL_REFUSED`). Keeping the gate closed for the
+ * whole turn would strand both. Rework goes back to the workers because
+ * the guidance says so; that part stays advice, because "this write is
+ * rework rather than integration" is not a thing the runtime can see.
+ *
+ * **What is never gated:** read-only tools (planning *is* reading),
+ * `fusion.delegate` itself, and the terminal verbs — vetoing `reply`
+ * would veto the turn's exit.
+ */
+
+/** Terminal verbs, never gated. Mirrors `plan-mode.ts`, deliberately. */
+const TERMINAL_TOOLS: ReadonlySet<string> = new Set(["reply", "finish"]);
+
+/** The fan-out itself: the one call this gate exists to steer towards. */
+const DELEGATE_TOOL = "fusion.delegate";
+
+export interface FusionOrchestratorVerdict {
+  /** False when the call must not reach the registry. */
+  allowed: boolean;
+  /** The result to fill the call's slot with. Present iff `allowed` is false. */
+  refusal?: CompressedToolResult;
+}
+
+export interface FusionOrchestratorState {
+  /** Whether this turn has already completed a `fusion.delegate` call. */
+  delegated: boolean;
+}
+
+/**
+ * Decide whether `tool` may run on the orchestrator's own turn.
+ *
+ * An unknown tool is allowed through untouched, for the reason plan mode
+ * does the same: the step executor's unknown-tool path has the better
+ * message, and answering "delegate first" to a typo sends the model
+ * looking for the wrong problem.
+ */
+export function checkFusionOrchestrator(
+  tool: string,
+  registry: Pick<ToolRegistry, "get" | "has">,
+  state: FusionOrchestratorState,
+): FusionOrchestratorVerdict {
+  if (state.delegated) return { allowed: true };
+  if (TERMINAL_TOOLS.has(tool) || tool === DELEGATE_TOOL) {
+    return { allowed: true };
+  }
+  if (!registry.has(tool)) return { allowed: true };
+  if (registry.get(tool).readonly) return { allowed: true };
+  return { allowed: false, refusal: refusalFor(tool) };
+}
+
+/**
+ * What the model is told.
+ *
+ * Same three parts plan mode's refusal has, in the same order: the call
+ * did not happen, why, and the exit. The exit is the whole point — a
+ * bare "not permitted" reads as a broken tool and gets retried, while
+ * naming the shape of the brief turns the refusal into the instruction
+ * the orchestrator needed in the first place.
+ */
+export function refusalFor(tool: string): CompressedToolResult {
+  return {
+    tool,
+    status: "error",
+    summary:
+      `fusion is on and this turn has not delegated yet, so \`${tool}\` ` +
+      `was not run. You are the orchestrator: the local workers do the ` +
+      `doing. Finish reading (every read-only tool still works), decide ` +
+      `the approach, then split the work and call \`fusion.delegate\` ` +
+      `— one task per independent part, each with the exact paths, what ` +
+      `counts as done, and the answer format you want back. Once the ` +
+      `workers report, you can write again: merge their results, and ` +
+      `send rework back out rather than doing it yourself.`,
+    details: { fusion_orchestrator: true, tool, delegated: false },
+    truncated: false,
+  };
+}

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -158,6 +158,15 @@ export interface StepDependencies {
    * as `BatchExecutionContext.isPlanMode`. Absent ⇒ off.
    */
   isPlanMode?: () => boolean;
+  /**
+   * Fusion's division of labour, forwarded to the batch context. Set by
+   * the loop only for an ORCHESTRATOR turn in fusion mode; a worker's
+   * own turn and every other run mode leave all three absent, which
+   * gates nothing.
+   */
+  isFusionOrchestrator?: () => boolean;
+  hasDelegated?: () => boolean;
+  onDelegated?: () => void;
   slotManager: SlotManager;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
   /**
@@ -1028,6 +1037,13 @@ async function executeStepInner(
     signal: ctx.signal,
     ...(deps.tracker ? { tracker: deps.tracker } : {}),
     ...(deps.isPlanMode ? { isPlanMode: deps.isPlanMode } : {}),
+    ...(deps.isFusionOrchestrator
+      ? {
+          isFusionOrchestrator: deps.isFusionOrchestrator,
+          ...(deps.hasDelegated ? { hasDelegated: deps.hasDelegated } : {}),
+          ...(deps.onDelegated ? { onDelegated: deps.onDelegated } : {}),
+        }
+      : {}),
     ...(batch.maxWaveSize !== undefined
       ? { maxWaveSize: batch.maxWaveSize }
       : {}),

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -61,7 +61,7 @@ export function isFusionActive(
  */
 export const FUSION_GUIDANCE = [
   "You orchestrate local workers: read enough to decide, plan, delegate the doing, review what comes back, integrate it.",
-  "Plan in the open: list the independent, self-contained parts, each with what it touches and how big it is. Size them — group small ones, give a big one its own worker.",
+  "Plan in the open, then delegate in the same turn — never stop at the plan: list the independent, self-contained parts with what each touches and how big it is, sized so a big one gets its own worker and small ones share.",
   "Send one task per part in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
   "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
   "Until this turn has delegated once, tools that change things are refused for you — the mode working, not a fault.",

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -60,13 +60,15 @@ export function isFusionActive(
  * exactly the block a machine-less build renders.
  */
 export const FUSION_GUIDANCE = [
-  "You orchestrate local worker agents: you plan and they execute. Decide the approach first, then delegate the independent bulk — reading many files, first drafts, boilerplate, tests, wide searches — with `fusion.delegate`.",
-  "Delegate whenever the work splits into independent, self-contained parts, and prefer sending more of them over doing the bulk yourself. You choose `maxWorkers` on each call: nothing caps it but the number of tasks and what this machine can serve.",
-  "Each task's `instructions` must stand alone: exact paths, what counts as done, and the format of the answer you want back. Workers have no memory of this conversation and cannot ask you anything.",
-  "Keep the design, the integration and the review yourself. Never delegate the decision you are being asked to make, or a part that only makes sense with this conversation in front of it — that part is yours to do.",
-  "Call `fusion.delegate` on its own, never alongside other tool calls in the same array — it runs several turns internally and takes a while.",
-  "Read every reply before you use it: verify what came back, merge it yourself, and redo or re-delegate any part that came back `failed` or `needs_orchestrator`.",
-  "Workers cannot reach the user and cannot get approval, so anything that needs a person — a shell command, a write at a low approval level — comes back to you to run.",
+  "You orchestrate local workers: read enough to decide, plan, delegate the doing, review what comes back, integrate it.",
+  "Plan in the open: list the independent, self-contained parts, each with what it touches and how big it is. Size them — group small ones, give a big one its own worker.",
+  "Send one task per part in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
+  "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
+  "Until this turn has delegated once, tools that change things are refused for you — the mode working, not a fault.",
+  "Keep the design, the judgement and the integration: read every reply against its brief, then merge the parts yourself.",
+  "Rework goes back out: anything `failed`, `needs_orchestrator`, or that you want refactored becomes another `fusion.delegate` saying what was wrong.",
+  "Yours alone: the decision you were asked for, a part that only makes sense with this conversation in front of it, and anything needing operator approval — workers cannot reach the user.",
+  "Call `fusion.delegate` on its own, never alongside other tool calls — it runs several turns internally and takes a while.",
 ].join("\n");
 
 /**

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -2303,6 +2303,10 @@ export async function createAgentRuntime(
     // gate is the single live switch rather than a boolean copied into
     // each tool registration.
     isPlanMode: () => planMode,
+    // The same live resolution the `fusion.delegate` descriptor gate
+    // reads, so the tool the orchestrator is being pushed towards is
+    // always in the catalog when the push happens.
+    isFusionMode: () => resolveCurrentRunMode().effective === "fusion",
     slotManager,
     grammar,
     llmComplete,


### PR DESCRIPTION
Fusion's division of labour has been advice since the mode shipped, and a capable cloud model handed a catalog of forty tools reads the twelve files itself and never fans anything out. A QA run on v0.5.6 showed exactly that: nine steps, twelve `os.fs.read` calls, **zero** delegations, every completion on the cloud model — with the orange `fusion` chip on screen the whole time.

### The gate

The first mutation of a fusion turn is refused until the turn has delegated once. Read, plan, split, delegate — then the gate opens, because two things genuinely belong to the orchestrator afterwards: **integration**, which is a write, and anything a worker handed up because it needed **approval**, which workers cannot request.

- A refusal, not a hidden descriptor: removing tools mid-turn rewrites the stable prefix and drops the session's KV cache, while a refusal costs one tool result and reads as an instruction. Same trade `plan-mode.ts` makes, and the same one `fusion.delegate` already makes for a worker that calls it.
- Never gated: read-only tools (planning *is* reading), the fan-out itself, and the terminal verbs — vetoing `reply` would veto the turn's exit.
- Never gated on a worker's own turn: the flag is per turn and skips ephemeral ones, so the hands the mode exists to free stay free.

### The loop, in the guidance

Rewritten around what the gate now enforces: plan in the open **and delegate in the same turn**, parts sized so a big one gets its own worker and small ones share, one task per part in one call, briefs that stand alone, read every reply against its brief, merge yourself, and send rework back out — `failed`, `needs_orchestrator`, or anything you want refactored — instead of quietly absorbing it. Same prefix budget as before: 1397 of 1400 bytes.

The "delegate in the same turn" clause is not decoration: the first live run of this branch, on a cheap auto-routed model, read the files and replied "no edits were needed" without touching anything. Stopping after the plan is the cheapest way to satisfy "plan in the open".

### Verified

`npx tsc --noEmit` clean; new unit tests for the gate (7) and executor-level tests (5, including that a held-back call's slot is filled with the refusal rather than dropped, that reads pass through while planning, that the same call dispatches once the turn has delegated, and that nothing is gated outside fusion); `src/prompt` and `src/agent` suites green.