### PR TITLE
feat(channels): a /model command for Telegram and Discord

### DIFF
--- a/src/channels/discord/discord-inbound-handler.ts
+++ b/src/channels/discord/discord-inbound-handler.ts
@@ -22,6 +22,7 @@ import {
   type AttachmentInbox,
   type AttachmentOutcome,
 } from "../attachments/inbox.js";
+import { runModelCommand } from "../model-command.js";
 import type { DiscordApi } from "./discord-api.js";
 import { scrubDiscordError } from "./discord-channel-types.js";
 import {
@@ -110,6 +111,7 @@ const HELP_TEXT = [
   "  `/sessions` — every channel this bot has a session for",
   "  `/switch <session-id>` — point this channel at an existing session",
   "  `/new` — rotate this channel to a fresh session (current one is archived)",
+  "  `/model` — show the provider and model in use; `/model <provider> [model-id]` switches",
   "  `/cancel` — abort this channel's current turn if one is running",
 ].join("\n");
 
@@ -243,6 +245,20 @@ async function handleSlashCommand(
       return;
     case "/switch":
       await switchSession(rest[0], ref, ctx);
+      return;
+    case "/model":
+      // Owner-gated already: `route` drops every message from outside
+      // `ownerUserIds` before this dispatch runs, so there is no second
+      // check here — the same contract `/switch` and `/new` run under.
+      await send(
+        ctx,
+        ref.channelId,
+        await runModelCommand(rest, {
+          runtime: ctx.runtime,
+          sessionId: ctx.sessionPointer.get(ref.channelId).current,
+          code: (text) => `\`${text}\``,
+        }),
+      );
       return;
     case "/new": {
       const previous = ctx.sessionPointer.get(ref.channelId).current;

--- a/src/channels/discord/discord-inbound-model-command.test.ts
+++ b/src/channels/discord/discord-inbound-model-command.test.ts
@@ -49,15 +49,31 @@ const API_KEY_ENV = [
   "OPENAI_COMPAT_API_KEY",
   "OPENAI_API_KEY",
   "ATOMIC_AGENT_OPENAI_API_KEY",
+  "GROQ_API_KEY",
 ] as const;
 
-function writeLlmConfig(stateDir: string): void {
+/** Same shape, and same reason, as the Telegram twin's. */
+type ConfigOverrides = {
+  activeTextProvider?: string;
+  runMode?: Record<string, unknown>;
+  managedModelId?: string;
+};
+
+function writeLlmConfig(stateDir: string, over: ConfigOverrides = {}): void {
   writeUserConfigFileSync(getUserConfigPath(stateDir), {
     ...USER_CONFIG_DEFAULTS,
+    localModels: {
+      ...USER_CONFIG_DEFAULTS.localModels,
+      managed: {
+        ...USER_CONFIG_DEFAULTS.localModels.managed,
+        modelId: over.managedModelId ?? null,
+      },
+    },
     llm: {
-      activeTextProvider: "local-llama",
+      activeTextProvider: over.activeTextProvider ?? "local-llama",
       activeEmbeddingProvider: "local-llama",
       toolTransport: "auto",
+      ...(over.runMode ? { runMode: over.runMode } : {}),
       providers: [
         {
           id: "local-llama",
@@ -78,11 +94,27 @@ function writeLlmConfig(stateDir: string): void {
           baseUrl: "http://127.0.0.1:1234/v1",
           defaultChatModel: "gpt-x",
         },
+        // A known-service preset: same kind as the entry above, told
+        // apart only by declaring its own `apiKeyEnvVar`.
+        {
+          id: "groq",
+          kind: "openai-compatible",
+          baseUrl: "https://api.groq.com/openai/v1",
+          defaultChatModel: "llama-3.3-70b",
+          apiKeyEnvVar: "GROQ_API_KEY",
+        },
+        // The one cloud entry with no model of its own, for the
+        // clear-the-pin rollback branch.
+        { id: "aimlapi", kind: "aimlapi" },
       ],
     },
   });
   resetConfigCache();
 }
+
+/** Every configured id, in fixture order, for the "Configured:" lines. */
+const ALL_IDS =
+  "`local-llama`, `openrouter`, `openai-compat`, `groq`, `aimlapi`";
 
 function makeRuntime(sessions: SessionState[]) {
   const busy = new Set<string>();
@@ -205,6 +237,7 @@ describe("/model over Discord", () => {
     expect(report).toContain("• `local-llama` · `provider default` (active)");
     expect(process.env.OPENROUTER_API_KEY).toBeUndefined();
     expect(report).toContain("no API key");
+    expect(report).toContain("Run mode: Local — active provider local-llama");
   });
 
   it("pins a model on a provider, activates it, and stamps the session", async () => {
@@ -229,9 +262,7 @@ describe("/model over Discord", () => {
   it("refuses an unknown provider and names the configured ones", async () => {
     await say("/model gpt-5.4-mini");
     expect(sent[0]).toContain("Unknown provider `gpt-5.4-mini`.");
-    expect(sent[0]).toContain(
-      "Configured: `local-llama`, `openrouter`, `openai-compat`.",
-    );
+    expect(sent[0]).toContain(`Configured: ${ALL_IDS}.`);
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
   });
 
@@ -309,6 +340,8 @@ describe("/model over Discord", () => {
       "local-llama",
       "openrouter",
       "openai-compat",
+      "groq",
+      "aimlapi",
     ]);
   });
 
@@ -326,16 +359,21 @@ describe("/model over Discord", () => {
   });
 
   it("clears a pin that did not exist before when the reload fails", async () => {
+    process.env.AIMLAPI_API_KEY = "k";
     fake.failures.reload = new Error("nope");
-    await say("/model local-llama some-model");
-    expect(sent[0]).toBe("Could not switch to `local-llama`: nope");
+    // `aimlapi` is the fixture's one cloud entry with no
+    // `defaultChatModel`, so this is the *unset* rollback branch —
+    // `restoreProviderDefaultChatModelInConfig(id, undefined)`.
+    await say("/model aimlapi some-model");
+    expect(sent[0]).toBe("Could not switch to `aimlapi`: nope");
     // The config parser always materialises the key, so assert the
     // value: the rollback has to leave it unset, not set to the id the
     // reload refused.
     expect(
-      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+      getConfig().llm?.providers.find((p) => p.id === "aimlapi")
         ?.defaultChatModel,
     ).toBeUndefined();
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
   });
 
   it("still answers when the session store cannot save the stamp", async () => {
@@ -345,6 +383,130 @@ describe("/model over Discord", () => {
       "Now on `openai-compat` · `gpt-x`. Takes effect on the next message.",
     ]);
     expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
+  });
+
+  it("accepts the one-token form and splits at the first slash", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    await say("/model openrouter/vendor/model-9");
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "openrouter")
+        ?.defaultChatModel,
+    ).toBe("vendor/model-9");
+  });
+
+  it("refuses to pin a model on a local llama-server provider", async () => {
+    // See the Telegram twin: the llama-server factory never reads
+    // `entry.defaultChatModel`, but `resolveActiveModelName()` reads it
+    // first, so the pin renames the model everywhere and changes
+    // nothing that runs.
+    writeLlmConfig(stateDir, { managedModelId: "qwen-3.8-27b" });
+    await say("/model local-llama gpt-4-turbo");
+    expect(sent[0]).toContain("nothing reads a model id off its config entry");
+    expect(sent[0]).toContain("Local Models tab");
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+        ?.defaultChatModel,
+    ).toBeUndefined();
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+    expect(fake.reloaded).toEqual([]);
+    await say("/model");
+    expect(sent[1]).toContain("Model: `local-llama` · `qwen-3.8-27b`");
+  });
+
+  it("reports the managed local model, not a placeholder", async () => {
+    writeLlmConfig(stateDir, { managedModelId: "qwen-3.8-27b" });
+    await say("/model");
+    expect(sent[0]).toContain("Model: `local-llama` · `qwen-3.8-27b`");
+    expect(sent[0]).toContain("• `local-llama` · `qwen-3.8-27b` (active)");
+  });
+
+  it("refuses a preset provider whose declared env var is unset", async () => {
+    expect(process.env.GROQ_API_KEY).toBeUndefined();
+    await say("/model groq");
+    expect(sent[0]).toContain(
+      "has no API key configured (`GROQ_API_KEY` is unset)",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+    await say("/model");
+    expect(sent[1]).toContain(
+      "• `groq` · `llama-3.3-70b` — no API key (GROQ_API_KEY is unset)",
+    );
+    // The keyless LM Studio-shaped entry must stay usable.
+    expect(sent[1]).toContain("• `openai-compat` · `gpt-x`\n");
+  });
+
+  it("accepts a preset provider once its declared env var is set", async () => {
+    process.env.GROQ_API_KEY = "gsk-x";
+    await say("/model groq");
+    expect(sent[0]).toBe(
+      "Now on `groq` · `llama-3.3-70b`. Takes effect on the next message.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("groq");
+  });
+
+  it("reports the run mode, including a fusion deployment", async () => {
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "openrouter",
+      runMode: {
+        mode: "fusion",
+        fusion: {
+          orchestratorProvider: "openrouter",
+          workerProvider: "local-llama",
+        },
+      },
+      managedModelId: "qwen-3.8-27b",
+    });
+    await say("/model");
+    expect(sent[0]).toContain(
+      "Run mode: Fusion — orchestrator openrouter (openrouter/auto), 2 workers on local-llama (qwen-3.8-27b)",
+    );
+  });
+
+  it("says so when a switch drops the deployment out of fusion", async () => {
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "openrouter",
+      runMode: {
+        mode: "fusion",
+        fusion: {
+          orchestratorProvider: "openrouter",
+          workerProvider: "local-llama",
+        },
+      },
+      managedModelId: "qwen-3.8-27b",
+    });
+    await say("/model local-llama");
+    expect(sent[0]).toBe(
+      "Now on `local-llama` · `qwen-3.8-27b`. Takes effect on the next message.\n\n" +
+        "Run mode: Fusion → Local. `fusion.delegate` and its guidance are gone " +
+        "from every session until `openrouter` is active again — " +
+        "`/model openrouter` restores it.",
+    );
+    await say("/model");
+    expect(sent[1]).toContain("stored fusion, effective local");
+  });
+
+  it("says so when a switch puts the deployment back into fusion", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "local-llama",
+      runMode: {
+        mode: "fusion",
+        fusion: {
+          orchestratorProvider: "openrouter",
+          workerProvider: "local-llama",
+        },
+      },
+    });
+    await say("/model openrouter");
+    expect(sent[0]).toContain("Run mode: Local → Fusion.");
+    expect(sent[0]).toContain("2 workers on `local-llama`");
+  });
+
+  it("stays quiet about an ordinary Local → Cloud switch", async () => {
+    await say("/model openai-compat");
+    expect(sent[0]).toBe(
+      "Now on `openai-compat` · `gpt-x`. Takes effect on the next message.",
+    );
   });
 
   it("lists /model in the help text", async () => {

--- a/src/channels/discord/discord-inbound-model-command.test.ts
+++ b/src/channels/discord/discord-inbound-model-command.test.ts
@@ -607,4 +607,119 @@ describe("/model over Discord", () => {
     );
     expect(report).toContain("more not shown");
   });
+
+  /**
+   * The three refusals and the one confirmation below all interpolate a
+   * name the config schema does not bound, and all four are reachable
+   * with a single chat message: Discord accepts 2000 characters inbound
+   * and Telegram 4096, so "the operator just typed it" is the *likeliest*
+   * source of a pathological id, not the least likely. The report's cap
+   * (above) never sees these paths.
+   */
+  it("clips the model id in the switch confirmation", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    // 2000 characters in total — exactly what Discord accepts inbound,
+    // and well inside Telegram's own 4096.
+    const long = `vendor/${"m".repeat(1975)}`;
+    await say(`/model openrouter ${long}`);
+    expect(sent).toHaveLength(1);
+    // The stub above does not chunk the way `DiscordApi.sendMessage`
+    // does, so the length is asserted directly.
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("…");
+    // Clipping is a display concern only: the pin the TUI reads back is
+    // the id that was typed, whole.
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "openrouter")
+        ?.defaultChatModel,
+    ).toBe(long);
+  });
+
+  it("clips the model id in the llama-server refusal", async () => {
+    const long = `vendor/${"m".repeat(1974)}`;
+    await say(`/model local-llama ${long}`);
+    expect(sent).toHaveLength(1);
+    // The stub above does not chunk the way `DiscordApi.sendMessage`
+    // does, so the length is asserted directly.
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("…");
+    // Still a refusal, not a pin.
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+        ?.defaultChatModel,
+    ).toBeUndefined();
+  });
+
+  it("clips a declared env var in the no-key refusal", async () => {
+    // `apiKeyEnvVar` is `parseOptionalString`, so it is any non-empty
+    // string — the report already clips it, and this refusal is the
+    // other place it is printed.
+    const long = `LONG_${"E".repeat(500)}`;
+    writeLlmConfig(stateDir, {
+      extraProviders: [
+        {
+          id: "long-env",
+          kind: "openai-compatible",
+          baseUrl: "http://127.0.0.1:1298/v1",
+          defaultChatModel: "gpt-x",
+          apiKeyEnvVar: long,
+        },
+      ],
+    });
+    await say("/model long-env");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("has no API key configured");
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("…");
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("names every candidate an ambiguous prefix matches", async () => {
+    // This is the one message whose whole job is "say which one", so it
+    // is fitted to the message limit rather than to an entry count: a
+    // candidate that is hidden cannot be picked, and a chat offers no
+    // way to page through the rest.
+    writeLlmConfig(stateDir, {
+      extraProviders: Array.from({ length: 60 }, (_, i) => ({
+        id: `compat-provider-${i}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: `vendor/really-long-model-identifier-v${i}-instruct`,
+      })),
+    });
+    await say("/model compat");
+    expect(sent).toHaveLength(1);
+    const [msg = ""] = sent;
+    expect(msg.length).toBeLessThanOrEqual(2000);
+    expect(msg).toContain("`compat-provider-0`");
+    // The sixtieth, not a count: all of them fit, so all of them print.
+    expect(msg).toContain("`compat-provider-59`");
+    expect(msg).not.toMatch(/and \d+ more/);
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("counts ambiguous candidates only past the limit, and says how to narrow", async () => {
+    // 120 entries at the longest id `PROVIDER_ID_RE` allows (32
+    // characters) — more than one message can hold however it is
+    // fitted, which is the only case where hiding one is unavoidable.
+    writeLlmConfig(stateDir, {
+      extraProviders: Array.from({ length: 120 }, (_, i) => ({
+        id: `zz-aaaaaaaaaaaaaaaaaaaaaaaaa-${String(i).padStart(3, "0")}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: "gpt-x",
+      })),
+    });
+    await say("/model zz");
+    expect(sent).toHaveLength(1);
+    const [msg = ""] = sent;
+    expect(msg.length).toBeLessThanOrEqual(2000);
+    expect(msg).toMatch(/and \d+ more/);
+    // A count alone would be unactionable; this is the one thing the
+    // operator can do about it from a chat.
+    expect(msg).toContain("type more of the id to narrow the list");
+  });
 });

--- a/src/channels/discord/discord-inbound-model-command.test.ts
+++ b/src/channels/discord/discord-inbound-model-command.test.ts
@@ -1,0 +1,242 @@
+/**
+ * `/model` over Discord, end to end through `handleDiscordMessage`.
+ *
+ * The Telegram twin of this file is
+ * `../telegram/inbound-model-command.test.ts`; the two are kept
+ * deliberately parallel, because the two handlers are. Nothing is
+ * mocked here either: the command writes the real user config in an
+ * isolated `ATOMIC_AGENT_STATE_DIR`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resetConfigCache } from "../../config/config-cache.js";
+import {
+  getUserConfigPath,
+  writeUserConfigFileSync,
+} from "../../config/config-file.js";
+import { USER_CONFIG_DEFAULTS } from "../../config/config-schema.js";
+import { getConfig } from "../../config/index.js";
+import type { AgentRuntime } from "../../runtime/bootstrap.js";
+import {
+  createEmptySessionState,
+  readSessionLlmStamp,
+  type SessionState,
+} from "../../session/index.js";
+import { StructuredLogger } from "../../tracing/structured-logger.js";
+import { createAttachmentInbox } from "../attachments/inbox.js";
+import {
+  handleDiscordMessage,
+  type DiscordInboundContext,
+} from "./discord-inbound-handler.js";
+import { DiscordSessionPointer } from "./discord-session-pointer.js";
+
+const OWNER = "111";
+const BOT = "999";
+const CHANNEL = "c-1";
+
+function writeLlmConfig(stateDir: string): void {
+  writeUserConfigFileSync(getUserConfigPath(stateDir), {
+    ...USER_CONFIG_DEFAULTS,
+    llm: {
+      activeTextProvider: "local-llama",
+      activeEmbeddingProvider: "local-llama",
+      toolTransport: "auto",
+      providers: [
+        {
+          id: "local-llama",
+          kind: "llama-server",
+          url: "http://127.0.0.1:19091",
+        },
+        {
+          id: "openrouter",
+          kind: "openrouter",
+          defaultChatModel: "openrouter/auto",
+        },
+        { id: "openai-compat", kind: "openai-compatible", model: "gpt-x" },
+      ],
+    },
+  });
+  resetConfigCache();
+}
+
+function makeRuntime(sessions: SessionState[]) {
+  const busy = new Set<string>();
+  const saved: SessionState[] = [];
+  const reloaded: string[] = [];
+  const activated: string[] = [];
+  const runtime = {
+    createSession: () => sessions[0],
+    sessionStore: {
+      load: (id: string) => sessions.find((s) => s.id === id) ?? null,
+      save: (state: SessionState) => {
+        saved.push(state);
+        const at = sessions.findIndex((s) => s.id === state.id);
+        if (at >= 0) sessions[at] = state;
+      },
+    },
+    turnController: { isBusy: (id: string) => busy.has(id) },
+    providerRegistry: {
+      listIds: () => ["local-llama", "openrouter"],
+      setActive: vi.fn(async (id: string) => {
+        activated.push(id);
+        return {};
+      }),
+    },
+    reloadLlmProvider: vi.fn(async (id: string) => {
+      reloaded.push(id);
+    }),
+    reloadLlmProviders: vi.fn(async () => {
+      reloaded.push("*");
+    }),
+    runTurn: async () => ({ session: sessions[0], reason: "reply" as const }),
+  } as unknown as AgentRuntime;
+  return { runtime, busy, saved, reloaded, activated };
+}
+
+describe("/model over Discord", () => {
+  let stateDir: string;
+  let dir: string;
+  let sent: string[];
+  let ctx: DiscordInboundContext;
+  let session: SessionState;
+  let fake: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "atomic-dc-model-state-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    resetConfigCache();
+    writeLlmConfig(stateDir);
+
+    dir = mkdtempSync(join(tmpdir(), "atomic-dc-model-"));
+    const pointer = new DiscordSessionPointer(
+      join(dir, "discord-session.json"),
+    );
+    session = createEmptySessionState({ id: "s-1", workingDir: "/tmp/test" });
+    pointer.setCurrent(CHANNEL, session.id, "DM");
+    fake = makeRuntime([session]);
+    sent = [];
+    ctx = {
+      runtime: fake.runtime,
+      api: {
+        sendMessage: vi.fn(async (_channelId: string, text: string) => {
+          sent.push(text);
+          return "m1";
+        }),
+      },
+      sessionPointer: pointer,
+      logger: new StructuredLogger({ level: "warn", sinks: [] }),
+      ownerUserIds: [OWNER],
+      botUserId: BOT,
+      inflight: new Map(),
+      inbox: createAttachmentInbox({ dir: join(dir, "inbox") }),
+    } as unknown as DiscordInboundContext;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+  });
+
+  async function say(content: string, authorId: string = OWNER): Promise<void> {
+    await handleDiscordMessage(
+      {
+        id: "m",
+        channel_id: CHANNEL,
+        content,
+        author: { id: authorId },
+      },
+      ctx,
+    );
+  }
+
+  it("reports the active provider and every configured one", async () => {
+    await say("/model");
+    expect(sent).toHaveLength(1);
+    const [report = ""] = sent;
+    expect(report).toContain("Model: `local-llama` · `provider default`");
+    expect(report).toContain("• `openrouter` · `openrouter/auto`");
+    expect(report).toContain("• `local-llama` · `provider default` (active)");
+    expect(report).toContain("no API key");
+  });
+
+  it("pins a model on a provider, activates it, and stamps the session", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    try {
+      await say("/model openrouter anthropic/claude-opus-4");
+    } finally {
+      delete process.env.OPENROUTER_API_KEY;
+    }
+    expect(sent).toEqual([
+      "Now on `openrouter` · `anthropic/claude-opus-4`. Takes effect on the next message.",
+    ]);
+    const llm = getConfig().llm;
+    expect(llm?.activeTextProvider).toBe("openrouter");
+    expect(
+      llm?.providers.find((p) => p.id === "openrouter")?.defaultChatModel,
+    ).toBe("anthropic/claude-opus-4");
+    expect(fake.reloaded).toEqual(["openrouter"]);
+    expect(fake.activated).toEqual(["openrouter"]);
+    expect(readSessionLlmStamp(fake.saved.at(-1)?.metadata)).toEqual({
+      providerId: "openrouter",
+      chatModel: "anthropic/claude-opus-4",
+    });
+  });
+
+  it("refuses an unknown provider and names the configured ones", async () => {
+    await say("/model gpt-5.4-mini");
+    expect(sent[0]).toContain("Unknown provider `gpt-5.4-mini`.");
+    expect(sent[0]).toContain(
+      "Configured: `local-llama`, `openrouter`, `openai-compat`.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses an ambiguous prefix", async () => {
+    await say("/model open");
+    expect(sent[0]).toBe(
+      "`open` matches `openrouter`, `openai-compat` — say which one.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses a provider whose API key is missing", async () => {
+    await say("/model openrouter");
+    expect(sent[0]).toContain("has no API key configured");
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses while this channel has a turn in progress", async () => {
+    fake.busy.add(session.id);
+    await say("/model openai-compat");
+    expect(sent[0]).toBe(
+      "This chat has a turn in progress; try /model again when it finishes.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("switches provider without touching its pinned model", async () => {
+    await say("/model openai-compat");
+    expect(sent[0]).toBe(
+      "Now on `openai-compat` · `gpt-x`. Takes effect on the next message.",
+    );
+    expect(fake.reloaded).toEqual(["*"]);
+    expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
+  });
+
+  it("lists /model in the help text", async () => {
+    await say("/help");
+    expect(sent[0]).toContain("`/model`");
+  });
+
+  it("is not reachable by a non-owner", async () => {
+    await say("/model openai-compat", "222");
+    expect(sent).toHaveLength(0);
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+});

--- a/src/channels/discord/discord-inbound-model-command.test.ts
+++ b/src/channels/discord/discord-inbound-model-command.test.ts
@@ -5,7 +5,9 @@
  * `../telegram/inbound-model-command.test.ts`; the two are kept
  * deliberately parallel, because the two handlers are. Nothing is
  * mocked here either: the command writes the real user config in an
- * isolated `ATOMIC_AGENT_STATE_DIR`.
+ * isolated `ATOMIC_AGENT_STATE_DIR`, and the API-key environment
+ * variables are cleared per test so an ambient key cannot decide the
+ * outcome of a "no API key" assertion.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,6 +22,7 @@ import {
 } from "../../config/config-file.js";
 import { USER_CONFIG_DEFAULTS } from "../../config/config-schema.js";
 import { getConfig } from "../../config/index.js";
+import { ProviderRegistry } from "../../llm/provider/registry/index.js";
 import type { AgentRuntime } from "../../runtime/bootstrap.js";
 import {
   createEmptySessionState,
@@ -37,6 +40,16 @@ import { DiscordSessionPointer } from "./discord-session-pointer.js";
 const OWNER = "111";
 const BOT = "999";
 const CHANNEL = "c-1";
+
+/** Same list, and same reason, as the Telegram twin. */
+const API_KEY_ENV = [
+  "OPENROUTER_API_KEY",
+  "AIMLAPI_API_KEY",
+  "GEMINI_API_KEY",
+  "OPENAI_COMPAT_API_KEY",
+  "OPENAI_API_KEY",
+  "ATOMIC_AGENT_OPENAI_API_KEY",
+] as const;
 
 function writeLlmConfig(stateDir: string): void {
   writeUserConfigFileSync(getUserConfigPath(stateDir), {
@@ -56,7 +69,15 @@ function writeLlmConfig(stateDir: string): void {
           kind: "openrouter",
           defaultChatModel: "openrouter/auto",
         },
-        { id: "openai-compat", kind: "openai-compatible", model: "gpt-x" },
+        // An `openai-compatible` entry without `baseUrl` and
+        // `defaultChatModel` is refused by the real registry, so the
+        // fixture carries both and the registry test below proves it.
+        {
+          id: "openai-compat",
+          kind: "openai-compatible",
+          baseUrl: "http://127.0.0.1:1234/v1",
+          defaultChatModel: "gpt-x",
+        },
       ],
     },
   });
@@ -68,17 +89,27 @@ function makeRuntime(sessions: SessionState[]) {
   const saved: SessionState[] = [];
   const reloaded: string[] = [];
   const activated: string[] = [];
+  /** Injectable failures for the two steps that talk to the world. */
+  const failures: { reload: Error | null; save: Error | null } = {
+    reload: null,
+    save: null,
+  };
   const runtime = {
     createSession: () => sessions[0],
+    logger: new StructuredLogger({ level: "warn", sinks: [] }),
     sessionStore: {
       load: (id: string) => sessions.find((s) => s.id === id) ?? null,
       save: (state: SessionState) => {
+        if (failures.save) throw failures.save;
         saved.push(state);
         const at = sessions.findIndex((s) => s.id === state.id);
         if (at >= 0) sessions[at] = state;
       },
     },
-    turnController: { isBusy: (id: string) => busy.has(id) },
+    turnController: {
+      isBusy: (id: string) => busy.has(id),
+      busySessionIds: () => [...busy],
+    },
     providerRegistry: {
       listIds: () => ["local-llama", "openrouter"],
       setActive: vi.fn(async (id: string) => {
@@ -87,14 +118,16 @@ function makeRuntime(sessions: SessionState[]) {
       }),
     },
     reloadLlmProvider: vi.fn(async (id: string) => {
+      if (failures.reload) throw failures.reload;
       reloaded.push(id);
     }),
     reloadLlmProviders: vi.fn(async () => {
+      if (failures.reload) throw failures.reload;
       reloaded.push("*");
     }),
     runTurn: async () => ({ session: sessions[0], reason: "reply" as const }),
   } as unknown as AgentRuntime;
-  return { runtime, busy, saved, reloaded, activated };
+  return { runtime, busy, saved, reloaded, activated, failures };
 }
 
 describe("/model over Discord", () => {
@@ -104,8 +137,12 @@ describe("/model over Discord", () => {
   let ctx: DiscordInboundContext;
   let session: SessionState;
   let fake: ReturnType<typeof makeRuntime>;
+  let savedEnv: Array<[string, string | undefined]>;
 
   beforeEach(() => {
+    savedEnv = API_KEY_ENV.map((name) => [name, process.env[name]]);
+    for (const name of API_KEY_ENV) delete process.env[name];
+
     stateDir = mkdtempSync(join(tmpdir(), "atomic-dc-model-state-"));
     process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
     resetConfigCache();
@@ -140,6 +177,10 @@ describe("/model over Discord", () => {
     rmSync(dir, { recursive: true, force: true });
     rmSync(stateDir, { recursive: true, force: true });
     delete process.env.ATOMIC_AGENT_STATE_DIR;
+    for (const [name, value] of savedEnv) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
     resetConfigCache();
   });
 
@@ -162,16 +203,13 @@ describe("/model over Discord", () => {
     expect(report).toContain("Model: `local-llama` · `provider default`");
     expect(report).toContain("• `openrouter` · `openrouter/auto`");
     expect(report).toContain("• `local-llama` · `provider default` (active)");
+    expect(process.env.OPENROUTER_API_KEY).toBeUndefined();
     expect(report).toContain("no API key");
   });
 
   it("pins a model on a provider, activates it, and stamps the session", async () => {
     process.env.OPENROUTER_API_KEY = "k";
-    try {
-      await say("/model openrouter anthropic/claude-opus-4");
-    } finally {
-      delete process.env.OPENROUTER_API_KEY;
-    }
+    await say("/model openrouter anthropic/claude-opus-4");
     expect(sent).toEqual([
       "Now on `openrouter` · `anthropic/claude-opus-4`. Takes effect on the next message.",
     ]);
@@ -197,6 +235,27 @@ describe("/model over Discord", () => {
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
   });
 
+  it("names the command's shape for a token that begins with a slash", async () => {
+    await say("/model /vendor/model-9");
+    expect(sent[0]).toBe(
+      "A model id has to name its provider: `/model <provider> <model-id>`.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses trailing arguments instead of ignoring them", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    await say("/model openrouter m-1 junk more");
+    expect(sent[0]).toBe(
+      "Too many arguments. Usage: `/model <provider> <model-id>`.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "openrouter")
+        ?.defaultChatModel,
+    ).toBe("openrouter/auto");
+  });
+
   it("refuses an ambiguous prefix", async () => {
     await say("/model open");
     expect(sent[0]).toBe(
@@ -220,12 +279,71 @@ describe("/model over Discord", () => {
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
   });
 
+  it("refuses while ANOTHER session has a turn in progress", async () => {
+    fake.busy.add("s-other");
+    await say("/model openai-compat");
+    expect(sent[0]).toContain("A turn is in progress on 1 other session.");
+    expect(sent[0]).toContain("at their next step");
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
   it("switches provider without touching its pinned model", async () => {
     await say("/model openai-compat");
     expect(sent[0]).toBe(
       "Now on `openai-compat` · `gpt-x`. Takes effect on the next message.",
     );
     expect(fake.reloaded).toEqual(["*"]);
+    expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
+  });
+
+  it("uses a provider config the real registry can actually build", async () => {
+    const registry = await ProviderRegistry.fromConfig(getConfig(), {
+      config: getConfig(),
+      logger: new StructuredLogger({ level: "warn", sinks: [] }),
+      llamaClient: {} as never,
+      getProfile: (() => {
+        throw new Error("no inference runs in this test");
+      }) as never,
+    });
+    expect([...registry.listIds()]).toEqual([
+      "local-llama",
+      "openrouter",
+      "openai-compat",
+    ]);
+  });
+
+  it("leaves no half-written config when the provider reload fails", async () => {
+    fake.failures.reload = new Error("llama-server unreachable");
+    await say("/model openai-compat brand-new-model");
+    expect(sent[0]).toBe(
+      "Could not switch to `openai-compat`: llama-server unreachable",
+    );
+    const llm = getConfig().llm;
+    expect(llm?.activeTextProvider).toBe("local-llama");
+    expect(
+      llm?.providers.find((p) => p.id === "openai-compat")?.defaultChatModel,
+    ).toBe("gpt-x");
+  });
+
+  it("clears a pin that did not exist before when the reload fails", async () => {
+    fake.failures.reload = new Error("nope");
+    await say("/model local-llama some-model");
+    expect(sent[0]).toBe("Could not switch to `local-llama`: nope");
+    // The config parser always materialises the key, so assert the
+    // value: the rollback has to leave it unset, not set to the id the
+    // reload refused.
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+        ?.defaultChatModel,
+    ).toBeUndefined();
+  });
+
+  it("still answers when the session store cannot save the stamp", async () => {
+    fake.failures.save = new Error("ENOSPC");
+    await say("/model openai-compat");
+    expect(sent).toEqual([
+      "Now on `openai-compat` · `gpt-x`. Takes effect on the next message.",
+    ]);
     expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
   });
 

--- a/src/channels/discord/discord-inbound-model-command.test.ts
+++ b/src/channels/discord/discord-inbound-model-command.test.ts
@@ -57,6 +57,8 @@ type ConfigOverrides = {
   activeTextProvider?: string;
   runMode?: Record<string, unknown>;
   managedModelId?: string;
+  /** Same field, and same reason, as the Telegram twin's. */
+  extraProviders?: Array<Record<string, unknown>>;
 };
 
 function writeLlmConfig(stateDir: string, over: ConfigOverrides = {}): void {
@@ -106,6 +108,7 @@ function writeLlmConfig(stateDir: string, over: ConfigOverrides = {}): void {
         // The one cloud entry with no model of its own, for the
         // clear-the-pin rollback branch.
         { id: "aimlapi", kind: "aimlapi" },
+        ...(over.extraProviders ?? []),
       ],
     },
   });
@@ -518,5 +521,90 @@ describe("/model over Discord", () => {
     await say("/model openai-compat", "222");
     expect(sent).toHaveLength(0);
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  /** Same path, and same reason, as the Telegram twin's. */
+  it("answers instead of rejecting when the config no longer parses", async () => {
+    writeLlmConfig(stateDir, { activeTextProvider: "ghost" });
+    await say("/model");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("Could not run /model:");
+    expect(sent[0]).toContain('unknown provider id "ghost"');
+  });
+
+  it("reports the managed local model only for the daemon that serves it", async () => {
+    writeLlmConfig(stateDir, {
+      managedModelId: "qwen-3.8-27b",
+      extraProviders: [
+        { id: "remote-box", kind: "llama-server", url: "http://10.0.0.9:8080" },
+      ],
+    });
+    await say("/model");
+    expect(sent[0]).toContain("• `local-llama` · `qwen-3.8-27b` (active)");
+    expect(sent[0]).toContain("• `remote-box` · `provider default`");
+  });
+
+  it("caps the provider list so the report stays one message", async () => {
+    writeLlmConfig(stateDir, {
+      // `PROVIDER_ID_RE` caps an id at 32 kebab-case characters, so
+      // the bulk here is the model names, which the schema does not
+      // bound at all.
+      extraProviders: Array.from({ length: 60 }, (_, i) => ({
+        id: `compat-provider-${i}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: `vendor/really-long-model-identifier-v${i}-instruct`,
+      })),
+    });
+    await say("/model");
+    expect(sent).toHaveLength(1);
+    const [report = ""] = sent;
+    // `DiscordApi.sendMessage` chunks silently at
+    // `DISCORD_MESSAGE_LIMIT`; the stub above does not, so the length
+    // is asserted directly.
+    expect(report.length).toBeLessThanOrEqual(2000);
+    expect(report).toContain("more not shown");
+    expect(report).toContain("Model: `local-llama` · `provider default`");
+    expect(report).toContain("`/model <provider>` switches provider");
+  });
+
+  it("clips a model id long enough to fill the message on its own", async () => {
+    // A provider id cannot get here — `PROVIDER_ID_RE` caps it at 32
+    // characters — but a model id is any non-empty string.
+    const long = `vendor/${"m".repeat(400)}`;
+    writeLlmConfig(stateDir, {
+      extraProviders: [
+        {
+          id: "long-model-compat",
+          kind: "openai-compatible",
+          baseUrl: "http://127.0.0.1:1299/v1",
+          defaultChatModel: long,
+        },
+      ],
+    });
+    await say("/model");
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("vendor/mmm");
+    expect(sent[0]).toContain("…");
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+  });
+
+  it("keeps the active provider in the list even when the cap drops the rest", async () => {
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "compat-provider-59",
+      extraProviders: Array.from({ length: 60 }, (_, i) => ({
+        id: `compat-provider-${i}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: `vendor/really-long-model-identifier-v${i}-instruct`,
+      })),
+    });
+    await say("/model");
+    const [report = ""] = sent;
+    expect(report.length).toBeLessThanOrEqual(2000);
+    expect(report).toContain(
+      "• `compat-provider-59` · `vendor/really-long-model-identifier-v59-instruct` (active)",
+    );
+    expect(report).toContain("more not shown");
   });
 });

--- a/src/channels/model-command.ts
+++ b/src/channels/model-command.ts
@@ -29,14 +29,31 @@
  * silently pin a typo as the chat model and leave the agent broken
  * until someone opened the TUI; a refusal that names the configured
  * providers costs one message and teaches the form.
+ *
+ * Two more refusals exist for the same reason — a chat has no undo, so
+ * a write it cannot take back must not happen at all. A model id is
+ * refused on a `llama-server` provider, whose factory never reads one
+ * (see {@link MODEL_PIN_IGNORED_KINDS}), and a provider whose entry
+ * declares an `apiKeyEnvVar` that is unset is refused even though its
+ * kind is not in {@link KEY_REQUIRED_KINDS} (see {@link missingApiKey}).
  */
 
+import type { AtomicAgentConfig } from "../config/config-schema.js";
 import { getConfig } from "../config/index.js";
+import { LOCAL_PROVIDER_KIND } from "../config/llm-run-mode-config.js";
+import type { RunModeName } from "../config/llm-run-mode-config.js";
 import { resolveLlmProviderApiKey } from "../config/resolve-llm-api-key.js";
 import {
   resolveLlmConfig,
   type LlmProviderConfigEntry,
+  type ResolvedLlmConfig,
 } from "../llm/provider/registry/index.js";
+import {
+  describeRunMode,
+  resolveRunMode,
+  runModeLabel,
+  type ResolvedRunMode,
+} from "../llm/run-mode/index.js";
 import type { AgentRuntime } from "../runtime/bootstrap.js";
 import { SESSION_LLM_METADATA_KEY } from "../session/index.js";
 import {
@@ -64,6 +81,25 @@ export interface ModelCommandChat {
 const KEY_REQUIRED_KINDS = new Set(["openrouter", "aimlapi", "gemini"]);
 
 /**
+ * Provider kinds whose factory never reads `entry.defaultChatModel`, so
+ * pinning a model on them changes no inference at all.
+ *
+ * `llama-server` is the only one (see `register-built-in-providers.ts`:
+ * every other factory passes `entry.defaultChatModel` to the provider,
+ * the llama-server factory does not — the daemon serves whichever GGUF
+ * it was started with). Writing a model id onto such an entry is worse
+ * than a no-op: `resolveActiveModelName()` in `bootstrap.ts` reads
+ * `entry.defaultChatModel` *first*, ahead of
+ * `localModels.managed.modelId`, so the pin would become the model name
+ * in every `message_sent` event, in the cost lookup and in the TUI —
+ * naming a model that is not running, with no way to clear it from a
+ * chat. The TUI cannot reach that state either: `openChatModelPicker`
+ * and `ensureInlineModels` both refuse non-cloud kinds. So neither can
+ * this command.
+ */
+const MODEL_PIN_IGNORED_KINDS = new Set([LOCAL_PROVIDER_KIND]);
+
+/**
  * Run `/model` and return the message to post. Never throws: a config
  * write, a provider reload or a session-store write that fails comes
  * back as a message, because the handlers that call this must not let
@@ -75,10 +111,11 @@ export async function runModelCommand(
   args: readonly string[],
   chat: ModelCommandChat,
 ): Promise<string> {
-  const resolved = resolveLlmConfig(getConfig());
-  if (args.length === 0) return formatReport(resolved, chat.code);
+  const config = getConfig();
+  const resolved = resolveLlmConfig(config);
+  if (args.length === 0) return formatReport(config, resolved, chat.code);
 
-  const target = resolveTarget(args, resolved, chat.code);
+  const target = resolveTarget(args, config, resolved, chat.code);
   if (!target.ok) return target.message;
 
   // Same shape as `/switch`: the arguments are validated first so a
@@ -91,6 +128,7 @@ export async function runModelCommand(
   const previousModelPin = resolved.providers.find(
     (p) => p.id === target.providerId,
   )?.defaultChatModel;
+  const modeBefore = currentRunMode(config, resolved).effective;
   let pinned = false;
   let activated = false;
   try {
@@ -137,20 +175,96 @@ export async function runModelCommand(
   // and the TUI restores a session's stamped provider when it opens it
   // (`session-llm.ts`). The switch itself has already landed in the
   // config, so a session store that cannot write must not turn a
-  // successful switch into no reply at all: log it and read the model
-  // straight off the config instead.
-  let chatModel: string | null;
+  // successful switch into no reply at all: log it and answer anyway.
   try {
-    chatModel = stampChatSession(chat, target.providerId);
+    stampChatSession(chat, target.providerId);
   } catch (err) {
     chat.runtime.logger.warn("model command: session stamp failed", {
       error: err instanceof Error ? err.message : String(err),
     });
-    chatModel = activeChatModelOf(target.providerId);
   }
-  return `Now on ${chat.code(target.providerId)} · ${chat.code(
-    chatModel ?? "provider default",
+
+  // Re-read: the reply has to describe what is now on disk, not what
+  // the pre-switch snapshot said. Guarded because this function promises
+  // its callers it never throws — Discord's dispatch is a bare
+  // `void this.onDispatch(...)` — and the switch has already landed, so
+  // a config that somehow no longer parses must degrade to the snapshot
+  // rather than turn a success into an unhandled rejection.
+  let after = config;
+  let afterResolved = resolved;
+  try {
+    after = getConfig();
+    afterResolved = resolveLlmConfig(after);
+  } catch (err) {
+    chat.runtime.logger.warn("model command: config re-read failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  const entry = afterResolved.providers.find((p) => p.id === target.providerId);
+  const shown = entry ? displayModelOf(entry, after) : null;
+  const reply = `Now on ${chat.code(target.providerId)} · ${chat.code(
+    shown ?? "provider default",
   )}. Takes effect on the next message.`;
+  const note = runModeChangeNote(
+    modeBefore,
+    currentRunMode(after, afterResolved),
+    chat.code,
+  );
+  return note === null ? reply : `${reply}\n\n${note}`;
+}
+
+/** The run mode the live config resolves to, the way `bootstrap` does. */
+function currentRunMode(
+  config: AtomicAgentConfig,
+  resolved: ResolvedLlmConfig,
+): ResolvedRunMode {
+  return resolveRunMode(resolved, {
+    managedModelId: config.localModels.managed.modelId,
+  });
+}
+
+/**
+ * The line to append when a provider switch also moved the run mode, or
+ * `null` when it did not.
+ *
+ * Switching the active provider by hand *is* how one leaves fusion —
+ * `resolveRunMode` derives the effective mode from `activeTextProvider`
+ * on purpose, so the two keys can never contradict each other, and the
+ * TUI's own LLM pane drops out of fusion the same way. What the TUI has
+ * and the channels did not is a place that says so: the run-mode chip.
+ * Silently removing `fusion.delegate` and the `### fusion` guidance from
+ * every session (`bootstrap.ts` gates the fan-out descriptor on
+ * `effective === "fusion"`) is a large change to answer with "Now on
+ * local-llama."
+ *
+ * Only fusion transitions are announced. Local ↔ Cloud is a change of
+ * mode too, but it is the whole content of the request and the reply
+ * already names the provider that caused it; a line restating it on
+ * every ordinary switch would be noise that teaches operators to skip
+ * the paragraph that matters.
+ */
+function runModeChangeNote(
+  before: RunModeName,
+  after: ResolvedRunMode,
+  code: (text: string) => string,
+): string | null {
+  if (after.effective === before) return null;
+  if (before !== "fusion" && after.effective !== "fusion") return null;
+  const head = `Run mode: ${runModeLabel(before)} → ${runModeLabel(after.effective)}.`;
+  if (before === "fusion") {
+    const back = after.orchestratorProviderId;
+    return `${head} ${code("fusion.delegate")} and its guidance are gone from every session${
+      back === null
+        ? ""
+        : ` until ${code(back)} is active again — ${code(`/model ${back}`)} restores it`
+    }.`;
+  }
+  if (after.effective === "fusion") {
+    return `${head} ${code("fusion.delegate")} is back, with ${after.workers} worker${
+      after.workers === 1 ? "" : "s"
+    } on ${code(after.workerProviderId ?? "the local provider")}.`;
+  }
+  return head;
 }
 
 /**
@@ -227,14 +341,6 @@ async function rollback(
   }
 }
 
-/** The model the config now pins on `providerId`, if any. */
-function activeChatModelOf(providerId: string): string | null {
-  const entry = resolveLlmConfig(getConfig()).providers.find(
-    (p) => p.id === providerId,
-  );
-  return entry ? chatModelOf(entry) : null;
-}
-
 type ResolvedTarget =
   | { ok: true; providerId: string; modelId: string | null }
   | { ok: false; message: string };
@@ -253,7 +359,8 @@ type ResolvedTarget =
  */
 function resolveTarget(
   args: readonly string[],
-  resolved: ReturnType<typeof resolveLlmConfig>,
+  config: AtomicAgentConfig,
+  resolved: ResolvedLlmConfig,
   code: (text: string) => string,
 ): ResolvedTarget {
   // Refuse rather than ignore the tail. A third word is always a
@@ -303,10 +410,15 @@ function resolveTarget(
   }
 
   const entry = match.entry;
-  if (KEY_REQUIRED_KINDS.has(entry.kind) && !hasApiKey(entry)) {
+  const missingKey = missingApiKey(entry, config);
+  if (missingKey) {
     return {
       ok: false,
-      message: `Provider ${code(entry.id)} has no API key configured; add one in the TUI's LLM tab before switching to it.`,
+      message: `Provider ${code(entry.id)} has no API key configured${
+        missingKey.envVar === null
+          ? ""
+          : ` (${code(missingKey.envVar)} is unset)`
+      }; add one in the TUI's LLM tab before switching to it.`,
     };
   }
   const modelId = inlineModel === null ? null : inlineModel.trim();
@@ -314,6 +426,16 @@ function resolveTarget(
     return {
       ok: false,
       message: `Usage: ${code("/model <provider> <model-id>")}.`,
+    };
+  }
+  if (modelId !== null && MODEL_PIN_IGNORED_KINDS.has(entry.kind)) {
+    return {
+      ok: false,
+      message: [
+        `${code(entry.id)} is a local ${code(entry.kind)} provider: it serves whichever model its daemon loaded, and nothing reads a model id off its config entry.`,
+        `Pinning ${code(modelId)} would rename it everywhere — reports, analytics, cost — without changing what runs, and no chat command could undo that.`,
+        `Use ${code(`/model ${entry.id}`)} to switch to it; pick the local model in the TUI's Local Models tab.`,
+      ].join(" "),
     };
   }
   return { ok: true, providerId: entry.id, modelId };
@@ -360,32 +482,105 @@ function hasApiKey(entry: LlmProviderConfigEntry): boolean {
   return Boolean(resolveLlmProviderApiKey(entry)?.length);
 }
 
-/** The chat model an entry pins, or `null` when it names none. */
+/**
+ * Why `providerId` cannot authenticate, or `null` when it can (or does
+ * not need to).
+ *
+ * Two reasons, and the second is the one a kind check alone misses. The
+ * known-service presets — Groq, Nous, Anthropic and friends — are all
+ * stored as `kind: "openai-compatible"` with their own `apiKeyEnvVar`
+ * (`providers-wizard-build-entry.ts`), so keying only on kind reports
+ * them as usable and switches to them happily while
+ * `resolveLlmProviderApiKey` returns `undefined`; every following turn
+ * then 401s with nothing in the channel to explain it. An entry that
+ * *declares* an env var has said it needs a key, which is exactly the
+ * signal that separates it from a bare keyless compat entry (LM Studio,
+ * Ollama) that must keep working.
+ *
+ * `apiKeyEnvVar` lives on the user-config entry rather than on
+ * `LlmProviderConfigEntry`, so it is read off the file entry here.
+ */
+function missingApiKey(
+  entry: LlmProviderConfigEntry,
+  config: AtomicAgentConfig,
+): { envVar: string | null } | null {
+  if (hasApiKey(entry)) return null;
+  const envVar = config.llm?.providers.find(
+    (e) => e.id === entry.id,
+  )?.apiKeyEnvVar;
+  if (envVar !== undefined && envVar.length > 0) return { envVar };
+  return KEY_REQUIRED_KINDS.has(entry.kind) ? { envVar: null } : null;
+}
+
+/**
+ * The chat model an entry *pins*, or `null` when it names none.
+ *
+ * This is the switch-and-stamp value, deliberately not the display one:
+ * `executeTurn` stamps sessions with exactly this expression, and a
+ * stamp carrying a model on a `llama-server` entry would make the TUI's
+ * session restore call `selectChatModel` on reopen
+ * (`session-model-restore.ts`), writing that id into
+ * `defaultChatModel` — the poisoning `MODEL_PIN_IGNORED_KINDS` exists
+ * to prevent. Use {@link displayModelOf} for anything an operator reads.
+ */
 function chatModelOf(entry: LlmProviderConfigEntry): string | null {
   return entry.defaultChatModel ?? entry.model ?? null;
 }
 
+/**
+ * The model to *show* for an entry: its pin when it has one, and for a
+ * local `llama-server` the managed daemon's GGUF id, which is what it
+ * actually serves.
+ *
+ * Same first two legs and same order as `resolveActiveModelName()` in
+ * `bootstrap.ts`, so the channel reports the model the cost lookup and
+ * the `message_sent` events report. The legs that one has and this does
+ * not are the operator `--alias` and the prompt-profile id, neither of
+ * which is reachable from config alone — an external-mode llama-server
+ * with no managed id still reads as "provider default" here.
+ */
+function displayModelOf(
+  entry: LlmProviderConfigEntry,
+  config: AtomicAgentConfig,
+): string | null {
+  const pinned = chatModelOf(entry);
+  if (pinned !== null) return pinned;
+  if (entry.kind === LOCAL_PROVIDER_KIND) {
+    return config.localModels.managed.modelId ?? null;
+  }
+  return null;
+}
+
 function formatReport(
-  resolved: ReturnType<typeof resolveLlmConfig>,
+  config: AtomicAgentConfig,
+  resolved: ResolvedLlmConfig,
   code: (text: string) => string,
 ): string {
   const activeId = resolved.activeTextProvider;
   const active = resolved.providers.find((p) => p.id === activeId);
   const lines = [
     active
-      ? `Model: ${code(active.id)} · ${code(chatModelOf(active) ?? "provider default")}`
+      ? `Model: ${code(active.id)} · ${code(displayModelOf(active, config) ?? "provider default")}`
       : `No active text provider is configured (config names ${code(activeId)}).`,
+    // The run mode is not cosmetic here: it decides whether
+    // `fusion.delegate` and the `### fusion` guidance are in the
+    // session at all, and switching provider is what turns it off.
+    // The TUI has a chip for this; the channels have this line.
+    `Run mode: ${describeRunMode(currentRunMode(config, resolved))}`,
   ];
   if (resolved.providers.length > 0) {
     lines.push("", "Providers:");
     for (const entry of resolved.providers) {
       const here = entry.id === activeId ? " (active)" : "";
+      const missing = missingApiKey(entry, config);
       const keyless =
-        KEY_REQUIRED_KINDS.has(entry.kind) && !hasApiKey(entry)
-          ? " — no API key"
-          : "";
+        missing === null
+          ? ""
+          : missing.envVar === null
+            ? " — no API key"
+            : ` — no API key (${missing.envVar} is unset)`;
       lines.push(
-        `• ${code(entry.id)} · ${code(chatModelOf(entry) ?? "provider default")}${here}${keyless}`,
+        `• ${code(entry.id)} · ${code(displayModelOf(entry, config) ?? "provider default")}${here}${keyless}`,
       );
     }
   }
@@ -398,23 +593,22 @@ function formatReport(
 
 /**
  * Write the provider/model stamp onto this chat's session and persist
- * it, and return the model that was stamped. Re-reads the config so the
- * stamp records what actually landed on disk (a provider switch with no
- * model argument keeps that provider's own model). No session yet means
- * nothing to stamp — the choice is the global default the chat's first
- * session will inherit anyway.
+ * it. Re-reads the config so the stamp records what actually landed on
+ * disk (a provider switch with no model argument keeps that provider's
+ * own model), and uses {@link chatModelOf} rather than
+ * {@link displayModelOf} so the stamp stays byte-identical to the one
+ * `executeTurn` writes. No session yet means nothing to stamp — the
+ * choice is the global default the chat's first session will inherit
+ * anyway.
  */
-function stampChatSession(
-  chat: ModelCommandChat,
-  providerId: string,
-): string | null {
+function stampChatSession(chat: ModelCommandChat, providerId: string): void {
   const entry = resolveLlmConfig(getConfig()).providers.find(
     (p) => p.id === providerId,
   );
   const chatModel = entry ? chatModelOf(entry) : null;
-  if (!chat.sessionId) return chatModel;
+  if (!chat.sessionId) return;
   const session = chat.runtime.sessionStore.load(chat.sessionId);
-  if (!session) return chatModel;
+  if (!session) return;
   chat.runtime.sessionStore.save({
     ...session,
     metadata: {
@@ -422,5 +616,4 @@ function stampChatSession(
       [SESSION_LLM_METADATA_KEY]: { providerId, chatModel },
     },
   });
-  return chatModel;
 }

--- a/src/channels/model-command.ts
+++ b/src/channels/model-command.ts
@@ -234,8 +234,11 @@ async function runModelCommandInner(
   // both landed above, so the managed-daemon leg of `displayModelOf`
   // applies to this entry the same way it applies in `bootstrap`.
   const shown = entry ? displayModelOf(entry, after, true) : null;
+  // Clipped exactly as the report clips it, and for the same reason:
+  // the model id here is whatever was just typed into the chat, so this
+  // is the *most* likely message to carry a pathological one.
   const reply = `Now on ${chat.code(target.providerId)} · ${chat.code(
-    shown ?? "provider default",
+    shown === null ? "provider default" : clipName(shown),
   )}. Takes effect on the next message.`;
   const note = runModeChangeNote(
     modeBefore,
@@ -436,12 +439,22 @@ function resolveTarget(
     };
   }
   if (match.kind === "ambiguous") {
+    // Fitted to a character budget rather than an entry count: this is
+    // the one message whose whole job is "say which one", so hiding a
+    // candidate that would have fitted removes the very information it
+    // asks the operator to act on. See {@link MAX_AMBIGUOUS_LIST_CHARS}.
+    const fitted = fitIds(match.ids, code, {
+      maxChars: MAX_AMBIGUOUS_LIST_CHARS,
+    });
+    const listed =
+      fitted.hidden === 0
+        ? fitted.text
+        : `${fitted.text} and ${fitted.hidden} more`;
     return {
       ok: false,
-      message: `${code(clipName(token))} matches ${joinIds(
-        match.ids,
-        code,
-      )} — say which one.`,
+      message: `${code(clipName(token))} matches ${listed} — say which one${
+        fitted.hidden === 0 ? "" : ", or type more of the id to narrow the list"
+      }.`,
     };
   }
 
@@ -453,7 +466,7 @@ function resolveTarget(
       message: `Provider ${code(entry.id)} has no API key configured${
         missingKey.envVar === null
           ? ""
-          : ` (${code(missingKey.envVar)} is unset)`
+          : ` (${code(clipName(missingKey.envVar))} is unset)`
       }; add one in the TUI's LLM tab before switching to it.`,
     };
   }
@@ -469,7 +482,7 @@ function resolveTarget(
       ok: false,
       message: [
         `${code(entry.id)} is a local ${code(entry.kind)} provider: it serves whichever model its daemon loaded, and nothing reads a model id off its config entry.`,
-        `Pinning ${code(modelId)} would rename it everywhere — reports, analytics, cost — without changing what runs, and no chat command could undo that.`,
+        `Pinning ${code(clipName(modelId))} would rename it everywhere — reports, analytics, cost — without changing what runs, and no chat command could undo that.`,
         `Use ${code(`/model ${entry.id}`)} to switch to it; pick the local model in the TUI's Local Models tab.`,
       ].join(" "),
     };
@@ -655,25 +668,73 @@ function clipName(text: string): string {
   return `${text.slice(0, MAX_NAME_CHARS - 1)}…`;
 }
 
-/** Most provider ids a refusal enumerates before it starts counting. */
+/**
+ * Most provider ids the **unknown-provider** refusal enumerates before
+ * it starts counting.
+ *
+ * That list is orientation, not a menu: the token matched nothing, so
+ * what the refusal has to teach is the *form* of the command plus
+ * enough real ids to recognise the shape of one. A dozen does that on
+ * any install, and keeps a hundred-entry config from turning a typo
+ * into the longest message the bot ever sends.
+ */
 const MAX_LISTED_IDS = 12;
 
 /**
- * Decorated, comma-joined provider ids for a refusal — capped the same
- * way {@link formatReport} caps its list, and for the same reason: a
- * refusal that names every entry on an install with dozens of them is
- * the message most likely to be sent, and the one an operator is least
- * able to act on when the chat splits it in two.
+ * Characters the **ambiguous-prefix** refusal may spend on its
+ * candidate list.
+ *
+ * Fitted by size and not by count, because unlike the list above these
+ * ids *are* the answer: the sentence asks the operator to pick one, and
+ * a candidate that was hidden cannot be picked — there is no way to
+ * page through them from a chat. So everything that fits in one message
+ * is printed. `PROVIDER_ID_RE` caps an id at 32 characters, so 1500
+ * holds at least 40 of the longest ids that can exist and about 75
+ * realistic ones, while leaving the rest of the sentence room under
+ * Discord's 2000. Past that the count appears — and then the message
+ * also says the one thing that shortens the list, which is typing more
+ * of the id.
+ */
+const MAX_AMBIGUOUS_LIST_CHARS = 1500;
+
+/**
+ * Decorated provider ids fitted to a limit, and how many did not fit.
+ *
+ * `maxIds` caps the entries, `maxChars` the printed length; either may
+ * be omitted. At least one id is always listed when there is one —
+ * a budget too small for even a single entry would otherwise render as
+ * "matches  and 3 more", which names nothing at all.
+ */
+function fitIds(
+  ids: readonly string[],
+  code: (text: string) => string,
+  limit: { maxIds?: number; maxChars?: number },
+): { text: string; hidden: number } {
+  const maxIds = limit.maxIds ?? ids.length;
+  const maxChars = limit.maxChars ?? Number.POSITIVE_INFINITY;
+  const listed: string[] = [];
+  let used = 0;
+  for (const id of ids) {
+    if (listed.length >= maxIds) break;
+    const piece = code(id);
+    const cost = piece.length + (listed.length === 0 ? 0 : 2);
+    if (listed.length > 0 && used + cost > maxChars) break;
+    listed.push(piece);
+    used += cost;
+  }
+  return { text: listed.join(", "), hidden: ids.length - listed.length };
+}
+
+/**
+ * Decorated, comma-joined provider ids for the unknown-provider
+ * refusal, capped at {@link MAX_LISTED_IDS} with the overflow counted.
  */
 function joinIds(
   ids: readonly string[],
   code: (text: string) => string,
 ): string {
-  const listed = ids.slice(0, MAX_LISTED_IDS).map((id) => code(id));
-  const hidden = ids.length - listed.length;
-  return hidden > 0
-    ? `${listed.join(", ")} and ${hidden} more`
-    : listed.join(", ");
+  const { text, hidden } = fitIds(ids, code, { maxIds: MAX_LISTED_IDS });
+  return hidden > 0 ? `${text} and ${hidden} more` : text;
 }
 
 /** One `• id · model (active) — no API key (VAR is unset)` line. */

--- a/src/channels/model-command.ts
+++ b/src/channels/model-command.ts
@@ -1,0 +1,283 @@
+/**
+ * `/model` for the chat channels — report what the agent runs on, and
+ * switch it from Telegram or Discord.
+ *
+ * Remote operators only ever had the TUI for this, so a bot running on
+ * someone else's machine was pinned to whatever model that machine was
+ * last told to use. The state read and written here is deliberately the
+ * *same* state the TUI's LLM pane owns — the active text provider and
+ * that provider's `defaultChatModel` in the user config, plus the
+ * per-session `llm` stamp from `session-llm.ts`. There is no second,
+ * channel-local store: a model picked from Telegram has to be the model
+ * the TUI then shows, and the session stamp has to be the one a session
+ * switch reads back.
+ *
+ * Both handlers dispatch into here from their own `/model` case. Only
+ * the id decoration differs between them (Discord wraps ids in
+ * backticks, Telegram sends plain text), which is what `code` is for —
+ * the wording itself stays shared so the two surfaces cannot drift.
+ *
+ * The grammar is deliberately strict: a bare token is a *provider*, and
+ * a model must be qualified with the provider it belongs to. Guessing
+ * that an unrecognised token is a model id on the active provider would
+ * silently pin a typo as the chat model and leave the agent broken
+ * until someone opened the TUI; a refusal that names the configured
+ * providers costs one message and teaches the form.
+ */
+
+import { getConfig } from "../config/index.js";
+import { resolveLlmProviderApiKey } from "../config/resolve-llm-api-key.js";
+import {
+  resolveLlmConfig,
+  type LlmProviderConfigEntry,
+} from "../llm/provider/registry/index.js";
+import type { AgentRuntime } from "../runtime/bootstrap.js";
+import { SESSION_LLM_METADATA_KEY } from "../session/index.js";
+import {
+  setActiveTextProviderInConfig,
+  setProviderDefaultChatModelInConfig,
+} from "../tui/persist-llm-provider.js";
+
+/** What a channel hands `/model` about the chat it arrived in. */
+export interface ModelCommandChat {
+  runtime: AgentRuntime;
+  /** The session this chat points at, or `null` when it has none yet. */
+  sessionId: string | null;
+  /** Decorate an id for the host chat — bare on Telegram, `code` on Discord. */
+  code: (text: string) => string;
+}
+
+/**
+ * Provider kinds whose entry is useless without a resolvable API key.
+ * Everything else is left alone on purpose: `llama-server` never wants
+ * one, and a keyless `openai-compatible` entry is how LM Studio and
+ * friends are configured (see `resolve-llm-api-key.ts`), so demanding a
+ * key there would refuse a working setup.
+ */
+const KEY_REQUIRED_KINDS = new Set(["openrouter", "aimlapi", "gemini"]);
+
+/**
+ * Run `/model` and return the message to post. Never throws: a config
+ * write or a provider reload that fails comes back as a plain refusal,
+ * because the handlers that call this must not let one bad command take
+ * the channel down.
+ */
+export async function runModelCommand(
+  args: readonly string[],
+  chat: ModelCommandChat,
+): Promise<string> {
+  const resolved = resolveLlmConfig(getConfig());
+  if (args.length === 0) return formatReport(resolved, chat.code);
+
+  const target = resolveTarget(args, resolved, chat.code);
+  if (!target.ok) return target.message;
+
+  // Same shape as `/switch`: the arguments are validated first so a
+  // typo is answered as a typo, and only a command that would actually
+  // change something is refused for being mid-turn. Switching under a
+  // running turn would swap the provider out from under its remaining
+  // steps, so this refuses rather than deferring — the operator can
+  // `/cancel` or wait, and either way knows which model ran.
+  if (chat.sessionId && chat.runtime.turnController.isBusy(chat.sessionId)) {
+    return "This chat has a turn in progress; try /model again when it finishes.";
+  }
+
+  try {
+    if (target.modelId !== null) {
+      setProviderDefaultChatModelInConfig(target.providerId, target.modelId);
+    }
+    // Same order the TUI's `selectChatModel` uses: write the model,
+    // rebuild the provider from the now-current config, then make it
+    // active. A provider the registry has never built (added to the
+    // config after boot) needs the full merge instead of a replace.
+    if (chat.runtime.providerRegistry.listIds().includes(target.providerId)) {
+      await chat.runtime.reloadLlmProvider(target.providerId);
+    } else {
+      await chat.runtime.reloadLlmProviders();
+    }
+    await chat.runtime.providerRegistry.setActive(target.providerId);
+    setActiveTextProviderInConfig(target.providerId);
+  } catch (err) {
+    return `Could not switch to ${chat.code(target.providerId)}: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+  }
+
+  // Stamp the chat's session now rather than waiting for `executeTurn`
+  // to do it at the top of the next turn: a `/model` followed by a
+  // `/switch` away would otherwise lose the choice entirely, which is
+  // the same reason the TUI stamps on selection (`session-llm.ts`).
+  const chatModel = stampChatSession(chat, target.providerId);
+  return `Now on ${chat.code(target.providerId)} · ${chat.code(
+    chatModel ?? "provider default",
+  )}. Takes effect on the next message.`;
+}
+
+type ResolvedTarget =
+  | { ok: true; providerId: string; modelId: string | null }
+  | { ok: false; message: string };
+
+/**
+ * Turn `/model` arguments into a provider (and optionally a model) or
+ * into the reason it could not be done. Accepted forms:
+ *
+ *   /model <provider>                 — switch provider, keep its model
+ *   /model <provider> <model-id>      — pin a model on that provider
+ *   /model <provider>/<model-id>      — the same, in one token
+ *
+ * The one-token form splits at the FIRST slash, which is what makes it
+ * work for the vendor-namespaced ids most gateways use
+ * (`openrouter/anthropic/claude-opus-4`).
+ */
+function resolveTarget(
+  args: readonly string[],
+  resolved: ReturnType<typeof resolveLlmConfig>,
+  code: (text: string) => string,
+): ResolvedTarget {
+  const first = args[0] ?? "";
+  const [token, inlineModel] =
+    args.length > 1 ? [first, args[1] ?? null] : splitAtFirstSlash(first);
+
+  const match = matchProvider(token, resolved.providers);
+  if (match.kind === "none") {
+    const ids = resolved.providers.map((p) => code(p.id)).join(", ");
+    return {
+      ok: false,
+      message: [
+        `Unknown provider ${code(token)}.`,
+        ids.length > 0 ? `Configured: ${ids}.` : "No providers are configured.",
+        `A model id has to name its provider: ${code("/model <provider> <model-id>")}.`,
+      ].join(" "),
+    };
+  }
+  if (match.kind === "ambiguous") {
+    return {
+      ok: false,
+      message: `${code(token)} matches ${match.ids
+        .map((id) => code(id))
+        .join(", ")} — say which one.`,
+    };
+  }
+
+  const entry = match.entry;
+  if (KEY_REQUIRED_KINDS.has(entry.kind) && !hasApiKey(entry)) {
+    return {
+      ok: false,
+      message: `Provider ${code(entry.id)} has no API key configured; add one in the TUI's LLM tab before switching to it.`,
+    };
+  }
+  const modelId = inlineModel === null ? null : inlineModel.trim();
+  if (modelId !== null && modelId.length === 0) {
+    return {
+      ok: false,
+      message: `Usage: ${code("/model <provider> <model-id>")}.`,
+    };
+  }
+  return { ok: true, providerId: entry.id, modelId };
+}
+
+function splitAtFirstSlash(token: string): [string, string | null] {
+  const at = token.indexOf("/");
+  if (at < 0) return [token, null];
+  return [token.slice(0, at), token.slice(at + 1)];
+}
+
+type ProviderMatch =
+  | { kind: "exact"; entry: LlmProviderConfigEntry }
+  | { kind: "ambiguous"; ids: string[] }
+  | { kind: "none" };
+
+/**
+ * Exact id first, then a unique case-insensitive prefix. The prefix
+ * step is what makes `/model openr` work from a phone keyboard; an
+ * exact id always wins over it, so a provider whose id is a prefix of
+ * another's is still reachable.
+ */
+function matchProvider(
+  token: string,
+  providers: readonly LlmProviderConfigEntry[],
+): ProviderMatch {
+  if (token.length === 0) return { kind: "none" };
+  const lower = token.toLowerCase();
+  const exact = providers.find((p) => p.id.toLowerCase() === lower);
+  if (exact) return { kind: "exact", entry: exact };
+  const prefixed = providers.filter((p) =>
+    p.id.toLowerCase().startsWith(lower),
+  );
+  if (prefixed.length === 1 && prefixed[0]) {
+    return { kind: "exact", entry: prefixed[0] };
+  }
+  if (prefixed.length > 1) {
+    return { kind: "ambiguous", ids: prefixed.map((p) => p.id) };
+  }
+  return { kind: "none" };
+}
+
+function hasApiKey(entry: LlmProviderConfigEntry): boolean {
+  return Boolean(resolveLlmProviderApiKey(entry)?.length);
+}
+
+/** The chat model an entry pins, or `null` when it names none. */
+function chatModelOf(entry: LlmProviderConfigEntry): string | null {
+  return entry.defaultChatModel ?? entry.model ?? null;
+}
+
+function formatReport(
+  resolved: ReturnType<typeof resolveLlmConfig>,
+  code: (text: string) => string,
+): string {
+  const activeId = resolved.activeTextProvider;
+  const active = resolved.providers.find((p) => p.id === activeId);
+  const lines = [
+    active
+      ? `Model: ${code(active.id)} · ${code(chatModelOf(active) ?? "provider default")}`
+      : `No active text provider is configured (config names ${code(activeId)}).`,
+  ];
+  if (resolved.providers.length > 0) {
+    lines.push("", "Providers:");
+    for (const entry of resolved.providers) {
+      const here = entry.id === activeId ? " (active)" : "";
+      const keyless =
+        KEY_REQUIRED_KINDS.has(entry.kind) && !hasApiKey(entry)
+          ? " — no API key"
+          : "";
+      lines.push(
+        `• ${code(entry.id)} · ${code(chatModelOf(entry) ?? "provider default")}${here}${keyless}`,
+      );
+    }
+  }
+  lines.push(
+    "",
+    `${code("/model <provider>")} switches provider; ${code("/model <provider> <model-id>")} pins a model on it.`,
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Write the provider/model stamp onto this chat's session and persist
+ * it, and return the model that was stamped. Re-reads the config so the
+ * stamp records what actually landed on disk (a provider switch with no
+ * model argument keeps that provider's own model). No session yet means
+ * nothing to stamp — the choice is the global default the chat's first
+ * session will inherit anyway.
+ */
+function stampChatSession(
+  chat: ModelCommandChat,
+  providerId: string,
+): string | null {
+  const entry = resolveLlmConfig(getConfig()).providers.find(
+    (p) => p.id === providerId,
+  );
+  const chatModel = entry ? chatModelOf(entry) : null;
+  if (!chat.sessionId) return chatModel;
+  const session = chat.runtime.sessionStore.load(chat.sessionId);
+  if (!session) return chatModel;
+  chat.runtime.sessionStore.save({
+    ...session,
+    metadata: {
+      ...session.metadata,
+      [SESSION_LLM_METADATA_KEY]: { providerId, chatModel },
+    },
+  });
+  return chatModel;
+}

--- a/src/channels/model-command.ts
+++ b/src/channels/model-command.ts
@@ -665,7 +665,10 @@ const MAX_LISTED_IDS = 12;
  * the message most likely to be sent, and the one an operator is least
  * able to act on when the chat splits it in two.
  */
-function joinIds(ids: readonly string[], code: (text: string) => string): string {
+function joinIds(
+  ids: readonly string[],
+  code: (text: string) => string,
+): string {
   const listed = ids.slice(0, MAX_LISTED_IDS).map((id) => code(id));
   const hidden = ids.length - listed.length;
   return hidden > 0

--- a/src/channels/model-command.ts
+++ b/src/channels/model-command.ts
@@ -100,14 +100,43 @@ const KEY_REQUIRED_KINDS = new Set(["openrouter", "aimlapi", "gemini"]);
 const MODEL_PIN_IGNORED_KINDS = new Set([LOCAL_PROVIDER_KIND]);
 
 /**
- * Run `/model` and return the message to post. Never throws: a config
- * write, a provider reload or a session-store write that fails comes
- * back as a message, because the handlers that call this must not let
- * one bad command take the channel down — Discord's dispatch is a bare
- * `void this.onDispatch(...)` with no catch at all, so a rejection here
- * is an unhandled rejection there.
+ * Run `/model` and return the message to post.
+ *
+ * **Never throws**, and the guarantee is enforced here rather than
+ * promised leg by leg: the whole command runs inside this one
+ * `catch`, so a failure with no specific message of its own — the
+ * entry `getConfig()` on a config that no longer parses, most of all —
+ * still comes back as a message. The handlers that call this must not
+ * let one bad command take the channel down: Discord's dispatch is a
+ * bare `void this.onDispatch(...)` with no catch at all, so a rejection
+ * here is an unhandled rejection there, and Telegram's chat gets no
+ * reply of any kind.
+ *
+ * The legs that *do* have something better to say — a failed provider
+ * reload, a failed session-store write, a post-switch config re-read —
+ * still catch it themselves, inside {@link runModelCommandInner}. This
+ * is the floor under them, not a replacement for them.
  */
 export async function runModelCommand(
+  args: readonly string[],
+  chat: ModelCommandChat,
+): Promise<string> {
+  try {
+    return await runModelCommandInner(args, chat);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      chat.runtime.logger.warn("model command failed", { error: message });
+    } catch {
+      // A logger that throws must not defeat the guarantee either.
+    }
+    // Deliberately undecorated: `chat.code` comes from the caller, and
+    // the one path that must never throw is not the place to call it.
+    return `Could not run /model: ${message}`;
+  }
+}
+
+async function runModelCommandInner(
   args: readonly string[],
   chat: ModelCommandChat,
 ): Promise<string> {
@@ -201,7 +230,10 @@ export async function runModelCommand(
     });
   }
   const entry = afterResolved.providers.find((p) => p.id === target.providerId);
-  const shown = entry ? displayModelOf(entry, after) : null;
+  // Active by construction: `setActive` + `setActiveTextProviderInConfig`
+  // both landed above, so the managed-daemon leg of `displayModelOf`
+  // applies to this entry the same way it applies in `bootstrap`.
+  const shown = entry ? displayModelOf(entry, after, true) : null;
   const reply = `Now on ${chat.code(target.providerId)} · ${chat.code(
     shown ?? "provider default",
   )}. Takes effect on the next message.`;
@@ -259,12 +291,12 @@ function runModeChangeNote(
         : ` until ${code(back)} is active again — ${code(`/model ${back}`)} restores it`
     }.`;
   }
-  if (after.effective === "fusion") {
-    return `${head} ${code("fusion.delegate")} is back, with ${after.workers} worker${
-      after.workers === 1 ? "" : "s"
-    } on ${code(after.workerProviderId ?? "the local provider")}.`;
-  }
-  return head;
+  // The two guards above leave exactly two shapes, and the branch just
+  // taken was the first: `before` is not "fusion", so `after.effective`
+  // is. No third case exists to fall through to.
+  return `${head} ${code("fusion.delegate")} is back, with ${after.workers} worker${
+    after.workers === 1 ? "" : "s"
+  } on ${code(after.workerProviderId ?? "the local provider")}.`;
 }
 
 /**
@@ -390,11 +422,14 @@ function resolveTarget(
 
   const match = matchProvider(token, resolved.providers);
   if (match.kind === "none") {
-    const ids = resolved.providers.map((p) => code(p.id)).join(", ");
+    const ids = joinIds(
+      resolved.providers.map((p) => p.id),
+      code,
+    );
     return {
       ok: false,
       message: [
-        `Unknown provider ${code(token)}.`,
+        `Unknown provider ${code(clipName(token))}.`,
         ids.length > 0 ? `Configured: ${ids}.` : "No providers are configured.",
         `A model id has to name its provider: ${code("/model <provider> <model-id>")}.`,
       ].join(" "),
@@ -403,9 +438,10 @@ function resolveTarget(
   if (match.kind === "ambiguous") {
     return {
       ok: false,
-      message: `${code(token)} matches ${match.ids
-        .map((id) => code(id))
-        .join(", ")} — say which one.`,
+      message: `${code(clipName(token))} matches ${joinIds(
+        match.ids,
+        code,
+      )} — say which one.`,
     };
   }
 
@@ -528,27 +564,134 @@ function chatModelOf(entry: LlmProviderConfigEntry): string | null {
 }
 
 /**
- * The model to *show* for an entry: its pin when it has one, and for a
- * local `llama-server` the managed daemon's GGUF id, which is what it
- * actually serves.
+ * The model to *show* for an entry: its pin when it has one, and — for
+ * the **active** local `llama-server` — the managed daemon's GGUF id,
+ * which is what it actually serves.
  *
- * Same first two legs and same order as `resolveActiveModelName()` in
+ * Same first legs and same order as `resolveActiveModelName()` in
  * `bootstrap.ts`, so the channel reports the model the cost lookup and
- * the `message_sent` events report. The legs that one has and this does
- * not are the operator `--alias` and the prompt-profile id, neither of
- * which is reachable from config alone — an external-mode llama-server
- * with no managed id still reads as "provider default" here.
+ * the `message_sent` events report. That parity is the whole
+ * justification for the `localModels` leg, and it only holds for the
+ * active entry: `bootstrap` computes that name for
+ * `resolved.activeTextProvider` alone, while the report walks every
+ * configured provider. `localModels.managed` describes *one* daemon —
+ * the managed one this install starts — so attributing its GGUF id to
+ * a second `llama-server` entry (a box on the LAN, say; `resolve-run-
+ * mode.ts` picks the worker leg with a `find`, so more than one is a
+ * shape the code expects) would report it as running a model it has
+ * never seen. A non-active local entry therefore reads as "provider
+ * default", which is the truth: nothing in the config says what it
+ * serves.
+ *
+ * `isActive` is passed in rather than re-derived so the post-switch
+ * reply — where the entry is active by construction — and the report
+ * cannot disagree about which entry that is.
+ *
+ * The legs `resolveActiveModelName` has and this does not are the
+ * operator `--alias` and the prompt-profile id, neither of which is
+ * reachable from config alone. The one thing this shares with it and
+ * would be wrong to "fix" here is that neither consults
+ * `localModels.mode`: an external-mode daemon with a managed id left
+ * over from an earlier download reads as that id in both places. Gating
+ * on the mode would make the channel disagree with the model name in
+ * every `message_sent` event and in the cost lookup, which is a worse
+ * failure than the stale id and belongs upstream in `bootstrap` if it
+ * is to be fixed at all.
  */
 function displayModelOf(
   entry: LlmProviderConfigEntry,
   config: AtomicAgentConfig,
+  isActive: boolean,
 ): string | null {
   const pinned = chatModelOf(entry);
   if (pinned !== null) return pinned;
-  if (entry.kind === LOCAL_PROVIDER_KIND) {
+  if (isActive && entry.kind === LOCAL_PROVIDER_KIND) {
     return config.localModels.managed.modelId ?? null;
   }
   return null;
+}
+
+/**
+ * Longest an unbounded name prints before it is clipped.
+ *
+ * Only the names the config schema does not already bound need this: a
+ * model id and an `apiKeyEnvVar` are `parseOptionalString`, so they are
+ * any non-empty string, and the token in `/model <token>` is whatever
+ * was typed into the chat. A *provider id* is not among them —
+ * `PROVIDER_ID_RE` in `llm-config.ts` caps it at 32 kebab-case
+ * characters — so ids print whole and clipping one would be dead code.
+ *
+ * 48 is generous enough that no realistic model id is touched
+ * (`openrouter/auto` is 15, and the vendor-namespaced ids the gateways
+ * use run to about 30) and short enough that one pathological entry
+ * cannot eat the whole message.
+ */
+const MAX_NAME_CHARS = 48;
+
+/**
+ * How long the provider report may get, in characters.
+ *
+ * A chat message is not a terminal pane. Discord splits at 2000
+ * characters (`DISCORD_MESSAGE_LIMIT`, and `DiscordApi.sendMessage`
+ * chunks silently), Telegram at 4096 (`outbound-sender.ts`), so an
+ * uncapped enumeration turns one answer into several messages — the
+ * heading in one, the active provider stranded in another, and on
+ * Telegram a chunk that a second 429 drops entirely. An install with a
+ * dozen `openai-compatible` entries is enough to cross the Discord
+ * limit. So the enumeration — the only unbounded part of the report —
+ * is fitted to a budget under the tighter of the two limits, and what
+ * does not fit is counted rather than printed. Nothing is lost by
+ * that: the active provider is named on the first line either way, and
+ * a provider that is not listed can still be switched to by name.
+ */
+const MAX_REPORT_CHARS = 1800;
+
+/** Room kept for the "…and N more" trailer while fitting the list. */
+const TRAILER_RESERVE_CHARS = 140;
+
+/** `text`, shortened to {@link MAX_NAME_CHARS} with a visible ellipsis. */
+function clipName(text: string): string {
+  if (text.length <= MAX_NAME_CHARS) return text;
+  return `${text.slice(0, MAX_NAME_CHARS - 1)}…`;
+}
+
+/** Most provider ids a refusal enumerates before it starts counting. */
+const MAX_LISTED_IDS = 12;
+
+/**
+ * Decorated, comma-joined provider ids for a refusal — capped the same
+ * way {@link formatReport} caps its list, and for the same reason: a
+ * refusal that names every entry on an install with dozens of them is
+ * the message most likely to be sent, and the one an operator is least
+ * able to act on when the chat splits it in two.
+ */
+function joinIds(ids: readonly string[], code: (text: string) => string): string {
+  const listed = ids.slice(0, MAX_LISTED_IDS).map((id) => code(id));
+  const hidden = ids.length - listed.length;
+  return hidden > 0
+    ? `${listed.join(", ")} and ${hidden} more`
+    : listed.join(", ");
+}
+
+/** One `• id · model (active) — no API key (VAR is unset)` line. */
+function providerLine(
+  entry: LlmProviderConfigEntry,
+  config: AtomicAgentConfig,
+  activeId: string,
+  code: (text: string) => string,
+): string {
+  const here = entry.id === activeId ? " (active)" : "";
+  const missing = missingApiKey(entry, config);
+  const keyless =
+    missing === null
+      ? ""
+      : missing.envVar === null
+        ? " — no API key"
+        : ` — no API key (${clipName(missing.envVar)} is unset)`;
+  const model = displayModelOf(entry, config, entry.id === activeId);
+  return `• ${code(entry.id)} · ${code(
+    model === null ? "provider default" : clipName(model),
+  )}${here}${keyless}`;
 }
 
 function formatReport(
@@ -558,9 +701,12 @@ function formatReport(
 ): string {
   const activeId = resolved.activeTextProvider;
   const active = resolved.providers.find((p) => p.id === activeId);
+  const activeModel = active ? displayModelOf(active, config, true) : null;
   const lines = [
     active
-      ? `Model: ${code(active.id)} · ${code(displayModelOf(active, config) ?? "provider default")}`
+      ? `Model: ${code(active.id)} · ${code(
+          activeModel === null ? "provider default" : clipName(activeModel),
+        )}`
       : `No active text provider is configured (config names ${code(activeId)}).`,
     // The run mode is not cosmetic here: it decides whether
     // `fusion.delegate` and the `### fusion` guidance are in the
@@ -568,26 +714,48 @@ function formatReport(
     // The TUI has a chip for this; the channels have this line.
     `Run mode: ${describeRunMode(currentRunMode(config, resolved))}`,
   ];
+  const foot = `${code("/model <provider>")} switches provider; ${code("/model <provider> <model-id>")} pins a model on it.`;
   if (resolved.providers.length > 0) {
     lines.push("", "Providers:");
+    // The active entry's line is budgeted up front and emitted wherever
+    // it falls in the list, so a long install cannot produce a report
+    // that omits the one provider it is reporting on. Everything above
+    // plus the footer is committed too; only the rest is fitted.
+    const activeLine = active
+      ? providerLine(active, config, activeId, code)
+      : null;
+    let used =
+      lines.join("\n").length +
+      1 +
+      foot.length +
+      1 +
+      (activeLine === null ? 0 : activeLine.length + 1);
+    let shown = 0;
     for (const entry of resolved.providers) {
-      const here = entry.id === activeId ? " (active)" : "";
-      const missing = missingApiKey(entry, config);
-      const keyless =
-        missing === null
-          ? ""
-          : missing.envVar === null
-            ? " — no API key"
-            : ` — no API key (${missing.envVar} is unset)`;
+      if (activeLine !== null && entry.id === activeId) {
+        lines.push(activeLine);
+        shown += 1;
+        continue;
+      }
+      const line = providerLine(entry, config, activeId, code);
+      // The trailer's room is always kept rather than predicted: at
+      // worst that costs one line on a report that turns out not to
+      // need one, and predicting it wrong costs a split message.
+      if (used + line.length + 1 + TRAILER_RESERVE_CHARS > MAX_REPORT_CHARS) {
+        continue;
+      }
+      lines.push(line);
+      used += line.length + 1;
+      shown += 1;
+    }
+    const hidden = resolved.providers.length - shown;
+    if (hidden > 0) {
       lines.push(
-        `• ${code(entry.id)} · ${code(displayModelOf(entry, config) ?? "provider default")}${here}${keyless}`,
+        `…and ${hidden} more not shown — ${code("/model <provider>")} switches to any of them, listed or not.`,
       );
     }
   }
-  lines.push(
-    "",
-    `${code("/model <provider>")} switches provider; ${code("/model <provider> <model-id>")} pins a model on it.`,
-  );
+  lines.push("", foot);
   return lines.join("\n");
 }
 

--- a/src/channels/model-command.ts
+++ b/src/channels/model-command.ts
@@ -9,8 +9,14 @@
  * that provider's `defaultChatModel` in the user config, plus the
  * per-session `llm` stamp from `session-llm.ts`. There is no second,
  * channel-local store: a model picked from Telegram has to be the model
- * the TUI then shows, and the session stamp has to be the one a session
- * switch reads back.
+ * the TUI then shows, and the session stamp has to be the one the TUI
+ * restores when it opens that session.
+ *
+ * The selection itself is **global**, because `llm.activeTextProvider`
+ * is: there is no per-session provider today — `executeTurn` re-stamps
+ * every session from the global config at the top of each turn. That is
+ * why the in-flight guard below covers every session and not only the
+ * issuing chat's.
  *
  * Both handlers dispatch into here from their own `/model` case. Only
  * the id decoration differs between them (Discord wraps ids in
@@ -34,6 +40,7 @@ import {
 import type { AgentRuntime } from "../runtime/bootstrap.js";
 import { SESSION_LLM_METADATA_KEY } from "../session/index.js";
 import {
+  restoreProviderDefaultChatModelInConfig,
   setActiveTextProviderInConfig,
   setProviderDefaultChatModelInConfig,
 } from "../tui/persist-llm-provider.js";
@@ -58,9 +65,11 @@ const KEY_REQUIRED_KINDS = new Set(["openrouter", "aimlapi", "gemini"]);
 
 /**
  * Run `/model` and return the message to post. Never throws: a config
- * write or a provider reload that fails comes back as a plain refusal,
- * because the handlers that call this must not let one bad command take
- * the channel down.
+ * write, a provider reload or a session-store write that fails comes
+ * back as a message, because the handlers that call this must not let
+ * one bad command take the channel down — Discord's dispatch is a bare
+ * `void this.onDispatch(...)` with no catch at all, so a rejection here
+ * is an unhandled rejection there.
  */
 export async function runModelCommand(
   args: readonly string[],
@@ -74,17 +83,20 @@ export async function runModelCommand(
 
   // Same shape as `/switch`: the arguments are validated first so a
   // typo is answered as a typo, and only a command that would actually
-  // change something is refused for being mid-turn. Switching under a
-  // running turn would swap the provider out from under its remaining
-  // steps, so this refuses rather than deferring — the operator can
-  // `/cancel` or wait, and either way knows which model ran.
-  if (chat.sessionId && chat.runtime.turnController.isBusy(chat.sessionId)) {
-    return "This chat has a turn in progress; try /model again when it finishes.";
-  }
+  // change something is refused for being mid-turn.
+  const busy = busyRefusal(chat);
+  if (busy) return busy;
 
+  const previousActiveId = resolved.activeTextProvider;
+  const previousModelPin = resolved.providers.find(
+    (p) => p.id === target.providerId,
+  )?.defaultChatModel;
+  let pinned = false;
+  let activated = false;
   try {
     if (target.modelId !== null) {
       setProviderDefaultChatModelInConfig(target.providerId, target.modelId);
+      pinned = true;
     }
     // Same order the TUI's `selectChatModel` uses: write the model,
     // rebuild the provider from the now-current config, then make it
@@ -96,8 +108,24 @@ export async function runModelCommand(
       await chat.runtime.reloadLlmProviders();
     }
     await chat.runtime.providerRegistry.setActive(target.providerId);
+    activated = true;
     setActiveTextProviderInConfig(target.providerId);
   } catch (err) {
+    // "Could not switch" has to mean nothing switched. The model pin is
+    // written first because rebuilding the provider reads it back off
+    // disk, so a rebuild that then fails would otherwise leave the
+    // config naming a model that was refused — and a later bare
+    // `/model` would report it as the provider's model. Undo both legs
+    // (config pin, in-memory active provider) before answering; each
+    // undo swallows its own failure so a rollback error cannot mask the
+    // real one.
+    await rollback(chat, {
+      providerId: target.providerId,
+      previousActiveId,
+      previousModelPin,
+      pinned,
+      activated,
+    });
     return `Could not switch to ${chat.code(target.providerId)}: ${
       err instanceof Error ? err.message : String(err)
     }`;
@@ -105,12 +133,106 @@ export async function runModelCommand(
 
   // Stamp the chat's session now rather than waiting for `executeTurn`
   // to do it at the top of the next turn: a `/model` followed by a
-  // `/switch` away would otherwise lose the choice entirely, which is
-  // the same reason the TUI stamps on selection (`session-llm.ts`).
-  const chatModel = stampChatSession(chat, target.providerId);
+  // `/switch` away would otherwise lose the choice before any turn ran,
+  // and the TUI restores a session's stamped provider when it opens it
+  // (`session-llm.ts`). The switch itself has already landed in the
+  // config, so a session store that cannot write must not turn a
+  // successful switch into no reply at all: log it and read the model
+  // straight off the config instead.
+  let chatModel: string | null;
+  try {
+    chatModel = stampChatSession(chat, target.providerId);
+  } catch (err) {
+    chat.runtime.logger.warn("model command: session stamp failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    chatModel = activeChatModelOf(target.providerId);
+  }
   return `Now on ${chat.code(target.providerId)} · ${chat.code(
     chatModel ?? "provider default",
   )}. Takes effect on the next message.`;
+}
+
+/**
+ * The refusal for a turn that is already running, or `null` when
+ * nothing is.
+ *
+ * This deliberately gates on **every** busy session, not just the
+ * issuing chat's. `llm.activeTextProvider` is one global setting and
+ * `bootstrap`'s `resolveActiveLlmSlice` re-resolves it *per inference
+ * attempt* ("Re-read on every inference so TUI `setActive` hot-swap
+ * takes effect"), returning the transport and tool-call adapter with
+ * it. So a switch while any other session is mid-turn does not wait for
+ * that session's next turn — it lands on its very next step, changing
+ * the model and possibly the tool transport (native_tools <-> grammar)
+ * underneath a turn already in flight. Concurrent sessions are the
+ * normal case here: Telegram is per-chat, Discord per-channel, and the
+ * TUI, the HTTP route and the scheduler all submit through the same
+ * `turnController`.
+ *
+ * The cost is that a long scheduled task blocks `/model`; the message
+ * names the count so the operator knows to wait or `/cancel`.
+ */
+function busyRefusal(chat: ModelCommandChat): string | null {
+  const busy = chat.runtime.turnController.busySessionIds();
+  if (busy.length === 0) return null;
+  const own = chat.sessionId !== null && busy.includes(chat.sessionId);
+  if (own && busy.length === 1) {
+    return "This chat has a turn in progress; try /model again when it finishes.";
+  }
+  const others = busy.filter((id) => id !== chat.sessionId).length;
+  const where = own
+    ? `this chat and ${others} other session${others === 1 ? "" : "s"}`
+    : `${others} other session${others === 1 ? "" : "s"}`;
+  return `A turn is in progress on ${where}. The provider is shared, so switching now would change what those turns run on at their next step — try /model again when they finish, or /cancel.`;
+}
+
+/**
+ * Undo whichever legs of a switch landed before it failed. Every step
+ * swallows its own error: this runs inside a `catch` whose job is to
+ * report the *original* failure, and a rollback that throws would
+ * replace it with a less useful one.
+ */
+async function rollback(
+  chat: ModelCommandChat,
+  state: {
+    providerId: string;
+    previousActiveId: string;
+    previousModelPin: string | undefined;
+    pinned: boolean;
+    activated: boolean;
+  },
+): Promise<void> {
+  if (state.pinned) {
+    try {
+      restoreProviderDefaultChatModelInConfig(
+        state.providerId,
+        state.previousModelPin,
+      );
+      // The registry may have been rebuilt from the rejected pin; put
+      // its copy back in step with the config too.
+      if (chat.runtime.providerRegistry.listIds().includes(state.providerId)) {
+        await chat.runtime.reloadLlmProvider(state.providerId);
+      }
+    } catch {
+      // Reported failure stands; nothing better to say here.
+    }
+  }
+  if (state.activated && state.previousActiveId !== state.providerId) {
+    try {
+      await chat.runtime.providerRegistry.setActive(state.previousActiveId);
+    } catch {
+      // As above.
+    }
+  }
+}
+
+/** The model the config now pins on `providerId`, if any. */
+function activeChatModelOf(providerId: string): string | null {
+  const entry = resolveLlmConfig(getConfig()).providers.find(
+    (p) => p.id === providerId,
+  );
+  return entry ? chatModelOf(entry) : null;
 }
 
 type ResolvedTarget =
@@ -134,9 +256,30 @@ function resolveTarget(
   resolved: ReturnType<typeof resolveLlmConfig>,
   code: (text: string) => string,
 ): ResolvedTarget {
+  // Refuse rather than ignore the tail. A third word is always a
+  // mistake — a provider id and a model id are one token each, and
+  // silently dropping the rest would accept `/model openrouter gpt-4
+  // please` as a pin of `gpt-4` while the operator believes something
+  // else was said.
+  if (args.length > 2) {
+    return {
+      ok: false,
+      message: `Too many arguments. Usage: ${code("/model <provider> <model-id>")}.`,
+    };
+  }
   const first = args[0] ?? "";
   const [token, inlineModel] =
     args.length > 1 ? [first, args[1] ?? null] : splitAtFirstSlash(first);
+
+  // A leading slash (`/vendor/model-9` — a bare model id typed with its
+  // vendor prefix) splits into an empty provider. Answer the shape of
+  // the command rather than "Unknown provider ", which names nothing.
+  if (token.length === 0) {
+    return {
+      ok: false,
+      message: `A model id has to name its provider: ${code("/model <provider> <model-id>")}.`,
+    };
+  }
 
   const match = matchProvider(token, resolved.providers);
   if (match.kind === "none") {

--- a/src/channels/telegram/inbound-handler.ts
+++ b/src/channels/telegram/inbound-handler.ts
@@ -10,6 +10,7 @@ import {
   type AttachmentInbox,
   type AttachmentOutcome,
 } from "../attachments/inbox.js";
+import { runModelCommand } from "../model-command.js";
 import {
   formatAttachmentFailure,
   sendAttachments,
@@ -238,6 +239,7 @@ function helpText(ctx: InboundContext): string {
     "  /sessions — every chat this bot has a session for\n" +
     "  /switch <session-id> — point this chat at an existing session\n" +
     "  /new — rotate this chat to a fresh session (current one is archived)\n" +
+    "  /model — show the provider and model in use; /model <provider> [model-id] switches\n" +
     "  /cancel — abort this chat's current turn if one is running"
   );
 }
@@ -640,6 +642,21 @@ async function handleSlashCommand(
       return;
     case "/switch": {
       await switchSession(rest[0], ref, ctx);
+      return;
+    }
+    case "/model": {
+      // Owner-gated already: `handleInboundText` drops every non-owner
+      // update before it reaches this dispatch, so there is no second
+      // check here — the same contract `/switch` and `/new` run under.
+      await sendText(
+        ctx,
+        ref.target,
+        await runModelCommand(rest, {
+          runtime: ctx.runtime,
+          sessionId: ctx.sessionPointer.get(ref.key).current,
+          code: (text) => text,
+        }),
+      );
       return;
     }
     case "/new": {

--- a/src/channels/telegram/inbound-model-command.test.ts
+++ b/src/channels/telegram/inbound-model-command.test.ts
@@ -690,4 +690,115 @@ describe("/model over Telegram", () => {
     );
     expect(report).toContain("more not shown");
   });
+
+  /**
+   * The three refusals and the one confirmation below all interpolate a
+   * name the config schema does not bound, and all four are reachable
+   * with a single chat message: Discord accepts 2000 characters inbound
+   * and Telegram 4096, so "the operator just typed it" is the *likeliest*
+   * source of a pathological id, not the least likely. The report's cap
+   * (above) never sees these paths.
+   */
+  it("clips the model id in the switch confirmation", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    // 2000 characters in total — exactly what Discord accepts inbound,
+    // and well inside Telegram's own 4096.
+    const long = `vendor/${"m".repeat(1975)}`;
+    await say(`/model openrouter ${long}`);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("…");
+    // Clipping is a display concern only: the pin the TUI reads back is
+    // the id that was typed, whole.
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "openrouter")
+        ?.defaultChatModel,
+    ).toBe(long);
+  });
+
+  it("clips the model id in the llama-server refusal", async () => {
+    const long = `vendor/${"m".repeat(1974)}`;
+    await say(`/model local-llama ${long}`);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("…");
+    // Still a refusal, not a pin.
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+        ?.defaultChatModel,
+    ).toBeUndefined();
+  });
+
+  it("clips a declared env var in the no-key refusal", async () => {
+    // `apiKeyEnvVar` is `parseOptionalString`, so it is any non-empty
+    // string — the report already clips it, and this refusal is the
+    // other place it is printed.
+    const long = `LONG_${"E".repeat(500)}`;
+    writeLlmConfig(stateDir, {
+      extraProviders: [
+        {
+          id: "long-env",
+          kind: "openai-compatible",
+          baseUrl: "http://127.0.0.1:1298/v1",
+          defaultChatModel: "gpt-x",
+          apiKeyEnvVar: long,
+        },
+      ],
+    });
+    await say("/model long-env");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("has no API key configured");
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("…");
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("names every candidate an ambiguous prefix matches", async () => {
+    // This is the one message whose whole job is "say which one", so it
+    // is fitted to the message limit rather than to an entry count: a
+    // candidate that is hidden cannot be picked, and a chat offers no
+    // way to page through the rest.
+    writeLlmConfig(stateDir, {
+      extraProviders: Array.from({ length: 60 }, (_, i) => ({
+        id: `compat-provider-${i}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: `vendor/really-long-model-identifier-v${i}-instruct`,
+      })),
+    });
+    await say("/model compat");
+    expect(sent).toHaveLength(1);
+    const [msg = ""] = sent;
+    expect(msg.length).toBeLessThanOrEqual(2000);
+    expect(msg).toContain("compat-provider-0");
+    // The sixtieth, not a count: all of them fit, so all of them print.
+    expect(msg).toContain("compat-provider-59");
+    expect(msg).not.toMatch(/and \d+ more/);
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("counts ambiguous candidates only past the limit, and says how to narrow", async () => {
+    // 120 entries at the longest id `PROVIDER_ID_RE` allows (32
+    // characters) — more than one message can hold however it is
+    // fitted, which is the only case where hiding one is unavoidable.
+    writeLlmConfig(stateDir, {
+      extraProviders: Array.from({ length: 120 }, (_, i) => ({
+        id: `zz-aaaaaaaaaaaaaaaaaaaaaaaaa-${String(i).padStart(3, "0")}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: "gpt-x",
+      })),
+    });
+    await say("/model zz");
+    expect(sent).toHaveLength(1);
+    const [msg = ""] = sent;
+    expect(msg.length).toBeLessThanOrEqual(2000);
+    expect(msg).toMatch(/and \d+ more/);
+    // A count alone would be unactionable; this is the one thing the
+    // operator can do about it from a chat.
+    expect(msg).toContain("type more of the id to narrow the list");
+  });
 });

--- a/src/channels/telegram/inbound-model-command.test.ts
+++ b/src/channels/telegram/inbound-model-command.test.ts
@@ -52,15 +52,38 @@ const API_KEY_ENV = [
   "OPENAI_COMPAT_API_KEY",
   "OPENAI_API_KEY",
   "ATOMIC_AGENT_OPENAI_API_KEY",
+  // The preset entry below declares this one; see the `groq` fixture.
+  "GROQ_API_KEY",
 ] as const;
 
-function writeLlmConfig(stateDir: string): void {
+/**
+ * What a test wants changed about the fixture config. Everything else
+ * is fixed, so a test that touches none of these reads the same world
+ * as every other one.
+ */
+type ConfigOverrides = {
+  activeTextProvider?: string;
+  /** `llm.runMode`, for the fusion cases. */
+  runMode?: Record<string, unknown>;
+  /** `localModels.managed.modelId` — the GGUF the local daemon serves. */
+  managedModelId?: string;
+};
+
+function writeLlmConfig(stateDir: string, over: ConfigOverrides = {}): void {
   writeUserConfigFileSync(getUserConfigPath(stateDir), {
     ...USER_CONFIG_DEFAULTS,
+    localModels: {
+      ...USER_CONFIG_DEFAULTS.localModels,
+      managed: {
+        ...USER_CONFIG_DEFAULTS.localModels.managed,
+        modelId: over.managedModelId ?? null,
+      },
+    },
     llm: {
-      activeTextProvider: "local-llama",
+      activeTextProvider: over.activeTextProvider ?? "local-llama",
       activeEmbeddingProvider: "local-llama",
       toolTransport: "auto",
+      ...(over.runMode ? { runMode: over.runMode } : {}),
       providers: [
         {
           id: "local-llama",
@@ -84,11 +107,28 @@ function writeLlmConfig(stateDir: string): void {
           baseUrl: "http://127.0.0.1:1234/v1",
           defaultChatModel: "gpt-x",
         },
+        // A known-service preset, exactly as
+        // `providers-wizard-build-entry.ts` writes one: the same
+        // `openai-compatible` kind as the LM Studio entry above, told
+        // apart from it only by declaring its own `apiKeyEnvVar`.
+        {
+          id: "groq",
+          kind: "openai-compatible",
+          baseUrl: "https://api.groq.com/openai/v1",
+          defaultChatModel: "llama-3.3-70b",
+          apiKeyEnvVar: "GROQ_API_KEY",
+        },
+        // The one cloud entry with no model of its own, so the rollback
+        // test below can prove a pin is *cleared* and not just reverted.
+        { id: "aimlapi", kind: "aimlapi" },
       ],
     },
   });
   resetConfigCache();
 }
+
+/** Every configured id, in fixture order, for the "Configured:" lines. */
+const ALL_IDS = "local-llama, openrouter, openai-compat, groq, aimlapi";
 
 function makeRuntime(sessions: SessionState[]) {
   const busy = new Set<string>();
@@ -213,6 +253,10 @@ describe("/model over Telegram", () => {
     // the developer's environment.
     expect(process.env.OPENROUTER_API_KEY).toBeUndefined();
     expect(report).toContain("no API key");
+    // The run mode decides whether `fusion.delegate` is in the session
+    // at all, and switching provider is what turns it off — so the
+    // report that exists to answer "what is this running on" says it.
+    expect(report).toContain("Run mode: Local — active provider local-llama");
     // Plain text on Telegram: the id decoration must not leak backticks.
     expect(report).not.toContain("`");
   });
@@ -251,9 +295,7 @@ describe("/model over Telegram", () => {
   it("refuses an unknown provider and names the configured ones", async () => {
     await say("/model gpt-5.4-mini");
     expect(sent[0]).toContain("Unknown provider gpt-5.4-mini.");
-    expect(sent[0]).toContain(
-      "Configured: local-llama, openrouter, openai-compat.",
-    );
+    expect(sent[0]).toContain(`Configured: ${ALL_IDS}.`);
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
   });
 
@@ -342,6 +384,8 @@ describe("/model over Telegram", () => {
       "local-llama",
       "openrouter",
       "openai-compat",
+      "groq",
+      "aimlapi",
     ]);
   });
 
@@ -361,16 +405,22 @@ describe("/model over Telegram", () => {
   });
 
   it("clears a pin that did not exist before when the reload fails", async () => {
+    process.env.AIMLAPI_API_KEY = "k";
     fake.failures.reload = new Error("nope");
-    await say("/model local-llama some-model");
-    expect(sent[0]).toBe("Could not switch to local-llama: nope");
+    // `aimlapi` is the fixture's one cloud entry with no
+    // `defaultChatModel`, so this is the *unset* rollback branch —
+    // `restoreProviderDefaultChatModelInConfig(id, undefined)` — and
+    // not the ordinary revert-to-previous one.
+    await say("/model aimlapi some-model");
+    expect(sent[0]).toBe("Could not switch to aimlapi: nope");
     // The config parser always materialises the key, so assert the
     // value: the rollback has to leave it unset, not set to the id the
     // reload refused.
     expect(
-      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+      getConfig().llm?.providers.find((p) => p.id === "aimlapi")
         ?.defaultChatModel,
     ).toBeUndefined();
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
   });
 
   it("still answers when the session store cannot save the stamp", async () => {
@@ -382,6 +432,140 @@ describe("/model over Telegram", () => {
       "Now on openai-compat · gpt-x. Takes effect on the next message.",
     ]);
     expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
+  });
+
+  it("refuses to pin a model on a local llama-server provider", async () => {
+    // The llama-server factory never reads `entry.defaultChatModel`
+    // (`register-built-in-providers.ts`), but `resolveActiveModelName()`
+    // reads it FIRST — ahead of `localModels.managed.modelId` — so a pin
+    // here renames the model in the report, in `message_sent` and in the
+    // cost lookup while inference carries on unchanged, and no chat
+    // command can clear it again.
+    writeLlmConfig(stateDir, { managedModelId: "qwen-3.8-27b" });
+    await say("/model local-llama gpt-4-turbo");
+    expect(sent[0]).toContain("nothing reads a model id off its config entry");
+    expect(sent[0]).toContain("Local Models tab");
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+        ?.defaultChatModel,
+    ).toBeUndefined();
+    // Nothing switched either, and the report is not poisoned.
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+    expect(fake.reloaded).toEqual([]);
+    await say("/model");
+    expect(sent[1]).toContain("Model: local-llama · qwen-3.8-27b");
+  });
+
+  it("reports the managed local model, not a placeholder", async () => {
+    // The default local-first install: a managed daemon serving a
+    // downloaded GGUF whose id the config knows. "provider default"
+    // there answers the operator's actual question with a shrug.
+    writeLlmConfig(stateDir, { managedModelId: "qwen-3.8-27b" });
+    await say("/model");
+    expect(sent[0]).toContain("Model: local-llama · qwen-3.8-27b");
+    expect(sent[0]).toContain("• local-llama · qwen-3.8-27b (active)");
+    expect(sent[0]).not.toContain("local-llama · provider default");
+  });
+
+  it("refuses a preset provider whose declared env var is unset", async () => {
+    // `groq` is `kind: "openai-compatible"` like the LM Studio entry,
+    // so a kind-only check waves it through and every later turn 401s.
+    expect(process.env.GROQ_API_KEY).toBeUndefined();
+    await say("/model groq");
+    expect(sent[0]).toContain(
+      "has no API key configured (GROQ_API_KEY is unset)",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+    // ...and the report flags it, naming the variable to set.
+    await say("/model");
+    expect(sent[1]).toContain(
+      "• groq · llama-3.3-70b — no API key (GROQ_API_KEY is unset)",
+    );
+    // The keyless LM Studio-shaped entry must stay usable.
+    expect(sent[1]).toContain("• openai-compat · gpt-x\n");
+  });
+
+  it("accepts a preset provider once its declared env var is set", async () => {
+    process.env.GROQ_API_KEY = "gsk-x";
+    await say("/model groq");
+    expect(sent[0]).toBe(
+      "Now on groq · llama-3.3-70b. Takes effect on the next message.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("groq");
+  });
+
+  it("reports the run mode, including a fusion deployment", async () => {
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "openrouter",
+      runMode: {
+        mode: "fusion",
+        fusion: {
+          orchestratorProvider: "openrouter",
+          workerProvider: "local-llama",
+        },
+      },
+      managedModelId: "qwen-3.8-27b",
+    });
+    await say("/model");
+    expect(sent[0]).toContain(
+      "Run mode: Fusion — orchestrator openrouter (openrouter/auto), 2 workers on local-llama (qwen-3.8-27b)",
+    );
+  });
+
+  it("says so when a switch drops the deployment out of fusion", async () => {
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "openrouter",
+      runMode: {
+        mode: "fusion",
+        fusion: {
+          orchestratorProvider: "openrouter",
+          workerProvider: "local-llama",
+        },
+      },
+      managedModelId: "qwen-3.8-27b",
+    });
+    await say("/model local-llama");
+    // Leaving fusion removes `fusion.delegate` and the `### fusion`
+    // guidance from EVERY session and invalidates every KV prefix
+    // (`bootstrap.ts` gates the fan-out descriptor on
+    // `effective === "fusion"`). "Now on local-llama." alone does not
+    // say that, and there is no /runmode verb in this channel.
+    expect(sent[0]).toBe(
+      "Now on local-llama · qwen-3.8-27b. Takes effect on the next message.\n\n" +
+        "Run mode: Fusion → Local. fusion.delegate and its guidance are gone " +
+        "from every session until openrouter is active again — " +
+        "/model openrouter restores it.",
+    );
+    // And the bare report agrees about where it ended up.
+    await say("/model");
+    expect(sent[1]).toContain("stored fusion, effective local");
+  });
+
+  it("says so when a switch puts the deployment back into fusion", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "local-llama",
+      runMode: {
+        mode: "fusion",
+        fusion: {
+          orchestratorProvider: "openrouter",
+          workerProvider: "local-llama",
+        },
+      },
+    });
+    await say("/model openrouter");
+    expect(sent[0]).toContain("Run mode: Local → Fusion.");
+    expect(sent[0]).toContain("2 workers on local-llama");
+  });
+
+  it("stays quiet about an ordinary Local → Cloud switch", async () => {
+    // The provider name in the reply already says it; a run-mode
+    // paragraph on every switch is the noise that gets paragraphs
+    // skipped.
+    await say("/model openai-compat");
+    expect(sent[0]).toBe(
+      "Now on openai-compat · gpt-x. Takes effect on the next message.",
+    );
   });
 
   it("lists /model in the help text", async () => {

--- a/src/channels/telegram/inbound-model-command.test.ts
+++ b/src/channels/telegram/inbound-model-command.test.ts
@@ -5,6 +5,11 @@
  * isolated `ATOMIC_AGENT_STATE_DIR`, which is the point — the whole
  * feature is "the chat writes the same state the TUI writes", so a test
  * against a stubbed config writer would prove nothing about that.
+ *
+ * The isolation is deliberate and total: the state dir *and* the API-key
+ * environment variables the report reads are both controlled here, so
+ * the outcome cannot depend on whether whoever runs the suite happens to
+ * have `OPENROUTER_API_KEY` exported.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,6 +24,7 @@ import {
 } from "../../config/config-file.js";
 import { USER_CONFIG_DEFAULTS } from "../../config/config-schema.js";
 import { getConfig } from "../../config/index.js";
+import { ProviderRegistry } from "../../llm/provider/registry/index.js";
 import type { AgentRuntime } from "../../runtime/bootstrap.js";
 import {
   createEmptySessionState,
@@ -33,6 +39,20 @@ import { TelegramSessionPointer } from "./telegram-session-pointer.js";
 const OWNER = 42;
 const CHAT = 100;
 const CHAT_KEY = String(CHAT);
+
+/**
+ * Every variable `resolveLlmProviderApiKey` consults for the provider
+ * kinds in the fixture below. Cleared before each test and restored
+ * after, so an ambient key cannot flip a "no API key" assertion.
+ */
+const API_KEY_ENV = [
+  "OPENROUTER_API_KEY",
+  "AIMLAPI_API_KEY",
+  "GEMINI_API_KEY",
+  "OPENAI_COMPAT_API_KEY",
+  "OPENAI_API_KEY",
+  "ATOMIC_AGENT_OPENAI_API_KEY",
+] as const;
 
 function writeLlmConfig(stateDir: string): void {
   writeUserConfigFileSync(getUserConfigPath(stateDir), {
@@ -52,7 +72,18 @@ function writeLlmConfig(stateDir: string): void {
           kind: "openrouter",
           defaultChatModel: "openrouter/auto",
         },
-        { id: "openai-compat", kind: "openai-compatible", model: "gpt-x" },
+        // `baseUrl` and `defaultChatModel` are not decoration: an
+        // `openai-compatible` entry without them is refused by
+        // `register-built-in-providers.ts`, so a fixture missing them
+        // would only ever "switch" because `reloadLlmProviders` is
+        // stubbed. The registry test below builds this same config for
+        // real to keep that honest.
+        {
+          id: "openai-compat",
+          kind: "openai-compatible",
+          baseUrl: "http://127.0.0.1:1234/v1",
+          defaultChatModel: "gpt-x",
+        },
       ],
     },
   });
@@ -64,17 +95,27 @@ function makeRuntime(sessions: SessionState[]) {
   const saved: SessionState[] = [];
   const reloaded: string[] = [];
   const activated: string[] = [];
+  /** Injectable failures for the two steps that talk to the world. */
+  const failures: { reload: Error | null; save: Error | null } = {
+    reload: null,
+    save: null,
+  };
   const runtime = {
     createSession: () => sessions[0],
+    logger: new StructuredLogger({ level: "warn", sinks: [] }),
     sessionStore: {
       load: (id: string) => sessions.find((s) => s.id === id) ?? null,
       save: (state: SessionState) => {
+        if (failures.save) throw failures.save;
         saved.push(state);
         const at = sessions.findIndex((s) => s.id === state.id);
         if (at >= 0) sessions[at] = state;
       },
     },
-    turnController: { isBusy: (id: string) => busy.has(id) },
+    turnController: {
+      isBusy: (id: string) => busy.has(id),
+      busySessionIds: () => [...busy],
+    },
     providerRegistry: {
       listIds: () => ["local-llama", "openrouter"],
       setActive: vi.fn(async (id: string) => {
@@ -83,14 +124,16 @@ function makeRuntime(sessions: SessionState[]) {
       }),
     },
     reloadLlmProvider: vi.fn(async (id: string) => {
+      if (failures.reload) throw failures.reload;
       reloaded.push(id);
     }),
     reloadLlmProviders: vi.fn(async () => {
+      if (failures.reload) throw failures.reload;
       reloaded.push("*");
     }),
     runTurn: async () => ({ session: sessions[0], reason: "reply" as const }),
   } as unknown as AgentRuntime;
-  return { runtime, busy, saved, reloaded, activated };
+  return { runtime, busy, saved, reloaded, activated, failures };
 }
 
 describe("/model over Telegram", () => {
@@ -101,8 +144,12 @@ describe("/model over Telegram", () => {
   let ctx: InboundContext;
   let session: SessionState;
   let fake: ReturnType<typeof makeRuntime>;
+  let savedEnv: Array<[string, string | undefined]>;
 
   beforeEach(() => {
+    savedEnv = API_KEY_ENV.map((name) => [name, process.env[name]]);
+    for (const name of API_KEY_ENV) delete process.env[name];
+
     stateDir = mkdtempSync(join(tmpdir(), "atomic-tg-model-state-"));
     process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
     resetConfigCache();
@@ -136,6 +183,10 @@ describe("/model over Telegram", () => {
     rmSync(dir, { recursive: true, force: true });
     rmSync(stateDir, { recursive: true, force: true });
     delete process.env.ATOMIC_AGENT_STATE_DIR;
+    for (const [name, value] of savedEnv) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
     resetConfigCache();
   });
 
@@ -158,7 +209,9 @@ describe("/model over Telegram", () => {
     expect(report).toContain("Model: local-llama · provider default");
     expect(report).toContain("• openrouter · openrouter/auto");
     expect(report).toContain("• local-llama · provider default (active)");
-    // No API key in the environment for the openrouter entry.
+    // Cleared in `beforeEach`, so this is the fixture's verdict and not
+    // the developer's environment.
+    expect(process.env.OPENROUTER_API_KEY).toBeUndefined();
     expect(report).toContain("no API key");
     // Plain text on Telegram: the id decoration must not leak backticks.
     expect(report).not.toContain("`");
@@ -166,11 +219,7 @@ describe("/model over Telegram", () => {
 
   it("pins a model on a provider, activates it, and stamps the session", async () => {
     process.env.OPENROUTER_API_KEY = "k";
-    try {
-      await say("/model openrouter anthropic/claude-opus-4");
-    } finally {
-      delete process.env.OPENROUTER_API_KEY;
-    }
+    await say("/model openrouter anthropic/claude-opus-4");
     expect(sent).toEqual([
       "Now on openrouter · anthropic/claude-opus-4. Takes effect on the next message.",
     ]);
@@ -183,7 +232,7 @@ describe("/model over Telegram", () => {
     // Rebuilt before it was made active, and only that provider.
     expect(fake.reloaded).toEqual(["openrouter"]);
     expect(fake.activated).toEqual(["openrouter"]);
-    // The stamp is what a later session switch reads back.
+    // The stamp is what the TUI reads back when it opens this session.
     expect(readSessionLlmStamp(fake.saved.at(-1)?.metadata)).toEqual({
       providerId: "openrouter",
       chatModel: "anthropic/claude-opus-4",
@@ -192,11 +241,7 @@ describe("/model over Telegram", () => {
 
   it("accepts the one-token form and splits at the first slash", async () => {
     process.env.OPENROUTER_API_KEY = "k";
-    try {
-      await say("/model openrouter/vendor/model-9");
-    } finally {
-      delete process.env.OPENROUTER_API_KEY;
-    }
+    await say("/model openrouter/vendor/model-9");
     expect(
       getConfig().llm?.providers.find((p) => p.id === "openrouter")
         ?.defaultChatModel,
@@ -210,6 +255,29 @@ describe("/model over Telegram", () => {
       "Configured: local-llama, openrouter, openai-compat.",
     );
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("names the command's shape for a token that begins with a slash", async () => {
+    // `/model /vendor/model-9` splits into an empty provider; the old
+    // wording was "Unknown provider ." and named nothing at all.
+    await say("/model /vendor/model-9");
+    expect(sent[0]).toBe(
+      "A model id has to name its provider: /model <provider> <model-id>.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses trailing arguments instead of ignoring them", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    await say("/model openrouter m-1 junk more");
+    expect(sent[0]).toBe(
+      "Too many arguments. Usage: /model <provider> <model-id>.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "openrouter")
+        ?.defaultChatModel,
+    ).toBe("openrouter/auto");
   });
 
   it("refuses an ambiguous prefix", async () => {
@@ -235,6 +303,17 @@ describe("/model over Telegram", () => {
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
   });
 
+  it("refuses while ANOTHER session has a turn in progress", async () => {
+    // The active provider is global and re-resolved per inference
+    // attempt, so a switch now would land on another session's very
+    // next step — not its next turn.
+    fake.busy.add("s-other");
+    await say("/model openai-compat");
+    expect(sent[0]).toContain("A turn is in progress on 1 other session.");
+    expect(sent[0]).toContain("at their next step");
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
   it("switches provider without touching its pinned model", async () => {
     await say("/model openai-compat");
     expect(sent[0]).toBe(
@@ -243,6 +322,65 @@ describe("/model over Telegram", () => {
     // Not in the registry yet, so the whole set is merged rather than
     // one entry replaced.
     expect(fake.reloaded).toEqual(["*"]);
+    expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
+  });
+
+  it("uses a provider config the real registry can actually build", async () => {
+    // `reloadLlmProviders` is stubbed above — the one mocked seam in an
+    // otherwise unmocked test — so build the same config for real once.
+    // Without this, the "not yet in the registry" test would keep
+    // passing for a config production refuses.
+    const registry = await ProviderRegistry.fromConfig(getConfig(), {
+      config: getConfig(),
+      logger: new StructuredLogger({ level: "warn", sinks: [] }),
+      llamaClient: {} as never,
+      getProfile: (() => {
+        throw new Error("no inference runs in this test");
+      }) as never,
+    });
+    expect([...registry.listIds()]).toEqual([
+      "local-llama",
+      "openrouter",
+      "openai-compat",
+    ]);
+  });
+
+  it("leaves no half-written config when the provider reload fails", async () => {
+    fake.failures.reload = new Error("llama-server unreachable");
+    await say("/model openai-compat brand-new-model");
+    expect(sent[0]).toBe(
+      "Could not switch to openai-compat: llama-server unreachable",
+    );
+    const llm = getConfig().llm;
+    expect(llm?.activeTextProvider).toBe("local-llama");
+    // "Could not switch" has to mean nothing switched: a later bare
+    // `/model` must not report the model that was just rejected.
+    expect(
+      llm?.providers.find((p) => p.id === "openai-compat")?.defaultChatModel,
+    ).toBe("gpt-x");
+  });
+
+  it("clears a pin that did not exist before when the reload fails", async () => {
+    fake.failures.reload = new Error("nope");
+    await say("/model local-llama some-model");
+    expect(sent[0]).toBe("Could not switch to local-llama: nope");
+    // The config parser always materialises the key, so assert the
+    // value: the rollback has to leave it unset, not set to the id the
+    // reload refused.
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "local-llama")
+        ?.defaultChatModel,
+    ).toBeUndefined();
+  });
+
+  it("still answers when the session store cannot save the stamp", async () => {
+    fake.failures.save = new Error("ENOSPC");
+    await say("/model openai-compat");
+    // The config write already landed; a failed stamp must not turn a
+    // successful switch into no reply at all.
+    expect(sent).toEqual([
+      "Now on openai-compat · gpt-x. Takes effect on the next message.",
+    ]);
     expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
   });
 

--- a/src/channels/telegram/inbound-model-command.test.ts
+++ b/src/channels/telegram/inbound-model-command.test.ts
@@ -67,6 +67,12 @@ type ConfigOverrides = {
   runMode?: Record<string, unknown>;
   /** `localModels.managed.modelId` — the GGUF the local daemon serves. */
   managedModelId?: string;
+  /**
+   * Appended to the fixture's five providers. Two cases need a longer
+   * list than the fixture: a second `llama-server` entry, and an
+   * install with enough entries to overflow a chat message.
+   */
+  extraProviders?: Array<Record<string, unknown>>;
 };
 
 function writeLlmConfig(stateDir: string, over: ConfigOverrides = {}): void {
@@ -121,6 +127,7 @@ function writeLlmConfig(stateDir: string, over: ConfigOverrides = {}): void {
         // The one cloud entry with no model of its own, so the rollback
         // test below can prove a pin is *cleared* and not just reverted.
         { id: "aimlapi", kind: "aimlapi" },
+        ...(over.extraProviders ?? []),
       ],
     },
   });
@@ -585,5 +592,102 @@ describe("/model over Telegram", () => {
     );
     expect(sent).toHaveLength(0);
     expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  /**
+   * A config the agent booted on can stop parsing afterwards — a hand
+   * edit, a torn write — and `/model` always re-reads it: its own
+   * `setActiveTextProviderInConfig` calls `resetConfigCache()`, so the
+   * next invocation goes to disk. `runModelCommand` documents that it
+   * never throws, and this is the path that has no message of its own.
+   */
+  it("answers instead of rejecting when the config no longer parses", async () => {
+    writeLlmConfig(stateDir, { activeTextProvider: "ghost" });
+    await say("/model");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toContain("Could not run /model:");
+    expect(sent[0]).toContain('unknown provider id "ghost"');
+  });
+
+  it("reports the managed local model only for the daemon that serves it", async () => {
+    // `localModels.managed` describes one daemon. A second
+    // `llama-server` entry — a box on the LAN — serves whatever it was
+    // started with, and the config says nothing about it.
+    writeLlmConfig(stateDir, {
+      managedModelId: "qwen-3.8-27b",
+      extraProviders: [
+        { id: "remote-box", kind: "llama-server", url: "http://10.0.0.9:8080" },
+      ],
+    });
+    await say("/model");
+    expect(sent[0]).toContain("• local-llama · qwen-3.8-27b (active)");
+    expect(sent[0]).toContain("• remote-box · provider default");
+  });
+
+  it("caps the provider list so the report stays one message", async () => {
+    writeLlmConfig(stateDir, {
+      // `PROVIDER_ID_RE` caps an id at 32 kebab-case characters, so
+      // the bulk here is the model names, which the schema does not
+      // bound at all.
+      extraProviders: Array.from({ length: 60 }, (_, i) => ({
+        id: `compat-provider-${i}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: `vendor/really-long-model-identifier-v${i}-instruct`,
+      })),
+    });
+    await say("/model");
+    // Telegram chunks at 4096 characters and Discord at 2000, and the
+    // shared report has to survive the tighter of the two.
+    expect(sent).toHaveLength(1);
+    const [report = ""] = sent;
+    expect(report.length).toBeLessThanOrEqual(2000);
+    expect(report).toContain("more not shown");
+    // Whatever the cap drops, the answer to "what is this running on"
+    // is on the first line, and every provider is still switchable.
+    expect(report).toContain("Model: local-llama · provider default");
+    expect(report).toContain("/model <provider> switches provider");
+  });
+
+  it("clips a model id long enough to fill the message on its own", async () => {
+    // A provider id cannot get here — `PROVIDER_ID_RE` caps it at 32
+    // characters — but a model id is any non-empty string.
+    const long = `vendor/${"m".repeat(400)}`;
+    writeLlmConfig(stateDir, {
+      extraProviders: [
+        {
+          id: "long-model-compat",
+          kind: "openai-compatible",
+          baseUrl: "http://127.0.0.1:1299/v1",
+          defaultChatModel: long,
+        },
+      ],
+    });
+    await say("/model");
+    expect(sent[0]).not.toContain(long);
+    expect(sent[0]).toContain("vendor/mmm");
+    expect(sent[0]).toContain("…");
+    expect(sent[0]?.length).toBeLessThanOrEqual(2000);
+  });
+
+  it("keeps the active provider in the list even when the cap drops the rest", async () => {
+    // Sixtieth of sixty-one: the entry the report exists to describe
+    // must not be the one the budget throws away.
+    writeLlmConfig(stateDir, {
+      activeTextProvider: "compat-provider-59",
+      extraProviders: Array.from({ length: 60 }, (_, i) => ({
+        id: `compat-provider-${i}`,
+        kind: "openai-compatible",
+        baseUrl: `http://127.0.0.1:${1300 + i}/v1`,
+        defaultChatModel: `vendor/really-long-model-identifier-v${i}-instruct`,
+      })),
+    });
+    await say("/model");
+    const [report = ""] = sent;
+    expect(report.length).toBeLessThanOrEqual(2000);
+    expect(report).toContain(
+      "• compat-provider-59 · vendor/really-long-model-identifier-v59-instruct (active)",
+    );
+    expect(report).toContain("more not shown");
   });
 });

--- a/src/channels/telegram/inbound-model-command.test.ts
+++ b/src/channels/telegram/inbound-model-command.test.ts
@@ -1,0 +1,267 @@
+/**
+ * `/model` over Telegram, end to end through `handleInboundText`.
+ *
+ * Nothing here is mocked: the command writes the real user config in an
+ * isolated `ATOMIC_AGENT_STATE_DIR`, which is the point — the whole
+ * feature is "the chat writes the same state the TUI writes", so a test
+ * against a stubbed config writer would prove nothing about that.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resetConfigCache } from "../../config/config-cache.js";
+import {
+  getUserConfigPath,
+  writeUserConfigFileSync,
+} from "../../config/config-file.js";
+import { USER_CONFIG_DEFAULTS } from "../../config/config-schema.js";
+import { getConfig } from "../../config/index.js";
+import type { AgentRuntime } from "../../runtime/bootstrap.js";
+import {
+  createEmptySessionState,
+  readSessionLlmStamp,
+  type SessionState,
+} from "../../session/index.js";
+import { StructuredLogger } from "../../tracing/structured-logger.js";
+import { createAttachmentInbox } from "../attachments/inbox.js";
+import { handleInboundText, type InboundContext } from "./inbound-handler.js";
+import { TelegramSessionPointer } from "./telegram-session-pointer.js";
+
+const OWNER = 42;
+const CHAT = 100;
+const CHAT_KEY = String(CHAT);
+
+function writeLlmConfig(stateDir: string): void {
+  writeUserConfigFileSync(getUserConfigPath(stateDir), {
+    ...USER_CONFIG_DEFAULTS,
+    llm: {
+      activeTextProvider: "local-llama",
+      activeEmbeddingProvider: "local-llama",
+      toolTransport: "auto",
+      providers: [
+        {
+          id: "local-llama",
+          kind: "llama-server",
+          url: "http://127.0.0.1:19091",
+        },
+        {
+          id: "openrouter",
+          kind: "openrouter",
+          defaultChatModel: "openrouter/auto",
+        },
+        { id: "openai-compat", kind: "openai-compatible", model: "gpt-x" },
+      ],
+    },
+  });
+  resetConfigCache();
+}
+
+function makeRuntime(sessions: SessionState[]) {
+  const busy = new Set<string>();
+  const saved: SessionState[] = [];
+  const reloaded: string[] = [];
+  const activated: string[] = [];
+  const runtime = {
+    createSession: () => sessions[0],
+    sessionStore: {
+      load: (id: string) => sessions.find((s) => s.id === id) ?? null,
+      save: (state: SessionState) => {
+        saved.push(state);
+        const at = sessions.findIndex((s) => s.id === state.id);
+        if (at >= 0) sessions[at] = state;
+      },
+    },
+    turnController: { isBusy: (id: string) => busy.has(id) },
+    providerRegistry: {
+      listIds: () => ["local-llama", "openrouter"],
+      setActive: vi.fn(async (id: string) => {
+        activated.push(id);
+        return {};
+      }),
+    },
+    reloadLlmProvider: vi.fn(async (id: string) => {
+      reloaded.push(id);
+    }),
+    reloadLlmProviders: vi.fn(async () => {
+      reloaded.push("*");
+    }),
+    runTurn: async () => ({ session: sessions[0], reason: "reply" as const }),
+  } as unknown as AgentRuntime;
+  return { runtime, busy, saved, reloaded, activated };
+}
+
+describe("/model over Telegram", () => {
+  let stateDir: string;
+  let dir: string;
+  let pointer: TelegramSessionPointer;
+  let sent: string[];
+  let ctx: InboundContext;
+  let session: SessionState;
+  let fake: ReturnType<typeof makeRuntime>;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "atomic-tg-model-state-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    resetConfigCache();
+    writeLlmConfig(stateDir);
+
+    dir = mkdtempSync(join(tmpdir(), "atomic-tg-model-"));
+    pointer = new TelegramSessionPointer(join(dir, "telegram-session.json"));
+    session = createEmptySessionState({ id: "s-1", workingDir: "/tmp/test" });
+    pointer.setCurrent(CHAT_KEY, session.id, "DM");
+    fake = makeRuntime([session]);
+    sent = [];
+    ctx = {
+      runtime: fake.runtime,
+      api: {
+        sendMessage: vi.fn(async (_chatId: number, text: string) => {
+          sent.push(text);
+          return { message_id: sent.length };
+        }),
+      },
+      sessionPointer: pointer,
+      logger: new StructuredLogger({ level: "warn", sinks: [] }),
+      ownerUserId: OWNER,
+      inflight: new Map(),
+      inbox: createAttachmentInbox({ dir: join(dir, "inbox") }),
+      mediaGroups: new Map(),
+      scheduleKeepalive: () => () => undefined,
+    } as unknown as InboundContext;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+  });
+
+  async function say(text: string): Promise<void> {
+    await handleInboundText(
+      {
+        from: { id: OWNER },
+        chat: { id: CHAT, type: "private" },
+        text,
+        message_id: 1,
+      },
+      ctx,
+    );
+  }
+
+  it("reports the active provider and every configured one", async () => {
+    await say("/model");
+    expect(sent).toHaveLength(1);
+    const [report = ""] = sent;
+    expect(report).toContain("Model: local-llama · provider default");
+    expect(report).toContain("• openrouter · openrouter/auto");
+    expect(report).toContain("• local-llama · provider default (active)");
+    // No API key in the environment for the openrouter entry.
+    expect(report).toContain("no API key");
+    // Plain text on Telegram: the id decoration must not leak backticks.
+    expect(report).not.toContain("`");
+  });
+
+  it("pins a model on a provider, activates it, and stamps the session", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    try {
+      await say("/model openrouter anthropic/claude-opus-4");
+    } finally {
+      delete process.env.OPENROUTER_API_KEY;
+    }
+    expect(sent).toEqual([
+      "Now on openrouter · anthropic/claude-opus-4. Takes effect on the next message.",
+    ]);
+    // The config the TUI reads is the config that changed.
+    const llm = getConfig().llm;
+    expect(llm?.activeTextProvider).toBe("openrouter");
+    expect(
+      llm?.providers.find((p) => p.id === "openrouter")?.defaultChatModel,
+    ).toBe("anthropic/claude-opus-4");
+    // Rebuilt before it was made active, and only that provider.
+    expect(fake.reloaded).toEqual(["openrouter"]);
+    expect(fake.activated).toEqual(["openrouter"]);
+    // The stamp is what a later session switch reads back.
+    expect(readSessionLlmStamp(fake.saved.at(-1)?.metadata)).toEqual({
+      providerId: "openrouter",
+      chatModel: "anthropic/claude-opus-4",
+    });
+  });
+
+  it("accepts the one-token form and splits at the first slash", async () => {
+    process.env.OPENROUTER_API_KEY = "k";
+    try {
+      await say("/model openrouter/vendor/model-9");
+    } finally {
+      delete process.env.OPENROUTER_API_KEY;
+    }
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "openrouter")
+        ?.defaultChatModel,
+    ).toBe("vendor/model-9");
+  });
+
+  it("refuses an unknown provider and names the configured ones", async () => {
+    await say("/model gpt-5.4-mini");
+    expect(sent[0]).toContain("Unknown provider gpt-5.4-mini.");
+    expect(sent[0]).toContain(
+      "Configured: local-llama, openrouter, openai-compat.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses an ambiguous prefix", async () => {
+    await say("/model open");
+    expect(sent[0]).toBe(
+      "open matches openrouter, openai-compat — say which one.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses a provider whose API key is missing", async () => {
+    await say("/model openrouter");
+    expect(sent[0]).toContain("has no API key configured");
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("refuses while this chat has a turn in progress", async () => {
+    fake.busy.add(session.id);
+    await say("/model openai-compat");
+    expect(sent[0]).toBe(
+      "This chat has a turn in progress; try /model again when it finishes.",
+    );
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+
+  it("switches provider without touching its pinned model", async () => {
+    await say("/model openai-compat");
+    expect(sent[0]).toBe(
+      "Now on openai-compat · gpt-x. Takes effect on the next message.",
+    );
+    // Not in the registry yet, so the whole set is merged rather than
+    // one entry replaced.
+    expect(fake.reloaded).toEqual(["*"]);
+    expect(getConfig().llm?.activeTextProvider).toBe("openai-compat");
+  });
+
+  it("lists /model in the help text", async () => {
+    await say("/help");
+    expect(sent[0]).toContain("/model");
+  });
+
+  it("is not reachable by a non-owner", async () => {
+    await handleInboundText(
+      {
+        from: { id: 99 },
+        chat: { id: CHAT, type: "private" },
+        text: "/model openai-compat",
+        message_id: 2,
+      },
+      ctx,
+    );
+    expect(sent).toHaveLength(0);
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+  });
+});

--- a/src/channels/telegram/telegram-channel.test.ts
+++ b/src/channels/telegram/telegram-channel.test.ts
@@ -29,6 +29,8 @@ interface FakeBotState {
   startCalls: number;
   stopCalls: number;
   setMyCommandsCalls: number;
+  /** The command menu of the most recent `setMyCommands` call. */
+  registeredCommands: string[];
   textHandler: ((u: unknown) => void | Promise<void>) | null;
   callbackHandler: ((u: unknown) => void | Promise<void>) | null;
   fileHandler: ((u: unknown) => void | Promise<void>) | null;
@@ -53,6 +55,7 @@ function makeBotFactory(opts: FakeBotOptions = {}): {
     startCalls: 0,
     stopCalls: 0,
     setMyCommandsCalls: 0,
+    registeredCommands: [],
     textHandler: null,
     callbackHandler: null,
     fileHandler: null,
@@ -74,11 +77,16 @@ function makeBotFactory(opts: FakeBotOptions = {}): {
           if (opts.getMeError) throw opts.getMeError;
           return { id: 1, username: "test_bot" };
         }),
-        setMyCommands: vi.fn(async () => {
-          state.setMyCommandsCalls += 1;
-          if (opts.setMyCommandsError) throw opts.setMyCommandsError;
-          return undefined;
-        }),
+        setMyCommands: vi.fn(
+          async (
+            cmds: ReadonlyArray<{ command: string; description: string }>,
+          ) => {
+            state.setMyCommandsCalls += 1;
+            state.registeredCommands = cmds.map((c) => c.command);
+            if (opts.setMyCommandsError) throw opts.setMyCommandsError;
+            return undefined;
+          },
+        ),
       },
       setTextHandler(handler) {
         state.textHandler = handler;
@@ -322,6 +330,19 @@ describe("TelegramChannel", () => {
     expect(state.startCalls).toBe(1);
     expect(state.textHandler).not.toBeNull();
     expect(state.setMyCommandsCalls).toBe(1);
+    // The command menu is the only discovery surface on a phone — every
+    // verb the slash dispatch answers has to be in it, `/model`
+    // included.
+    expect(state.registeredCommands).toEqual([
+      "start",
+      "help",
+      "status",
+      "sessions",
+      "switch",
+      "new",
+      "model",
+      "cancel",
+    ]);
   });
 
   it("emits down with the right error when token is null", async () => {

--- a/src/channels/telegram/telegram-channel.ts
+++ b/src/channels/telegram/telegram-channel.ts
@@ -321,6 +321,10 @@ export class TelegramChannel {
             command: "new",
             description: "Start a fresh session for this chat",
           },
+          {
+            command: "model",
+            description: "Show or switch the provider and model",
+          },
           { command: "cancel", description: "Cancel this chat's current turn" },
         ]);
       } catch (err) {

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -921,6 +921,15 @@ export interface AtomicAgentConfig {
        * accept `Authorization: Bearer` (Anthropic wants `x-api-key`).
        */
       apiKeyHeader?: string;
+      /**
+       * Env var holding this entry's API key, set by the known-service
+       * presets so each service keeps its own (`GROQ_API_KEY`,
+       * `NOUS_API_KEY`, ...). Authoritative when present — see
+       * `resolveLlmProviderApiKey`. `parseLlmProviders` has always
+       * carried it through `UserLlmProviderEntry`; it was simply
+       * missing from this mirror of that shape.
+       */
+      apiKeyEnvVar?: string;
       supportsTools?: boolean;
       supportsVision?: boolean;
       requestTimeoutMs?: number;

--- a/src/tui/persist-llm-provider.test.ts
+++ b/src/tui/persist-llm-provider.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { resetConfigCache } from "../config/config-cache.js";
+import {
+  getUserConfigPath,
+  writeUserConfigFileSync,
+} from "../config/config-file.js";
+import { USER_CONFIG_DEFAULTS } from "../config/config-schema.js";
+import { getConfig } from "../config/index.js";
 import {
   dotenvKeyForProviderKind,
   parseAddProviderJson,
+  restoreProviderDefaultChatModelInConfig,
+  setProviderDefaultChatModelInConfig,
 } from "./persist-llm-provider.js";
 
 describe("persist-llm-provider", () => {
@@ -55,5 +67,106 @@ describe("persist-llm-provider", () => {
       }),
     );
     expect(entry.id).toBe("cloud");
+  });
+});
+
+/**
+ * `restoreProviderDefaultChatModelInConfig` is the undo half of
+ * `setProviderDefaultChatModelInConfig`, and the only writer that can
+ * express *unset* — which is why it exists and why it is tested here
+ * against a real config file rather than only through the callers that
+ * happen to use it.
+ */
+describe("restoreProviderDefaultChatModelInConfig", () => {
+  let stateDir: string;
+
+  function write(defaultChatModel?: string): void {
+    writeUserConfigFileSync(getUserConfigPath(stateDir), {
+      ...USER_CONFIG_DEFAULTS,
+      llm: {
+        activeTextProvider: "cloud",
+        activeEmbeddingProvider: "cloud",
+        toolTransport: "auto",
+        providers: [
+          {
+            id: "cloud",
+            kind: "openai-compatible",
+            baseUrl: "https://api.example.com/v1",
+            ...(defaultChatModel === undefined ? {} : { defaultChatModel }),
+          },
+          { id: "other", kind: "openrouter", defaultChatModel: "keep/me" },
+        ],
+      },
+    });
+    resetConfigCache();
+  }
+
+  /** The raw file, to tell "key absent" from "key present as undefined". */
+  function rawProvider(id: string): Record<string, unknown> {
+    const file = JSON.parse(
+      readFileSync(getUserConfigPath(stateDir), "utf8"),
+    ) as { llm: { providers: Array<Record<string, unknown>> } };
+    const entry = file.llm.providers.find((p) => p.id === id);
+    if (!entry) throw new Error(`no provider ${id} in the written file`);
+    return entry;
+  }
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "atomic-persist-llm-"));
+    process.env.ATOMIC_AGENT_STATE_DIR = stateDir;
+    resetConfigCache();
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.ATOMIC_AGENT_STATE_DIR;
+    resetConfigCache();
+  });
+
+  it("puts a previous model id back", () => {
+    write("was-here");
+    setProviderDefaultChatModelInConfig("cloud", "rejected-later");
+    restoreProviderDefaultChatModelInConfig("cloud", "was-here");
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "cloud")
+        ?.defaultChatModel,
+    ).toBe("was-here");
+  });
+
+  it("removes the key when there was no previous pin", () => {
+    // The state `setProviderDefaultChatModelInConfig` cannot reach: it
+    // refuses an empty id, so without this function a rollback could
+    // only ever overwrite, never clear.
+    write();
+    expect(() => setProviderDefaultChatModelInConfig("cloud", " ")).toThrow(
+      /empty/,
+    );
+    setProviderDefaultChatModelInConfig("cloud", "rejected-later");
+    expect(rawProvider("cloud").defaultChatModel).toBe("rejected-later");
+
+    restoreProviderDefaultChatModelInConfig("cloud", undefined);
+    // Deleted outright, not written as `null` or `""` — the config
+    // parser and every reader treat those differently from absent.
+    expect(rawProvider("cloud")).not.toHaveProperty("defaultChatModel");
+    expect(
+      getConfig().llm?.providers.find((p) => p.id === "cloud")
+        ?.defaultChatModel,
+    ).toBeUndefined();
+  });
+
+  it("leaves every other provider alone", () => {
+    write("was-here");
+    restoreProviderDefaultChatModelInConfig("cloud", undefined);
+    expect(rawProvider("other").defaultChatModel).toBe("keep/me");
+  });
+
+  it("is a no-op for a provider id that is not configured", () => {
+    // A rollback path must not throw a second error over the first one
+    // it is trying to report.
+    write("was-here");
+    expect(() =>
+      restoreProviderDefaultChatModelInConfig("ghost", "anything"),
+    ).not.toThrow();
+    expect(rawProvider("cloud").defaultChatModel).toBe("was-here");
   });
 });

--- a/src/tui/persist-llm-provider.ts
+++ b/src/tui/persist-llm-provider.ts
@@ -285,6 +285,39 @@ export function setProviderDefaultChatModelInConfig(
   resetConfigCache();
 }
 
+/**
+ * Put one provider's `defaultChatModel` back to a previous value —
+ * including *unset*, which {@link setProviderDefaultChatModelInConfig}
+ * cannot express (it rejects an empty id).
+ *
+ * This exists for callers that must write the model *before* an
+ * operation that can still fail — rebuilding the provider from the
+ * now-current config reads it off disk, so it cannot be written after.
+ * Without an undo, a failed rebuild leaves the config pinning a model
+ * that nothing ever accepted while the caller reports a failure, and
+ * the next reader (a `/model` report, the TUI's LLM pane) shows the
+ * rejected id as the provider's model. Unknown provider id is a no-op:
+ * a rollback path must not throw a second error over the first.
+ */
+export function restoreProviderDefaultChatModelInConfig(
+  providerId: string,
+  previous: string | undefined,
+): void {
+  const path = getConfig().paths.userConfigFile;
+  const file = ensureUserConfigFileSync(path);
+  const llm = readLlmBlockOrDefault(file);
+  const providers = llm.providers.map((provider) => {
+    if (provider.id !== providerId) return provider;
+    if (previous === undefined) {
+      const { defaultChatModel: _dropped, ...rest } = provider;
+      return rest;
+    }
+    return { ...provider, defaultChatModel: previous };
+  });
+  writeUserConfigFileSync(path, { ...file, llm: { ...llm, providers } });
+  resetConfigCache();
+}
+
 export function setProviderDefaultEmbeddingModelInConfig(
   providerId: string,
   modelId: string,


### PR DESCRIPTION
Discord `#feedback-and-bugs`, `thegreatteacher`, 2026-09-09 21:42 / 21:44 UTC: "Some crucial features should be managable through telegram or discord. Such as being able to switch models. Currently, they are pretty limited." … "Therefore, important features of TUI should be accessible through telegram or discord commands." The maintainer replied that he'd add it.

Both channels already had `/start`, `/help`, `/status`, `/sessions`, `/switch`, `/new`, `/cancel`, and a session already remembers its own provider/model (#321). What was missing was the one verb that changes it — so a bot running on someone else's machine was pinned to whatever model that machine was last told to use, with no remote way out.

## What the command does

`/model` — report: the active provider and the model it actually runs, the run mode, the configured providers (active one marked, ones that cannot authenticate flagged with the variable to set), and the two forms below.

`/model <provider>` — switch provider, keeping that provider's own pinned model.
`/model <provider> <model-id>` — pin a model on that provider and activate it.
`/model <provider>/<model-id>` — the same in one token; it splits at the **first** slash, so `openrouter/anthropic/claude-opus-4` works.

Registered in Telegram's `setMyCommands` alongside the other verbs, so it shows up in the command menu and autocomplete.

## Where the state lives

No new store. The command writes exactly what the TUI's LLM pane writes, through the same helpers, in the same order as `ProvidersOrchestrator.selectChatModel`:

1. `setProviderDefaultChatModelInConfig` (when a model was named),
2. `reloadLlmProvider(id)` — or `reloadLlmProviders()` for a provider the registry has not built yet,
3. `providerRegistry.setActive(id)` + `setActiveTextProviderInConfig(id)`.

Then it stamps the chat's session with `session-llm.ts`'s `llm` metadata key, for the same reason the TUI stamps on selection: that stamp is what the TUI restores when it later opens the session.

Shared logic lives in `src/channels/model-command.ts`; each handler keeps its own `/model` case and passes a `code` formatter (bare on Telegram, backticks on Discord). The handlers stay parallel — no unification.

## Reporting the model that is actually running

`chatModelOf` (the config pin) and `displayModelOf` (what an operator reads) are deliberately two things.

The **stamp** uses the pin, byte-identical to what `executeTurn` writes. The **report and the confirmation** use `displayModelOf`, which for the **active** `llama-server` entry with no pin falls back to `localModels.managed.modelId` — the same first legs, in the same order, as `resolveActiveModelName()` in `bootstrap.ts`, which is what feeds the pricing key and every `message_sent` event. On the default local-first install that turns "Model: local-llama · provider default" into the GGUF id the config already knows.

That fallback is scoped to the active entry on purpose, and the scope is the whole justification for it. `bootstrap` computes that name for `resolved.activeTextProvider` alone; the report walks every configured provider. `localModels.managed` describes *one* daemon — the managed one this install starts — so applying it to a second `llama-server` entry (a box on the LAN; `resolve-run-mode.ts` picks the worker leg with a `find`, so more than one is a shape the code expects) would report that box as running a GGUF it has never seen. A non-active local entry reads "provider default", which is what the config actually says about it.

They must not be merged: a stamp carrying a model on a llama-server entry would make the TUI's session restore call `selectChatModel` on reopen (`session-model-restore.ts` → `planModelRestore`), writing that id into `defaultChatModel` — the exact poisoning the next section refuses.

## Run mode is part of the answer

Switching the active provider is how a deployment leaves fusion: `resolveRunMode` derives the effective mode from `llm.activeTextProvider` on purpose, so the two keys can never contradict each other, and the TUI's own LLM pane drops out of fusion the same way. What the TUI has and a chat did not is a place that *says so* — the run-mode chip. Leaving fusion removes the `fusion.delegate` tool and the `### fusion` guidance from every session and invalidates every session's KV prefix (`bootstrap.ts` gates the fan-out descriptor on `effective === "fusion"`); "Now on local-llama." is not an adequate answer to that.

So the bare report carries a `Run mode:` line built from the same `describeRunMode` the TUI uses — including the "stored fusion, effective local" disagreement — and a switch that crosses **into or out of** fusion appends a line naming the provider that restores it. Ordinary Local ↔ Cloud switches stay silent: the reply already names the provider that caused it, and a paragraph on every switch is the noise that teaches operators to skip the paragraph that matters.

## Every answer has to fit in one chat message

A chat message is not a terminal pane. Discord rejects a `content` past 2000 characters and `DiscordApi.sendMessage` chunks silently at `DISCORD_MESSAGE_LIMIT`; Telegram's own limit is 4096 and `outbound-sender.ts` chunks at 4000, where a chunk that takes a second 429 is dropped with a log line and no reply. So an oversized answer does not merely read badly — it becomes several messages, and on Telegram one of them can vanish.

Three parts of an answer are unbounded. All three are fitted. Every figure below is a measurement through the real handler on the fixture in the tests, re-run for this revision.

**The provider enumeration.** On the fixture plus sixty `openai-compatible` entries, the uncapped report was **4962 characters** on Discord — three messages, 1983 / 1975 / 1002 — and **4694** on Telegram, which `sendOutbound` split into 3960 + 734, stranding the tail. It is now fitted to a budget under the tighter of the two limits with the overflow counted: **1703** characters on Discord and **1681** on Telegram, one message each, ending `…and 44 more not shown — /model <provider> switches to any of them, listed or not.` Nothing is lost by that: the active provider is named on the first line either way, and a provider that is not listed is still switchable by name. The active entry's own line is budgeted up front and emitted wherever it falls in the list, so the cap can never drop the one provider the report is about. Ordinary installs are untouched — on Telegram a fresh install is 224 characters and the five-provider fixture 394, byte-identical to before the cap existed.

**Names the config schema does not bound.** A model id and an `apiKeyEnvVar` are `parseOptionalString`, and the token in `/model <token>` is whatever was typed; each is clipped to 48 characters with a visible ellipsis. That now holds on **every** path that prints one, which it did not in the previous revision of this branch: the switch confirmation and the `llama-server` pin refusal both interpolated the model id whole, and `resolveTarget`'s no-API-key refusal printed `apiKeyEnvVar` whole while `providerLine` clipped it. Those are the likeliest paths to carry a pathological name, because the operator has just typed it, and one Discord-legal 2000-character command reached two of them: `/model openrouter <1982 m's>` answered in **2041** characters and `/model local-llama <1981 m's>` in **2352**, each past the Discord limit and therefore two messages. They now answer in 107 and 419. Clipping is display only — the id written to `defaultChatModel` is the whole one, and a test asserts it. Provider ids are *not* clipped: `PROVIDER_ID_RE` already caps them at 32 kebab-case characters, so clipping one would be dead code.

**The id lists in the two refusals**, which are deliberately capped by different rules.

- The unknown-provider `Configured:` list is orientation, not a menu — the token matched nothing, so what the message has to teach is the *form* of the command plus enough real ids to recognise one. Twelve entries, then a count.
- The ambiguous-prefix list *is* the answer: the sentence's whole job is "say which one", and a candidate that is hidden cannot be picked, with no way to page through the rest from a chat. So it is fitted to a character budget rather than an entry count, and everything that fits in one message prints — all sixty `compat-*` candidates, 1342 characters on Discord and 1220 on Telegram. Only past a message's worth does a count appear (120 entries at the longest id the regex allows renders 41 of them in 1559 characters on Discord), and there the message also names the one thing that shortens the list from a chat: type more of the id.

Worst case measured across every shape `/model` can answer with: 1703 characters, one message on both surfaces. The single exception is error text, which is passed through whole — see "What this does not cover".

## The switch is global, and in-flight turns are refused

`llm.activeTextProvider` is one config setting, and `bootstrap`'s `resolveActiveLlmSlice` re-reads it **per inference attempt** ("Re-read on every inference so TUI `setActive` hot-swap takes effect") — returning the tool transport and tool-call adapter with it. So a switch does not politely wait for anyone's next turn: it lands on the very next *step* of every turn already running, and can flip native_tools ↔ grammar underneath one.

`/model` therefore refuses whenever **any** session has a turn in flight, not just the issuing chat's — `turnController.busySessionIds()`, which is where every origin (Telegram per chat, Discord per channel, TUI, HTTP, scheduler) registers. Arguments are validated first, so a typo is still answered as a typo, and only a command that would actually change something is refused. The message says how many sessions are running so the operator can wait or `/cancel`; a successful switch says "Takes effect on the next message."

Making selection genuinely per-session is a separate design call — `executeTurn` re-stamps every session from the global config at the top of each turn, so it is not a small change (see "What this does not cover").

## Gating

Confirmed, not re-implemented: Telegram drops every non-owner update in `handleInboundText` (the `ownerUserId` check) and Discord drops everything outside `ownerUserIds` in `route`, both **before** the slash dispatch runs. `/model` adds no second check; a test in each file asserts a non-owner `/model` sends nothing and changes no config.

## Refusals and failure handling

A chat has no undo, so a write it could not take back must not happen at all. That is the shape of the refusal list.

- **a model id on a `llama-server` provider** — refused. The llama-server factory never reads `entry.defaultChatModel` (`register-built-in-providers.ts`; every other kind's factory does), but `resolveActiveModelName()` reads it **first**, ahead of `localModels.managed.modelId`. A pin there would rename the model in the report, in the cost lookup and in every `message_sent` event while the daemon carried on serving its own GGUF — and no chat command clears it again. The TUI cannot reach that state either (`openChatModelPicker` and `ensureInlineModels` both refuse non-cloud kinds), so neither does this. The refusal points at the Local Models tab.
- **provider cannot authenticate** — two cases. An `openrouter`/`aimlapi`/`gemini` entry with no resolvable key, and *any* entry that declares its own `apiKeyEnvVar` (which is how the known-service presets — Groq, Nous, Anthropic — are written by `providers-wizard-build-entry.ts`, all under `kind: "openai-compatible"`) while that variable is unset. A kind-only check waved those through and every following turn 401'd with nothing in the channel to explain it. A bare keyless `openai-compatible` entry declares no variable — that is how LM Studio and Ollama are configured — and keeps working. The refusal and the report name the variable to set.
- **unknown id** — names the configured providers and the `/model <provider> <model-id>` form.
- **ambiguous prefix** — a token that prefixes more than one provider id (`open` → `openrouter`, `openai-compat`). The refusal names the candidates, as many as one message holds.
- **a token starting with a slash** (`/model /vendor/model-9`, a model id typed with its vendor prefix) — answered with the command's shape rather than an "Unknown provider" naming nothing.
- **trailing arguments** — refused, not dropped: a provider id and a model id are one token each.
- **a turn in flight** — above.
- **a failed config write or provider reload** — comes back as a message, and **rolls back**. The model pin must be written before the rebuild (the rebuild reads it off disk), so on failure the pin and the in-memory active provider are both restored before answering: "Could not switch" means nothing switched, and a later bare `/model` cannot report a model that was just rejected. `restoreProviderDefaultChatModelInConfig` is the undo half, and the only writer that can express *unset* — `setProviderDefaultChatModelInConfig` rejects an empty id.
- **anything else that throws** — logged, and answered. `runModelCommand` wraps its whole body in one `catch`, so the guarantee is enforced in a single place rather than promised leg by leg. The legs with something better to say still catch first (a failed session-store write after a successful switch, a post-switch config re-read), but the read with *no* message of its own is the entry `getConfig()` / `resolveLlmConfig()` — and that is the one most likely to fail, because `/model`'s own `setActiveTextProviderInConfig` calls `resetConfigCache()`, so every invocation goes back to disk. A config hand-edited or torn since boot used to reject the whole command: no reply at all on Telegram, an unhandled rejection on Discord's bare `void this.onDispatch(...)`. It now answers `Could not run /model: <reason>`.

## One config-type gap fixed along the way

`apiKeyEnvVar` was missing from the `llm.providers[]` shape in `AtomicAgentConfig`, although `parseLlmProviders` has always parsed and carried it (it is on `UserLlmProviderEntry`, and `resolveLlmProviderApiKey` reads it). Added to the mirror; no behaviour change of its own.

## Test evidence

`src/channels/telegram/inbound-model-command.test.ts` (35) and `src/channels/discord/discord-inbound-model-command.test.ts` (35) — the same 35 cases on both surfaces, differing only in id decoration and in the one name that has to differ (Telegram's "this chat" is Discord's "this channel"). Each drives the real handler and writes the real user config in an isolated `ATOMIC_AGENT_STATE_DIR`, then asserts on `getConfig()` — the feature *is* "the chat writes the state the TUI writes", so a stubbed config writer would prove nothing. The API-key environment variables (`GROQ_API_KEY` included) are saved, cleared and restored per test, so an exported key cannot decide a "no API key" assertion either way.

The fixture carries a `groq` preset (`openai-compatible` + `apiKeyEnvVar`) next to a keyless `openai-compat` entry, so the two are told apart by what the code actually keys on, and an `aimlapi` entry with no model of its own so the rollback test exercises the *clear the pin* branch and not just revert-to-previous.

`reloadLlmProvider(s)` is the one stubbed seam, so one test in each file builds the same fixture through the real `ProviderRegistry.fromConfig`: without it the "provider not yet in the registry" case would keep passing for a config production refuses (`openai-compatible` requires `baseUrl` and `defaultChatModel`).

`src/tui/persist-llm-provider.test.ts` now tests `restoreProviderDefaultChatModelInConfig` directly against a real config file — restore, clear (asserting the key is *deleted* from the file, not written as `null`), leave other providers alone, and no-op on an unknown id.

`src/channels/telegram/telegram-channel.test.ts` asserts the full `setMyCommands` menu, `/model` included.

- `npm run lint` (`tsc --noEmit`) — clean. `prettier --check` — clean.
- `npx vitest run src/channels src/session src/tui/providers src/tui/persist-llm-provider.test.ts` — 788 passed, 53 files, 0 failed.
- `npx vitest run src/tui src/runtime src/config src/llm` — 4679 passed, 403 files, 0 failed. (One unhandled `spawn llama-server EACCES` from `local-models-orchestrator-auto-update.test.ts` — sandbox noise on `origin/main` too, no test fails.)

**Fails without the src change**, all five controls re-run and counted for this revision, over the 123 tests in the four touched files:

- whole feature removed (`model-command.ts` deleted, both handlers + `telegram-channel.ts` + `persist-llm-provider.ts` + `config-schema.ts` back to `origin/main`): 71 of 123 fail.
- second-round fix reverted (`model-command.ts` + `config-schema.ts` back to `bf546815`): 32 fail.
- third-round fix reverted (`model-command.ts` back to `be5f676a`, tests kept): 18 fail. The config-parse case fails there by *rejecting* `handleInboundText` outright, which is the defect it exists to pin.
- fourth-round fix reverted (`model-command.ts` back to `fb14b122`, tests kept): 10 fail — the five new cases per channel, the same five names on both surfaces.
- Two of those ten — "names every candidate an ambiguous prefix matches", one per channel — pass at `be5f676a` and `bf546815` and fail only at `fb14b122`. That is the correct shape: they pin a cap that revision introduced, not a defect the earlier ones had. It is why the third-round control moves 10 → 18 rather than 10 → 20.
- Two of the older cases pass either way *by design*, and are labelled controls rather than evidence: "accepts a preset provider once its declared env var is set" (the switch must still work) and "stays quiet about an ordinary Local → Cloud switch" (a guard on the run-mode note, not on old behaviour).

## What this does not cover

- **The switch is global, not per chat.** A `/model` from Telegram changes what the TUI and every other session run on. That is the existing model-selection contract, not something this command introduces: `executeTurn` overwrites every session's `llm` stamp from the global `resolveLlmConfig` at the top of each turn, so the stamp cannot make channel selection per-session as things stand — it only steers what the TUI restores. The in-flight guard above is what keeps the global switch from corrupting a running turn. **This is a declared deviation from the issue**, which asked for `/model <id>` to switch *this chat's* session; genuinely per-session selection is a design call for the maintainer, not something to smuggle in here.
- **There is no `/runmode` verb.** `/model` reports the run mode and announces a fusion transition it caused, but it cannot *set* one — choosing fusion, or setting the worker count, is still TUI-only. A remote operator who leaves fusion by switching provider can get back in with `/model <orchestrator>`, and nothing else.
- **No unpin verb.** `/model <provider> <model-id>` overwrites a pin, but nothing clears one back to "provider default" from a chat; `restoreProviderDefaultChatModelInConfig` is reachable only from the rollback path. Since a llama-server pin is now refused outright, the state a chat can create is always one another `/model` can overwrite — but a config hand-edited to a bad pin still needs the TUI.
- **`localModels.mode` is not consulted, here or in `bootstrap`.** An *external*-mode llama-server whose config still carries a `localModels.managed.modelId` from an earlier download reports that stale id, not "provider default" — exactly as `resolveActiveModelName()` does, so the channel agrees with every `message_sent` event and with the cost lookup. Gating the channel on the mode would buy a truer report at the price of disagreeing with every other surface; if it is worth fixing it is worth fixing in `bootstrap`, not here. An external-mode entry with no managed id does read "provider default". The two further legs `resolveActiveModelName()` has — the operator `--alias` from the `/props` probe and the prompt-profile id — live inside `bootstrap` and are not on the runtime interface, so neither is reachable from a channel at all.
- **The report lists providers, not models.** The issue asked for "what can be selected"; what this lists is the configured providers and their models. There is no `/model list <provider>` and no fuzzy model search. A headless deployment never refreshes the cloud catalogs (that is driven by the TUI's providers tab), so any model list it printed would be the stale bundled one.
- **No model-id validation on cloud providers.** `/model openrouter typo-9` is accepted and pinned; the gateway rejects it on the next turn. Validating against the bundled catalog would wrongly refuse models added since the release, which is worse than a wrong pin the next `/model` fixes. (This is *not* the llama-server case above, where nothing ever rejects it.)
- **A bare token is a provider, never a model.** `/model gpt-5.4-mini` is refused rather than guessed onto the active provider — guessing would silently pin a typo as the chat model and leave the agent broken until someone opened the TUI. The refusal names the form.
- **Error text is not clipped.** The three unbounded *names* above are; the two error replies — `Could not switch to <provider>: <reason>` and the never-throws floor's `Could not run /model: <reason>` — pass the underlying message through whole. That is a deliberate asymmetry: an error is diagnostic rather than a label, and truncating the one message whose job is to explain an unexpected failure would repeat exactly the mistake the ambiguous-prefix cap made. In practice these are short and come from this codebase rather than from what was typed — the two config-parse cases I can construct, an unknown `activeTextProvider` and a duplicate provider id, both answer in a little under 300 characters, most of which is the config path the error names — but neither is *bounded*, so a provider factory or config validator that produced a multi-kilobyte message would still split the reply in two on Discord. Bounding it wants an error-sized budget rather than the 48-character name cap, and that is a call worth making against a real long error rather than a hypothetical one.
- **A long-running turn blocks `/model`.** A scheduled task holding a session busy makes the command refuse until it finishes or is cancelled. That is the price of refusing rather than deferring; deferring would need a queue and a drain hook that do not exist today.
- Embedding provider selection, `/llm`-style health checks, and adding a provider are still TUI-only.


