### PR TITLE
fix(tracing): keep the end of a long session's trace, not the start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2459,7 +2459,7 @@ Emitted `TraceEvent` types (see [src/tracing/trace/trace-event.ts](src/tracing/t
 
 Invariants:
 
-- **Append-only.** Sinks never rewrite past lines. `trace_truncated` is a synthetic final marker when the per-session cap (`tracing.trace.maxBytesPerSession`, default 10 MiB) is hit; further events are dropped silently.
+- **Append-only, except at the cap.** Sinks never rewrite a line's content. When the per-session cap (`tracing.trace.maxBytesPerSession`, default 10 MiB) would be crossed, the NDJSON sink rewrites the file keeping its TAIL — whole leading lines are dropped down to half the cap and a synthetic `trace_truncated` marker is left at the seam with `droppedEvents` / `droppedBytes`. Writing then continues: the end of a long session, where postmortems live, is never lost. The rewrite is atomic (temp file + rename) and there is still exactly one file per session.
 - **Per-session file.** One NDJSON per `sessionId`; no cross-session mixing.
 - **Monotonic `seq`.** Every event carries a monotonic in-session sequence starting at `0`.
 - **No redaction yet.** Secret redaction is an explicit NON-goal of this milestone; treat trace files as sensitive local artefacts.

--- a/eval-memory/harness/memory-profiles.ts
+++ b/eval-memory/harness/memory-profiles.ts
@@ -144,11 +144,12 @@ export function buildMemoryConfig(
       // about ~55 turns on a reflection-heavy `full_v2` profile —
       // enough for interactive use but not for LoCoMo / LongMemEval
       // runs that feed 30+ session prefills then ask 100+ questions.
-      // When the cap is hit, `trace_truncated` fires and further
-      // events are silently dropped (see AGENTS.md §"Traceability and
-      // replay"). The harness reads `assistantReply` out of the trace,
-      // so post-truncation turns surface as `""` even when the agent
-      // really did reply on stdout — see `multi-turn-driver.ts`'s
+      // When the cap is hit the sink drops the OLDEST events and
+      // leaves a `trace_truncated` marker at the seam (see AGENTS.md
+      // §"Traceability and replay"). The harness reads
+      // `assistantReply` out of the trace, so the EARLY turns of an
+      // over-cap run surface as `""` even when the agent really did
+      // reply on stdout — see `multi-turn-driver.ts`'s
       // truncation-fallback for the read-side guard. Bumped here to
       // 200 MiB so a full conv-44 (158 QA × 28 sessions ≈ 35 MiB of
       // trace at full fidelity) leaves comfortable head-room.

--- a/eval-memory/harness/postmortem-trace.test.ts
+++ b/eval-memory/harness/postmortem-trace.test.ts
@@ -187,14 +187,16 @@ describe("renderPostmortem", () => {
     expect(out).toContain("| 1 | max_steps | 16 | 60000 | 20000 | 0 |");
   });
 
-  it("notes when trace was truncated", () => {
+  it("notes which end of the trace was dropped", () => {
     const events: TraceEvent[] = [
       turnStarted(0, 0),
       turnFinished(0, 1, "reply"),
       { type: "trace_truncated", seq: 2, sessionId, ts, reason: "cap" },
     ];
     const out = renderPostmortem(analyzeTrace(events));
-    expect(out).toContain("Trace truncated at seq=2");
+    // The marker means the events at or below this seq are gone, not
+    // that the trace stops here — the sink keeps writing past it.
+    expect(out).toContain("Trace head dropped up to seq=2");
   });
 
   it("explicitly says (none) when no problem turns", () => {

--- a/eval-memory/harness/postmortem-trace.ts
+++ b/eval-memory/harness/postmortem-trace.ts
@@ -64,10 +64,12 @@ export interface PostmortemReport {
    */
   problemTurns: readonly TurnSummary[];
   /**
-   * Last `trace_truncated` event if any was recorded, indicating the
-   * trace hit `tracing.trace.maxBytesPerSession` and subsequent
-   * events were dropped — important caveat for postmortems on long
-   * runs.
+   * Last `trace_truncated` event if any was recorded. The sink writes
+   * one at the seam where it dropped the OLDEST part of the file to
+   * stay under `tracing.trace.maxBytesPerSession`: everything at or
+   * below `atSeq` is missing, everything after it is intact. Important
+   * caveat for postmortems on long runs — the opening turns are the
+   * ones that are gone.
    */
   traceTruncated: { reason: string; atSeq: number } | null;
 }
@@ -219,7 +221,7 @@ export function renderPostmortem(report: PostmortemReport): string {
   lines.push(`- Total turns: ${report.totalTurns}`);
   if (report.traceTruncated) {
     lines.push(
-      `- ⚠ Trace truncated at seq=${report.traceTruncated.atSeq} (reason: ${report.traceTruncated.reason})`,
+      `- ⚠ Trace head dropped up to seq=${report.traceTruncated.atSeq} (reason: ${report.traceTruncated.reason})`,
     );
   }
   lines.push("");

--- a/src/cli/trace-formatter.ts
+++ b/src/cli/trace-formatter.ts
@@ -110,7 +110,17 @@ function formatTraceEvent(event: TraceEvent, raw: boolean): string {
     case "error":
       return `${head} message=${event.message}`;
     case "trace_truncated":
-      return `${head} reason=${event.reason}`;
+      // The counts are the point of the row: they tell the reader how
+      // much of the session is missing above this line.
+      return `${head}${
+        event.droppedEvents !== undefined
+          ? ` droppedEvents=${event.droppedEvents}`
+          : ""
+      }${
+        event.droppedBytes !== undefined
+          ? ` droppedBytes=${event.droppedBytes}`
+          : ""
+      } reason=${event.reason}`;
     default:
       return `${head} ${JSON.stringify(event)}`;
   }

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -496,7 +496,11 @@ export interface AtomicAgentConfig {
       enabled: boolean | null;
       /** Directory for per-session NDJSON trace files. */
       dir: string;
-      /** Hard cap on a single session's trace file before writes stop. */
+      /**
+       * Hard cap on a single session's trace file. Crossing it drops
+       * the OLDEST events, not the newest: the sink trims the head
+       * back to half the cap and keeps recording.
+       */
       maxBytesPerSession: number;
     };
   };

--- a/src/tracing/trace/trace-event.ts
+++ b/src/tracing/trace/trace-event.ts
@@ -431,13 +431,26 @@ export interface TraceError extends TraceEventBase {
 }
 
 /**
- * Synthetic terminal marker emitted by the NDJSON sink when a trace file
- * hits `maxBytesPerSession`. Subsequent events are dropped silently — the
- * runtime never stops because of trace overflow.
+ * Synthetic marker written by the NDJSON sink at the seam where it
+ * dropped the oldest part of a trace file to stay under
+ * `maxBytesPerSession`. It is NOT terminal: events keep being appended
+ * after it. Its job is to stop a reader — human or agent — from taking
+ * the row that follows it for the start of the session.
+ *
+ * `seq` and `ts` are those of the LAST dropped event, so the file stays
+ * ordered by both and the marker sits exactly where the gap ends.
  */
 export interface TraceTruncated extends TraceEventBase {
   type: "trace_truncated";
   reason: string;
+  /**
+   * Events removed from the head of this file so far, across every
+   * trim it has been through. Optional: traces recorded before the
+   * sink learned to keep the tail carry a marker without it.
+   */
+  droppedEvents?: number;
+  /** Bytes of event data removed so far. Optional, as `droppedEvents`. */
+  droppedBytes?: number;
 }
 
 /** Stable JSON serialization: one event per line, trailing newline. */

--- a/src/tracing/trace/trace-sink.test.ts
+++ b/src/tracing/trace/trace-sink.test.ts
@@ -3,7 +3,9 @@ import {
   chmodSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -124,6 +126,162 @@ describe("createNdjsonTraceSink", () => {
     // is every event that was ever handed to the sink.
     const kept = lines.filter((l) => l.type === "step_finished").length;
     expect(kept + (markers[0]!.droppedEvents as number)).toBe(60);
+  });
+
+  // The cap tests above run at 600 bytes, where the target (300) is
+  // below `MARKER_BUDGET_BYTES` — the trim degenerates to "wipe
+  // everything but the header" and no surviving tail is ever cut. The
+  // caps here are large enough for the real path: whole events survive
+  // a trim, so the cut has to land on a line boundary to be readable.
+  it("keeps whole surviving events when a tail actually fits", () => {
+    // Several cap/size pairs so the target lands mid-line, not on a
+    // convenient multiple of the event size.
+    for (const [cap, pad] of [
+      [8192, 40],
+      [8192, 137],
+      [4096, 71],
+      [12_345, 213],
+    ] as const) {
+      const id = `s-tail-${cap}-${pad}`;
+      const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: cap });
+      const emitted = new Map<number, string>();
+      for (let i = 0; i < 400; i++) {
+        const event = paddedEvent(id, i, pad);
+        emitted.set(i, JSON.stringify(event));
+        sink(event);
+      }
+      const raw = readFileSync(traceFilePath(dir, id), "utf8");
+      const rows = raw.split("\n").filter((l) => l.length > 0);
+      // A real tail, not just the marker plus the last append.
+      expect(rows.length).toBeGreaterThan(5);
+      expect(rows[0]).toContain('"trace_truncated"');
+      // Every surviving row is the event that was handed to the sink,
+      // byte for byte. A cut that ignored line boundaries would leave
+      // a fragment here and poison every reader of the file.
+      for (const row of rows.slice(1)) {
+        const parsed = JSON.parse(row) as { seq: number };
+        expect(row).toBe(emitted.get(parsed.seq));
+      }
+      expect(JSON.parse(rows[rows.length - 1]!)).toMatchObject({ seq: 399 });
+      // The marker stands exactly where the gap ends: its `seq` is the
+      // last dropped event's, one before the first survivor.
+      const marker = JSON.parse(rows[0]!) as { seq: number };
+      const firstKept = JSON.parse(rows[1]!) as { seq: number };
+      expect(marker.seq).toBe(firstKept.seq - 1);
+    }
+  });
+
+  it("does not rewrite the file for an event that can never fit", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 8192 });
+    for (let i = 0; i < 4; i++) sink(paddedEvent("s-nofit", i, 40));
+    const path = traceFilePath(dir, "s-nofit");
+    const before = readFileSync(path, "utf8");
+    const ino = statSync(path).ino;
+    expect(before.length).toBeLessThanOrEqual(4096);
+
+    sink(paddedEvent("s-nofit", 4, 20_000));
+    // Untouched: same inode, same bytes. Rewriting a file that is
+    // already below the trim target buys nothing, and paying for it
+    // per event is how a stream of oversized rows turns the trace
+    // sink into an O(file size) write amplifier.
+    expect(statSync(path).ino).toBe(ino);
+    expect(readFileSync(path, "utf8")).toBe(before);
+    sink(paddedEvent("s-nofit", 5, 40));
+    expect(readFileSync(path, "utf8")).toContain('"seq":5');
+  });
+
+  it("stops rewriting when the cap is too small to hold anything", () => {
+    // A cap below the marker itself is a legal configuration
+    // (`parsePositiveInt`). Nothing can be stored under it — but the
+    // sink must work that out once, not re-derive it with a whole-file
+    // rewrite on every event for the rest of the session.
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 256 });
+    const path = traceFilePath(dir, "s-tiny");
+    let previous = -1;
+    let rewrites = 0;
+    for (let i = 0; i < 40; i++) {
+      sink(paddedEvent("s-tiny", i, 20));
+      const ino = statSync(path).ino;
+      if (ino !== previous) {
+        rewrites += 1;
+        previous = ino;
+      }
+    }
+    // One creation plus at most one trim that discovers the floor.
+    expect(rewrites).toBeLessThanOrEqual(2);
+  });
+
+  it("bounds rewrites when a huge session_started crowds out the tail", () => {
+    const cap = 8192;
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: cap });
+    sink({
+      type: "session_started",
+      sessionId: "s-fat",
+      seq: 0,
+      ts: 1,
+      workingDir: `/${"d".repeat(7000)}`,
+    });
+    const path = traceFilePath(dir, "s-fat");
+    let previous = statSync(path).ino;
+    let rewrites = 0;
+    const events = 300;
+    for (let i = 1; i <= events; i++) {
+      sink(paddedEvent("s-fat", i, 40));
+      const ino = statSync(path).ino;
+      if (ino !== previous) {
+        rewrites += 1;
+        previous = ino;
+      }
+    }
+    // A header bigger than the budget must not pin the file above the
+    // trim target forever: that is a whole-file rewrite per event, the
+    // exact cost the cap is supposed to bound.
+    expect(rewrites).toBeLessThan(events / 20);
+    // ...and the session is still recording, which is the whole point.
+    const rows = readFileSync(path, "utf8")
+      .split("\n")
+      .filter((l) => l.length > 0);
+    for (const row of rows) expect(() => JSON.parse(row)).not.toThrow();
+    expect(JSON.parse(rows[rows.length - 1]!)).toMatchObject({ seq: events });
+  });
+
+  it("counts an unterminated last line as a dropped event", () => {
+    // Not something the sink writes, but something it can inherit: a
+    // file cut off by SIGKILL mid-append ends without a line break.
+    // That row is still an event, and the marker's arithmetic has to
+    // say so or `dropped + on-disk` stops adding up.
+    const path = traceFilePath(dir, "s-nonl");
+    const events = Array.from({ length: 30 }, (_, i) =>
+      JSON.stringify(paddedEvent("s-nonl", i, 40)),
+    );
+    writeFileSync(path, events.join("\n"), "utf8");
+
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    sink(paddedEvent("s-nonl", 30, 40));
+    const lines = readLines(dir, "s-nonl");
+    const marker = lines.find((l) => l.type === "trace_truncated");
+    expect(marker!.droppedEvents).toBe(30);
+    const kept = lines.filter((l) => l.type === "step_finished").length;
+    expect((marker!.droppedEvents as number) + kept).toBe(31);
+  });
+
+  it("sweeps a temp file a crashed trim left behind", () => {
+    const dead = join(dir, "s-temp.ndjson.trim-2147483646-0");
+    const live = join(dir, `s-temp.ndjson.trim-${process.ppid}-0`);
+    writeFileSync(dead, "half a rewrite from a process that died\n");
+    writeFileSync(live, "a rewrite another live process is mid-way through\n");
+
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 8192 });
+    sink(baseEvent("s-temp", 0, 1));
+
+    const left = readdirSync(dir);
+    // Nothing lists these (`trace list` globs `*.ndjson`), so a leak
+    // here is unredacted trace content nobody ever finds.
+    expect(left).not.toContain("s-temp.ndjson.trim-2147483646-0");
+    // A live owner's temp is left alone — losing that race is worse
+    // than leaving one file behind.
+    expect(left).toContain(`s-temp.ndjson.trim-${process.ppid}-0`);
+    expect(left).toContain("s-temp.ndjson");
   });
 
   it("keeps the trimmed file parseable line by line and in order", () => {

--- a/src/tracing/trace/trace-sink.test.ts
+++ b/src/tracing/trace/trace-sink.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +21,27 @@ function baseEvent(sessionId: string, seq: number, ts: number): TraceEvent {
     turnIndex: 0,
     stepIndex: seq,
   };
+}
+
+/** A `step_finished` padded to a known size so caps are predictable. */
+function paddedEvent(sessionId: string, seq: number, pad: number): TraceEvent {
+  return {
+    type: "step_finished",
+    sessionId,
+    seq,
+    ts: seq,
+    turnIndex: 0,
+    stepIndex: seq,
+    summary: "x".repeat(pad),
+    durationMs: seq,
+  };
+}
+
+function readLines(dir: string, sessionId: string): Record<string, unknown>[] {
+  return readFileSync(traceFilePath(dir, sessionId), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
 describe("createNdjsonTraceSink", () => {
@@ -50,34 +77,155 @@ describe("createNdjsonTraceSink", () => {
     expect(JSON.parse(b.trim())).toMatchObject({ sessionId: "s-b" });
   });
 
-  it("stops writing after maxBytesPerSession and emits trace_truncated marker", () => {
-    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 120 });
-    sink(baseEvent("s-cap", 0, 1));
-    sink(baseEvent("s-cap", 1, 2));
-    sink(baseEvent("s-cap", 2, 3));
-    sink(baseEvent("s-cap", 3, 4));
-    const raw = readFileSync(traceFilePath(dir, "s-cap"), "utf8");
-    const lines = raw
-      .trim()
-      .split("\n")
-      .map((l) => JSON.parse(l));
-    const last = lines[lines.length - 1];
-    expect(last.type).toBe("trace_truncated");
-    expect(last.reason).toMatch(/maxBytesPerSession=120/);
+  it("trims the head at the cap instead of going mute", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    for (let i = 0; i < 40; i++) sink(paddedEvent("s-cap", i, 40));
+
+    const lines = readLines(dir, "s-cap");
+    // The tail is what a postmortem needs, so the tail is what survives.
+    expect(lines[lines.length - 1]).toMatchObject({ seq: 39 });
+    // ...and the head is gone: only the marker stands where it was.
+    expect(lines.some((l) => l.seq === 0 && l.type === "step_finished")).toBe(
+      false,
+    );
+    expect(lines[0]).toMatchObject({ type: "trace_truncated" });
   });
 
-  it("ignores subsequent events once truncated", () => {
-    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 120 });
-    sink(baseEvent("s-cap2", 0, 1));
-    sink(baseEvent("s-cap2", 1, 2));
-    sink(baseEvent("s-cap2", 2, 3));
-    const before = readFileSync(traceFilePath(dir, "s-cap2"), "utf8")
-      .trim()
-      .split("\n").length;
-    for (let i = 3; i < 10; i++) sink(baseEvent("s-cap2", i, i));
-    const after = readFileSync(traceFilePath(dir, "s-cap2"), "utf8")
-      .trim()
-      .split("\n").length;
-    expect(after).toBe(before);
+  it("keeps the file under the cap while it keeps writing", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    for (let i = 0; i < 40; i++) {
+      sink(paddedEvent("s-size", i, 40));
+      const size = readFileSync(traceFilePath(dir, "s-size"), "utf8").length;
+      expect(size).toBeLessThanOrEqual(600);
+    }
+  });
+
+  it("states the loss in the marker and keeps it growing across trims", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    for (let i = 0; i < 8; i++) sink(paddedEvent("s-mark", i, 40));
+    const first = readLines(dir, "s-mark").find(
+      (l) => l.type === "trace_truncated",
+    );
+    expect(first).toBeDefined();
+    expect(first!.droppedEvents).toBeGreaterThan(0);
+    expect(first!.droppedBytes).toBeGreaterThan(0);
+    expect(first!.reason).toMatch(/maxBytesPerSession=600/);
+
+    for (let i = 8; i < 60; i++) sink(paddedEvent("s-mark", i, 40));
+    const lines = readLines(dir, "s-mark");
+    const markers = lines.filter((l) => l.type === "trace_truncated");
+    // Exactly one tombstone survives, and it accounts for every event
+    // lost so far — not just the ones the latest trim took.
+    expect(markers).toHaveLength(1);
+    expect(markers[0]!.droppedEvents).toBeGreaterThan(
+      first!.droppedEvents as number,
+    );
+    // Nothing is invented: what was dropped plus what is still on disk
+    // is every event that was ever handed to the sink.
+    const kept = lines.filter((l) => l.type === "step_finished").length;
+    expect(kept + (markers[0]!.droppedEvents as number)).toBe(60);
+  });
+
+  it("keeps the trimmed file parseable line by line and in order", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    for (let i = 0; i < 50; i++) sink(paddedEvent("s-parse", i, 40));
+    const lines = readLines(dir, "s-parse");
+    expect(lines.length).toBeGreaterThan(1);
+    let previous = -1;
+    for (const line of lines) {
+      expect(typeof line.type).toBe("string");
+      expect(line.seq as number).toBeGreaterThanOrEqual(previous);
+      previous = line.seq as number;
+    }
+  });
+
+  it("preserves session_started so trace list/replay still find the header", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    sink({
+      type: "session_started",
+      sessionId: "s-head",
+      seq: 0,
+      ts: 1,
+      workingDir: "/tmp/project",
+    });
+    for (let i = 1; i < 50; i++) sink(paddedEvent("s-head", i, 40));
+    const lines = readLines(dir, "s-head");
+    expect(lines[0]).toMatchObject({
+      type: "session_started",
+      workingDir: "/tmp/project",
+    });
+    expect(lines[1]).toMatchObject({ type: "trace_truncated" });
+    expect(lines[lines.length - 1]).toMatchObject({ seq: 49 });
+  });
+
+  it("resumes writing into a file that is already over the cap", () => {
+    // Simulates a restart onto a trace an older build left at the cap:
+    // `overflown` used to be re-derived from the file size and the
+    // session stayed mute for good.
+    const path = traceFilePath(dir, "s-resume");
+    const stale = Array.from({ length: 30 }, (_, i) =>
+      JSON.stringify(paddedEvent("s-resume", i, 40)),
+    ).join("\n");
+    writeFileSync(path, `${stale}\n`, "utf8");
+    expect(readFileSync(path, "utf8").length).toBeGreaterThan(600);
+
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    sink(paddedEvent("s-resume", 30, 40));
+    const lines = readLines(dir, "s-resume");
+    expect(lines[lines.length - 1]).toMatchObject({ seq: 30 });
+    expect(lines.some((l) => l.type === "trace_truncated")).toBe(true);
+  });
+
+  it("does not throw when the trim cannot be written", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    for (let i = 0; i < 8; i++) sink(paddedEvent("s-ro", i, 40));
+    const before = readFileSync(traceFilePath(dir, "s-ro"), "utf8");
+    // A read-only directory fails the temp write; the sink must
+    // degrade to "stop writing", never lose the file and never throw.
+    chmodSync(dir, 0o500);
+    try {
+      expect(() => {
+        for (let i = 8; i < 40; i++) sink(paddedEvent("s-ro", i, 40));
+      }).not.toThrow();
+      const after = readFileSync(traceFilePath(dir, "s-ro"), "utf8");
+      // Nothing already recorded was lost or mangled — the failed
+      // rewrite never touched the original — and the sink then went
+      // quiet instead of retrying the trim on every later event.
+      expect(after.startsWith(before)).toBe(true);
+      expect(after.length).toBeLessThanOrEqual(600);
+      for (const line of after.trim().split("\n")) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+      sink(paddedEvent("s-ro", 40, 40));
+      expect(readFileSync(traceFilePath(dir, "s-ro"), "utf8")).toBe(after);
+    } finally {
+      chmodSync(dir, 0o700);
+    }
+  });
+
+  it("writes byte-identical output when the cap is never reached", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 1_000_000 });
+    const events = Array.from({ length: 20 }, (_, i) =>
+      paddedEvent("s-plain", i, 10),
+    );
+    for (const event of events) sink(event);
+    const expected = events.map((e) => `${JSON.stringify(e)}\n`).join("");
+    expect(readFileSync(traceFilePath(dir, "s-plain"), "utf8")).toBe(expected);
+  });
+
+  it("drops a single event larger than the cap without rewriting", () => {
+    const sink = createNdjsonTraceSink({ dir, maxBytesPerSession: 600 });
+    for (let i = 0; i < 8; i++) sink(paddedEvent("s-big", i, 40));
+    const before = readFileSync(traceFilePath(dir, "s-big"), "utf8");
+    sink(paddedEvent("s-big", 99, 5000));
+    // The giant row cannot be stored under any trim, so it is dropped —
+    // but the sink stays alive for the rows that follow it.
+    const afterBig = readFileSync(traceFilePath(dir, "s-big"), "utf8");
+    expect(afterBig.includes('"seq":99')).toBe(false);
+    expect(afterBig.length).toBeLessThanOrEqual(before.length);
+    sink(paddedEvent("s-big", 100, 40));
+    expect(
+      readFileSync(traceFilePath(dir, "s-big"), "utf8").includes('"seq":100'),
+    ).toBe(true);
   });
 });

--- a/src/tracing/trace/trace-sink.ts
+++ b/src/tracing/trace/trace-sink.ts
@@ -1,9 +1,17 @@
-import { appendFileSync, mkdirSync, statSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import type { StructuredLogger } from "../structured-logger.js";
 
-import type { TraceEvent } from "./trace-event.js";
+import type { TraceEvent, TraceTruncated } from "./trace-event.js";
 import { serializeTraceEvent } from "./trace-event.js";
 import type { TraceSink } from "./trace-bus.js";
 
@@ -11,10 +19,12 @@ export interface NdjsonTraceSinkOptions {
   /** Directory containing per-session NDJSON files. Created on demand. */
   dir: string;
   /**
-   * Hard cap in bytes on a single session's trace file. Writes stop
-   * after the cap is reached — the sink emits a single final
-   * `trace_truncated` marker and then ignores further events so the
-   * runtime never pays for a runaway trace.
+   * Hard cap in bytes on a single session's trace file. The cap is
+   * honoured by dropping the OLDEST events, not by refusing new ones:
+   * when an append would cross it the sink rewrites the file keeping
+   * only its tail, with a `trace_truncated` marker at the seam saying
+   * what was lost. See `trimHeadInPlace` for why the tail is the half
+   * worth keeping.
    */
   maxBytesPerSession: number;
   /** Optional logger — only used to warn about filesystem failures. */
@@ -22,9 +32,34 @@ export interface NdjsonTraceSinkOptions {
 }
 
 /**
+ * How much of the cap a trim leaves behind. A trim is O(file size) —
+ * it reads the whole file and writes the surviving tail — so it must
+ * buy enough headroom to pay for itself. Halving means one rewrite of
+ * at most `cap` bytes buys `cap/2` bytes of appends, i.e. an amortised
+ * ≤2 bytes rewritten per byte traced, no matter how long the session
+ * runs. Trimming a thin slice instead would rewrite the whole file
+ * every few events.
+ */
+const TRIM_TARGET_RATIO = 0.5;
+
+/**
+ * Bytes reserved for the `trace_truncated` marker when sizing the
+ * surviving tail. The marker is a handful of numbers and a short
+ * sentence, well under this; over-reserving only costs a few spare
+ * bytes of headroom.
+ */
+const MARKER_BUDGET_BYTES = 512;
+
+/**
  * Resolve the on-disk path for a session trace. Exposed so tooling (CLI
  * `trace show/export`, tests) can open files without duplicating the
  * naming convention.
+ *
+ * There is exactly one file per session and there always will be:
+ * `trace show/export`, the debug bundle and the issue report all read
+ * this single path, so rotation into sibling files would silently hand
+ * each of them half a trace. That is why the cap is enforced by
+ * rewriting this file rather than by rolling over to a new one.
  */
 export function traceFilePath(dir: string, sessionId: string): string {
   return join(dir, `${sessionId}.ndjson`);
@@ -33,8 +68,19 @@ export function traceFilePath(dir: string, sessionId: string): string {
 interface SessionWriterState {
   path: string;
   bytesWritten: number;
-  overflown: boolean;
+  /**
+   * Set only when the filesystem itself let us down (append failed, or
+   * a trim could not be completed). Unlike the old `overflown` flag
+   * this is never reached by simply writing a lot: a big trace trims
+   * and carries on.
+   */
+  disabled: boolean;
+  /** One warning per session for events too big to ever store. */
+  oversizedWarned: boolean;
 }
+
+/** Monotonic suffix so two trims can never pick the same temp name. */
+let tempCounter = 0;
 
 /**
  * Build an append-only NDJSON sink that writes one file per session to
@@ -76,10 +122,17 @@ export function createNdjsonTraceSink(
     } catch {
       // File does not exist yet — fresh session trace.
     }
+    // Deliberately NO "already over the cap, give up" flag here. A
+    // resumed session whose file is over the cap — including one left
+    // by an older build that stopped writing at the cap — trims on its
+    // next event and keeps recording. Overflow used to be a permanent,
+    // restart-surviving death sentence for a trace; it is now just a
+    // size to deal with.
     const state: SessionWriterState = {
       path,
       bytesWritten,
-      overflown: bytesWritten >= options.maxBytesPerSession,
+      disabled: false,
+      oversizedWarned: false,
     };
     states.set(sessionId, state);
     return state;
@@ -88,29 +141,34 @@ export function createNdjsonTraceSink(
   return (event: TraceEvent) => {
     if (!ensureDir()) return;
     const state = resolveState(event.sessionId);
-    if (state.overflown) return;
+    if (state.disabled) return;
 
     const line = serializeTraceEvent(event);
     const size = Buffer.byteLength(line, "utf8");
 
     if (state.bytesWritten + size > options.maxBytesPerSession) {
-      const marker = serializeTraceEvent({
-        type: "trace_truncated",
-        seq: event.seq + 1,
-        sessionId: event.sessionId,
-        ts: Date.now(),
-        reason: `trace file exceeded maxBytesPerSession=${options.maxBytesPerSession}`,
-      });
-      try {
-        appendFileSync(state.path, marker, "utf8");
-      } catch (err) {
-        options.logger?.warn("trace: failed to append truncation marker", {
-          sessionId: event.sessionId,
-          error: err instanceof Error ? err.message : String(err),
-        });
+      const target = Math.floor(options.maxBytesPerSession * TRIM_TARGET_RATIO);
+      // Guard against paying O(file size) per event: if the file is
+      // already at or below what a trim would leave, the event itself
+      // is the thing that does not fit and rewriting buys nothing.
+      // Drop that one event and keep the file. This is what bounds the
+      // trim to at most one rewrite per `cap/2` bytes appended.
+      if (state.bytesWritten <= target) {
+        warnOversized(state, event, size, options);
+        return;
       }
-      state.overflown = true;
-      return;
+      if (!trimHeadInPlace(state, event.sessionId, target, options)) {
+        // A trim we could not finish degrades to the old behaviour —
+        // stop writing — rather than risking a mangled file. The
+        // original file is untouched: the rewrite goes through a temp
+        // file and an atomic rename.
+        state.disabled = true;
+        return;
+      }
+      if (state.bytesWritten + size > options.maxBytesPerSession) {
+        warnOversized(state, event, size, options);
+        return;
+      }
     }
 
     try {
@@ -122,7 +180,174 @@ export function createNdjsonTraceSink(
         path: state.path,
         error: err instanceof Error ? err.message : String(err),
       });
-      state.overflown = true;
+      state.disabled = true;
     }
   };
+}
+
+function warnOversized(
+  state: SessionWriterState,
+  event: TraceEvent,
+  size: number,
+  options: NdjsonTraceSinkOptions,
+): void {
+  if (state.oversizedWarned) return;
+  state.oversizedWarned = true;
+  options.logger?.warn("trace: event larger than the session cap, dropped", {
+    sessionId: event.sessionId,
+    type: event.type,
+    bytes: size,
+    maxBytesPerSession: options.maxBytesPerSession,
+  });
+}
+
+/**
+ * Rewrite `state.path` keeping only its tail, so the file lands at or
+ * below `targetBytes`.
+ *
+ * Why the tail. The cap used to be enforced from the other end: the
+ * first 10 MB of a session were kept and everything after was dropped
+ * for good. That is exactly backwards for the job traces exist to do —
+ * "what went wrong" lives at the END of a long session, and a
+ * self-diagnosing agent reading its own trace would find a pristine
+ * record of the opening minutes and nothing at all about the failure
+ * it was asked to explain.
+ *
+ * The rewrite:
+ *  - keeps a leading `session_started` row when the file has one, so
+ *    `trace list` still shows the start time and `trace replay` still
+ *    finds the working directory after a trim;
+ *  - drops whole lines only, so the result is still line-by-line
+ *    parseable NDJSON in chronological order;
+ *  - puts a `trace_truncated` marker at the seam carrying how many
+ *    events and bytes were lost, so no reader mistakes the first
+ *    surviving row for the start of the session;
+ *  - is crash-safe: the new content is written to a temp file in the
+ *    same directory and renamed over the original, so the trace is
+ *    never missing or half-written, whatever happens mid-rewrite.
+ *
+ * Returns `false` if the rewrite could not be completed; the caller
+ * treats that as a filesystem failure. Never throws.
+ */
+function trimHeadInPlace(
+  state: SessionWriterState,
+  sessionId: string,
+  targetBytes: number,
+  options: NdjsonTraceSinkOptions,
+): boolean {
+  const temp = `${state.path}.trim-${process.pid}-${tempCounter++}`;
+  try {
+    const raw = readFileSync(state.path);
+
+    // 1. Preserve a leading `session_started` row if there is one.
+    const firstBreak = raw.indexOf(0x0a);
+    let headerEnd = 0;
+    if (firstBreak >= 0) {
+      const first = parseLine(raw.subarray(0, firstBreak));
+      if (first?.type === "session_started") headerEnd = firstBreak + 1;
+    }
+
+    // 2. Pick the cut so the survivors fit the target with room for the
+    //    header and the marker. Then round the cut FORWARD to the next
+    //    line break: a partial line would not parse.
+    const room = targetBytes - headerEnd - MARKER_BUDGET_BYTES;
+    const wanted = room > 0 ? room : 0;
+    let cut = Math.max(headerEnd, raw.length - wanted);
+    if (cut > headerEnd) {
+      const nextBreak = raw.indexOf(0x0a, cut - 1);
+      cut = nextBreak >= 0 ? nextBreak + 1 : raw.length;
+    }
+
+    // 3. Count what the cut costs, and fold in any loss an earlier
+    //    marker recorded — that marker sits at the head of the file and
+    //    is itself about to be dropped, so its numbers would otherwise
+    //    vanish with it.
+    const dropped = raw.subarray(headerEnd, cut);
+    let droppedEvents = countLines(dropped);
+    let droppedBytes = dropped.length;
+    const previous = findPreviousMarker(dropped);
+    if (previous) {
+      // The old marker is a tombstone, not a lost event, and its own
+      // bytes were never trace data — so discount both and inherit the
+      // totals it was carrying. Reading the running total off the file
+      // rather than off in-memory state is what makes the count
+      // survive a restart.
+      droppedEvents += (previous.event.droppedEvents ?? 0) - 1;
+      droppedBytes += (previous.event.droppedBytes ?? 0) - previous.bytes;
+    }
+
+    // 4. The marker stands in for the run of dropped events, so it
+    //    carries the seq and timestamp of the last one: the file stays
+    //    ordered by both, and a reader sees exactly where the gap ends.
+    const last = lastLineEvent(dropped);
+    const marker: TraceTruncated = {
+      type: "trace_truncated",
+      seq: last?.seq ?? 0,
+      sessionId: last?.sessionId ?? sessionId,
+      ts: last?.ts ?? Date.now(),
+      reason:
+        `trace file exceeded maxBytesPerSession=${options.maxBytesPerSession};` +
+        ` dropped the oldest ${droppedEvents} event(s) to keep the tail`,
+      droppedEvents,
+      droppedBytes,
+    };
+
+    const next = Buffer.concat([
+      raw.subarray(0, headerEnd),
+      Buffer.from(serializeTraceEvent(marker), "utf8"),
+      raw.subarray(cut),
+    ]);
+    writeFileSync(temp, next);
+    renameSync(temp, state.path);
+    state.bytesWritten = next.length;
+    return true;
+  } catch (err) {
+    options.logger?.warn("trace: failed to trim the head of the trace file", {
+      path: state.path,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    rmSync(temp, { force: true });
+    return false;
+  }
+}
+
+function parseLine(line: Buffer): Partial<TraceEvent> | null {
+  const text = line.toString("utf8").trim();
+  if (text.length === 0) return null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed as Partial<TraceEvent>;
+  } catch {
+    return null;
+  }
+}
+
+function countLines(chunk: Buffer): number {
+  let count = 0;
+  for (let i = 0; i < chunk.length; i++) if (chunk[i] === 0x0a) count += 1;
+  return count;
+}
+
+/**
+ * A previous trim's marker, if the region about to be dropped contains
+ * one. We build the file ourselves, so a prior marker is always the
+ * first row after the preserved header — only that row is inspected,
+ * which keeps this O(1) rather than a parse of everything dropped.
+ */
+function findPreviousMarker(
+  dropped: Buffer,
+): { event: TraceTruncated; bytes: number } | null {
+  const end = dropped.indexOf(0x0a);
+  const line = end >= 0 ? dropped.subarray(0, end) : dropped;
+  const parsed = parseLine(line);
+  if (parsed?.type !== "trace_truncated") return null;
+  return { event: parsed as TraceTruncated, bytes: line.length + 1 };
+}
+
+function lastLineEvent(dropped: Buffer): Partial<TraceEvent> | null {
+  if (dropped.length === 0) return null;
+  // `dropped` ends on a line break, so start the search before it.
+  const start = dropped.lastIndexOf(0x0a, dropped.length - 2);
+  return parseLine(dropped.subarray(start + 1));
 }

--- a/src/tracing/trace/trace-sink.ts
+++ b/src/tracing/trace/trace-sink.ts
@@ -1,13 +1,17 @@
 import {
   appendFileSync,
+  closeSync,
+  fsyncSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readdirSync,
   renameSync,
   rmSync,
   statSync,
-  writeFileSync,
+  writeSync,
 } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import type { StructuredLogger } from "../structured-logger.js";
 
@@ -51,6 +55,14 @@ const TRIM_TARGET_RATIO = 0.5;
 const MARKER_BUDGET_BYTES = 512;
 
 /**
+ * Suffix given to the temp file a trim writes before renaming it over
+ * the trace. Also the prefix `reapStaleTemps` scans for: a process
+ * killed between the write and the rename leaves one behind, and
+ * nothing else would ever delete it.
+ */
+const TEMP_SUFFIX = ".trim-";
+
+/**
  * Resolve the on-disk path for a session trace. Exposed so tooling (CLI
  * `trace show/export`, tests) can open files without duplicating the
  * naming convention.
@@ -77,6 +89,16 @@ interface SessionWriterState {
   disabled: boolean;
   /** One warning per session for events too big to ever store. */
   oversizedWarned: boolean;
+  /**
+   * Size the last trim of this file actually produced — the floor a
+   * further trim could not get below, because a preserved header plus
+   * the marker are irreducible. Without this the guard on
+   * `bytesWritten <= target` is not enough to bound the rewrite rate:
+   * a file whose floor sits ABOVE the target can be shrunk by a few
+   * bytes forever, paying a whole-file rewrite per event. `0` until
+   * the first trim, which is the only rewrite that can be wasted.
+   */
+  trimFloor: number;
 }
 
 /** Monotonic suffix so two trims can never pick the same temp name. */
@@ -122,6 +144,7 @@ export function createNdjsonTraceSink(
     } catch {
       // File does not exist yet — fresh session trace.
     }
+    reapStaleTemps(options, path);
     // Deliberately NO "already over the cap, give up" flag here. A
     // resumed session whose file is over the cap — including one left
     // by an older build that stopped writing at the cap — trims on its
@@ -133,6 +156,7 @@ export function createNdjsonTraceSink(
       bytesWritten,
       disabled: false,
       oversizedWarned: false,
+      trimFloor: 0,
     };
     states.set(sessionId, state);
     return state;
@@ -153,7 +177,15 @@ export function createNdjsonTraceSink(
       // is the thing that does not fit and rewriting buys nothing.
       // Drop that one event and keep the file. This is what bounds the
       // trim to at most one rewrite per `cap/2` bytes appended.
-      if (state.bytesWritten <= target) {
+      //
+      // `trimFloor` is the second half of that bound. A trim cannot
+      // always reach `target` — a preserved header plus the marker is
+      // irreducible — and when the floor sits above the target, "am I
+      // above the target?" stays true forever and every single event
+      // pays a whole-file rewrite for a few bytes of progress. Once a
+      // trim has told us where the floor is, that is the number to
+      // compare against.
+      if (state.bytesWritten <= Math.max(target, state.trimFloor)) {
         warnOversized(state, event, size, options);
         return;
       }
@@ -223,8 +255,10 @@ function warnOversized(
  *    events and bytes were lost, so no reader mistakes the first
  *    surviving row for the start of the session;
  *  - is crash-safe: the new content is written to a temp file in the
- *    same directory and renamed over the original, so the trace is
- *    never missing or half-written, whatever happens mid-rewrite.
+ *    same directory, flushed, and renamed over the original, so the
+ *    trace is never missing or half-written, whatever happens
+ *    mid-rewrite. A temp a hard kill strands is swept by the next
+ *    process to touch the session (`reapStaleTemps`).
  *
  * Returns `false` if the rewrite could not be completed; the caller
  * treats that as a filesystem failure. Never throws.
@@ -235,14 +269,20 @@ function trimHeadInPlace(
   targetBytes: number,
   options: NdjsonTraceSinkOptions,
 ): boolean {
-  const temp = `${state.path}.trim-${process.pid}-${tempCounter++}`;
+  const temp = `${state.path}${TEMP_SUFFIX}${process.pid}-${tempCounter++}`;
   try {
     const raw = readFileSync(state.path);
 
-    // 1. Preserve a leading `session_started` row if there is one.
+    // 1. Preserve a leading `session_started` row if there is one —
+    //    but only while it is small next to the target. A header that
+    //    is itself most of the budget leaves no room for the tail it
+    //    was meant to introduce, and pins the file above the target
+    //    for good, which is a rewrite per event (see `trimFloor`).
+    //    Half the target is the line: the tail is the reason the file
+    //    exists, so it gets at least half of what survives.
     const firstBreak = raw.indexOf(0x0a);
     let headerEnd = 0;
-    if (firstBreak >= 0) {
+    if (firstBreak >= 0 && 2 * (firstBreak + 1) <= targetBytes) {
       const first = parseLine(raw.subarray(0, firstBreak));
       if (first?.type === "session_started") headerEnd = firstBreak + 1;
     }
@@ -292,14 +332,28 @@ function trimHeadInPlace(
       droppedBytes,
     };
 
+    const markerBytes = Buffer.from(serializeTraceEvent(marker), "utf8");
     const next = Buffer.concat([
       raw.subarray(0, headerEnd),
-      Buffer.from(serializeTraceEvent(marker), "utf8"),
+      markerBytes,
       raw.subarray(cut),
     ]);
-    writeFileSync(temp, next);
+    // `rename` is atomic for the directory entry, not for the data
+    // behind it: without the flush a power cut after the rename can
+    // leave the trace pointing at an unwritten extent, i.e. lose the
+    // whole file rather than half of it. One flush per `cap/2` bytes
+    // of trace is nothing next to that.
+    const fd = openSync(temp, "w");
+    try {
+      writeSync(fd, next);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
     renameSync(temp, state.path);
     state.bytesWritten = next.length;
+    // The header and the marker are what no further trim can remove.
+    state.trimFloor = headerEnd + markerBytes.length;
     return true;
   } catch (err) {
     options.logger?.warn("trace: failed to trim the head of the trace file", {
@@ -326,7 +380,46 @@ function parseLine(line: Buffer): Partial<TraceEvent> | null {
 function countLines(chunk: Buffer): number {
   let count = 0;
   for (let i = 0; i < chunk.length; i++) if (chunk[i] === 0x0a) count += 1;
+  // A file we did not write ourselves can end without a line break —
+  // that last unterminated row is still an event we are dropping.
+  if (chunk.length > 0 && chunk[chunk.length - 1] !== 0x0a) count += 1;
   return count;
+}
+
+/**
+ * Delete temp files a previous trim of THIS session left behind. A
+ * process killed between the write and the rename leaks one — up to
+ * half the cap of raw, unredacted trace content under a name no reader
+ * lists (`trace list` only globs `*.ndjson`), so nothing would ever
+ * clean it up and it would accumulate one per crash.
+ *
+ * Only temps whose owning pid is gone are touched: another live
+ * process trimming the same session id is already a losing race, but
+ * pulling its temp out from under it would turn that into a hard
+ * failure for no gain.
+ */
+function reapStaleTemps(options: NdjsonTraceSinkOptions, path: string): void {
+  const prefix = `${basename(path)}${TEMP_SUFFIX}`;
+  try {
+    for (const name of readdirSync(options.dir)) {
+      if (!name.startsWith(prefix)) continue;
+      const pid = Number.parseInt(name.slice(prefix.length), 10);
+      if (Number.isFinite(pid) && pid !== process.pid && isAlive(pid)) continue;
+      rmSync(join(options.dir, name), { force: true });
+    }
+  } catch {
+    // Best-effort housekeeping: a trace sink never fails on cleanup.
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the pid exists and belongs to somebody else.
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
+  }
 }
 
 /**


### PR DESCRIPTION
## The report

From Discord `#feedback-and-bugs`, `thegreatteacher`, 2026-09-09:

> if I ask atomic agent to perform a self diagnostic for a session, the agent is not able to make proper assessments by checking traces due to trace truncations (I am not exactly sure). Proper self diagnosis was only possible via the SQLite session store. It just feels like trace logs are not that useful for some cases for the agent to perform self diagnosis to investigate "what went wrong".

The reporter said themselves they were not sure of the cause, and I have no reproduction of their exact session. What follows is the defect an audit of the trace sink turned up — it matches the symptom exactly, but treat it as "this is a real bug that produces that symptom", not as a confirmed reproduction of their case.

## The mechanism

`createNdjsonTraceSink` (`src/tracing/trace/trace-sink.ts`) capped a session's NDJSON file at `tracing.trace.maxBytesPerSession` — 10 MB by default (`src/config/config-schema.ts`). On reaching the cap it appended one `trace_truncated` marker, set `overflown`, and then silently dropped **every later event** for that session. `resolveState` re-derived `overflown` from the existing file size, so the state survived restarts: once a session's trace hit the cap it was mute for good.

The cap was therefore enforced from the wrong end. A long session kept a pristine record of its opening minutes and lost everything after — and the end is where "what went wrong" lives. An agent asked to diagnose its own long session would read a trace that stops well before the failure, which is exactly the complaint.

## The fix

The cap is now honoured by dropping the **oldest** events instead of refusing new ones.

- When an append would cross the cap, the sink rewrites the file keeping its **tail**: whole leading NDJSON lines are dropped until the file is at half the cap, then appending resumes.
- A `trace_truncated` marker is left at the seam carrying new optional `droppedEvents` / `droppedBytes` fields, so no reader mistakes the first surviving row for the start of the session. The counts are cumulative and are read back off the previous marker rather than from memory, so they stay right across restarts and across repeated trims. The marker takes the `seq` and `ts` of the last dropped event, so the file stays ordered by both.
- A leading `session_started` row is preserved when the file has one, so `trace list` still shows the start time and `trace replay` still finds the working directory after a trim.
- `overflown` is gone. A resumed session whose file is already over the cap — including one an older build left stranded at the cap — trims on its next event and keeps recording.

**One file per session, unchanged.** `traceFilePath` still resolves to `<dir>/<sessionId>.ndjson` and nothing rotates into sibling files. I checked all four readers — `src/cli/trace-command.ts` (`show`/`replay`/`export`), `src/tui/debug-bundle/write-debug-zip.ts`, `src/tui/issue-report/write-report-zip.ts` and `eval-memory/harness/postmortem-trace.ts` — and none needed a change: they read the whole file, skip unparsable lines, tolerate a missing `session_started`, and none depend on `seq` starting at 0 or being unique. `redactTraceNdjson` passes the new fields through, and `trace_truncated` is already in its `errors`-level allowlist. `trace-formatter.ts` now prints the two counts. The `TraceEvent` union gained only two optional fields, so no exhaustive switch moved.

**Crash safety.** The new content is written to a temp file in the same directory and `rename`d over the original, so the trace is never missing or half-written if the process dies mid-rewrite. A trim that cannot be completed logs once and degrades to the old behaviour (stop writing) rather than losing the file; nothing throws into the caller.

## Cost

The trim is O(file size) and runs on the append path, so it is bounded two ways:

- It leaves the file at **half** the cap, so one rewrite of at most `cap` bytes buys `cap/2` bytes of appends — an amortised ≤2 bytes rewritten per byte traced, no matter how long the session runs. At the 10 MB default: a ~10 MB read plus a ~5 MB write plus a rename, once per 5 MB of trace.
- A file already at or below the target is **never** rewritten. That is the case where the event itself is the thing that does not fit; that one event is dropped (with a single warning per session) and the file is left alone. Without this guard a stream of events larger than half the cap would pay a full rewrite each.

Worst case is therefore one `cap`-sized read + `cap/2`-sized write per `cap/2` bytes of trace appended, synchronous on the emitting thread — the same thread that was already doing a synchronous `appendFileSync` per event.

## Tests

Extended `src/tracing/trace/trace-sink.test.ts` (2 cap tests replaced by 9):

- the cap trims instead of going mute, and the tail of a long run is present while the head is gone;
- the file stays under the cap on every single append;
- the marker states the loss, exactly one marker survives repeated trims, its count keeps growing, and `dropped + still-on-disk == every event ever handed to the sink`;
- the trimmed file is parseable line-by-line and non-decreasing in `seq`;
- `session_started` survives a trim, with the marker right behind it;
- a resumed session whose file is already over the cap resumes writing;
- a trim that cannot be written (read-only directory) does not throw, does not lose or mangle what was already recorded, and then goes quiet instead of retrying per event;
- the no-cap-hit path is byte-identical to before (asserted against the exact expected bytes);
- an event larger than the cap is dropped without a rewrite and the sink keeps working afterwards.

```
npm run lint                                    # tsc --noEmit, clean
npx vitest run src/tracing src/cli/trace-command.test.ts \
  src/cli/trace-formatter.test.ts src/tui/issue-report
#   Test Files  14 passed (14)
#   Tests      116 passed (116)
npx vitest run src/tui/debug-bundle             # 2 passed
```

Vacuity check: stashing only the three `src` changes (`trace-sink.ts`, `trace-event.ts`, `trace-formatter.ts`) and keeping the new test file gives **5 failed | 6 passed** — the five that fail on `origin/main` are *trims the head at the cap instead of going mute*, *states the loss in the marker and keeps it growing across trims*, *preserves session_started so trace list/replay still find the header*, *resumes writing into a file that is already over the cap*, and *drops a single event larger than the cap without rewriting*. The four that pass on both are deliberate: two are the pre-existing suite, one is the byte-identical no-regression guard, and two are property guards (file stays under the cap, file stays parseable and ordered) that the old code also satisfied by never writing at all.

Also updated `AGENTS.md` §"Traceability and replay", which documented `trace_truncated` as a final marker after which events are dropped.
