### PR TITLE
fix(telegram): stop intraword asterisks being eaten as italics

### DIFF
--- a/src/channels/telegram/markdown-to-html.test.ts
+++ b/src/channels/telegram/markdown-to-html.test.ts
@@ -106,6 +106,23 @@ describe("convertMarkdownToTelegramHtml", () => {
       ],
       ["an ASCII snake_case identifier", "snake_case_name", "snake_case_name"],
       ["a spaced underscore", "a _ b _ c", "a _ b _ c"],
+      // Scripts written without spaces are exempt from the *word*
+      // guard (see below), but the exemption is per-character: real
+      // arithmetic puts an ASCII operand next to the `*`, so the same
+      // MATLAB line embedded in Chinese prose is still protected.
+      [
+        "a loose pair spanning a call inside Chinese prose",
+        "这是 20*log10(abs(15-1*25)) 的结果",
+        "这是 20*log10(abs(15-1*25)) 的结果",
+      ],
+      // CommonMark forbids intraword `_` in every script, CJK
+      // included, so there is nothing to give back here.
+      ["a Chinese underscore run", "这是_重点_内容", "这是_重点_内容"],
+      // The flanking character is U+20E3 COMBINING ENCLOSING KEYCAP,
+      // which is a mark rather than a digit; the word guard counts
+      // marks so the keycap behaves like the bare digit beside it.
+      ["a keycap-flanked pair", "1️⃣*x*", "1️⃣*x*"],
+      ["a digit-flanked pair", "1*x*", "1*x*"],
     ];
     for (const [name, input, expected] of literal) {
       it(`leaves ${name} literal`, () => {
@@ -136,6 +153,15 @@ describe("convertMarkdownToTelegramHtml", () => {
         "это _очень_ важно",
         "это <i>очень</i> важно",
       ],
+      // Chinese, Japanese, Korean and Thai are written without spaces
+      // between words, so *every* emphasis run in them is flanked by
+      // letters. Applying the word guard there is not a heuristic, it
+      // is a blanket disable of single-`*` italics for the language —
+      // these four are the reason `SPACELESS_SCRIPT` is exempt.
+      ["Chinese prose", "这是*重点*内容", "这是<i>重点</i>内容"],
+      ["Japanese prose", "これは*重要*です", "これは<i>重要</i>です"],
+      ["Korean prose", "이것은*중요*합니다", "이것은<i>중요</i>합니다"],
+      ["Thai prose", "ราคา*สอง*บาท", "ราคา<i>สอง</i>บาท"],
     ];
     for (const [name, input, expected] of emphasised) {
       it(`still emphasises ${name}`, () => {
@@ -195,6 +221,30 @@ describe("convertMarkdownToTelegramHtml", () => {
 
     it("refuses an underscore run that would cross a bold tag", () => {
       expect(convertMarkdownToTelegramHtml("**_ _a** _")).toBe("<b>_ _a</b> _");
+    });
+
+    it("keeps bold working in a script written without spaces", () => {
+      expect(convertMarkdownToTelegramHtml("这是**重点**内容")).toBe(
+        "这是<b>重点</b>内容",
+      );
+    });
+
+    // A `*` inside a URL splits the `<a href="…">` that `renderLinks`
+    // emitted, so the emphasis body holds no complete tag for
+    // `tagsBalanced` to reject and the run used to be wrapped anyway —
+    // producing `<i>&lt;a href="http://x/</i>">a</a>*`, an orphan
+    // `</a>` that Telegram answers with a 400. A delimiter sitting
+    // inside an already-emitted tag now refuses the candidate.
+    it("refuses a run whose delimiter sits inside an emitted anchor", () => {
+      expect(convertMarkdownToTelegramHtml("*[a](http://x/*)*")).toBe(
+        '*<a href="http://x/*">a</a>*',
+      );
+    });
+
+    it("refuses an underscore run whose delimiter sits inside an anchor", () => {
+      expect(convertMarkdownToTelegramHtml("_[a](http://x/_)_")).toBe(
+        '_<a href="http://x/_">a</a>_',
+      );
     });
   });
 

--- a/src/channels/telegram/markdown-to-html.test.ts
+++ b/src/channels/telegram/markdown-to-html.test.ts
@@ -123,6 +123,16 @@ describe("convertMarkdownToTelegramHtml", () => {
       // marks so the keycap behaves like the bare digit beside it.
       ["a keycap-flanked pair", "1️⃣*x*", "1️⃣*x*"],
       ["a digit-flanked pair", "1*x*", "1*x*"],
+      // A `*` carrying VARIATION SELECTOR-16 is itself part of the
+      // `*️⃣` keycap emoji, so it is not a closing delimiter: reading
+      // it as one would emit `<i>x</i>️⃣` and delete the `*` out of
+      // an emoji. This is why the selector exemption applies to the
+      // opening flank only.
+      ["a pair closed by a keycap asterisk", "*x*️⃣", "*x*️⃣"],
+      // Combining marks that really are part of a word still block:
+      // Devanagari `की` ends in U+0940, decomposed `é` in U+0301.
+      ["a Devanagari-flanked pair", "की*x*", "की*x*"],
+      ["a pair flanked by a decomposed letter", "é*x*", "é*x*"],
     ];
     for (const [name, input, expected] of literal) {
       it(`leaves ${name} literal`, () => {
@@ -162,6 +172,24 @@ describe("convertMarkdownToTelegramHtml", () => {
       ["Japanese prose", "これは*重要*です", "これは<i>重要</i>です"],
       ["Korean prose", "이것은*중요*합니다", "이것은<i>중요</i>합니다"],
       ["Thai prose", "ราคา*สอง*บาท", "ราคา<i>สอง</i>บาท"],
+      // VARIATION SELECTOR-16 is a combining mark and so falls in
+      // `WORD_FLANK`, but the `⚠` it attaches to is a symbol, not a
+      // word. Counting it disabled italics after every emoji spelled
+      // with a selector — which is most of the ones agents reach for
+      // at the start of a warning line.
+      [
+        "a run opened after a variation-selector emoji",
+        "⚠️*Do not* run this",
+        "⚠️<i>Do not</i> run this",
+      ],
+      [
+        "an underscore run opened after a variation-selector emoji",
+        "ℹ️_note_",
+        "ℹ️<i>note</i>",
+      ],
+      // The same symbol without the selector always worked; the two
+      // have to agree.
+      ["a run opened after a bare symbol", "⚠*x*", "⚠<i>x</i>"],
     ];
     for (const [name, input, expected] of emphasised) {
       it(`still emphasises ${name}`, () => {

--- a/src/channels/telegram/markdown-to-html.test.ts
+++ b/src/channels/telegram/markdown-to-html.test.ts
@@ -47,11 +47,12 @@ describe("convertMarkdownToTelegramHtml", () => {
     );
   });
 
-  // Word-flanked asterisks are multiplication, not emphasis. Reading
-  // them as emphasis does not merely restyle the text: Telegram turns
-  // `<i>` into italics and the `*` characters are gone from the
-  // rendered reply, so `2*pi*5` reaches the operator as `2pi5`.
-  describe("asterisk emphasis requires non-word flanking", () => {
+  // Word-flanked asterisks are multiplication, not emphasis, and so
+  // are space-flanked ones. Reading either as emphasis does not merely
+  // restyle the text: Telegram turns `<i>` into italics and the `*`
+  // characters are gone from the rendered reply, so `2*pi*5` reaches
+  // the operator as `2pi5` and `G1 * G2 * G3` as `G1  G2  G3`.
+  describe("asterisk emphasis requires non-word, non-space flanking", () => {
     const literal: Array<[name: string, input: string, expected: string]> = [
       ["a product of two factors", "2*pi*5", "2*pi*5"],
       [
@@ -65,6 +66,46 @@ describe("convertMarkdownToTelegramHtml", () => {
         "G_cont = 2*pi*5 and G1*G2*G3",
         "G_cont = 2*pi*5 and G1*G2*G3",
       ],
+      // The same arithmetic written with spaces around the operator.
+      // The word guard alone does not reach these — the flanks are
+      // spaces — but a `*` followed by whitespace cannot open emphasis
+      // under CommonMark either, and these are the shapes an agent
+      // emits when it pretty-prints a control-systems script.
+      [
+        "a spaced chain of transfer functions",
+        "G_cont = G1 * G2 * G3",
+        "G_cont = G1 * G2 * G3",
+      ],
+      ["a spaced product", "omega = 2 * pi * 5", "omega = 2 * pi * 5"],
+      [
+        "a spaced loose pair spanning a call",
+        "y = 20 * log10(abs(15 - 1 * 25))",
+        "y = 20 * log10(abs(15 - 1 * 25))",
+      ],
+      [
+        "Octave element-wise multiplication",
+        "matrix A .* B .* C",
+        "matrix A .* B .* C",
+      ],
+      [
+        "a SQL star next to a comparison",
+        "SELECT * FROM t WHERE c = *",
+        "SELECT * FROM t WHERE c = *",
+      ],
+      // `\w` is ASCII-only in JS, so the word guard on its own leaves
+      // Cyrillic-flanked products emphasised; the rule uses Unicode
+      // letter/number classes so prose in any script behaves the same.
+      ["a product inside Cyrillic prose", "пи*2*пи", "пи*2*пи"],
+      ["a Cyrillic factor", "цена 2*пи*5 герц", "цена 2*пи*5 герц"],
+      // The `_` rule had the same ASCII-only leak: `snake_case_name`
+      // was safe but its Cyrillic equivalent was not.
+      [
+        "a Cyrillic snake_case identifier",
+        "слово_это_слово",
+        "слово_это_слово",
+      ],
+      ["an ASCII snake_case identifier", "snake_case_name", "snake_case_name"],
+      ["a spaced underscore", "a _ b _ c", "a _ b _ c"],
     ];
     for (const [name, input, expected] of literal) {
       it(`leaves ${name} literal`, () => {
@@ -80,6 +121,21 @@ describe("convertMarkdownToTelegramHtml", () => {
       ["followed by punctuation", "*this*.", "<i>this</i>."],
       ["two runs on one line", "*one* and *two*", "<i>one</i> and <i>two</i>"],
       ["a multi-word run", "read *the whole thing* now", "read <i>the whole thing</i> now"],
+      [
+        "a run whose body is punctuation-flanked",
+        "see *(this)* here",
+        "see <i>(this)</i> here",
+      ],
+      [
+        "Cyrillic prose",
+        "это *очень* важно",
+        "это <i>очень</i> важно",
+      ],
+      [
+        "Cyrillic prose with underscores",
+        "это _очень_ важно",
+        "это <i>очень</i> важно",
+      ],
     ];
     for (const [name, input, expected] of emphasised) {
       it(`still emphasises ${name}`, () => {
@@ -112,6 +168,33 @@ describe("convertMarkdownToTelegramHtml", () => {
       );
       expect(html.match(/<i>/g)?.length ?? 0).toBe(3);
       expect(html.match(/<\/i>/g)?.length ?? 0).toBe(3);
+    });
+
+    it("still renders a bullet list whose marker is an asterisk", () => {
+      expect(convertMarkdownToTelegramHtml("* list item")).toBe("• list item");
+    });
+
+    it("keeps a lone spaced asterisk literal", () => {
+      expect(convertMarkdownToTelegramHtml("5 * 3 = 15")).toBe("5 * 3 = 15");
+    });
+
+    it("still emphasises a run that wraps bold", () => {
+      expect(convertMarkdownToTelegramHtml("*a **b** c*")).toBe(
+        "<i>a <b>b</b> c</i>",
+      );
+    });
+
+    // Telegram answers crossing tags with a 400 on the whole
+    // sendMessage; `sendOutbound` recovers by re-sending the chunk as
+    // plain text, but that costs every bit of formatting in the reply.
+    // An emphasis candidate whose body does not close what it opens
+    // stays literal instead of emitting an `<i>` across a `<b>`.
+    it("refuses an emphasis run that would cross a bold tag", () => {
+      expect(convertMarkdownToTelegramHtml("__* *a__*")).toBe("<b>* *a</b>*");
+    });
+
+    it("refuses an underscore run that would cross a bold tag", () => {
+      expect(convertMarkdownToTelegramHtml("**_ _a** _")).toBe("<b>_ _a</b> _");
     });
   });
 

--- a/src/channels/telegram/markdown-to-html.test.ts
+++ b/src/channels/telegram/markdown-to-html.test.ts
@@ -47,6 +47,74 @@ describe("convertMarkdownToTelegramHtml", () => {
     );
   });
 
+  // Word-flanked asterisks are multiplication, not emphasis. Reading
+  // them as emphasis does not merely restyle the text: Telegram turns
+  // `<i>` into italics and the `*` characters are gone from the
+  // rendered reply, so `2*pi*5` reaches the operator as `2pi5`.
+  describe("asterisk emphasis requires non-word flanking", () => {
+    const literal: Array<[name: string, input: string, expected: string]> = [
+      ["a product of two factors", "2*pi*5", "2*pi*5"],
+      [
+        "a loose pair spanning a call",
+        "20*log10(abs(15-1*25))",
+        "20*log10(abs(15-1*25))",
+      ],
+      ["a chain of transfer functions", "G_cont = G1*G2*G3", "G_cont = G1*G2*G3"],
+      [
+        "mixed identifier and product",
+        "G_cont = 2*pi*5 and G1*G2*G3",
+        "G_cont = 2*pi*5 and G1*G2*G3",
+      ],
+    ];
+    for (const [name, input, expected] of literal) {
+      it(`leaves ${name} literal`, () => {
+        expect(convertMarkdownToTelegramHtml(input)).toBe(expected);
+      });
+    }
+
+    const emphasised: Array<[name: string, input: string, expected: string]> = [
+      ["space-flanked", "an *emphasised* word", "an <i>emphasised</i> word"],
+      ["at the start of the line", "*emphasised* word", "<i>emphasised</i> word"],
+      ["at the end of the line", "an *emphasised*", "an <i>emphasised</i>"],
+      ["parenthesised", "(*this*)", "(<i>this</i>)"],
+      ["followed by punctuation", "*this*.", "<i>this</i>."],
+      ["two runs on one line", "*one* and *two*", "<i>one</i> and <i>two</i>"],
+      ["a multi-word run", "read *the whole thing* now", "read <i>the whole thing</i> now"],
+    ];
+    for (const [name, input, expected] of emphasised) {
+      it(`still emphasises ${name}`, () => {
+        expect(convertMarkdownToTelegramHtml(input)).toBe(expected);
+      });
+    }
+
+    it("keeps bold working next to a product", () => {
+      expect(convertMarkdownToTelegramHtml("**gain**: G1*G2*G3")).toBe(
+        "<b>gain</b>: G1*G2*G3",
+      );
+    });
+
+    it("does not strand an asterisk when bold is word-flanked", () => {
+      expect(convertMarkdownToTelegramHtml("x**bold**y")).toBe("x<b>bold</b>y");
+    });
+
+    // Whatever stops being emphasis still has to reach the escaper —
+    // an unbalanced `<i>` makes Telegram reject the whole sendMessage
+    // with a 400 and the reply is demoted to plain text.
+    it("still escapes HTML characters in a line it leaves literal", () => {
+      expect(convertMarkdownToTelegramHtml("if 2*pi*5 > x && y < z")).toBe(
+        "if 2*pi*5 &gt; x &amp;&amp; y &lt; z",
+      );
+    });
+
+    it("emits balanced <i> tags for every emphasised run", () => {
+      const html = convertMarkdownToTelegramHtml(
+        "*a* 2*pi*5 *b* G1*G2*G3 *c*",
+      );
+      expect(html.match(/<i>/g)?.length ?? 0).toBe(3);
+      expect(html.match(/<\/i>/g)?.length ?? 0).toBe(3);
+    });
+  });
+
   it("renders strikethrough via ~~", () => {
     expect(convertMarkdownToTelegramHtml("~~old~~ new")).toBe("<s>old</s> new");
   });

--- a/src/channels/telegram/markdown-to-html.ts
+++ b/src/channels/telegram/markdown-to-html.ts
@@ -236,30 +236,91 @@ function renderBold(s: string): string {
 }
 
 function renderItalic(s: string): string {
-  // Single `*` or `_` only, and both require a non-word character on
-  // the outer side of each delimiter. For `_` that keeps
-  // `snake_case_identifier` intact; for `*` it keeps arithmetic and
-  // shell globs intact, which matters more than it looks. Without
-  // the `*` guard a MATLAB expression like `20*log10(abs(15-1*25))`
-  // has its two loose asterisks read as an emphasis pair and comes
-  // out as `20<i>log10(abs(15-1</i>25))` — under `parse_mode: "HTML"`
-  // Telegram renders that as italics, so the asterisks are *deleted*
-  // from what the operator sees and the expression silently changes
-  // meaning. Restyling is recoverable; character loss is not.
+  // A single `*` or `_` opens emphasis only when it is not glued to a
+  // letter or digit on the outside and not followed by whitespace on
+  // the inside; the closing delimiter is the mirror image. Both
+  // conditions matter, and each covers a different half of the
+  // reported bug:
+  //
+  //  - The word guard keeps `20*log10(abs(15-1*25))` literal. Without
+  //    it the two loose asterisks are read as an emphasis pair and the
+  //    line comes out as `20<i>log10(abs(15-1</i>25))`; under
+  //    `parse_mode: "HTML"` Telegram renders that as italics, so the
+  //    asterisks are *deleted* from what the operator sees and the
+  //    expression silently changes meaning. Restyling is recoverable;
+  //    character loss is not.
+  //  - The whitespace guard keeps the spaced form of the same
+  //    arithmetic literal — `G_cont = G1 * G2 * G3`, `2 * pi * 5`,
+  //    Octave's `A .* B .* C`, `SELECT * FROM t`. There the outer
+  //    flanks are punctuation or spaces, so the word guard alone lets
+  //    the pair through.
+  //
+  // Deliberate divergence from CommonMark, in both directions:
+  //
+  //  - Stricter. CommonMark allows intraword emphasis with `*` (and
+  //    only with `*`; `_` is guarded there precisely so that
+  //    `snake_case` survives), so upstream `*Note*s` and
+  //    `un*frigging*believable` are `<em>` and here they stay
+  //    literal. That asymmetry is intentional in the spec, and we are
+  //    overriding it on purpose: in an agent transcript a `*` wedged
+  //    between two word characters is arithmetic or a glob far more
+  //    often than it is emphasis, and guessing wrong destroys
+  //    characters rather than merely dropping a style.
+  //  - Looser. This is a flanking approximation, not CommonMark's
+  //    left/right-flanking algorithm. A pair flanked on the outside
+  //    by punctuation — `rm build/*.o obj/*.o` — is still read as
+  //    emphasis. CommonMark emphasises that one too, so it is not a
+  //    divergence in itself, but the general punctuation case is only
+  //    approximated; closing it means porting the whole algorithm.
+  //
+  // Both rules use Unicode letter/number classes rather than `\w`,
+  // which is ASCII-only in JS. With `\w` the guards silently stopped
+  // applying to non-Latin prose: `пи*2*пи` was emphasised where
+  // `pi*2*pi` was not, and `слово_это_слово` lost its underscores
+  // where `snake_case_name` kept them.
   //
   // `renderBold` has already consumed `**pairs**`, so the remaining
   // `*` runs here are single delimiters; the closing lookahead still
   // rejects a trailing `*` so a stray third asterisk is never
   // stranded next to an emitted `<i>`.
   //
-  // This is a word guard, not CommonMark's full left/right-flanking
-  // rule: asterisks flanked by punctuation rather than by word
-  // characters — `build/*.o obj/*.o` — are still read as a pair.
-  // CommonMark reads that one as emphasis too, and closing it means
-  // porting the whole flanking algorithm.
+  // `tagsBalanced` is the safety net rather than a style rule: earlier
+  // passes have already emitted `<b>` / `<s>` / `<a>` into this
+  // string, and a marker soup like `__* *a__*` can otherwise place an
+  // `<i>` that crosses one of them. Telegram answers crossing tags
+  // with a 400 on the whole `sendMessage` — the outbound sender
+  // recovers by re-sending as plain text, but that costs the operator
+  // every bit of formatting in the reply — so a candidate whose body
+  // does not close what it opens stays literal instead.
   return s
-    .replace(/(^|[^*\w])\*([^*\n]+?)\*(?![\w*])/g, "$1<i>$2</i>")
-    .replace(/(^|[^_\w])_([^_\n]+?)_(?!\w)/g, "$1<i>$2</i>");
+    .replace(
+      /(^|[^*\p{L}\p{N}_])\*([^*\s](?:[^*\n]*?[^*\s])?)\*(?![\p{L}\p{N}_*])/gu,
+      (match: string, before: string, body: string) =>
+        tagsBalanced(body) ? `${before}<i>${body}</i>` : match,
+    )
+    .replace(
+      /(^|[^_\p{L}\p{N}])_([^_\s](?:[^_\n]*?[^_\s])?)_(?![\p{L}\p{N}_])/gu,
+      (match: string, before: string, body: string) =>
+        tagsBalanced(body) ? `${before}<i>${body}</i>` : match,
+    );
+}
+
+/**
+ * True when every HTML tag inside an emphasis candidate's body is
+ * opened and closed within that body. Used to refuse a `<i>` wrapper
+ * that would cross a `<b>` / `<s>` / `<a>` emitted by an earlier
+ * inline pass, which Telegram rejects with a 400.
+ */
+function tagsBalanced(body: string): boolean {
+  const stack: string[] = [];
+  for (const m of body.matchAll(/<(\/?)([a-z-]+)[^>]*>/g)) {
+    if (m[1] === "/") {
+      if (stack.pop() !== m[2]) return false;
+    } else {
+      stack.push(m[2] ?? "");
+    }
+  }
+  return stack.length === 0;
 }
 
 function renderStrikethrough(s: string): string {

--- a/src/channels/telegram/markdown-to-html.ts
+++ b/src/channels/telegram/markdown-to-html.ts
@@ -236,12 +236,29 @@ function renderBold(s: string): string {
 }
 
 function renderItalic(s: string): string {
-  // Single `*` or `_` only. We require a non-word boundary on the
-  // outer side for `_` so `snake_case_identifier` does not turn
-  // into `snake<i>case</i>identifier`. The same guard for `*` is
-  // not needed because `*` is rare inside identifiers.
+  // Single `*` or `_` only, and both require a non-word character on
+  // the outer side of each delimiter. For `_` that keeps
+  // `snake_case_identifier` intact; for `*` it keeps arithmetic and
+  // shell globs intact, which matters more than it looks. Without
+  // the `*` guard a MATLAB expression like `20*log10(abs(15-1*25))`
+  // has its two loose asterisks read as an emphasis pair and comes
+  // out as `20<i>log10(abs(15-1</i>25))` — under `parse_mode: "HTML"`
+  // Telegram renders that as italics, so the asterisks are *deleted*
+  // from what the operator sees and the expression silently changes
+  // meaning. Restyling is recoverable; character loss is not.
+  //
+  // `renderBold` has already consumed `**pairs**`, so the remaining
+  // `*` runs here are single delimiters; the closing lookahead still
+  // rejects a trailing `*` so a stray third asterisk is never
+  // stranded next to an emitted `<i>`.
+  //
+  // This is a word guard, not CommonMark's full left/right-flanking
+  // rule: asterisks flanked by punctuation rather than by word
+  // characters — `build/*.o obj/*.o` — are still read as a pair.
+  // CommonMark reads that one as emphasis too, and closing it means
+  // porting the whole flanking algorithm.
   return s
-    .replace(/(^|[^*])\*([^*\n]+?)\*(?!\*)/g, "$1<i>$2</i>")
+    .replace(/(^|[^*\w])\*([^*\n]+?)\*(?![\w*])/g, "$1<i>$2</i>")
     .replace(/(^|[^_\w])_([^_\n]+?)_(?!\w)/g, "$1<i>$2</i>");
 }
 

--- a/src/channels/telegram/markdown-to-html.ts
+++ b/src/channels/telegram/markdown-to-html.ts
@@ -240,7 +240,9 @@ function renderBold(s: string): string {
 // them. `\p{M}` is in the set because a mark is part of the word it
 // sits on — without it the keycap `1️⃣*x*` would open emphasis (the
 // character immediately before the `*` is U+20E3 COMBINING ENCLOSING
-// KEYCAP) where the bare `1*x*` does not.
+// KEYCAP) where the bare `1*x*` does not. Not every mark attaches to
+// a word, though — see `VARIATION_SELECTOR` below for the exception
+// that class needs.
 //
 // These are Unicode classes rather than `\w`, which is ASCII-only in
 // JS. With `\w` the guards silently stopped applying to non-Latin
@@ -248,6 +250,31 @@ function renderBold(s: string): string {
 // `слово_это_слово` lost its underscores where `snake_case_name` kept
 // them.
 const WORD_FLANK = String.raw`\p{L}\p{N}\p{M}_`;
+
+// Variation selectors (U+FE00–U+FE0F). These are `\p{M}` and so land
+// in `WORD_FLANK`, but the thing they attach to is usually not a word:
+// VARIATION SELECTOR-16 is what turns a bare symbol into an emoji, so
+// `⚠️`, `❗️`, `ℹ️`, `⭐️`, `▶️` and the rest end in a mark that belongs
+// to a symbol. Counting it as a word character disabled single-`*`
+// and `_` italics after every one of them: `⚠️*Do not* run this` came
+// out with the asterisks visible while the selector-less
+// `⚠*Do not*` rendered `<i>`, and over U+2000–U+2BFF that was 2,791
+// of 3,072 code points losing italics the moment the selector was
+// appended.
+//
+// So a variation selector is accepted as the character *before* an
+// opening delimiter, and only there. Before an opening delimiter a
+// selector belongs to whatever precedes it, and judging the run by a
+// selector rather than by its base is what caused the bug above.
+// After a closing delimiter it belongs to the delimiter itself:
+// `*` is an emoji base, so in `*x*️⃣` the trailing `*️⃣` is a keycap
+// and taking it as a closing delimiter would emit `<i>x</i>️⃣` and
+// delete the `*` out of an emoji — the same character loss the word
+// guard exists to prevent. There the mark keeps blocking.
+//
+// U+20E3 COMBINING ENCLOSING KEYCAP is not a variation selector and
+// is not listed here, so `1️⃣*x*` stays literal like the bare `1*x*`.
+const VARIATION_SELECTOR = String.raw`\uFE00-\uFE0F`;
 
 // Scripts written without spaces between words, exempted from the `*`
 // word guard.
@@ -274,14 +301,14 @@ const WORD_FLANK = String.raw`\p{L}\p{N}\p{M}_`;
 const SPACELESS_SCRIPT = String.raw`\p{scx=Han}\p{scx=Hiragana}\p{scx=Katakana}\p{scx=Hangul}\p{scx=Bopomofo}\p{scx=Thai}\p{scx=Lao}\p{scx=Khmer}\p{scx=Myanmar}\p{scx=Tibetan}`;
 
 const ITALIC_STAR = new RegExp(
-  `(^|[^*${WORD_FLANK}]|[${SPACELESS_SCRIPT}])` +
+  `(^|[^*${WORD_FLANK}]|[${SPACELESS_SCRIPT}]|[${VARIATION_SELECTOR}])` +
     String.raw`\*([^*\s](?:[^*\n]*?[^*\s])?)\*` +
     `(?!\\*)(?:(?=[${SPACELESS_SCRIPT}])|(?![${WORD_FLANK}]))`,
   "gu",
 );
 
 const ITALIC_UNDERSCORE = new RegExp(
-  `(^|[^${WORD_FLANK}])` +
+  `(^|[^${WORD_FLANK}]|[${VARIATION_SELECTOR}])` +
     String.raw`_([^_\s](?:[^_\n]*?[^_\s])?)_` +
     `(?![${WORD_FLANK}])`,
   "gu",
@@ -361,10 +388,22 @@ function renderItalic(s: string): string {
   //    same class of damage these nets exist to stop.
   //
   // Neither net is a well-formedness proof for the converter as a
-  // whole. A raw `<` typed by the user still reaches the output
-  // unescaped through `escapeNonTagText` (`convert("<b>hello")` is
-  // `"<b>hello"`, on this branch and on `origin/main` alike); that is a
-  // separate, pre-existing hole and is not addressed here.
+  // whole. Two pre-existing holes stay open, both of them identical on
+  // `origin/main` and neither addressed here:
+  //
+  //  - A raw `<` typed by the user reaches the output unescaped
+  //    through `escapeNonTagText` (`convert("<b>hello")` is
+  //    `"<b>hello"`).
+  //  - `renderBold` and `renderStrikethrough` run after `renderLinks`
+  //    and have no `tagMask` / `tagsBalanced` of their own, so a `**`
+  //    or `~~` pair can still cross an emitted `<a href="…">`:
+  //    `convert("[**](tg:*)**")` is `'<a href="tg:*"><b></a></b>'`
+  //    and `convert("~~**[_](tg:_)~~**")` is
+  //    `'<s><b><a href="tg:_">_</a></s></b>'` — crossing tags with no
+  //    user-typed `<` anywhere. The nets above shrink this class by
+  //    roughly 8x on an anchor-template sweep and add nothing to it,
+  //    but they do not close it: what remains is bold and
+  //    strikethrough, not italics.
   return renderItalicPass(renderItalicPass(s, ITALIC_STAR), ITALIC_UNDERSCORE);
 }
 

--- a/src/channels/telegram/markdown-to-html.ts
+++ b/src/channels/telegram/markdown-to-html.ts
@@ -235,9 +235,61 @@ function renderBold(s: string): string {
     .replace(/__([^_\n]+?)__/g, "<b>$1</b>");
 }
 
+// Characters that count as "inside a word" for the flanking guards
+// below: letters, digits, `_`, and the combining marks that attach to
+// them. `\p{M}` is in the set because a mark is part of the word it
+// sits on — without it the keycap `1️⃣*x*` would open emphasis (the
+// character immediately before the `*` is U+20E3 COMBINING ENCLOSING
+// KEYCAP) where the bare `1*x*` does not.
+//
+// These are Unicode classes rather than `\w`, which is ASCII-only in
+// JS. With `\w` the guards silently stopped applying to non-Latin
+// prose: `пи*2*пи` was emphasised where `pi*2*pi` was not, and
+// `слово_это_слово` lost its underscores where `snake_case_name` kept
+// them.
+const WORD_FLANK = String.raw`\p{L}\p{N}\p{M}_`;
+
+// Scripts written without spaces between words, exempted from the `*`
+// word guard.
+//
+// In Chinese, Japanese, Korean or Thai prose *every* emphasis run is
+// flanked by letters, so there the word guard is not a heuristic that
+// tells arithmetic from emphasis — it is a blanket disable of
+// single-`*` italics for the whole language, which is what it silently
+// became when the guard moved from `\w` to `\p{L}`. `这是*重点*内容`
+// has to stay `<i>`; CommonMark emphasises it and so do we.
+//
+// Exempting them costs very little on the arithmetic side, because the
+// guard only ever inspects the character immediately beside the
+// delimiter, and real code and arithmetic put an ASCII operand there:
+// `这是 20*log10(abs(15-1*25)) 的结果` is still literal, every `*` in
+// it flanked by ASCII digits and letters. What is given up is the
+// CJK-identifier product written with no spaces at all (`长*宽*高`
+// becomes `长<i>宽</i>高`) — the same result every CommonMark renderer
+// produces for that input.
+//
+// `_` is deliberately *not* exempted: CommonMark forbids intraword `_`
+// in every script, CJK included, so `这是_重点_内容` is literal
+// upstream too and matching that costs nothing.
+const SPACELESS_SCRIPT = String.raw`\p{scx=Han}\p{scx=Hiragana}\p{scx=Katakana}\p{scx=Hangul}\p{scx=Bopomofo}\p{scx=Thai}\p{scx=Lao}\p{scx=Khmer}\p{scx=Myanmar}\p{scx=Tibetan}`;
+
+const ITALIC_STAR = new RegExp(
+  `(^|[^*${WORD_FLANK}]|[${SPACELESS_SCRIPT}])` +
+    String.raw`\*([^*\s](?:[^*\n]*?[^*\s])?)\*` +
+    `(?!\\*)(?:(?=[${SPACELESS_SCRIPT}])|(?![${WORD_FLANK}]))`,
+  "gu",
+);
+
+const ITALIC_UNDERSCORE = new RegExp(
+  `(^|[^${WORD_FLANK}])` +
+    String.raw`_([^_\s](?:[^_\n]*?[^_\s])?)_` +
+    `(?![${WORD_FLANK}])`,
+  "gu",
+);
+
 function renderItalic(s: string): string {
   // A single `*` or `_` opens emphasis only when it is not glued to a
-  // letter or digit on the outside and not followed by whitespace on
+  // word character on the outside and not followed by whitespace on
   // the inside; the closing delimiter is the mirror image. Both
   // conditions matter, and each covers a different half of the
   // reported bug:
@@ -262,47 +314,103 @@ function renderItalic(s: string): string {
   //    `snake_case` survives), so upstream `*Note*s` and
   //    `un*frigging*believable` are `<em>` and here they stay
   //    literal. That asymmetry is intentional in the spec, and we are
-  //    overriding it on purpose: in an agent transcript a `*` wedged
-  //    between two word characters is arithmetic or a glob far more
-  //    often than it is emphasis, and guessing wrong destroys
-  //    characters rather than merely dropping a style.
+  //    overriding it on purpose: in a space-separated script, a `*`
+  //    wedged between two word characters is arithmetic or a glob far
+  //    more often than it is emphasis, and guessing wrong destroys
+  //    characters rather than merely dropping a style. In a script
+  //    written without spaces that reasoning does not hold at all,
+  //    which is why `SPACELESS_SCRIPT` is exempt.
   //  - Looser. This is a flanking approximation, not CommonMark's
   //    left/right-flanking algorithm. A pair flanked on the outside
   //    by punctuation — `rm build/*.o obj/*.o` — is still read as
   //    emphasis. CommonMark emphasises that one too, so it is not a
   //    divergence in itself, but the general punctuation case is only
   //    approximated; closing it means porting the whole algorithm.
-  //
-  // Both rules use Unicode letter/number classes rather than `\w`,
-  // which is ASCII-only in JS. With `\w` the guards silently stopped
-  // applying to non-Latin prose: `пи*2*пи` was emphasised where
-  // `pi*2*pi` was not, and `слово_это_слово` lost its underscores
-  // where `snake_case_name` kept them.
+  //    The `SPACELESS_SCRIPT` exemption widens that same gap a little,
+  //    because the word guard was masking part of it: over the 55,986
+  //    strings from the alphabet `* _ space a 这 点` up to length 6,
+  //    the count we emphasise and CommonMark leaves literal is 465
+  //    here against 71 with the guard applied to CJK — and 5,565 on
+  //    `origin/main`. All of the extra ones are marker soup (`*_*重`),
+  //    none of them are ill-formed, and none of them emphasise
+  //    anything `origin/main` leaves literal.
   //
   // `renderBold` has already consumed `**pairs**`, so the remaining
   // `*` runs here are single delimiters; the closing lookahead still
   // rejects a trailing `*` so a stray third asterisk is never
   // stranded next to an emitted `<i>`.
   //
-  // `tagsBalanced` is the safety net rather than a style rule: earlier
-  // passes have already emitted `<b>` / `<s>` / `<a>` into this
-  // string, and a marker soup like `__* *a__*` can otherwise place an
-  // `<i>` that crosses one of them. Telegram answers crossing tags
-  // with a 400 on the whole `sendMessage` — the outbound sender
-  // recovers by re-sending as plain text, but that costs the operator
-  // every bit of formatting in the reply — so a candidate whose body
-  // does not close what it opens stays literal instead.
-  return s
-    .replace(
-      /(^|[^*\p{L}\p{N}_])\*([^*\s](?:[^*\n]*?[^*\s])?)\*(?![\p{L}\p{N}_*])/gu,
-      (match: string, before: string, body: string) =>
-        tagsBalanced(body) ? `${before}<i>${body}</i>` : match,
-    )
-    .replace(
-      /(^|[^_\p{L}\p{N}])_([^_\s](?:[^_\n]*?[^_\s])?)_(?![\p{L}\p{N}_])/gu,
-      (match: string, before: string, body: string) =>
-        tagsBalanced(body) ? `${before}<i>${body}</i>` : match,
-    );
+  // The two structural guards below are safety nets rather than style
+  // rules. Earlier passes have already emitted `<b>` / `<s>` / `<a>`
+  // into this string, and Telegram answers malformed markup with a 400
+  // on the whole `sendMessage` — the outbound sender recovers by
+  // re-sending the chunk as plain text, but that costs the operator
+  // every bit of formatting in the reply.
+  //
+  //  - `tagsBalanced` refuses a candidate whose body opens a tag it
+  //    does not close, so a marker soup like `__* *a__*` cannot place
+  //    an `<i>` that crosses an earlier `<b>` / `<s>` / `<a>`.
+  //  - `tagMask` refuses a candidate whose own delimiter sits inside
+  //    a tag that an earlier pass emitted. `tagsBalanced` cannot see
+  //    that case, because a delimiter that splits `<a href="…">` down
+  //    the middle leaves no complete tag in the body to be unbalanced:
+  //    `*[a](http://x/*)*` used to come out as
+  //    `<i>&lt;a href="http://x/</i>">a</a>*`, with an orphan `</a>`
+  //    that Telegram rejects. That one is not caused by the emphasis
+  //    guards — it reproduces on `origin/main` too — but it is the
+  //    same class of damage these nets exist to stop.
+  //
+  // Neither net is a well-formedness proof for the converter as a
+  // whole. A raw `<` typed by the user still reaches the output
+  // unescaped through `escapeNonTagText` (`convert("<b>hello")` is
+  // `"<b>hello"`, on this branch and on `origin/main` alike); that is a
+  // separate, pre-existing hole and is not addressed here.
+  return renderItalicPass(renderItalicPass(s, ITALIC_STAR), ITALIC_UNDERSCORE);
+}
+
+function renderItalicPass(s: string, pattern: RegExp): string {
+  const tags = tagMask(s);
+  return s.replace(
+    pattern,
+    (match: string, before: string, body: string, offset: number) => {
+      const open = offset + before.length;
+      const close = offset + match.length - 1;
+      if (tags && (tags[open] === 1 || tags[close] === 1)) return match;
+      return tagsBalanced(body) ? `${before}<i>${body}</i>` : match;
+    },
+  );
+}
+
+/**
+ * Exactly the tags an earlier inline pass can have put into the string
+ * by the time `renderItalic` runs: `<b>` / `<i>` / `<s>` from
+ * `renderBold` and `renderStrikethrough`, and the anchor from
+ * `renderLinks` (whose href is already attribute-escaped, so it can
+ * hold no raw `"`). Code spans and fences are placeholders at this
+ * point, not tags.
+ *
+ * The pattern is deliberately this narrow rather than a generic
+ * `<[^<>]*>`: a `<a *>` the *user* typed is not one of our tags, and
+ * treating it as one would shield it from the emphasis pass and let it
+ * reach the output verbatim through the pre-existing
+ * `escapeNonTagText` hole.
+ */
+const EMITTED_TAG = /<\/?[bis]>|<a href="[^"]*">|<\/a>/g;
+
+/**
+ * A byte per character, 1 where that character belongs to a tag this
+ * converter has already emitted, or `null` when there is no such tag.
+ * Used to keep an emphasis delimiter from splitting an `<a href="…">`
+ * down the middle.
+ */
+function tagMask(s: string): Uint8Array | null {
+  if (!s.includes("<")) return null;
+  let mask: Uint8Array | null = null;
+  for (const m of s.matchAll(EMITTED_TAG)) {
+    mask ??= new Uint8Array(s.length);
+    mask.fill(1, m.index, m.index + m[0].length);
+  }
+  return mask;
 }
 
 /**


### PR DESCRIPTION
Reported in Discord `#feedback-and-bugs` by `thegreatteacher` on v0.5.6 (2026-09-09): a reply containing MATLAB/Octave was stored correctly — `2*pi*5`, `20*log10(...)`, `abs(15-1*25)`, `G_cont = G1*G2*G3` — but reached Telegram as `2pi5`, `20log10(...)`, `abs(15-125)`. Nothing was truncated; the full 26 KB arrived.

### What was wrong

`renderItalic` in `src/channels/telegram/markdown-to-html.ts` matched single-`*` emphasis with no flanking guard at all:

```js
.replace(/(^|[^*])\*([^*\n]+?)\*(?!\*)/g, "$1<i>$2</i>")
```

Its own comment said the guard the `_` rule has "is not needed because `*` is rare inside identifiers". `*` is not rare inside *arithmetic*, and that is what an agent asked for a control-systems script emits. `2*pi*5` matches as `2` + `*pi*` and becomes `2<i>pi</i>5`; `G1*G2*G3` becomes `G1<i>G2</i>G3`; a loose pair spanning a call, `20*log10(abs(15-1*25))`, becomes `20<i>log10(abs(15-1</i>25))` — which is exactly the reported `20log10(abs(15-125))`.

The distinction that makes this worth fixing: under `parse_mode: "HTML"` those asterisks are not restyled, they are **deleted**. The reader sees `2pi5` and cannot recover the expression, and the expression has silently changed meaning. This only bites text outside code spans and fences — `extractInlineCode` / `extractFencedCode` already protect those — so the fix belongs in the emphasis rule, not in the extractors.

### The fix

A single `*` or `_` opens emphasis only when it is not glued to a word character on the outside and not followed by whitespace on the inside; the closing delimiter is the mirror image. Scripts written without spaces between words are exempt from the word half of that rule, and a delimiter that sits inside a tag an earlier pass emitted is refused outright.

```js
const WORD_FLANK = String.raw`\p{L}\p{N}\p{M}_`;
const SPACELESS_SCRIPT = String.raw`\p{scx=Han}\p{scx=Hiragana}\p{scx=Katakana}\p{scx=Hangul}…`;

const ITALIC_STAR = new RegExp(
  `(^|[^*${WORD_FLANK}]|[${SPACELESS_SCRIPT}])` +
    String.raw`\*([^*\s](?:[^*\n]*?[^*\s])?)\*` +
    `(?!\\*)(?:(?=[${SPACELESS_SCRIPT}])|(?![${WORD_FLANK}]))`,
  "gu",
);
```

Guards, each earning its place:

**Word flanking** keeps the reporter's tight forms literal — `2*pi*5`, `20*log10(abs(15-1*25))`, `G1*G2*G3`.

**Whitespace flanking** keeps the *spaced* form of the same arithmetic literal. The word guard alone does not reach `G_cont = G1 * G2 * G3`, `omega = 2 * pi * 5`, `y = 20 * log10(abs(15 - 1 * 25))`, Octave's `matrix A .* B .* C` or `SELECT * FROM t WHERE c = *`, because there the outer flanks are spaces and punctuation — all five were still being eaten. CommonMark rejects all five for the single reason that a `*` followed by whitespace cannot open emphasis, so this costs one token and closes the rest of the reported class.

**Unicode classes instead of `\w`**, which is ASCII-only in JS. With `\w` the guards silently stopped applying to non-Latin prose: `пи*2*пи` was emphasised where `pi*2*pi` was not, and — the same leak in the `_` rule, which has been there all along — `слово_это_слово` lost its underscores where `snake_case_name` kept them. Both are now literal, and space-flanked emphasis in any script (`это *очень* важно`, `это _очень_ важно`) still renders. `\p{M}` is in the word class because a combining mark is usually part of the word it attaches to — without it the keycap `1️⃣*x*` opened emphasis where the bare `1*x*` did not, and Devanagari `की*x*` and decomposed `é*x*` opened it mid-word. Variation selectors are the exception and are handled separately below.

**A `SPACELESS_SCRIPT` exemption for `*`, and the reason it is needed.** Moving the guard off `\w` had a cost that the first two rounds of this PR did not state: CJK ideographs and Hangul are `\p{L}`, and Chinese, Japanese, Korean and Thai are written without spaces, so in those scripts *every* emphasis run is flanked by letters. The guard stopped being a heuristic that tells arithmetic from emphasis and became a blanket disable of single-`*` italics for the whole language — `这是*重点*内容` came out with the asterisks visible, where both `origin/main` and CommonMark render emphasis. (`**bold**` was unaffected, so the loss was italics-specific.) Those scripts are now exempt from the word guard. It costs little on the arithmetic side, because the guard only ever inspects the character immediately beside the delimiter and real code puts an ASCII operand there: `这是 20*log10(abs(15-1*25)) 的结果` is still literal. `_` is deliberately *not* exempted — CommonMark forbids intraword `_` in every script, CJK included, so `这是_重点_内容` is literal upstream too.

**A variation-selector exception to the word class, and what it cost before it was there.** U+FE0F VARIATION SELECTOR-16 is `\p{M}`, and it is what turns a bare symbol into an emoji — so putting `\p{M}` in the word class silently disabled single-`*` and `_` italics after every emoji spelled with one. `⚠️*Do not* run this` came out with the asterisks visible where the selector-less `⚠*Do not*` rendered `<i>`, and where `origin/main` and both earlier commits on this branch rendered `<i>`. Over U+2000–U+2BFF that was **2,791 of 3,072 code points** losing italics the moment the selector was appended — ⚠️ ✔️ ⭐️ ❤️ ▶️ ℹ️ ❗️ ⏱️ among them. A variation selector is now accepted as the character *before* an opening delimiter, and only there: before an opening delimiter it belongs to whatever precedes it, and judging the run by the selector instead of by its base is the bug. After a *closing* delimiter it belongs to the delimiter itself — `*` is an emoji base, so in `*x*️⃣` the trailing `*️⃣` is a keycap, and reading it as a closing delimiter would emit `<i>x</i>️⃣` and delete the `*` out of an emoji. There the mark keeps blocking. U+20E3 COMBINING ENCLOSING KEYCAP is not a variation selector, so `1️⃣*x*` still stays literal like `1*x*`, and marks that really are part of a word (`की*x*`, decomposed `é*x*`) still block — both regress if `\p{M}` is simply dropped instead.

**`tagsBalanced` and `tagMask`** are safety nets rather than style rules. `renderLinks` / `renderStrikethrough` / `renderBold` have already emitted `<a>` / `<s>` / `<b>` into the string by the time `renderItalic` runs, and Telegram answers malformed markup with a 400 on the whole `sendMessage`; `sendOutbound` recovers by re-sending the chunk as plain text (`parseFallbacks`), but that costs the operator every bit of formatting in the reply.

- `tagsBalanced` refuses a candidate whose body opens a tag it does not close, so a marker soup like `__* *a__*` cannot place an `<i>` that crosses an earlier `<b>` / `<s>` / `<a>`.
- `tagMask` refuses a candidate whose own delimiter sits *inside* an emitted tag. `tagsBalanced` cannot see that case: a `*` inside a URL splits `<a href="…">` down the middle and leaves no complete tag in the body to be unbalanced, so `*[a](http://x/*)*` came out as `<i>&lt;a href="http://x/</i>">a</a>*` — an orphan `</a>` that Telegram rejects. That one is **not** caused by the emphasis guards; it reproduces identically on `origin/main`. It is fixed here because it is the same class of damage these nets exist to stop, and because an earlier revision of this PR claimed a candidate could never cross an emitted tag, which was wrong.

`renderBold` still runs first and consumes `**pairs**`, and the closing lookahead still rejects a trailing `*`, so the change cannot strand a leftover asterisk beside an emitted `<i>` — `x**bold**y` and `**gain**: G1*G2*G3` are both pinned. Escape correctness is unchanged: what stops being emphasis stays literal text and still reaches `escapeNonTagText`, asserted directly (`if 2*pi*5 > x && y < z`).

### Test evidence

Table-driven tests in `markdown-to-html.test.ts` covering every string in the report plus the spaced, Cyrillic, CJK/Thai and tag-crossing cases, both directions — now-literal (`2*pi*5`, `20*log10(abs(15-1*25))`, `G_cont = G1*G2*G3`, all five spaced forms, `пи*2*пи`, `слово_это_слово`, `这是 20*log10(abs(15-1*25)) 的结果`, `这是_重点_内容`, `1️⃣*x*`, `*x*️⃣`, `की*x*`, decomposed `é*x*`) and still-emphasised (space-flanked, line-initial, line-final, `(*this*)`, `*this*.`, `see *(this)* here`, a multi-word run, `*a **b** c*`, Cyrillic prose, Chinese / Japanese / Korean / Thai prose, `⚠️*Do not* run this`, `ℹ️_note_`, `⚠*x*`, and `* list item` still becoming a bullet).

- `npm run lint` (tsc --noEmit): clean.
- `npx vitest run src/channels/telegram`: 280 passed / 14 files. `npx vitest run src/channels`: 427 passed / 26 files.
- Full suite: 812/813 files, 8964 passed / 3 skipped. The one failure moves between runs and is environmental — `src/sidecar/send-message-concurrency.test.ts` and `eval-memory/harness/multi-turn-driver.test.ts` (EPIPE) have each been the single failure; the sidecar one reproduces with this diff stashed, in a file the diff does not touch.
- Negative controls, all three real. With `src/channels/telegram/markdown-to-html.ts` reverted and the tests kept:
  - `origin/main` → **27 of 76 fail**.
  - the first commit on this branch, the word guard alone → **17 fail**.
  - the second commit, before the CJK fix → **10 fail**: the four CJK/Thai emphasis cases, the keycap case, the two anchor-splitting cases, and the three mark pins.
  - the third commit, before the variation-selector fix → **2 fail**: exactly the two emoji cases, `⚠️*Do not* run this` and `ℹ️_note_`.

  The remaining new tests are deliberate regression pins for behaviour that was already correct.

Four measured properties, since a hand-picked example is what let the spaced cases through the first time:

- **Never looser than CommonMark, on ASCII.** Over 177,155 strings from the alphabet `* a 1 . / - ( ) , !` plus a space — eleven symbols — up to length 5, compared against `marked.parseInline` (already in `node_modules`), there is **no input this converter emphasises that CommonMark leaves literal**. It is stricter on 496, all multi-asterisk runs (`***a*`) or intraword pairs.
- **Never emits crossing tags on marker soup.** Exhaustive over all 2,015,538 strings from `* _ space a b c` up to length 8: `origin/main` produces ill-formed HTML for 1,151 of them, the first commit on this branch for 788, and this version for **0**. Same result (**0**, against 4 on main) over the 597,870 strings from `* _ [ ] ( ) : space a`, and over the 335,922 strings from `* _ space a 这 点` up to length 7.
- **Never worse than `origin/main` on well-formedness.** On an alphabet that contains raw `<` and `>` (`* _ < > space a b`, 137,256 strings) the ill-formed count is **3,584 either way** — every one of them from the pre-existing `escapeNonTagText` hole, not from emphasis.
- **The variation-selector fix changes nothing outside emoji.** Over all four ASCII / angle-bracket alphabets above, output is byte-identical to the previous commit. On an alphabet containing `⚠️` and `1️⃣` (`* _ space ⚠️ 1️⃣ a` to length 5, 9,330 strings) it differs on 105, all in the looser direction; against `marked.parseInline` it is looser than CommonMark on 66 of those strings, every one of which `origin/main` also emphasises — `origin/main` is looser on 475.
- **Still a strict narrowing of shipped behaviour.** Over three alphabets (`* _ space a b c` to length 7, `* _ space a 这 点` to length 6, `* _ [ ] ( : / a` to length 6), plus the emoji and combining-mark alphabets, the count of inputs this version emphasises and `origin/main` does not is **0**, so it cannot introduce a character loss that main does not already have.

### What this does not cover

**Punctuation-flanked asterisks.** This is a flanking *approximation*, not CommonMark's left/right-flanking algorithm. A pair flanked on the outside by punctuation — `rm build/*.o obj/*.o` — is still read as emphasis. CommonMark emphasises that specific line too, and the ASCII sweep found no case where we emphasise and CommonMark does not, so it is not a divergence in itself; but the general punctuation case is only approximated, and closing it properly means porting the whole algorithm. Noted in the source comment; deliberately out of scope.

**The `SPACELESS_SCRIPT` exemption widens that approximation gap, and here is the number.** With the word guard applied to CJK it masked part of the gap. Over the 55,986 strings from `* _ space a 这 点` up to length 6, the count we emphasise and CommonMark leaves literal is **465** here, against 71 with the guard applied and 5,565 on `origin/main` (same `marked.parseInline` oracle; a block-level oracle gives slightly different absolute counts in the same proportion). Every one of the extra cases is marker soup (`*_*重`), none produce ill-formed HTML, and none emphasise anything `origin/main` leaves literal. The other thing given up is a CJK-identifier product written with no spaces at all: `长*宽*高` becomes `长<i>宽</i>高` — the same result every CommonMark renderer gives for that input. The alternative was leaving single-`*` italics dead in four major languages.

**Intraword emphasis in space-separated scripts is stricter than the spec, on purpose.** CommonMark deliberately allows intraword emphasis with `*` and forbids it with `_` — that asymmetry is intentional there, so `*Note*s` and `un*frigging*believable` are `<em>` upstream and stay literal here. We are overriding it knowingly: in a space-separated script a `*` wedged between two word characters is arithmetic or a glob far more often than it is emphasis, and guessing wrong deletes characters rather than merely dropping a style. In a script written without spaces that reasoning does not hold at all, which is exactly why those scripts are exempt.

**Raw `<` typed by the user still escapes the escaper.** `convert("<b>hello")` returns `"<b>hello"` — an unclosed tag Telegram will 400 on. That is a pre-existing hole in `escapeNonTagText`, identical on `origin/main`, and it is the entire residual of the `<`/`>` sweep above.

**And it is not the only crossing-tag hole left.** `renderBold` and `renderStrikethrough` run after `renderLinks` and have no `tagMask` / `tagsBalanced` of their own, so a `**` or `~~` pair can still cross an emitted anchor with no `<` typed anywhere: `convert("[**](tg:*)**")` is `<a href="tg:*"><b></a></b>` and `convert("~~**[_](tg:_)~~**")` is `<s><b><a href="tg:_">_</a></s></b>`, both byte-identical on `origin/main`. On an anchor-template sweep this PR shrinks that class by roughly 8x and adds nothing to it, but what remains is bold and strikethrough rather than italics, and closing it means giving those two passes the same nets. Neither `tagsBalanced` nor `tagMask` is a well-formedness proof for the converter as a whole, and this PR does not claim to be one. The source comment previously named only the raw `<`; it now names both.

**The second half of the report — diff lines rendering as bullets — is not fixed here, and the reporter's screenshot was not downloaded.** I did verify the mechanism, and it is real, though not for the reason one would guess: `matchListItem` uses `/^\s{0,6}[-*+]\s+(.*)$/`, so a bare `-foo` does *not* match, but a removed or added line of *indented* code does — `-    const x = 1;` and `+    const y = 2;` both become `• const …`, losing the sigil and the indentation. What I cannot tell without the screenshot is whether their diff carried `@@`/`--- `/`+++ ` markers, which is the only signal I would trust to switch the behaviour off; a run-detection heuristic without that evidence risks breaking ordinary bullet lists, which are far more common in agent replies than unfenced diffs. It wants its own change, once someone has looked at the attachment.

