### PR TITLE
fix(agent): retry a wholly empty native-tools completion instead of ending the turn

### DIFF
--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -2375,6 +2375,224 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(failures[0]?.message).toContain("twice in a row");
   });
 
+  it("does not announce an empty-completion retry it has no step left to spend", async () => {
+    // A leg of one: the retry would land on the leg boundary, where a
+    // leg that produced nothing usable stops the task. Announcing the
+    // retry there would burn the step with ZERO extra inference and
+    // swallow the model diagnosis into "ran out of steps" — the
+    // operator would read "trying again (1/1)" for a try that never
+    // happened, and Sentry would never see the failure.
+    const registry = buildDefaultToolRegistry();
+    let llmCalls = 0;
+    const recoveries: number[] = [];
+    const failures: Array<{ category: string; message: string }> = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async () => {
+        llmCalls += 1;
+        return makeNativeCompletion();
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "empty_completion_recovered")
+          recoveries.push(event.stepIndex);
+        if (event.type === "loop_failed")
+          failures.push({
+            category: event.category,
+            message: event.error.message,
+          });
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-empty-nt-leg", workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 1,
+        taskMaxSteps: 50,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(recoveries).toEqual([]);
+    expect(llmCalls).toBe(1);
+    expect(result.reason).toBe("failed");
+    expect(result.session.status).toBe("failed");
+    // The model diagnosis survives — and it does not claim a second
+    // attempt that never ran.
+    expect(failures[0]?.category).toBe("model");
+    expect(failures[0]?.message).toContain("empty");
+    expect(failures[0]?.message).not.toContain("twice in a row");
+  });
+
+  it("gives a fresh empty-completion retry to an empty that follows a working step", async () => {
+    // The budget counts empties IN A ROW. A model that answered a step
+    // and then went quiet has just proved the link works, so it gets
+    // the same one nudge the first empty got — and the terminal
+    // "twice in a row" message is never printed over a working step.
+    const registry = buildDefaultToolRegistry();
+    registry.register(osFsReadTool);
+    writeFileSync(join(workingDir, "src.ts"), "line 1\n", "utf8");
+    const script: Array<CompletionResult> = [
+      makeNativeCompletion(),
+      makeNativeCompletion([
+        { name: "os.fs.read", arguments: JSON.stringify({ path: "src.ts" }) },
+      ]),
+      makeNativeCompletion(),
+      makeNativeCompletion([
+        { name: "reply", arguments: JSON.stringify({ text: "done" }) },
+      ]),
+    ];
+    let llmCalls = 0;
+    const recoveries: Array<{ stepIndex: number; attempt: number }> = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async () => {
+        const completion = script[llmCalls] ?? makeNativeCompletion();
+        llmCalls += 1;
+        return completion;
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "empty_completion_recovered")
+          recoveries.push({
+            stepIndex: event.stepIndex,
+            attempt: event.attempt,
+          });
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-empty-nt-gap", workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 8,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(result.reason).toBe("reply");
+    expect(llmCalls).toBe(4);
+    // Two recoveries, each the FIRST of its run — the working step in
+    // between cleared the count.
+    expect(recoveries).toEqual([
+      { stepIndex: 0, attempt: 1 },
+      { stepIndex: 2, attempt: 1 },
+    ]);
+  });
+
+  it("still spends the empty-completion retry when the leg is going to continue", async () => {
+    // The other side of the guard above: the retry lands on a leg
+    // boundary, but the leg produced something usable, so the boundary
+    // continues the task and the retry really does happen. The guard
+    // must be about the `no_progress` break, not about boundaries.
+    const registry = buildDefaultToolRegistry();
+    registry.register(osFsReadTool);
+    writeFileSync(join(workingDir, "src.ts"), "line 1\n", "utf8");
+    const script: Array<CompletionResult> = [
+      makeNativeCompletion([
+        { name: "os.fs.read", arguments: JSON.stringify({ path: "src.ts" }) },
+      ]),
+      makeNativeCompletion(),
+      makeNativeCompletion([
+        { name: "reply", arguments: JSON.stringify({ text: "done" }) },
+      ]),
+    ];
+    let llmCalls = 0;
+    const recoveries: Array<{ stepIndex: number; attempt: number }> = [];
+    let continued = 0;
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async () => {
+        const completion = script[llmCalls] ?? makeNativeCompletion();
+        llmCalls += 1;
+        return completion;
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "empty_completion_recovered")
+          recoveries.push({
+            stepIndex: event.stepIndex,
+            attempt: event.attempt,
+          });
+        if (event.type === "task_continued") continued += 1;
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-empty-nt-boundary", workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 2,
+        taskMaxSteps: 50,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(recoveries).toEqual([{ stepIndex: 1, attempt: 1 }]);
+    expect(continued).toBe(1);
+    expect(llmCalls).toBe(3);
+    expect(result.reason).toBe("reply");
+  });
+
+  it("does not announce a parse-failure retry it has no step left to spend", async () => {
+    // Same leg-boundary guard on the parse path, which had the same
+    // hazard: the retry announced on the last step of a barren leg is
+    // never performed, and the operator was handed "ran out of steps"
+    // in place of the grammar diagnosis.
+    const registry = buildDefaultToolRegistry();
+    let llmCalls = 0;
+    const recoveries: number[] = [];
+    const failures: Array<{ category: string; message: string }> = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      llmComplete: async () => {
+        llmCalls += 1;
+        return makeCompletion('[{"tool":"reply","args":{"text":');
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "parse_failure_recovered")
+          recoveries.push(event.stepIndex);
+        if (event.type === "loop_failed")
+          failures.push({
+            category: event.category,
+            message: event.error.message,
+          });
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-parse-leg", workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 1,
+        taskMaxSteps: 50,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(recoveries).toEqual([]);
+    // One inference and its in-step repair, and no third.
+    expect(llmCalls).toBe(2);
+    expect(result.reason).toBe("failed");
+    expect(failures[0]?.category).toBe("grammar");
+  });
+
   it("does not recover a request the model server itself rejected", async () => {
     const registry = buildDefaultToolRegistry();
     let llmCalls = 0;

--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -10,6 +10,7 @@ import { SlotManager } from "../llm/slot-manager.js";
 import { TransportError } from "../llm/reliability/llm-failures.js";
 import { LlamaServerError } from "../llm/llama-server-client.js";
 import { PARSE_RECOVERY_BUDGET } from "./parse-failure-recovery.js";
+import { EMPTY_COMPLETION_RECOVERY_BUDGET } from "./empty-completion-recovery.js";
 import { createEmptySessionState } from "../session/session-state.js";
 import type {
   CompletionResult,
@@ -46,6 +47,30 @@ function makeCompletion(
     cacheHitTokens: 0,
     slotId: 0,
     modelId,
+  };
+}
+
+/**
+ * A completion as a native-tools provider returns one: everything in
+ * `tool_calls`, nothing in `content`. Called with no arguments it is the
+ * wholly-empty completion behind Sentry CLI-BA — no content, no
+ * reasoning, no calls.
+ */
+function makeNativeCompletion(
+  toolCalls?: Array<{ name: string; arguments: string }>,
+): CompletionResult {
+  return {
+    ...makeCompletion("", "openai/gpt-5.5"),
+    slotId: -1,
+    ...(toolCalls === undefined
+      ? {}
+      : {
+          toolCalls: toolCalls.map((call, index) => ({
+            id: `call-${index}`,
+            type: "function" as const,
+            function: call,
+          })),
+        }),
   };
 }
 
@@ -2255,6 +2280,99 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect((last as { text: string }).text).toContain(
       "Nothing from it took effect",
     );
+  });
+
+  it("recovers a wholly empty native-tools completion by spending a step", async () => {
+    // Sentry CLI-BA: on `native_tools` a completion with nothing in any
+    // channel has no parse to retry and no repair to run, so before this
+    // it ended the turn on the first inference and the operator had to
+    // notice the silence and type "try again".
+    const registry = buildDefaultToolRegistry();
+    let llmCalls = 0;
+    const prompts: string[] = [];
+    const recoveries: Array<{ attempt: number; budget: number }> = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async (params) => {
+        llmCalls += 1;
+        prompts.push(params.prompt);
+        return llmCalls === 1
+          ? makeNativeCompletion()
+          : makeNativeCompletion([
+              { name: "reply", arguments: JSON.stringify({ text: "done" }) },
+            ]);
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "empty_completion_recovered")
+          recoveries.push({ attempt: event.attempt, budget: event.budget });
+      },
+    });
+    const session = createEmptySessionState({ id: "s-empty-nt", workingDir });
+    const result = await loop.runTurn(session, {
+      userMessage: "go",
+      maxSteps: 5,
+      signal: new AbortController().signal,
+    });
+    expect(result.reason).toBe("reply");
+    expect(result.session.status).toBe("pending");
+    expect(recoveries).toEqual([
+      { attempt: 1, budget: EMPTY_COMPLETION_RECOVERY_BUDGET },
+    ]);
+    // The retry is a different request, not a replay: the step that
+    // follows is told its predecessor came back empty.
+    expect(prompts[1] ?? "").toContain("completely empty");
+    expect(prompts[1] ?? "").toContain("Nothing has happened yet");
+    const replies = result.session.turns.filter(
+      (t) => t.kind === "assistant_reply",
+    );
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({ text: "done" });
+  });
+
+  it("ends the turn on the second empty native-tools completion, saying so", async () => {
+    const registry = buildDefaultToolRegistry();
+    let llmCalls = 0;
+    const failures: Array<{ category: string; message: string }> = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async () => {
+        llmCalls += 1;
+        return makeNativeCompletion();
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "loop_failed")
+          failures.push({
+            category: event.category,
+            message: event.error.message,
+          });
+      },
+    });
+    const session = createEmptySessionState({ id: "s-empty-nt2", workingDir });
+    const result = await loop.runTurn(session, {
+      userMessage: "go",
+      maxSteps: 5,
+      signal: new AbortController().signal,
+    });
+    expect(result.reason).toBe("failed");
+    expect(result.session.status).toBe("failed");
+    // One recovery, then terminal — the budget is not a retry loop.
+    expect(llmCalls).toBe(EMPTY_COMPLETION_RECOVERY_BUDGET + 1);
+    expect(failures[0]?.category).toBe("model");
+    expect(failures[0]?.message).toContain("twice in a row");
   });
 
   it("does not recover a request the model server itself rejected", async () => {

--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -2593,6 +2593,122 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     expect(failures[0]?.category).toBe("grammar");
   });
 
+  it("reports the doubled empty when the announced retry lands on the final allowed step", async () => {
+    // The retry is announced at step `stepCeiling - 2` and spent at
+    // `stepCeiling - 1`, which is the finalization step — and a
+    // finalization failure normally ends the turn `max_steps`/`stalled`
+    // with `runError` dropped. That would be a REGRESSION: without the
+    // recovery this scenario fails on the first empty carrying the
+    // model's diagnosis, so swallowing it would hand the operator "ran
+    // out of steps" for a promise the turn made and kept, and drop the
+    // error report with it. `run --max-steps 2` is the smallest window
+    // that reaches it.
+    const registry = buildDefaultToolRegistry();
+    let llmCalls = 0;
+    let recovered = 0;
+    const failures: Array<{ category: string; message: string }> = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async () => {
+        llmCalls += 1;
+        return makeNativeCompletion();
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (event.type === "empty_completion_recovered") recovered += 1;
+        if (event.type === "loop_failed")
+          failures.push({
+            category: event.category,
+            message: event.error.message,
+          });
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-empty-nt-final", workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 2,
+        autoContinue: false,
+        signal: new AbortController().signal,
+      },
+    );
+    // The retry really happened — this is not the "no step left" guard.
+    expect(recovered).toBe(1);
+    expect(llmCalls).toBe(2);
+    expect(result.reason).toBe("failed");
+    expect(result.session.status).toBe("failed");
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.category).toBe("model");
+    expect(failures[0]?.message).toContain("twice in a row");
+  });
+
+  it("reports the doubled empty when the announced retry lands past the duration ceiling", async () => {
+    // The other way a retry lands on a finalization step: the step
+    // ceiling is nowhere near, but `agent.task.maxDurationMs` is
+    // crossed by the first attempt, so the retry starts `outOfTime`.
+    // Same swallow, same fix — and this one is unreachable by the
+    // `stepCeiling` arithmetic alone, which is why the guard is on the
+    // failure, not on the step count.
+    let clock = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    try {
+      const registry = buildDefaultToolRegistry();
+      let llmCalls = 0;
+      let recovered = 0;
+      const failures: Array<{ category: string; message: string }> = [];
+      const loop = new AgentLoop({
+        registry,
+        slotManager: new SlotManager(2),
+        grammar: 'root ::= "ok"',
+        toolTransport: "native_tools",
+        toolCallAdapter: null,
+        llmComplete: async () => {
+          llmCalls += 1;
+          // Each attempt burns twice the task's whole time budget, so
+          // the step after the first one starts past the ceiling.
+          clock += 60_000;
+          return makeNativeCompletion();
+        },
+        toolDescriptors: TOOLS,
+        capabilities: CAPS,
+        skillCatalog: SKILLS,
+        onEvent: (event) => {
+          if (event.type === "empty_completion_recovered") recovered += 1;
+          if (event.type === "loop_failed")
+            failures.push({
+              category: event.category,
+              message: event.error.message,
+            });
+        },
+      });
+      const result = await loop.runTurn(
+        createEmptySessionState({ id: "s-empty-nt-time", workingDir }),
+        {
+          userMessage: "go",
+          maxSteps: 40,
+          taskMaxSteps: 40,
+          taskMaxDurationMs: 30_000,
+          signal: new AbortController().signal,
+        },
+      );
+      expect(recovered).toBe(1);
+      expect(llmCalls).toBe(2);
+      expect(result.reason).toBe("failed");
+      expect(result.session.status).toBe("failed");
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.category).toBe("model");
+      expect(failures[0]?.message).toContain("twice in a row");
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
   it("does not recover a request the model server itself rejected", async () => {
     const registry = buildDefaultToolRegistry();
     let llmCalls = 0;

--- a/src/agent/agent-loop.test.ts
+++ b/src/agent/agent-loop.test.ts
@@ -2709,6 +2709,127 @@ describe("AgentLoop end-to-end with mock LLM", () => {
     }
   });
 
+  it("lets a rejected completion between two empties buy the second one its own retry", async () => {
+    // The parse-recovery reset. A body that failed to parse is still
+    // tokens on the wire, so the empty that follows it is the FIRST of
+    // a new run, not the second of the old one — it gets its own nudge,
+    // and the terminal message never says "twice in a row" over a
+    // completion that carried something.
+    const registry = buildDefaultToolRegistry();
+    const script: CompletionResult[] = [
+      makeNativeCompletion(),
+      // Bad arguments twice: the first is the step's own one-shot
+      // repair, the second is what makes the step fail to parse.
+      makeNativeCompletion([{ name: "reply", arguments: "{ not json" }]),
+      makeNativeCompletion([{ name: "reply", arguments: "{ still not" }]),
+      makeNativeCompletion(),
+      makeNativeCompletion([
+        { name: "reply", arguments: JSON.stringify({ text: "done" }) },
+      ]),
+    ];
+    let llmCalls = 0;
+    const events: string[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async () => {
+        const completion = script[llmCalls] ?? makeNativeCompletion();
+        llmCalls += 1;
+        return completion;
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (
+          event.type === "empty_completion_recovered" ||
+          event.type === "parse_failure_recovered"
+        )
+          events.push(event.type);
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-empty-nt-parse-reset", workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 10,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(events).toEqual([
+      "empty_completion_recovered",
+      "parse_failure_recovered",
+      "empty_completion_recovered",
+    ]);
+    expect(llmCalls).toBe(5);
+    expect(result.reason).toBe("reply");
+  });
+
+  it("lets a cut reply between two empties buy the second one its own retry", async () => {
+    // The truncation-retry reset, same argument as the parse one: a
+    // reply the server cut short is a link that answered.
+    const registry = buildDefaultToolRegistry();
+    const script: CompletionResult[] = [
+      makeNativeCompletion(),
+      {
+        ...makeNativeCompletion(),
+        stop: false,
+        truncated: true,
+        usage: {
+          promptTokens: 6_000,
+          completionTokens: 8_192,
+          totalTokens: 14_192,
+        },
+      },
+      makeNativeCompletion(),
+      makeNativeCompletion([
+        { name: "reply", arguments: JSON.stringify({ text: "done" }) },
+      ]),
+    ];
+    let llmCalls = 0;
+    const events: string[] = [];
+    const loop = new AgentLoop({
+      registry,
+      slotManager: new SlotManager(2),
+      grammar: 'root ::= "ok"',
+      toolTransport: "native_tools",
+      toolCallAdapter: null,
+      llmComplete: async () => {
+        const completion = script[llmCalls] ?? makeNativeCompletion();
+        llmCalls += 1;
+        return completion;
+      },
+      toolDescriptors: TOOLS,
+      capabilities: CAPS,
+      skillCatalog: SKILLS,
+      onEvent: (event) => {
+        if (
+          event.type === "empty_completion_recovered" ||
+          event.type === "completion_truncated"
+        )
+          events.push(event.type);
+      },
+    });
+    const result = await loop.runTurn(
+      createEmptySessionState({ id: "s-empty-nt-trunc-reset", workingDir }),
+      {
+        userMessage: "go",
+        maxSteps: 10,
+        signal: new AbortController().signal,
+      },
+    );
+    expect(events).toEqual([
+      "empty_completion_recovered",
+      "completion_truncated",
+      "empty_completion_recovered",
+    ]);
+    expect(llmCalls).toBe(4);
+    expect(result.reason).toBe("reply");
+  });
+
   it("does not recover a request the model server itself rejected", async () => {
     const registry = buildDefaultToolRegistry();
     let llmCalls = 0;

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -63,6 +63,12 @@ import {
   formatTurnFailedRecord,
   isRecoverableParseFailure,
 } from "./parse-failure-recovery.js";
+import {
+  EMPTY_COMPLETION_RECOVERY_BUDGET,
+  composeEmptyCompletionNotice,
+  isRecoverableEmptyCompletion,
+  repeatedEmptyCompletionError,
+} from "./empty-completion-recovery.js";
 import { getConfig } from "../config/index.js";
 import type { AgentMetrics } from "../tracing/agent-metrics.js";
 import type { StructuredLogger } from "../tracing/structured-logger.js";
@@ -572,6 +578,20 @@ export type AgentLoopEvent =
     }
   | {
       /**
+       * The completion for step `stepIndex` came back with nothing in
+       * any channel, and the turn is spending another step on it rather
+       * than ending: the next prompt carries a `### notice` saying the
+       * reply was empty. Its own type rather than a
+       * `parse_failure_recovered` with an odd reason — there was no
+       * output to reject, and the operator line has to say so.
+       */
+      type: "empty_completion_recovered";
+      stepIndex: number;
+      attempt: number;
+      budget: number;
+    }
+  | {
+      /**
        * A leg of the task finished and the work is continuing. Fired at
        * every `maxSteps` boundary that does not end the task, so a long
        * job reports itself instead of going quiet for an hour.
@@ -913,6 +933,15 @@ export class AgentLoop {
      * the third try either, and the operator is owed the failure.
      */
     let parseRecoveries = 0;
+    /**
+     * Completions this turn that came back with nothing in any channel
+     * and were spent another step on. Bounded by
+     * `EMPTY_COMPLETION_RECOVERY_BUDGET`, and separate from
+     * `parseRecoveries` because the two shapes are different evidence:
+     * an unparseable body is a model that tried, an empty one is a model
+     * that emitted no tokens at all.
+     */
+    let emptyRecoveries = 0;
     // Per-turn no-progress loop tracker (OpenClaw-style). Threaded into
     // `executeStep` so the synchronous batch gate can veto looping calls
     // before they are dispatched; the agent loop consumes the resulting
@@ -1545,6 +1574,51 @@ export class AgentLoop {
           );
           runError = null;
           continue;
+        }
+        // The completion came back with nothing in it at all — no
+        // content, no reasoning, no tool calls — so there was nothing
+        // for the parser to read and nothing for the in-step repair to
+        // fix. Spend an ordinary step on it for the same reason as the
+        // parse failure above: the inference threw before any tool was
+        // dispatched, so nothing is repeated, and the next prompt
+        // carries a `### notice` telling the model its reply was empty,
+        // which is the only correction available for this shape.
+        //
+        // The step is counted, as the parse recovery is: it consumed an
+        // inference, and a leg made of empty completions must still
+        // reach its boundary as `no_progress`.
+        if (
+          !cancelled &&
+          emptyRecoveries < EMPTY_COMPLETION_RECOVERY_BUDGET &&
+          isRecoverableEmptyCompletion(err)
+        ) {
+          emptyRecoveries += 1;
+          stepsTaken += 1;
+          pendingNotice = composeEmptyCompletionNotice(noticeForThisStep);
+          this.deps.onEvent?.({
+            type: "empty_completion_recovered",
+            stepIndex: i,
+            attempt: emptyRecoveries,
+            budget: EMPTY_COMPLETION_RECOVERY_BUDGET,
+          });
+          this.deps.logger?.warn("completion was empty; retrying the turn", {
+            sessionId: state.id,
+            stepIndex: i,
+            attempt: emptyRecoveries,
+            budget: EMPTY_COMPLETION_RECOVERY_BUDGET,
+            category,
+          });
+          runError = null;
+          continue;
+        }
+        // The budget is spent and the model returned nothing again. The
+        // turn is terminal now, but `detectModelFailure`'s message
+        // describes a single empty completion — an operator reading it
+        // would reasonably conclude the runtime never retried. Say the
+        // count instead.
+        if (emptyRecoveries > 0 && isRecoverableEmptyCompletion(err)) {
+          runError = repeatedEmptyCompletionError(err);
+          category = classifyFailure(runError);
         }
         // The provider is not answering. Park the turn instead of
         // killing it: nothing of this step has been committed (a

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -934,14 +934,44 @@ export class AgentLoop {
      */
     let parseRecoveries = 0;
     /**
-     * Completions this turn that came back with nothing in any channel
-     * and were spent another step on. Bounded by
+     * Empty completions spent another step on, counted only while they
+     * are CONSECUTIVE — any completion that carried something resets it
+     * (see the reset next to `stepsTaken += 1` below). Bounded by
      * `EMPTY_COMPLETION_RECOVERY_BUDGET`, and separate from
      * `parseRecoveries` because the two shapes are different evidence:
      * an unparseable body is a model that tried, an empty one is a model
      * that emitted no tokens at all.
      */
     let emptyRecoveries = 0;
+    /**
+     * Is there a step left for a recovery to actually be spent in?
+     *
+     * A recovery that "spends a step" is a promise of another
+     * inference: the operator is told the turn is trying again, and the
+     * failure is dropped on the strength of that. All three ceilings
+     * can make that promise false. The task and time ceilings are
+     * already covered — the finalization guard above preempts every
+     * recovery on the last allowed step and on any step that starts
+     * past the duration ceiling, which is why the `stepCeiling` test
+     * here is belt-and-braces — but the LEG boundary is not covered by
+     * anything. A recovery taken on the final step of a
+     * leg that has produced nothing usable lands on the `no_progress`
+     * break, which leaves the loop before `executeStep` runs again: the
+     * announced retry never happens, the step is burnt for nothing, and
+     * the model diagnosis is swallowed into "ran out of steps" — taking
+     * the error report with it, since only `loop_failed` is captured.
+     *
+     * Reading `legMadeProgress` here is reading exactly what the
+     * boundary will read: a recovery cannot set it (it produced nothing
+     * usable, by definition), and nothing else runs in between.
+     */
+    const recoveryStepAvailable = (stepIndex: number): boolean => {
+      const next = stepIndex + 1;
+      if (next >= stepCeiling) return false;
+      const boundaryRuns =
+        next > 0 && next % legSteps === 0 && next !== lastBoundaryIndex;
+      return !boundaryRuns || legMadeProgress;
+    };
     // Per-turn no-progress loop tracker (OpenClaw-style). Threaded into
     // `executeStep` so the synchronous batch gate can veto looping calls
     // before they are dispatched; the agent loop consumes the resulting
@@ -1196,6 +1226,12 @@ export class AgentLoop {
         }
         state = outcome.nextSession;
         stepsTaken += 1;
+        // A completion the step could act on. Whatever run of empty
+        // completions was in progress is over: the link has just proved
+        // it answers, so an empty one later in this turn is a fresh
+        // event and is owed its own retry, and the terminal message can
+        // keep saying "twice in a row" and mean it.
+        emptyRecoveries = 0;
         const tokensUsed =
           (outcome.completion.timing?.promptTokens ??
             outcome.prompt.tokens.total) +
@@ -1478,6 +1514,12 @@ export class AgentLoop {
           if (retry.kind === "fit_window") {
             this.deps.onContextWindowObserved?.(retry.contextWindow);
           }
+          // A cut reply is still tokens on the wire, so — like the
+          // parse failure below — it breaks any run of empty
+          // completions. (A provider outage does not: it produces no
+          // completion at all, so the empties on either side of it are
+          // still consecutive completions.)
+          emptyRecoveries = 0;
           // The notice the cut attempt carried (loop detector, steering,
           // a trimmed batch) is still owed to the retry.
           pendingNotice = composeTruncationNotice(
@@ -1541,13 +1583,22 @@ export class AgentLoop {
         // The step is counted. It consumed an inference, and leaving
         // `legMadeProgress` false means a leg made entirely of rejected
         // completions still stops at the boundary as `no_progress`.
+        //
+        // `recoveryStepAvailable` is the leg-boundary half of the
+        // finalization guard above: a recovery on the last step of a
+        // barren leg would announce a retry the `no_progress` break
+        // never performs.
         if (
           !cancelled &&
           parseRecoveries < PARSE_RECOVERY_BUDGET &&
+          recoveryStepAvailable(i) &&
           isRecoverableParseFailure(err)
         ) {
           parseRecoveries += 1;
           stepsTaken += 1;
+          // The model emitted tokens, just not readable ones — so this
+          // breaks any run of empty completions.
+          emptyRecoveries = 0;
           // The notice this step was carrying (loop detector, steering,
           // a trimmed batch) is still owed to the next one.
           pendingNotice = composeParseFailureNotice(
@@ -1587,9 +1638,15 @@ export class AgentLoop {
         // The step is counted, as the parse recovery is: it consumed an
         // inference, and a leg made of empty completions must still
         // reach its boundary as `no_progress`.
+        //
+        // And it is only taken when a step is actually left to spend:
+        // on the last step of a barren leg the retry would be announced
+        // and never performed, and the operator would be handed
+        // "ran out of steps" in place of the model's own diagnosis.
         if (
           !cancelled &&
           emptyRecoveries < EMPTY_COMPLETION_RECOVERY_BUDGET &&
+          recoveryStepAvailable(i) &&
           isRecoverableEmptyCompletion(err)
         ) {
           emptyRecoveries += 1;

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -948,18 +948,27 @@ export class AgentLoop {
      *
      * A recovery that "spends a step" is a promise of another
      * inference: the operator is told the turn is trying again, and the
-     * failure is dropped on the strength of that. All three ceilings
-     * can make that promise false. The task and time ceilings are
-     * already covered — the finalization guard above preempts every
-     * recovery on the last allowed step and on any step that starts
-     * past the duration ceiling, which is why the `stepCeiling` test
-     * here is belt-and-braces — but the LEG boundary is not covered by
-     * anything. A recovery taken on the final step of a
-     * leg that has produced nothing usable lands on the `no_progress`
-     * break, which leaves the loop before `executeStep` runs again: the
-     * announced retry never happens, the step is burnt for nothing, and
-     * the model diagnosis is swallowed into "ran out of steps" — taking
-     * the error report with it, since only `loop_failed` is captured.
+     * failure is dropped on the strength of that. The LEG boundary is
+     * the one ceiling that can make that promise entirely false, and it
+     * is the one this predicate exists for. A recovery taken on the
+     * final step of a leg that has produced nothing usable lands on the
+     * `no_progress` break, which leaves the loop before `executeStep`
+     * runs again: the announced retry never happens, the step is burnt
+     * for nothing, and the model diagnosis is swallowed into "ran out
+     * of steps" — taking the error report with it, since only
+     * `loop_failed` is captured.
+     *
+     * The step and duration ceilings are deliberately NOT solved here.
+     * The finalization guard preempts a recovery on a step that is
+     * already final, but nothing stops one from LANDING on the final
+     * step — and there the retry genuinely runs, so refusing it would
+     * forfeit a real inference (and, on the last step of a long task,
+     * the summary it might still produce). What that case needs is for
+     * its failure to be reported instead of swallowed, which is
+     * `repeatedEmptyAfterAnnouncedRetry` in the catch below. The
+     * `stepCeiling` test that follows is therefore only a floor: it
+     * rejects a retry with no step at all left to run in, which the
+     * finalization guard already makes unreachable.
      *
      * Reading `legMadeProgress` here is reading exactly what the
      * boundary will read: a recovery cannot set it (it produced nothing
@@ -1552,7 +1561,32 @@ export class AgentLoop {
           i -= 1;
           continue;
         }
-        if (finalizationStep && !cancelled) {
+        // The retry this turn ANNOUNCED, landing on the finalization
+        // step and coming back empty again.
+        //
+        // The guard below normally swallows a finalization failure: the
+        // turn ends `max_steps`/`stalled` and `runError` is dropped.
+        // That is right for a step nobody was promised, and wrong here.
+        // The operator was told the turn was trying again, and without
+        // this recovery the same scenario ends `failed` carrying the
+        // model's own diagnosis — so swallowing it would trade a
+        // readable failure for "ran out of steps" AND drop the error
+        // report, since only `loop_failed` is captured. Reporting it
+        // executes no further work, which is the one thing the
+        // finalization guard exists to prevent.
+        //
+        // Both ceilings put the retry here: the step ceiling whenever
+        // the empty lands on the second-to-last allowed step (`run
+        // --max-steps 2`; a fusion worker at step 38 of its 40), and
+        // the duration ceiling whenever `agent.task.maxDurationMs` is
+        // crossed between the two attempts.
+        const repeatedEmptyAfterAnnouncedRetry =
+          emptyRecoveries > 0 && isRecoverableEmptyCompletion(err);
+        if (
+          finalizationStep &&
+          !cancelled &&
+          !repeatedEmptyAfterAnnouncedRetry
+        ) {
           // A failed finalization must not execute more work or turn a
           // bounded run into an unbounded retry. Preserve the established
           // explicit max-steps/stalled outcome instead.
@@ -1643,8 +1677,15 @@ export class AgentLoop {
         // on the last step of a barren leg the retry would be announced
         // and never performed, and the operator would be handed
         // "ran out of steps" in place of the model's own diagnosis.
+        //
+        // `!finalizationStep` is redundant today — the guard above only
+        // falls through to here for a repeated empty, which has already
+        // spent the budget — but it is the invariant that keeps it
+        // redundant: a budget above one must never announce a retry on
+        // a step the loop is about to leave.
         if (
           !cancelled &&
+          !finalizationStep &&
           emptyRecoveries < EMPTY_COMPLETION_RECOVERY_BUDGET &&
           recoveryStepAvailable(i) &&
           isRecoverableEmptyCompletion(err)
@@ -1673,9 +1714,12 @@ export class AgentLoop {
         // describes a single empty completion — an operator reading it
         // would reasonably conclude the runtime never retried. Say the
         // count instead.
-        if (emptyRecoveries > 0 && isRecoverableEmptyCompletion(err)) {
+        // `category` is deliberately not recomputed: the rewrite keeps
+        // the same `reason` on a `ModelError`, whose category is pinned
+        // to `model`, so reclassifying could only ever return what it
+        // already holds.
+        if (repeatedEmptyAfterAnnouncedRetry) {
           runError = repeatedEmptyCompletionError(err);
-          category = classifyFailure(runError);
         }
         // The provider is not answering. Park the turn instead of
         // killing it: nothing of this step has been committed (a

--- a/src/agent/empty-completion-recovery.test.ts
+++ b/src/agent/empty-completion-recovery.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { ModelError } from "../llm/reliability/llm-failures.js";
+import { GrammarError } from "../llm/reliability/llm-failures.js";
+import {
+  EMPTY_COMPLETION_RECOVERY_BUDGET,
+  composeEmptyCompletionNotice,
+  formatEmptyCompletionNotice,
+  isRecoverableEmptyCompletion,
+  repeatedEmptyCompletionError,
+} from "./empty-completion-recovery.js";
+
+function emptyOn(
+  transport: "grammar" | "native_tools",
+  stage: "initial" | "repair",
+): ModelError {
+  return new ModelError("empty", "model returned an empty completion", {
+    transport,
+    stage,
+  });
+}
+
+describe("isRecoverableEmptyCompletion", () => {
+  it("accepts a wholly empty native_tools completion at the initial stage", () => {
+    expect(
+      isRecoverableEmptyCompletion(emptyOn("native_tools", "initial")),
+    ).toBe(true);
+  });
+
+  it("rejects the grammar transport, which has its own in-step repair", () => {
+    expect(isRecoverableEmptyCompletion(emptyOn("grammar", "initial"))).toBe(
+      false,
+    );
+  });
+
+  it("rejects the repair stage, which has already had its extra attempt", () => {
+    expect(
+      isRecoverableEmptyCompletion(emptyOn("native_tools", "repair")),
+    ).toBe(false);
+  });
+
+  it("rejects truncated and no_stop, which a second pass cannot fix", () => {
+    for (const reason of ["truncated", "no_stop"] as const) {
+      expect(
+        isRecoverableEmptyCompletion(
+          new ModelError(reason, "cut off", {
+            transport: "native_tools",
+            stage: "initial",
+          }),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("rejects an untagged ModelError and everything that is not one", () => {
+    expect(isRecoverableEmptyCompletion(new ModelError("empty", "x"))).toBe(
+      false,
+    );
+    expect(isRecoverableEmptyCompletion(new GrammarError("bad", ""))).toBe(
+      false,
+    );
+    expect(isRecoverableEmptyCompletion(new Error("nope"))).toBe(false);
+    expect(isRecoverableEmptyCompletion("not an error")).toBe(false);
+  });
+});
+
+describe("formatEmptyCompletionNotice", () => {
+  it("says what came back, that nothing ran, and what to do", () => {
+    const notice = formatEmptyCompletionNotice();
+    expect(notice).toContain("completely empty");
+    expect(notice).toContain("Nothing has happened yet");
+    expect(notice).toContain("Answer this step now");
+  });
+});
+
+describe("composeEmptyCompletionNotice", () => {
+  it("returns the block alone when the step owed nothing", () => {
+    expect(composeEmptyCompletionNotice(undefined)).toBe(
+      formatEmptyCompletionNotice(),
+    );
+    expect(composeEmptyCompletionNotice("")).toBe(
+      formatEmptyCompletionNotice(),
+    );
+  });
+
+  it("puts the empty-reply block first, ahead of the notice already owed", () => {
+    const composed = composeEmptyCompletionNotice("stop re-reading that file");
+    expect(composed.startsWith(formatEmptyCompletionNotice())).toBe(true);
+    expect(composed).toContain("stop re-reading that file");
+  });
+});
+
+describe("repeatedEmptyCompletionError", () => {
+  it("says the model returned nothing twice and keeps the diagnostic tags", () => {
+    const first = emptyOn("native_tools", "initial");
+    const repeated = repeatedEmptyCompletionError(first);
+    expect(repeated).toBeInstanceOf(ModelError);
+    expect(repeated.message).toContain("twice in a row");
+    expect(repeated.message).toContain(first.message);
+    expect(repeated.reason).toBe("empty");
+    expect(repeated.transport).toBe("native_tools");
+    expect(repeated.stage).toBe("initial");
+    expect(repeated.category).toBe("model");
+    expect(repeated.cause).toBe(first);
+  });
+});
+
+describe("EMPTY_COMPLETION_RECOVERY_BUDGET", () => {
+  it("buys exactly one retry, so the second empty is terminal", () => {
+    expect(EMPTY_COMPLETION_RECOVERY_BUDGET).toBe(1);
+  });
+});

--- a/src/agent/empty-completion-recovery.ts
+++ b/src/agent/empty-completion-recovery.ts
@@ -31,7 +31,7 @@
 import { ModelError } from "../llm/index.js";
 
 /**
- * Recoveries allowed per turn.
+ * Recoveries allowed per RUN of consecutive empty completions.
  *
  * One, not the two `PARSE_RECOVERY_BUDGET` allows. An unparseable body
  * is a model that tried and slipped on serialization, and a second
@@ -41,10 +41,25 @@ import { ModelError } from "../llm/index.js";
  * Two nothings in a row is enough evidence, and a third empty
  * inference only delays the message the operator has to read anyway.
  *
- * Per turn rather than per step index, because the recovery step moves
- * forward instead of replaying the index: a turn whose link has stopped
- * answering would otherwise buy a fresh empty retry at every one of its
- * steps and burn the whole leg discovering the same thing.
+ * "In a row" is the whole of the scoping, and the agent loop enforces
+ * it: any completion that carried something — a step that ran, a body
+ * that failed to parse, a reply the server cut short — resets the
+ * count. Two consequences, both wanted:
+ *
+ *  - A link that has stopped answering still buys exactly ONE retry
+ *    for the whole turn, because nothing ever resets the count: the
+ *    turn does not get to burn a leg rediscovering the same silence,
+ *    which is what a per-step budget would have cost.
+ *  - A model that answered a step and then went quiet gets the same
+ *    one nudge the first empty got. It has just proved the link works,
+ *    so its silence is a fresh event, not the second half of an old
+ *    one — and a per-turn budget would have denied it a retry on the
+ *    strength of an empty completion twenty steps and a dozen working
+ *    tool calls ago.
+ *
+ * It is also what makes {@link repeatedEmptyCompletionError}'s message
+ * true: the turn only ever says "twice in a row" about two empties
+ * with no completion of any kind between them.
  */
 export const EMPTY_COMPLETION_RECOVERY_BUDGET = 1;
 
@@ -107,9 +122,22 @@ export function composeEmptyCompletionNotice(
  *
  * `detectModelFailure`'s own message describes one empty completion, and
  * an operator reading it after a silent retry would reasonably conclude
- * the runtime never tried. Say the count instead, and keep every
- * diagnostic tag (`transport`, `stage`) so the Sentry cluster this fixes
- * stays distinguishable from a first-and-only empty.
+ * the runtime never tried. Say the count instead — and only ever about
+ * two empties with nothing between them, which is what the consecutive
+ * budget above guarantees.
+ *
+ * The tags (`reason`, `transport`, `stage`) and the `cause` chain are
+ * kept so this stays the SAME Sentry issue as the empty it wraps, not a
+ * new one: `pickFrames` prefers the cause's stack, so the fingerprint's
+ * top frame remains the original step-executor throw. That is
+ * deliberate — a doubled empty is the same defect on the same link, and
+ * splitting it into its own cluster would fragment the very volume this
+ * recovery is measured by. Sentry will therefore NOT show the two
+ * apart: the rewritten message is for the operator's terminal, and the
+ * scrubber never transmits a message (`STATIC_MESSAGE_ERRORS` is empty
+ * by design). The trace is where the two are told apart — a turn that
+ * spent its retry carries an `empty_completion_recovered` event and one
+ * that failed on the first empty does not.
  */
 export function repeatedEmptyCompletionError(err: ModelError): ModelError {
   return new ModelError(

--- a/src/agent/empty-completion-recovery.ts
+++ b/src/agent/empty-completion-recovery.ts
@@ -1,0 +1,124 @@
+/**
+ * Recovery from a native-tools completion that came back wholly empty.
+ *
+ * On `native_tools` the step executor lets a completion through when
+ * ANY channel carries something: `tool_calls` the parser can read, or
+ * `reasoning_content` the parser gets a crack at (and, failing that,
+ * the one-shot repair). A completion with nothing in any channel has
+ * nothing to parse and nothing to repair, so it throws `ModelError`
+ * with `reason: "empty"` and `stage: "initial"` and the turn ends —
+ * the surfaces print `Turn failed [model]: …` and the operator has to
+ * notice the silence and type "try again".
+ *
+ * That silence is the whole defect. It is the same UX failure the
+ * unparseable-tool-call and length-truncated paths each already fixed,
+ * and this module gives the third shape the same treatment: spend one
+ * ordinary step on a fresh prompt carrying a `### notice` that says the
+ * previous reply was empty and nothing ran.
+ *
+ * Why the retry is a different request, not a replay: the empty
+ * completion consumed no budget and left no transcript row, so the only
+ * thing that changes between the two inferences is the notice — which
+ * is exactly the point. A wholly empty native-tools completion is
+ * overwhelmingly a stop-token or chat-template misfire (the model
+ * closed the turn before emitting anything), not a considered decision
+ * about the prompt; naming it in the prompt is the one lever we have,
+ * and there is no cap to raise the way `truncation-recovery` raises
+ * one. If the second attempt is empty too the fault is in the link, not
+ * in the wording, and the turn is owed the failure.
+ */
+
+import { ModelError } from "../llm/index.js";
+
+/**
+ * Recoveries allowed per turn.
+ *
+ * One, not the two `PARSE_RECOVERY_BUDGET` allows. An unparseable body
+ * is a model that tried and slipped on serialization, and a second
+ * nudge often lands; a body with nothing in any channel is a model that
+ * emitted no tokens at all, which is a binary condition — the next
+ * inference either produces something or the link is misconfigured.
+ * Two nothings in a row is enough evidence, and a third empty
+ * inference only delays the message the operator has to read anyway.
+ *
+ * Per turn rather than per step index, because the recovery step moves
+ * forward instead of replaying the index: a turn whose link has stopped
+ * answering would otherwise buy a fresh empty retry at every one of its
+ * steps and burn the whole leg discovering the same thing.
+ */
+export const EMPTY_COMPLETION_RECOVERY_BUDGET = 1;
+
+/**
+ * Is this the wholly-empty native-tools completion described above?
+ *
+ * All three facts are load-bearing:
+ *
+ *  - `native_tools` — on a grammar link an empty body already routes
+ *    into the in-step repair (`isGrammarEmptyCompletionWorthRepairing`),
+ *    so a turn-level retry would stack a second recovery on top of one
+ *    that already ran.
+ *  - `stage: "initial"` — the same `reason`/`transport` pair is raised
+ *    again after the one-shot repair, and that one HAS had its extra
+ *    attempt: it is the reasoning-only completion the parser handles.
+ *  - `reason: "empty"` — `truncated` and `no_stop` are excluded here for
+ *    the same reason the repair path excludes them: the model spent its
+ *    budget on this prefix and a second pass hits the same wall.
+ */
+export function isRecoverableEmptyCompletion(err: unknown): err is ModelError {
+  return (
+    err instanceof ModelError &&
+    err.reason === "empty" &&
+    err.transport === "native_tools" &&
+    err.stage === "initial"
+  );
+}
+
+/**
+ * The `### notice` block for the step that follows an empty completion.
+ *
+ * Says what came back, that nothing ran, and what to do — the model has
+ * no other way to learn any of it, because an empty completion leaves
+ * no transcript row behind.
+ */
+export function formatEmptyCompletionNotice(): string {
+  return [
+    "Your previous reply to this step was completely empty — no text, no reasoning, no tool call.",
+    "Nothing has happened yet: no file was written, no command ran, and the transcript above is unchanged.",
+    "Answer this step now. Either call a tool or write your reply as text; do not end your turn without emitting one of them.",
+  ].join("\n");
+}
+
+/**
+ * Fold the notice into whatever one-shot notice the step already owed
+ * the model (loop detector, steering, a trimmed batch). The empty reply
+ * comes first: it explains why the step is being asked again at all,
+ * which is context for the instruction that follows.
+ */
+export function composeEmptyCompletionNotice(
+  existing: string | undefined,
+): string {
+  const block = formatEmptyCompletionNotice();
+  if (existing === undefined || existing.length === 0) return block;
+  return `${block}\n\n${existing}`;
+}
+
+/**
+ * The failure the turn ends with when the retry came back empty too.
+ *
+ * `detectModelFailure`'s own message describes one empty completion, and
+ * an operator reading it after a silent retry would reasonably conclude
+ * the runtime never tried. Say the count instead, and keep every
+ * diagnostic tag (`transport`, `stage`) so the Sentry cluster this fixes
+ * stays distinguishable from a first-and-only empty.
+ */
+export function repeatedEmptyCompletionError(err: ModelError): ModelError {
+  return new ModelError(
+    err.reason,
+    `the model returned an empty completion twice in a row (no text, no reasoning, no tool call); last attempt: ${err.message}`,
+    {
+      cause: err,
+      ...(err.transport !== undefined ? { transport: err.transport } : {}),
+      ...(err.stage !== undefined ? { stage: err.stage } : {}),
+    },
+  );
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -51,6 +51,13 @@ export {
   formatTurnFailedRecord,
   isRecoverableParseFailure,
 } from "./parse-failure-recovery.js";
+export {
+  EMPTY_COMPLETION_RECOVERY_BUDGET,
+  composeEmptyCompletionNotice,
+  formatEmptyCompletionNotice,
+  isRecoverableEmptyCompletion,
+  repeatedEmptyCompletionError,
+} from "./empty-completion-recovery.js";
 export { classifyTestCommand } from "./test-command-key.js";
 export type { RecognizedTestCommand } from "./test-command-key.js";
 export {

--- a/src/cli/trace-formatter.test.ts
+++ b/src/cli/trace-formatter.test.ts
@@ -154,3 +154,35 @@ describe("formatTraceChronology parse_failure_recovered", () => {
     expect(line.length).toBeLessThan(300);
   });
 });
+
+describe("formatTraceChronology empty_completion_recovered", () => {
+  const event: TraceEvent = {
+    type: "empty_completion_recovered",
+    seq: 12,
+    sessionId: "s-1",
+    ts: Date.parse("2026-09-01T10:00:00.000Z"),
+    turnIndex: 0,
+    stepIndex: 2,
+    attempt: 1,
+    budget: 1,
+  };
+
+  it("says which step came back empty and how far into the budget", () => {
+    // The row a post-mortem of Sentry CLI-BA needs: an empty completion
+    // leaves nothing else in the trace — no tool call, no text, no
+    // error — so this line is the only evidence the step happened at
+    // all, and the only way to tell a turn that spent its retry from
+    // one that failed on the first empty.
+    const line = render([event]);
+    expect(line).toContain("#12 empty_completion_recovered");
+    expect(line).toContain("step=2 attempt=1/1");
+  });
+
+  it("carries no reason — there was no output to have rejected", () => {
+    const line = render([event]);
+    expect(line).not.toContain("reason=");
+    expect(line).not.toContain("undefined");
+    // One row, one line: the chronology stays greppable.
+    expect(line.trim().split("\n")).toHaveLength(1);
+  });
+});

--- a/src/cli/trace-formatter.ts
+++ b/src/cli/trace-formatter.ts
@@ -86,6 +86,8 @@ function formatTraceEvent(event: TraceEvent, raw: boolean): string {
       )}s`;
     case "parse_failure_recovered":
       return `${head} step=${event.stepIndex} attempt=${event.attempt}/${event.budget} reason=${truncate(event.reason, 120, raw)}`;
+    case "empty_completion_recovered":
+      return `${head} step=${event.stepIndex} attempt=${event.attempt}/${event.budget}`;
     case "provider_waiting":
       return `${head} attempt=${event.attempt} waited=${Math.round(
         event.waitedMs / 1000,

--- a/src/tracing/trace/trace-event.ts
+++ b/src/tracing/trace/trace-event.ts
@@ -32,6 +32,7 @@ export type TraceEvent =
   | TraceProviderRecovered
   | TraceCompletionTruncated
   | TraceParseFailureRecovered
+  | TraceEmptyCompletionRecovered
   | TraceLessonDeprecated
   | TraceVoteApplied
   | TraceVoteRejected
@@ -204,6 +205,20 @@ export interface TraceParseFailureRecovered extends TraceEventBase {
   attempt: number;
   budget: number;
   reason: string;
+}
+
+/**
+ * A completion came back with nothing in any channel and the turn spent
+ * another step on it instead of ending. Distinct from
+ * `parse_failure_recovered`: there was no output to reject, so a
+ * post-mortem reading a `reason` here would be reading a fiction.
+ */
+export interface TraceEmptyCompletionRecovered extends TraceEventBase {
+  type: "empty_completion_recovered";
+  turnIndex: number;
+  stepIndex: number;
+  attempt: number;
+  budget: number;
 }
 
 /** The provider answered again and the parked turn resumed. */

--- a/src/tracing/trace/trace-recorder.test.ts
+++ b/src/tracing/trace/trace-recorder.test.ts
@@ -54,6 +54,36 @@ describe("createTraceRecorder", () => {
     });
   });
 
+  it("records an empty-completion recovery against the current turn and step", () => {
+    const { events, emit } = collector();
+    const rec = createTraceRecorder({ sessionId: "s-empty", emit, now });
+    rec.onAgentEvent({ type: "turn_started", turnIndex: 4 } as AgentLoopEvent);
+    rec.onAgentEvent({
+      type: "empty_completion_recovered",
+      stepIndex: 6,
+      attempt: 1,
+      budget: 1,
+    } as AgentLoopEvent);
+    const recorded = events.find(
+      (e) => e.type === "empty_completion_recovered",
+    );
+    // `turnIndex` comes from the recorder's own cursor, the rest from
+    // the loop event — an empty completion leaves nothing else in the
+    // trace, so a wrong index here strands the only row that shows the
+    // step happened.
+    expect(recorded).toMatchObject({
+      type: "empty_completion_recovered",
+      sessionId: "s-empty",
+      turnIndex: 4,
+      stepIndex: 6,
+      attempt: 1,
+      budget: 1,
+      ts: 1000,
+    });
+    // No `reason`: there was no output to have rejected.
+    expect(recorded).not.toHaveProperty("reason");
+  });
+
   it("attaches user_message to the next turn_started", () => {
     const { events, emit } = collector();
     const rec = createTraceRecorder({ sessionId: "s-2", emit, now });

--- a/src/tracing/trace/trace-recorder.ts
+++ b/src/tracing/trace/trace-recorder.ts
@@ -394,6 +394,18 @@ export function createTraceRecorder(
             reason: event.reason,
           });
           return;
+        case "empty_completion_recovered":
+          push({
+            type: "empty_completion_recovered",
+            seq: nextSeq(),
+            sessionId,
+            ts: now(),
+            turnIndex: currentTurnIndex,
+            stepIndex: event.stepIndex,
+            attempt: event.attempt,
+            budget: event.budget,
+          });
+          return;
         case "provider_waiting":
           push({
             type: "provider_waiting",

--- a/src/tui/agent-event-reducer.test.ts
+++ b/src/tui/agent-event-reducer.test.ts
@@ -1178,6 +1178,60 @@ describe("parse-failure recovery", () => {
   });
 });
 
+describe("empty-completion recovery", () => {
+  const recovered = (over: Record<string, unknown> = {}): TuiAction => ({
+    type: "agent_event",
+    event: {
+      type: "empty_completion_recovered",
+      stepIndex: 3,
+      attempt: 1,
+      budget: 1,
+      ...over,
+    } as never,
+  });
+
+  it("says the reply was empty and that the turn is trying again", () => {
+    // The whole point of the line: an empty completion produces no tool
+    // call, no text and no error, so a feed without it shows a step
+    // that appears never to have happened.
+    const next = reduceTuiState(
+      createInitialTuiState(fakeSession()),
+      recovered(),
+    );
+    const row = next.feed.at(-1);
+    expect(row?.kind).toBe("runtime_info");
+    expect(row?.line ?? "").toContain("empty reply");
+    expect(row?.line ?? "").toContain("trying again");
+    expect(row?.line ?? "").toContain("(1/1)");
+    expect(row?.color).toBe("yellow");
+    // Attributed to the step it happened on, not to the turn.
+    expect(row?.stepIndex).toBe(3);
+  });
+
+  it("does not read as a step boundary", () => {
+    // The recovery is a failure inside the step that was already
+    // running; the status line and the step counter belong to it.
+    const running = apply(createInitialTuiState(fakeSession()), [
+      { type: "agent_event", event: { type: "step_started", stepIndex: 3 } },
+    ]);
+    const next = reduceTuiState(running, recovered());
+    expect(next.status).toBe(running.status);
+    expect(next.currentStep).toBe(3);
+  });
+
+  it("leaves one line per recovery, and says which attempt each is", () => {
+    const next = apply(createInitialTuiState(fakeSession()), [
+      recovered(),
+      recovered({ stepIndex: 7, attempt: 1, budget: 1 }),
+    ]);
+    const lines = next.feed
+      .filter((row) => row.line.includes("empty reply"))
+      .map((row) => row.line);
+    expect(lines).toHaveLength(2);
+    expect(lines.every((line) => line.includes("(1/1)"))).toBe(true);
+  });
+});
+
 describe("provider outage", () => {
   const waiting = (over: Record<string, unknown> = {}): TuiAction => ({
     type: "agent_event",

--- a/src/tui/agent-event-reducer.ts
+++ b/src/tui/agent-event-reducer.ts
@@ -750,6 +750,16 @@ function reduceAgentEvent(state: TuiState, event: AgentLoopEvent): TuiState {
         color: "yellow",
       });
     }
+    case "empty_completion_recovered":
+      // Same reason as above, and more so: an empty completion produces
+      // literally nothing, so without this line the feed shows a step
+      // that never happened.
+      return appendFeed(state, {
+        kind: "runtime_info",
+        stepIndex: event.stepIndex,
+        line: `» the model returned an empty reply — trying again (${event.attempt}/${event.budget})`,
+        color: "yellow",
+      });
     case "loop_detected":
       // Deliberately not rendered: the loop detector's own `### notice`
       // changes what the model does, and the operator sees the effect


### PR DESCRIPTION
## What was wrong

Sentry cluster `CLI-BA` — **70 events / 37 users** in 14 days (53 on 0.5.5, 9 on 0.5.6, 5 on 0.5.4),
tagged `error_type=ModelError`, `category=model`, `reason=empty`. The `tool_transport` /
`failure_stage` tags that #340 added land on all 9 of the 0.5.6 events and are unanimous:
`tool_transport=native_tools`, `failure_stage=initial`.

(The cluster's `os=win32` exclusivity is a fingerprinting artefact, not a Windows bug: Sentry keys on
`frames[0].filename`, which is `atomic-agent.exe` for the single-file bundle on Windows and
`step-executor.js` elsewhere, so the same failure on macOS/Linux lands in a sibling cluster. This
change is platform-independent.)

The path is `step-executor.ts` ~530–590. On `native_tools`, `detectModelFailure` returns
`reason: "empty"`; `isGrammarEmptyCompletionWorthRepairing` says no (that is the grammar transport's
in-step repair); and `isNativeToolsEmptyCompletionHandledByParser` says no because there is nothing
in *any* channel — no `content`, no `reasoningContent`, no `toolCalls`. So `ModelError` is thrown on
the very first inference, the turn ends, and the surfaces print `Turn failed [model]: …`.

There was no repair and no retry on this path at all. The operator had to notice the silence and
type "try again" — the same UX failure #387 (unparseable tool call) and #359 (length-truncated
completion) each just fixed for the other two failure shapes. This is the third.

## What the fix does

A new `src/agent/empty-completion-recovery.ts`, shaped after the two precedents, plus its consumption
in the agent loop's catch clause. On the recoverable shape the turn spends **one ordinary step** on a
freshly built prompt carrying a `### notice` that says the previous reply was empty and that nothing
ran, instead of ending.

`isRecoverableEmptyCompletion` requires all three of `reason: "empty"`, `transport: "native_tools"`
and `stage: "initial"`. That triple is exactly the wholly-empty case: a native completion that still
had `reasoning_content` never reaches the throw (the parser gets it), and the same
`reason`/`transport` pair raised at `stage: "repair"` is that reasoning-only case *after* it already
had its extra attempt. Grammar transport, `truncated` and `no_stop` are all untouched.

### The three design calls

**One retry, per run of consecutive empties.** `PARSE_RECOVERY_BUDGET` is 2 because an unparseable
body is a model that tried and slipped on serialization, and a second nudge often lands. A body with
nothing in any channel is different evidence: the model emitted no tokens at all. That is close to
binary — the next inference either produces something or the link is misconfigured — so two nothings
in a row is enough and a third only delays the message the operator has to read.

"In a row" is enforced, not assumed: any completion that carried something — a step that ran, a body
that failed to parse, a reply the server cut short — resets the count. (A provider outage does not:
it produces no completion at all, so the empties on either side of it are still consecutive
completions.) That is deliberately *not* a per-turn budget, which was this PR's first draft and was
wrong on both ends:

- a link that has stopped answering still buys exactly ONE retry for the whole turn, because nothing
  ever resets the count — the turn does not get to burn a leg rediscovering the same silence, which
  is the per-*step* budget's failure mode;
- but a model that answered a step and then went quiet has just proved the link works, so its silence
  is a fresh event and gets the same one nudge the first empty got. A per-turn budget denied it a
  retry on the strength of an empty completion twenty steps and a dozen working tool calls ago.

It is also what makes the terminal message's "twice in a row" *true*. Per-turn, it was not: two
empties separated by a working step were reported as consecutive.

**A different request, not a replay** — and this is the objection worth answering head-on, because
unlike truncation there is no cap to raise: the empty completion spent no budget, so nothing about
the *parameters* is worth changing. What changes is the prompt. The empty completion left no
transcript row, so without the notice the model would be handed a byte-identical prompt; with it, it
is told its previous reply was empty, that nothing ran, and to emit a tool call or text now. A
wholly empty native-tools completion is overwhelmingly a stop-token or chat-template misfire rather
than a considered reading of the prompt, so naming it is the one lever available — and the test below
asserts the second prompt actually carries it.

**The second empty is terminal, and says so.** `detectModelFailure`'s message describes a single
empty completion; an operator reading it after a silent retry would reasonably conclude the runtime
never tried. `repeatedEmptyCompletionError` re-raises as `the model returned an empty completion
twice in a row (no text, no reasoning, no tool call); last attempt: …`, chaining the original as
`cause` and keeping `reason`, `transport` and `stage`.

Keeping the tags and the cause keeps this the **same** Sentry issue as the empty it wraps, which is
the intent: `pickFrames` prefers the cause's stack, so the fingerprint's top frame stays the original
`step-executor` throw and the doubled empty does not fork a new cluster out of the volume this PR is
measured by. To be explicit, since an earlier draft of this body claimed the opposite: Sentry will
**not** show a doubled empty apart from a first-and-only empty. Every reported field is identical and
the message is never transmitted at all (`STATIC_MESSAGE_ERRORS` is empty by design). The rewritten
message is for the operator's terminal; the **trace** is where the two are told apart — a turn that
spent its retry carries an `empty_completion_recovered` event and one that failed on the first empty
does not.

### The retry has to be a promise the loop can keep

A recovery that "spends a step" is a promise of another inference: the operator is told the turn is
trying again, and the failure is dropped on the strength of that. Two different ceilings can break
that promise, and they need opposite fixes.

**The leg boundary — do not announce it.** On the last step of a leg that has produced nothing
usable, the retry cannot happen at all. The recovery burnt the step; the next iteration hit the leg
boundary, found `legMadeProgress === false`, and broke out as `no_progress` — before `executeStep`
ran again. The operator read `trying again (1/1)` for a try that never happened, then got "ran out of
steps" in place of the model's own diagnosis, with the `ModelError` dropped (`runError = null`) and
no `loop_failed` emitted, so the event never reached error reporting either.
`recoveryStepAvailable(i)` reads exactly what the boundary is about to read and declines the
recovery. **The parse-failure recovery from #387 had the identical hazard and gets the same guard** —
a deliberate change to already-merged behaviour, not collateral: on the last step of a barren leg it
announced the same unperformable retry and swallowed the `GrammarError` the same way. Both now fail
the turn with the model's own diagnosis, which is what `main` did before either recovery existed.

**The step and duration ceilings — do not swallow the result.** These are the opposite shape: the
retry *does* run, it just runs on the finalization step, where a failure hits the guard that ends the
turn `max_steps`/`stalled` and drops `runError`. An earlier revision of this PR left that open and it
was a regression, reachable with `run --max-steps 2` (empty at step 0, retry at step 1), on a fusion
worker's 40-step ceiling (`DEFAULT_FUSION_WORKER_MAX_STEPS`), and on any long task that crosses
`agent.task.maxDurationMs` between the two attempts: a scenario that fails cleanly on `main` with
`model returned empty content` ended `stalled` with no `loop_failed` and no error report, which is
worse than not recovering at all.

Refusing the retry would be the wrong fix — it really runs, and on the last allowed step it may still
produce the summary that step exists for. So the fix is on the failure, not on the step count: a
repeated empty that follows a retry *this turn announced* is reported instead of swallowed. Reporting
executes no further work, which is the one thing the finalization guard exists to prevent. Every
other finalization failure keeps its established `max_steps` outcome, untouched.

The event, and the surfaces
---------------------------

The recovery gets its own `empty_completion_recovered` event rather than borrowing
`parse_failure_recovered`: there was no output to reject, so its `reason` field would have to carry a
fiction, and the TUI line ("the model's output could not be read as a tool call") would be wrong. The
TUI, trace recorder and `atomic-agent trace` formatter each render the new one. Without a line the
feed would show a step that produced literally nothing — which is the silence this PR exists to fix.
The step is counted, as the parse recovery's is, so a leg made of empty completions still stops at
its boundary as `no_progress`.

## Test evidence

`npm run lint` (tsc --noEmit) — clean. `npx prettier --check` on every touched file — clean.

`npx vitest run src/agent/agent-loop.test.ts src/agent/empty-completion-recovery.test.ts
src/agent/parse-failure-recovery.test.ts src/agent/truncation-recovery.test.ts
src/agent/step-executor.test.ts src/tui/agent-event-reducer.test.ts
src/tracing/trace/trace-recorder.test.ts src/cli/trace-formatter.test.ts`
— **274 passed, 8 files, 0 failed.**

`npx vitest run src/agent src/tui src/tracing src/runtime src/cli` — **4040 passed, 358 files, 0
failed**, plus the environmental `EACCES` noted below.

Full suite: `npx vitest run` — 814 files, 8940 tests, 5 failed, none from this diff.
`src/sidecar/send-message-concurrency.test.ts` (FIFO ordering) fails in isolation on this branch and
is unrelated; `src/tui/provider-outage-composer.test.tsx` (4) passes in isolation and fails only
under full-suite load. There is also an environmental `EACCES` spawning `llama-server` in
`local-models-orchestrator-auto-update.test.ts`.

Tests: 10 unit tests in `empty-completion-recovery.test.ts` (the predicate accepts the triple and
rejects grammar / `stage: "repair"` / `truncated` / `no_stop` / an untagged `ModelError`; the notice
text; the composed order; the tags and `cause` preserved on the repeated error), 10 end-to-end loop
tests, and 6 rendering tests.

**Verified the loop tests fail without the `agent-loop.ts` change.** Against `origin/main`, with the
first two tests kept:

- *recovers a wholly empty native-tools completion by spending a step* — `expected 'failed' to be
  'reply'`
- *ends the turn on the second empty native-tools completion, saying so* — `llmCalls: expected 1 to
  be 2`

and against the previous commit of this branch, with the four newer tests kept, exactly the three
behavioural ones fail:

- *does not announce an empty-completion retry it has no step left to spend* — `expected [ 0 ] to
  deeply equal []` (the announced-but-unperformed retry)
- *gives a fresh empty-completion retry to an empty that follows a working step* — `expected 'failed'
  to be 'reply'`
- *does not announce a parse-failure retry it has no step left to spend* — same shape on the parse
  path

The fourth, *still spends the empty-completion retry when the leg is going to continue*, passes both
ways on purpose: it pins that the guard is about the `no_progress` break and not about leg boundaries
in general.

**The four newest tests are each pinned to their own line**, and all four fail against
`origin/main`:

- *reports the doubled empty when the announced retry lands on the final allowed step* and *…past the
  duration ceiling* — both fail when the finalization guard's `!repeatedEmptyAfterAnnouncedRetry`
  exemption is removed (`expected 'max_steps' to be 'failed'`, no `loop_failed`). The second uses a
  stubbed `Date.now`, so it is deterministic rather than wall-clock dependent.
- *lets a rejected completion between two empties buy the second one its own retry* fails when only
  the parse branch's `emptyRecoveries = 0` is deleted; *lets a cut reply…* fails when only the
  truncation branch's is. These two reset sites were previously uncovered — deleting either left
  `src/agent src/tui src/tracing` fully green.

**The three rendering branches are mutation-checked**, since an earlier revision of this PR shipped
them uncovered: replacing the reducer's line and colour, replacing the formatter's case body, and
setting the recorder's `turnIndex`/`stepIndex`/`attempt`/`budget` to `-999` each fails the new tests
(2, 1 and 1 respectively). Restored afterwards; the tree is clean.

## What this does not cover

- **Only `native_tools` + `stage: "initial"`.** A grammar-link empty body keeps its existing in-step
  repair, untouched; `truncated` and `no_stop` keep their existing exclusion at
  `step-executor.ts:1303`; the reasoning-only native completion the parser already handles is not
  affected.
- **It does not diagnose *why* the model returned nothing.** If the cause is a broken chat template,
  a wrong stop-token set, or a provider returning `finish_reason: stop` with an empty choice on
  every call, this buys one extra inference and then fails with a clearer message — it does not fix
  the link. The Sentry volume should drop rather than vanish, and the residue is the genuinely
  systematic half.
- **No parameter is changed on the retry** (temperature, `tool_choice`, transport fallover). Those
  are real options for a stubborn provider, but each is a behaviour change to the request that wants
  its own evidence; this PR deliberately changes only the prompt.
- **A doubled empty is not separable in Sentry**, by choice — see above. If it later needs to be, the
  distinguishing axis is a new scrubber field, not a message, and it wants its own allowlist audit.
- **The budget is per run of empties, and one turn can pay it many times.** The count resets on any
  completion that carried something, so a model that alternates empty / working inside a single turn
  buys a retry for every empty. Measured on a loop driven with a strictly alternating script
  (`maxSteps: 4`, `taskMaxSteps: 30`): 16 inferences, 8 of them recoveries, for 8 useful steps —
  100% overhead, and every recovery also consumes a step from the task's ceiling. That is the price
  of the alternative being wrong in the other direction (a per-turn budget denies a retry to a model
  that has since proved the link works), but it is a real cost and it is not capped per turn. Making
  it adaptive would need a cross-turn signal the loop does not carry today.
- **The retry costs a step, not just an inference.** The recovery is counted in `stepsTaken` and
  advances the loop index, so on a step-bounded run each empty shortens the work the turn can still
  do by one step.
- **`atomic-agent run` renders no line for it.** The non-TUI CLI surface switches on a fixed set of
  events and `empty_completion_recovered` is not among them, so an operator there sees only a longer
  pause where the TUI shows "trying again (1/1)". This matches `parse_failure_recovered`, which that
  surface does not render either; closing the gap is a change to `run-agent.ts`'s event switch that
  should cover both, not one.
- **`os=win32` was treated as a fingerprinting artefact** on the reasoning above rather than
  verified against a Windows run; if the same `reason=empty` + `native_tools` triple turns out to be
  genuinely Windows-only, the fix is still correct but the diagnosis in this PR is not.

