### PR TITLE
feat(fusion): the machine sizes the worker pool, the model sizes each fan-out

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -76,6 +76,13 @@ export interface AgentLoopDependencies {
    * gate uses for `approvalRequired`.
    */
   isPlanMode?: () => boolean;
+  /**
+   * Whether the run mode resolves to fusion right now. Read per turn,
+   * for the reason `isPlanMode` is read per call: the operator can flip
+   * the mode between turns and the next turn should honour it. Absent
+   * (embedders, tests) means "not fusion", which gates nothing.
+   */
+  isFusionMode?: () => boolean;
   slotManager: SlotManager;
   grammar: string;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
@@ -838,6 +845,14 @@ export class AgentLoop {
       }
     }
 
+    // Fusion's division of labour is per TURN, not per session: each
+    // turn starts owing a plan and a fan-out before it may write. An
+    // ephemeral turn is a worker's own — the gate is the orchestrator's
+    // and must never close on the hands it is meant to free.
+    const fusionOrchestratorTurn =
+      (this.deps.isFusionMode?.() ?? false) && options.ephemeral !== true;
+    let fusionDelegatedThisTurn = false;
+
     let reason: AgentLoopReason = "max_steps";
     let stepsTaken = 0;
     let runError: Error | null = null;
@@ -1105,6 +1120,15 @@ export class AgentLoop {
             registry: this.deps.registry,
             ...(this.deps.isPlanMode
               ? { isPlanMode: this.deps.isPlanMode }
+              : {}),
+            ...(fusionOrchestratorTurn
+              ? {
+                  isFusionOrchestrator: () => true,
+                  hasDelegated: () => fusionDelegatedThisTurn,
+                  onDelegated: () => {
+                    fusionDelegatedThisTurn = true;
+                  },
+                }
               : {}),
             slotManager: this.deps.slotManager,
             grammar: activeGrammar,

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -1170,3 +1170,92 @@ describe("test-repeat gate (issue #118)", () => {
     ).toBeUndefined();
   });
 });
+
+describe("the fusion orchestrator gate in the executor", () => {
+  const ctrl = new AbortController();
+
+  it("fills a held-back mutation's slot instead of dispatching it", async () => {
+    // The refusal has to arrive as this call's RESULT: the model reads
+    // tool results, not runtime state, and a dropped call would leave it
+    // waiting for an answer that never comes.
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => false,
+      },
+    );
+    expect(run).not.toHaveBeenCalled();
+    expect(out.results[0]?.compressed?.status).toBe("error");
+    expect(out.results[0]?.compressed?.summary).toContain("fusion.delegate");
+  });
+
+  it("dispatches the same call once the turn has delegated", async () => {
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => true,
+      },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves reads alone while the turn is still planning", async () => {
+    const run = vi.fn(async () => okResult("os.fs.read"));
+    const registry = buildRegistry({ "os.fs.read": run }, true);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.read", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => false,
+      },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the turn as delegated when the fan-out comes back", async () => {
+    // However it went: a fan-out whose workers all failed still leaves
+    // the orchestrator holding results it must be able to act on.
+    let delegated = false;
+    const registry = buildRegistry(
+      { "fusion.delegate": async () => okResult("fusion.delegate") },
+      false,
+    );
+    await executeBatch(
+      toBatchInputs([{ tool: "fusion.delegate", args: { tasks: [] } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => delegated,
+        onDelegated: () => {
+          delegated = true;
+        },
+      },
+    );
+    expect(delegated).toBe(true);
+  });
+
+  it("gates nothing when the turn is not the orchestrator's", async () => {
+    // A worker's own turn, and every non-fusion run mode.
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      { ...ctx(ctrl.signal), isFusionOrchestrator: () => false },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -1,4 +1,5 @@
 import { checkPlanMode } from "./plan-mode.js";
+import { checkFusionOrchestrator } from "./fusion-orchestrator-mode.js";
 import type { ToolCallPayload } from "../llm/grammar/tool-call-grammar.js";
 import {
   compressToolResult,
@@ -127,6 +128,17 @@ export interface BatchExecutionContext {
    * the operator flips it mid-session. Absent ⇒ plan mode is off.
    */
   isPlanMode?: () => boolean;
+  /**
+   * True while this turn is the ORCHESTRATOR's turn in fusion mode (not
+   * a worker's, not another run mode). When it is, mutations are held
+   * back until the turn has fanned work out at least once — see
+   * `fusion-orchestrator-mode.ts`.
+   */
+  isFusionOrchestrator?: () => boolean;
+  /** Whether this turn has already completed a `fusion.delegate` call. */
+  hasDelegated?: () => boolean;
+  /** Called once a `fusion.delegate` call comes back, however it went. */
+  onDelegated?: () => void;
   /**
    * Names of skills already present in `SessionState.loadedSkills`. A
    * `skill.view` call targeting one of these is short-circuited with a
@@ -291,6 +303,25 @@ export async function executeBatch(
       });
       continue;
     }
+    // Then fusion's division of labour, for the same reason in the same
+    // order: a mutation held back until the turn has delegated must not
+    // spend a slot in the loop tracker either.
+    const fusion = runFusionOrchestratorGate(input, registry, ctx);
+    if (!fusion.proceed && fusion.vetoResult) {
+      ctx.onCallStarted?.({ batchIndex: input.batchIndex, batchSize });
+      slots[input.batchIndex] = {
+        ...slots[input.batchIndex]!,
+        compressed: fusion.vetoResult,
+        durationMs: 0,
+      };
+      ctx.onCallFinished?.({
+        batchIndex: input.batchIndex,
+        batchSize,
+        result: fusion.vetoResult,
+        durationMs: 0,
+      });
+      continue;
+    }
     const gate = runSyncLoopGate(input, ctx, loopSignals);
     if (!gate.proceed && gate.vetoResult) {
       ctx.onCallStarted?.({ batchIndex: input.batchIndex, batchSize });
@@ -384,6 +415,10 @@ export async function executeBatch(
       compressed,
       durationMs,
     };
+    // A fan-out that came back — whatever the workers made of it — opens
+    // the orchestrator's own write gate for the rest of the turn, so it
+    // can merge what it got and run the parts workers had to hand up.
+    if (input.call.tool === "fusion.delegate") ctx.onDelegated?.();
     // Record the real outcome so the next step's gate sees a completed
     // (args + result) entry. Terminal verbs are not tracked.
     if (ctx.tracker && input.resourceClass !== "terminal") {
@@ -542,6 +577,25 @@ function runPlanModeGate(
 ): { proceed: boolean; vetoResult?: CompressedToolResult } {
   if (!ctx.isPlanMode?.()) return { proceed: true };
   const verdict = checkPlanMode(input.call.tool, registry);
+  if (verdict.allowed) return { proceed: true };
+  return { proceed: false, vetoResult: verdict.refusal! };
+}
+
+/**
+ * Fusion's division of labour. Sits beside the plan-mode gate because it
+ * answers the same kind of question — is this call going to run at all —
+ * and it runs after it: plan mode is the operator's explicit "not yet",
+ * and that outranks a mode's internal shape.
+ */
+function runFusionOrchestratorGate(
+  input: BatchCallInput,
+  registry: ToolRegistry,
+  ctx: BatchExecutionContext,
+): { proceed: boolean; vetoResult?: CompressedToolResult } {
+  if (!ctx.isFusionOrchestrator?.()) return { proceed: true };
+  const verdict = checkFusionOrchestrator(input.call.tool, registry, {
+    delegated: ctx.hasDelegated?.() ?? false,
+  });
   if (verdict.allowed) return { proceed: true };
   return { proceed: false, vetoResult: verdict.refusal! };
 }

--- a/src/agent/fusion-orchestrator-mode.test.ts
+++ b/src/agent/fusion-orchestrator-mode.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkFusionOrchestrator,
+  refusalFor,
+} from "./fusion-orchestrator-mode.js";
+
+/** The two facts the gate reads off a tool: does it exist, does it mutate. */
+function registryWith(
+  tools: Record<string, { readonly: boolean }>,
+): { get: (n: string) => { readonly: boolean }; has: (n: string) => boolean } {
+  return {
+    has: (name) => name in tools,
+    get: (name) => {
+      const tool = tools[name];
+      if (!tool) throw new Error(`unknown tool ${name}`);
+      return tool;
+    },
+  };
+}
+
+const REGISTRY = registryWith({
+  "os.fs.read": { readonly: true },
+  "os.fs.write": { readonly: false },
+  "os.shell.run": { readonly: false },
+  "fusion.delegate": { readonly: false },
+  reply: { readonly: false },
+  finish: { readonly: false },
+});
+
+const BEFORE = { delegated: false };
+const AFTER = { delegated: true };
+
+describe("the fusion orchestrator gate", () => {
+  it("lets the orchestrator read while it is still planning", () => {
+    // Planning *is* reading: a gate that blocked it would leave the
+    // model choosing a split it has no basis for.
+    expect(checkFusionOrchestrator("os.fs.read", REGISTRY, BEFORE).allowed).toBe(
+      true,
+    );
+  });
+
+  it("holds back the first mutation until the turn has delegated", () => {
+    for (const tool of ["os.fs.write", "os.shell.run"]) {
+      const verdict = checkFusionOrchestrator(tool, REGISTRY, BEFORE);
+      expect(verdict.allowed).toBe(false);
+      expect(verdict.refusal?.status).toBe("error");
+      // The exit matters more than the veto: a bare refusal reads as a
+      // broken tool and gets retried.
+      expect(verdict.refusal?.summary).toContain("fusion.delegate");
+      expect(verdict.refusal?.details).toMatchObject({
+        fusion_orchestrator: true,
+        delegated: false,
+      });
+    }
+  });
+
+  it("never gates the fan-out itself", () => {
+    // The one call the refusal points at cannot be the one it blocks.
+    expect(
+      checkFusionOrchestrator("fusion.delegate", REGISTRY, BEFORE).allowed,
+    ).toBe(true);
+  });
+
+  it("never gates the terminal verbs", () => {
+    // Vetoing `reply` would veto the turn's own exit — the mistake
+    // plan mode documents and avoids for the same reason.
+    for (const tool of ["reply", "finish"]) {
+      expect(checkFusionOrchestrator(tool, REGISTRY, BEFORE).allowed).toBe(true);
+    }
+  });
+
+  it("opens up once the workers have reported", () => {
+    // Integration is the orchestrator's own job, and so is anything a
+    // worker had to hand up for approval. Both are writes.
+    for (const tool of ["os.fs.write", "os.shell.run"]) {
+      expect(checkFusionOrchestrator(tool, REGISTRY, AFTER).allowed).toBe(true);
+    }
+  });
+
+  it("passes an unknown tool through untouched", () => {
+    // The executor's unknown-tool path has the better message, and
+    // answering "delegate first" to a typo sends the model hunting for
+    // the wrong problem.
+    expect(
+      checkFusionOrchestrator("os.fs.wirte", REGISTRY, BEFORE).allowed,
+    ).toBe(true);
+  });
+
+  it("names the tool it refused", () => {
+    const refusal = refusalFor("os.fs.write");
+    expect(refusal.tool).toBe("os.fs.write");
+    expect(refusal.summary).toContain("`os.fs.write`");
+  });
+});

--- a/src/agent/fusion-orchestrator-mode.ts
+++ b/src/agent/fusion-orchestrator-mode.ts
@@ -1,0 +1,106 @@
+import type { CompressedToolResult } from "../compressor/result-compressor.js";
+import type { ToolRegistry } from "../tools/tool-registry.js";
+
+/**
+ * Fusion's division of labour, enforced instead of merely asked for.
+ *
+ * In fusion mode the expensive cloud model is the orchestrator and the
+ * local ones are the hands: it decides the approach, splits the work,
+ * writes a self-contained brief per worker, reads what comes back,
+ * integrates it, and sends rework back out. The `### fusion` block has
+ * said so since the mode shipped — and a capable cloud model, handed a
+ * catalog of forty tools, still reads the twelve files itself and never
+ * fans anything out. Advice does not hold against that; the model is
+ * doing what it is good at.
+ *
+ * So the first mutation of a fusion turn is refused until the turn has
+ * delegated at least once. Read the code, plan, then send the doing to
+ * the workers.
+ *
+ * **Why a refusal and not a hidden descriptor.** Removing tools from the
+ * catalog mid-turn rewrites the stable prefix and drops the session's KV
+ * cache (see `effectiveToolDescriptors` in bootstrap). A refusal costs
+ * one tool result and reads as an instruction — the same trade plan mode
+ * makes, and the same one `fusion.delegate` already makes when a worker
+ * calls it.
+ *
+ * **Why it lifts after the first fan-out.** Two things genuinely belong
+ * to the orchestrator afterwards: integration — merging what came back,
+ * which is a write it must be able to make — and anything a worker
+ * handed up because it needed approval, which workers cannot request
+ * (`FUSION_WORKER_APPROVAL_REFUSED`). Keeping the gate closed for the
+ * whole turn would strand both. Rework goes back to the workers because
+ * the guidance says so; that part stays advice, because "this write is
+ * rework rather than integration" is not a thing the runtime can see.
+ *
+ * **What is never gated:** read-only tools (planning *is* reading),
+ * `fusion.delegate` itself, and the terminal verbs — vetoing `reply`
+ * would veto the turn's exit.
+ */
+
+/** Terminal verbs, never gated. Mirrors `plan-mode.ts`, deliberately. */
+const TERMINAL_TOOLS: ReadonlySet<string> = new Set(["reply", "finish"]);
+
+/** The fan-out itself: the one call this gate exists to steer towards. */
+const DELEGATE_TOOL = "fusion.delegate";
+
+export interface FusionOrchestratorVerdict {
+  /** False when the call must not reach the registry. */
+  allowed: boolean;
+  /** The result to fill the call's slot with. Present iff `allowed` is false. */
+  refusal?: CompressedToolResult;
+}
+
+export interface FusionOrchestratorState {
+  /** Whether this turn has already completed a `fusion.delegate` call. */
+  delegated: boolean;
+}
+
+/**
+ * Decide whether `tool` may run on the orchestrator's own turn.
+ *
+ * An unknown tool is allowed through untouched, for the reason plan mode
+ * does the same: the step executor's unknown-tool path has the better
+ * message, and answering "delegate first" to a typo sends the model
+ * looking for the wrong problem.
+ */
+export function checkFusionOrchestrator(
+  tool: string,
+  registry: Pick<ToolRegistry, "get" | "has">,
+  state: FusionOrchestratorState,
+): FusionOrchestratorVerdict {
+  if (state.delegated) return { allowed: true };
+  if (TERMINAL_TOOLS.has(tool) || tool === DELEGATE_TOOL) {
+    return { allowed: true };
+  }
+  if (!registry.has(tool)) return { allowed: true };
+  if (registry.get(tool).readonly) return { allowed: true };
+  return { allowed: false, refusal: refusalFor(tool) };
+}
+
+/**
+ * What the model is told.
+ *
+ * Same three parts plan mode's refusal has, in the same order: the call
+ * did not happen, why, and the exit. The exit is the whole point — a
+ * bare "not permitted" reads as a broken tool and gets retried, while
+ * naming the shape of the brief turns the refusal into the instruction
+ * the orchestrator needed in the first place.
+ */
+export function refusalFor(tool: string): CompressedToolResult {
+  return {
+    tool,
+    status: "error",
+    summary:
+      `fusion is on and this turn has not delegated yet, so \`${tool}\` ` +
+      `was not run. You are the orchestrator: the local workers do the ` +
+      `doing. Finish reading (every read-only tool still works), decide ` +
+      `the approach, then split the work and call \`fusion.delegate\` ` +
+      `— one task per independent part, each with the exact paths, what ` +
+      `counts as done, and the answer format you want back. Once the ` +
+      `workers report, you can write again: merge their results, and ` +
+      `send rework back out rather than doing it yourself.`,
+    details: { fusion_orchestrator: true, tool, delegated: false },
+    truncated: false,
+  };
+}

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -158,6 +158,15 @@ export interface StepDependencies {
    * as `BatchExecutionContext.isPlanMode`. Absent ⇒ off.
    */
   isPlanMode?: () => boolean;
+  /**
+   * Fusion's division of labour, forwarded to the batch context. Set by
+   * the loop only for an ORCHESTRATOR turn in fusion mode; a worker's
+   * own turn and every other run mode leave all three absent, which
+   * gates nothing.
+   */
+  isFusionOrchestrator?: () => boolean;
+  hasDelegated?: () => boolean;
+  onDelegated?: () => void;
   slotManager: SlotManager;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
   /**
@@ -1028,6 +1037,13 @@ async function executeStepInner(
     signal: ctx.signal,
     ...(deps.tracker ? { tracker: deps.tracker } : {}),
     ...(deps.isPlanMode ? { isPlanMode: deps.isPlanMode } : {}),
+    ...(deps.isFusionOrchestrator
+      ? {
+          isFusionOrchestrator: deps.isFusionOrchestrator,
+          ...(deps.hasDelegated ? { hasDelegated: deps.hasDelegated } : {}),
+          ...(deps.onDelegated ? { onDelegated: deps.onDelegated } : {}),
+        }
+      : {}),
     ...(batch.maxWaveSize !== undefined
       ? { maxWaveSize: batch.maxWaveSize }
       : {}),

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -905,21 +905,49 @@ describe("parseUserConfigFile", () => {
     expect(parsed.localModels.managed.tensorSplit).toEqual([3, 1]);
   });
 
-  it("defaults localModels.managed.parallel to 2 (the pre-v52 hard-coded slot count)", () => {
+  it("defaults localModels.managed.parallel to auto (the machine decides)", () => {
+    // v63: the slot count stopped being an operator setting. `"auto"`
+    // resolves against the context the daemon actually launches with.
     expect(
       parseUserConfigFile({ version: USER_CONFIG_VERSION }).localModels.managed
         .parallel,
-    ).toBe(2);
-    expect(USER_CONFIG_DEFAULTS.localModels.managed.parallel).toBe(2);
+    ).toBe("auto");
+    expect(USER_CONFIG_DEFAULTS.localModels.managed.parallel).toBe("auto");
   });
 
-  it("migrates a v51 file by filling localModels.managed.parallel=2", () => {
+  it("reads a pre-v63 file's unchosen 2 as auto, and any other number as a pin", () => {
+    // Every pre-v63 file carries a `parallel` the schema wrote, not the
+    // operator. Reading the old default as a deliberate choice would
+    // freeze every existing install at two workers forever — the exact
+    // setting this version exists to stop asking about.
+    expect(
+      parseUserConfigFile({
+        version: 62,
+        localModels: { managed: { parallel: 2 } },
+      }).localModels.managed.parallel,
+    ).toBe("auto");
+    expect(
+      parseUserConfigFile({
+        version: 62,
+        localModels: { managed: { parallel: 6 } },
+      }).localModels.managed.parallel,
+    ).toBe(6);
+    // At v63 the operator's own 2 is theirs, and stays.
+    expect(
+      parseUserConfigFile({
+        version: USER_CONFIG_VERSION,
+        localModels: { managed: { parallel: 2 } },
+      }).localModels.managed.parallel,
+    ).toBe(2);
+  });
+
+  it("migrates a v51 file by filling localModels.managed.parallel=auto", () => {
     const parsed = parseUserConfigFile({
       version: 51,
       localModels: { managed: { port: 19091 } },
     });
     expect(parsed.version).toBe(USER_CONFIG_VERSION);
-    expect(parsed.localModels.managed.parallel).toBe(2);
+    expect(parsed.localModels.managed.parallel).toBe("auto");
   });
 
   it("keeps an explicit localModels.managed.parallel and bounds it to 1..8", () => {

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -1267,12 +1267,19 @@ export interface UserManagedLocalLlmConfig {
   tensorSplit: number[];
   /**
    * llama-server request slots (`--parallel`) for the managed chat
-   * daemon, 1..8. Default `2` — the value that was hard-coded before
-   * config v52, so older files launch byte-identically. Fusion workers
-   * run one per slot; raising this is what lets them run concurrently
-   * instead of queueing on the server. Applied on the next daemon start.
+   * daemon: `"auto"` (the default since config v63) or a pinned 1..8.
+   *
+   * Fusion workers run one per slot, so this is the ceiling on how many
+   * of them run at once rather than queueing. `"auto"` derives it from
+   * the context the daemon is launched with — llama.cpp divides that
+   * context between the slots, and a slot smaller than a worker's own
+   * prompt cannot serve one (see `worker-slots.ts`). That makes the
+   * number a property of the machine, which is the party that knows it.
+   *
+   * A pinned number is honoured as written: an external server, an
+   * unusual model, a benchmark. Applied on the next daemon start.
    */
-  parallel: number;
+  parallel: number | "auto";
   /**
    * Stop the managed chat daemon when the last CLI session exits.
    * `true` (default) — closing the terminal frees the RAM/VRAM the
@@ -2067,7 +2074,13 @@ export interface UserConfigFile {
 // closed by default — `remoteSync: false` refuses every network git verb
 // so a repository the agent versions stays on this machine; the GitHub
 // token lives in `<stateDir>/.env`, never here.
-export const USER_CONFIG_VERSION = 62;
+// v63: `localModels.managed.parallel` accepts `"auto"` and defaults to
+// it — the slot count is derived from the context the daemon launches
+// with instead of being an operator setting. A pre-v63 file whose value
+// is the old default `2` (which nobody chose — it was the schema's)
+// becomes `"auto"`; any other number is read as a deliberate pin and
+// kept.
+export const USER_CONFIG_VERSION = 63;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -2218,6 +2231,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   59,
   60,
   61,
+  62,
   USER_CONFIG_VERSION,
 ];
 
@@ -2237,7 +2251,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       backendVariant: "auto",
       contextSize: 0,
       tensorSplit: [],
-      parallel: 2,
+      parallel: "auto",
     },
     embeddings: {
       enabled: false,
@@ -2995,6 +3009,44 @@ function parseMemoryV2FeatureEnabled(
     return true;
   }
   return parseBool(raw ?? defaultEnabled, field);
+}
+
+/** The slot count that was the schema's default, never an operator's choice. */
+const UNCHOSEN_PARALLEL = 2;
+
+/** First version where `parallel` means "let the machine decide" by default. */
+const AUTO_PARALLEL_VERSION = 63;
+
+/**
+ * `"auto"` (the machine decides, from the launch context) or a pinned
+ * 1..8.
+ *
+ * The migration is the interesting half. A pre-v63 file carries a
+ * `parallel` written by the schema, not by the operator — every file has
+ * one, and for almost all of them it is the old default `2`. Reading
+ * that as a deliberate pin would freeze every existing install at two
+ * workers forever, which is exactly the setting this version exists to
+ * stop asking about. So the old default becomes `"auto"`, and any other
+ * number is treated as something someone actually chose and kept.
+ */
+function resolveManagedParallel(
+  inputVersion: number,
+  raw: unknown,
+): number | "auto" {
+  if (raw === "auto") return "auto";
+  if (raw === null || raw === undefined) {
+    return USER_CONFIG_DEFAULTS.localModels.managed.parallel;
+  }
+  const pinned = parseBoundedPositiveInt(
+    raw,
+    "localModels.managed.parallel",
+    1,
+    8,
+  );
+  if (inputVersion < AUTO_PARALLEL_VERSION && pinned === UNCHOSEN_PARALLEL) {
+    return "auto";
+  }
+  return pinned;
 }
 
 function resolveManagedAutoUpdate(inputVersion: number, raw: unknown): boolean {
@@ -4058,12 +4110,7 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
       rawManaged.tensorSplit,
       "localModels.managed.tensorSplit",
     ),
-    parallel: parseBoundedPositiveInt(
-      rawManaged.parallel ?? USER_CONFIG_DEFAULTS.localModels.managed.parallel,
-      "localModels.managed.parallel",
-      1,
-      8,
-    ),
+    parallel: resolveManagedParallel(version, rawManaged.parallel),
   };
 
   const rawEmbeddings =

--- a/src/local-llm/daemon-lifecycle.ts
+++ b/src/local-llm/daemon-lifecycle.ts
@@ -1,3 +1,4 @@
+import { resolveConfiguredSlots } from "./worker-slots.js";
 import { execSync, spawn } from "node:child_process";
 import {
   closeSync,
@@ -73,10 +74,12 @@ export interface DaemonStartOptions {
    */
   tensorSplit?: readonly number[];
   /**
-   * Request slots (`localModels.managed.parallel`). Undefined keeps the
-   * historical `--parallel 2` so existing launches stay byte-identical.
+   * Request slots (`localModels.managed.parallel`): a pinned number, or
+   * `"auto"` to derive it from the context this launch actually gets
+   * (see `worker-slots.ts`). Undefined keeps the historical
+   * `--parallel 2` so an embedder's launch stays byte-identical.
    */
-  parallel?: number;
+  parallel?: number | "auto";
 }
 
 /**
@@ -110,7 +113,21 @@ export function buildLlamaServerArgs(
     "--cache-type-v",
     "turbo3",
     "--parallel",
-    String(opts.parallel ?? 2),
+    // Resolved here rather than at the call sites because this is where
+    // the *effective* context is known — the number of slots is how many
+    // usable shares that context divides into, and the callers pass the
+    // configured `0` (auto-size) straight through.
+    String(
+      opts.parallel === undefined
+        ? 2
+        : resolveConfiguredSlots(opts.parallel, {
+            contextSize:
+              effectiveContextSize && effectiveContextSize > 0
+                ? effectiveContextSize
+                : null,
+            cpuOnly: opts.device === "cpu",
+          }),
+    ),
     "-kvu",
     "-a",
     modelAlias,

--- a/src/local-llm/worker-slots.test.ts
+++ b/src/local-llm/worker-slots.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SLOTS,
+  MAX_AUTO_SLOTS,
+  MIN_SLOT_CONTEXT,
+  resolveConfiguredSlots,
+  resolveWorkerSlots,
+} from "./worker-slots.js";
+
+describe("resolveWorkerSlots", () => {
+  it("gives one slot per worth-having share of the context", () => {
+    // The context is divided between slots, so the count is how many
+    // times a usable slot fits in what the daemon was given.
+    expect(resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT, cpuOnly: false })).toBe(1);
+    expect(resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 3, cpuOnly: false })).toBe(3);
+    expect(
+      resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 3 + 5_000, cpuOnly: false }),
+    ).toBe(3);
+  });
+
+  it("never returns zero, however small the context", () => {
+    // A machine that can only serve one worker still serves one; the
+    // fan-out then runs its tasks in sequence rather than not at all.
+    expect(resolveWorkerSlots({ contextSize: 4_096, cpuOnly: false })).toBe(1);
+  });
+
+  it("stops at the ceiling on a very large context", () => {
+    expect(
+      resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 40, cpuOnly: false }),
+    ).toBe(MAX_AUTO_SLOTS);
+  });
+
+  it("serves one at a time on CPU", () => {
+    // Concurrency on shared cores buys nothing: both legs finish at the
+    // same time, both late.
+    expect(
+      resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 8, cpuOnly: true }),
+    ).toBe(1);
+  });
+
+  it("falls back to the historical default when the context is unknown", () => {
+    // No `--ctx-size` flag: llama.cpp picks, and this process does not
+    // learn the number. Guessing high here would be guessing with the
+    // operator's memory.
+    expect(resolveWorkerSlots({ contextSize: null, cpuOnly: false })).toBe(DEFAULT_SLOTS);
+    expect(resolveWorkerSlots({ contextSize: 0, cpuOnly: false })).toBe(DEFAULT_SLOTS);
+  });
+});
+
+describe("resolveConfiguredSlots", () => {
+  it("asks the machine for auto", () => {
+    expect(
+      resolveConfiguredSlots("auto", { contextSize: MIN_SLOT_CONTEXT * 4, cpuOnly: false }),
+    ).toBe(4);
+  });
+
+  it("honours a pinned number as written", () => {
+    // The escape hatch: an external server, an unusual model, a
+    // benchmark. A pin the runtime second-guessed would not be one.
+    expect(
+      resolveConfiguredSlots(6, { contextSize: MIN_SLOT_CONTEXT, cpuOnly: false }),
+    ).toBe(6);
+    expect(resolveConfiguredSlots(1, { contextSize: null, cpuOnly: true })).toBe(1);
+  });
+});

--- a/src/local-llm/worker-slots.ts
+++ b/src/local-llm/worker-slots.ts
@@ -1,0 +1,86 @@
+/**
+ * How many workers this machine can actually serve at once.
+ *
+ * The count used to be an operator setting — `localModels.managed.parallel`,
+ * default 2, edited from a list in the composer. That is the wrong party
+ * to ask. The number is not a preference: it is a property of the
+ * machine and the model loaded on it, and the operator choosing it means
+ * either a timid two on hardware that could serve six, or six on a
+ * server whose context cannot hold them.
+ *
+ * **What actually bounds it.** llama.cpp divides `--ctx-size` between
+ * `--parallel` slots: each slot gets `ctx / parallel` tokens, and a
+ * worker whose slot is smaller than its own prompt cannot run at all. A
+ * worker's prompt is the same stable prefix every turn carries (persona,
+ * tool catalog, capabilities — ~5.2k tokens on its own) plus the brief
+ * and whatever it reads, and it generates against
+ * `completionMaxTokens`. So the honest ceiling is how many times
+ * `MIN_SLOT_CONTEXT` fits in the context the daemon was actually given —
+ * which is itself already sized from VRAM by `context-size.ts`. Bigger
+ * machine, bigger context, more slots, with no new hardware probe and
+ * nothing for the operator to decide.
+ *
+ * The context is the binding constraint rather than VRAM directly
+ * because the KV cache for the whole context is allocated up front:
+ * splitting it four ways costs nothing extra in memory, it just makes
+ * each share smaller.
+ */
+
+/**
+ * Tokens a worker slot needs to be useful. Same figure as
+ * `MIN_AUTO_CONTEXT`, and for the same reason: below it a worker has
+ * room for the prefix and not much else, so it truncates mid-tool-call
+ * and reports a failure the orchestrator then has to re-delegate.
+ */
+export const MIN_SLOT_CONTEXT = 16_384;
+
+/**
+ * Ceiling on the derived count. Past a handful of slots the local server
+ * is sharing one set of weights and one memory bus between all of them:
+ * each leg gets slower in proportion, so the wall-clock win flattens
+ * while the failure modes (evicted KV, queued requests timing out) do
+ * not. Eight is generous for a single-GPU or unified-memory machine,
+ * which is what a managed daemon runs on.
+ */
+export const MAX_AUTO_SLOTS = 8;
+
+/** What a launch with nothing known falls back to — the historical default. */
+export const DEFAULT_SLOTS = 2;
+
+export interface WorkerSlotsInput {
+  /**
+   * The context the daemon is being launched with, in tokens. `null`
+   * when it is left to llama.cpp (no `--ctx-size` flag), where the model
+   * decides and this process does not know the number.
+   */
+  contextSize: number | null;
+  /** CPU-only launch (`-ngl 0`). */
+  cpuOnly: boolean;
+}
+
+/**
+ * The slot count for a managed launch.
+ *
+ * CPU-only is always one: concurrent slots there share the same cores,
+ * so two workers do not finish sooner than two in a row — they finish at
+ * the same time, both late, having doubled the memory traffic.
+ */
+export function resolveWorkerSlots(input: WorkerSlotsInput): number {
+  if (input.cpuOnly) return 1;
+  const ctx = input.contextSize;
+  if (ctx === null || !Number.isFinite(ctx) || ctx <= 0) return DEFAULT_SLOTS;
+  const fits = Math.floor(ctx / MIN_SLOT_CONTEXT);
+  return Math.max(1, Math.min(fits, MAX_AUTO_SLOTS));
+}
+
+/**
+ * Resolve the configured value, where `"auto"` means "ask the machine".
+ * A number the operator pinned is honoured as written — the escape hatch
+ * for an external server, an unusual model, or a benchmark.
+ */
+export function resolveConfiguredSlots(
+  configured: number | "auto",
+  input: WorkerSlotsInput,
+): number {
+  return configured === "auto" ? resolveWorkerSlots(input) : configured;
+}

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -61,7 +61,7 @@ export function isFusionActive(
  */
 export const FUSION_GUIDANCE = [
   "You orchestrate local workers: read enough to decide, plan, delegate the doing, review what comes back, integrate it.",
-  "Plan in the open: list the independent, self-contained parts, each with what it touches and how big it is. Size them — group small ones, give a big one its own worker.",
+  "Plan in the open, then delegate in the same turn — never stop at the plan: list the independent, self-contained parts with what each touches and how big it is, sized so a big one gets its own worker and small ones share.",
   "Send one task per part in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
   "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
   "Until this turn has delegated once, tools that change things are refused for you — the mode working, not a fault.",

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -60,13 +60,15 @@ export function isFusionActive(
  * exactly the block a machine-less build renders.
  */
 export const FUSION_GUIDANCE = [
-  "You orchestrate local worker agents: you plan and they execute. Decide the approach first, then delegate the independent bulk — reading many files, first drafts, boilerplate, tests, wide searches — with `fusion.delegate`.",
-  "Delegate whenever the work splits into independent, self-contained parts, and prefer sending more of them over doing the bulk yourself. You choose `maxWorkers` on each call: nothing caps it but the number of tasks and what this machine can serve.",
-  "Each task's `instructions` must stand alone: exact paths, what counts as done, and the format of the answer you want back. Workers have no memory of this conversation and cannot ask you anything.",
-  "Keep the design, the integration and the review yourself. Never delegate the decision you are being asked to make, or a part that only makes sense with this conversation in front of it — that part is yours to do.",
-  "Call `fusion.delegate` on its own, never alongside other tool calls in the same array — it runs several turns internally and takes a while.",
-  "Read every reply before you use it: verify what came back, merge it yourself, and redo or re-delegate any part that came back `failed` or `needs_orchestrator`.",
-  "Workers cannot reach the user and cannot get approval, so anything that needs a person — a shell command, a write at a low approval level — comes back to you to run.",
+  "You orchestrate local workers: read enough to decide, plan, delegate the doing, review what comes back, integrate it.",
+  "Plan in the open: list the independent, self-contained parts, each with what it touches and how big it is. Size them — group small ones, give a big one its own worker.",
+  "Send one task per part in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
+  "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
+  "Until this turn has delegated once, tools that change things are refused for you — the mode working, not a fault.",
+  "Keep the design, the judgement and the integration: read every reply against its brief, then merge the parts yourself.",
+  "Rework goes back out: anything `failed`, `needs_orchestrator`, or that you want refactored becomes another `fusion.delegate` saying what was wrong.",
+  "Yours alone: the decision you were asked for, a part that only makes sense with this conversation in front of it, and anything needing operator approval — workers cannot reach the user.",
+  "Call `fusion.delegate` on its own, never alongside other tool calls — it runs several turns internally and takes a while.",
 ].join("\n");
 
 /**

--- a/src/prompt/fusion-machine-facts.ts
+++ b/src/prompt/fusion-machine-facts.ts
@@ -28,6 +28,7 @@
  */
 
 import type { AtomicAgentConfig } from "../config/config-schema.js";
+import { resolveWorkerSlots } from "../local-llm/worker-slots.js";
 
 export interface FusionMachineFacts {
   /**
@@ -66,7 +67,22 @@ export function resolveFusionMachineFacts(
   // the runtime itself launches the daemon with `managed.parallel`. An
   // external server was started by the operator with flags this process
   // never saw.
-  const workerSlots = local.mode === "managed" ? local.managed.parallel : null;
+  // `"auto"` is the default now, and it resolves against the context the
+  // daemon is launched with — which this process only knows when the
+  // operator pinned one (`contextSize: 0` means llama.cpp sizes it from
+  // VRAM at start-up, well after the prefix is built). Unknown stays
+  // unknown: a guessed slot count is a number the model would plan
+  // against, which is the one thing this module refuses to produce.
+  const configured = local.mode === "managed" ? local.managed.parallel : null;
+  const pinnedContext = local.mode === "managed" ? local.managed.contextSize : 0;
+  const workerSlots =
+    configured === null
+      ? null
+      : configured === "auto"
+        ? pinnedContext > 0
+          ? resolveWorkerSlots({ contextSize: pinnedContext, cpuOnly: false })
+          : null
+        : configured;
 
   // Same chain `resolveRunMode` uses for its worker label, minus the
   // resolver: the explicit pin, then the managed daemon's model, then

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -2303,6 +2303,10 @@ export async function createAgentRuntime(
     // gate is the single live switch rather than a boolean copied into
     // each tool registration.
     isPlanMode: () => planMode,
+    // The same live resolution the `fusion.delegate` descriptor gate
+    // reads, so the tool the orchestrator is being pushed towards is
+    // always in the catalog when the push happens.
+    isFusionMode: () => resolveCurrentRunMode().effective === "fusion",
     slotManager,
     grammar,
     llmComplete,

--- a/src/tools/fusion/fusion-delegate.test.ts
+++ b/src/tools/fusion/fusion-delegate.test.ts
@@ -274,13 +274,16 @@ describe("fusion.delegate", () => {
     expect(result.summary).not.toContain("localModels.managed.parallel");
   });
 
-  it("falls back to the configured `workers` when the call names none", async () => {
+  it("falls back to what the machine serves when the call names no width", async () => {
+    // Not to `runMode.fusion.workers`: the operator is not the party
+    // that knows how divisible this job is, and the slot pool is already
+    // the honest ceiling. A call that named nothing gets the capacity.
     const tool = buildFusionDelegateTool(
       deps({ slotManager: { poolSize: () => 8 } }),
     );
     const result = await tool.run({ tasks: sixTasks() }, ctx());
-    expect(result.details.maxWorkers).toBe(3);
-    expect(result.details.requestedWorkers).toBe(3);
+    expect(result.details.maxWorkers).toBe(6);
+    expect(result.details.requestedWorkers).toBe(8);
   });
 
   it("never runs more workers than there are tasks", async () => {
@@ -338,10 +341,13 @@ describe("fusion.delegate", () => {
       deps({ slotManager: { poolSize: () => 2 } }),
     );
     const result = await tool.run({ tasks: sixTasks(), maxWorkers: 6 }, ctx());
-    expect(result.summary).toContain("6 workers were wanted");
+    expect(result.summary).toContain("6 workers' worth of work was sent");
     expect(result.summary).toContain("2 request slots");
     expect(result.summary).toContain("only 2 ran at a time");
+    // The knob is still named, but as where the number comes from
+    // rather than as something to go and raise: it is `"auto"` now.
     expect(result.summary).toContain("localModels.managed.parallel");
+    expect(result.summary).toContain("comes from the machine");
   });
 
   it("says nothing about the pool when it was not what held the fan-out down", async () => {

--- a/src/tools/fusion/fusion-delegate.ts
+++ b/src/tools/fusion/fusion-delegate.ts
@@ -130,10 +130,21 @@ export function buildFusionDelegateTool(
       // on a slot-affine leg you cannot run more than the server has
       // request slots (the rest would queue and evict each other's KV
       // cache rather than run).
-      const requested = parsed.maxWorkers ?? mode.workers;
+      // A call that named no width gets the machine's capacity, not a
+      // number from a config file. The operator is not the party that
+      // knows how divisible this particular job is, and the slot pool is
+      // already the honest ceiling — `runMode.fusion.workers` survives
+      // only as a pin for someone who deliberately wrote one.
+      const requested =
+        parsed.maxWorkers ??
+        (Number.isFinite(poolSize) ? (poolSize as number) : mode.workers);
       const wanted = Math.max(1, Math.min(requested, parsed.tasks.length));
       const maxWorkers = Math.max(1, Math.min(wanted, poolSize));
-      const poolIsBinding = maxWorkers < wanted;
+      // The pool held this fan-out down when it ran fewer at a time than
+      // there was work for — whether the orchestrator asked for a wider
+      // number or simply had more tasks than the machine has slots.
+      const poolIsBinding =
+        maxWorkers < wanted || maxWorkers < parsed.tasks.length;
 
       // Labels, never guesses: the resolver's pin when it has one, the
       // provider id when it does not. Both legs are read from the same
@@ -202,7 +213,7 @@ export function buildFusionDelegateTool(
       // all three things it needs: what was wanted, what actually ran
       // concurrently, and the config key that changes the second number.
       const hint = poolIsBinding
-        ? `\n\nNote: ${wanted} workers were wanted for this fan-out but the local server has ${poolSize} request slot${poolSize === 1 ? "" : "s"}, so only ${maxWorkers} ran at a time and the rest queued — raise \`localModels.managed.parallel\` (llama-server \`--parallel\`) to widen it.`
+        ? `\n\nNote: ${Math.max(wanted, parsed.tasks.length)} workers' worth of work was sent but the local server has ${poolSize} request slot${poolSize === 1 ? "" : "s"}, so only ${maxWorkers} ran at a time and the rest queued. That number comes from the machine — llama-server divides its context between slots (\`localModels.managed.parallel\`, \`"auto"\` by default). Split into fewer, larger tasks if the queueing is costing more than the parallelism buys.`
         : "";
       return compressToolResult(
         {

--- a/src/tui/composer-switch/composer-switch-activate.test.ts
+++ b/src/tui/composer-switch/composer-switch-activate.test.ts
@@ -337,12 +337,13 @@ describe("the fusion configurators", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("sends the worker count to the one writer that moves it with the slot count", () => {
+  it("offers no worker count to pick at all", () => {
+    // v63: the count left the composer. The machine sizes the slot pool
+    // (`managed.parallel: "auto"`) and the orchestrator sizes each
+    // fan-out inside it, so there is nothing here for a person to set.
     const app = harness(fusionState());
-    app.pick("workers", "4 workers");
-    expect(app.callbacks.onFusionWorkersChangeRequested).toHaveBeenCalledWith(
-      4,
-    );
+    expect(() => app.pick("workers", "4 workers")).toThrow();
+    expect(app.callbacks.onFusionWorkersChangeRequested).not.toHaveBeenCalled();
   });
 
   it("re-pins the orchestrator when a provider is picked under fusion", () => {

--- a/src/tui/composer-switch/composer-switch-worker-rows.test.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.test.ts
@@ -12,59 +12,35 @@ import {
 } from "./composer-switch-worker-rows.js";
 
 describe("the workers switch", () => {
-  it("lists the downloaded local models, then every worker count, then the deep link", () => {
+  it("lists the downloaded local models, then the deep link — and no counts", () => {
+    // The count rows are gone with v63: how many workers run at once is
+    // the machine's answer (`managed.parallel: "auto"` derives it from
+    // the launch context) and how many a turn spends is the
+    // orchestrator's, per call. Neither is an operator's list.
     const rows = selectWorkerRows(fusionState());
     expect(rows[0]?.label).toBe("qwen-3.5-4b");
     expect(rows[0]?.detail).toBe("worker model");
-    expect(rows.slice(1, 9).map((row) => row.label)).toEqual([
-      "1 worker",
-      "2 workers",
-      "3 workers",
-      "4 workers",
-      "5 workers",
-      "6 workers",
-      "7 workers",
-      "8 workers",
+    expect(rows.map((row) => row.label)).toEqual([
+      "qwen-3.5-4b",
+      "Download more models…",
     ]);
-    expect(rows.at(-1)?.label).toBe("Download more models…");
+    expect(rows.some((row) => /worker(s)?$/.test(row.label))).toBe(false);
   });
 
-  it("marks the model in force and the count in force", () => {
+  it("marks the model in force", () => {
     const rows = selectWorkerRows(fusionState({ workers: 4 }));
     expect(rows.filter((row) => row.active).map((row) => row.label)).toEqual([
       "qwen-3.5-4b",
-      "4 workers",
     ]);
   });
 
-  it("carries the intents the activation path branches on", () => {
+  it("carries the one intent the activation path still branches on", () => {
     const rows = selectWorkerRows(fusionState());
     expect(rows.find((row) => row.label === "qwen-3.5-4b")?.intent).toEqual({
       kind: "fusionWorkerModel",
       modelId: "qwen-3.5-4b",
     });
-    expect(rows.find((row) => row.label === "3 workers")?.intent).toEqual({
-      kind: "fusionWorkers",
-      workers: 3,
-    });
-  });
-
-  it("says the slot count is the operator's problem on an external server", () => {
-    const base = fusionState();
-    const external = {
-      ...base,
-      localModelsPanel: {
-        ...base.localModelsPanel,
-        configMode: "external" as const,
-      },
-    };
-    expect(
-      selectWorkerRows(external).find((row) => row.label === "2 workers")
-        ?.detail,
-    ).toBe("external server — set --parallel yourself");
-    expect(
-      selectWorkerRows(base).find((row) => row.label === "2 workers")?.detail,
-    ).toBe("llama-server --parallel 2 · restart to apply");
+    expect(rows.some((row) => row.intent?.kind === "fusionWorkers")).toBe(false);
   });
 
   it("never offers a model that is not on disk", () => {
@@ -95,10 +71,12 @@ describe("the workers switch", () => {
 });
 
 describe("the meta bar's worker label", () => {
-  it("counts the workers on the fusion route", () => {
-    expect(selectComposerWorkersLabel(fusionState())).toBe("2 workers");
+  it("states the machine's capacity on the fusion route, not a setting", () => {
+    // "up to N": N is what this machine serves at once, not a number
+    // anyone picked and not a promise about this turn.
+    expect(selectComposerWorkersLabel(fusionState())).toBe("up to 2 workers");
     expect(selectComposerWorkersLabel(fusionState({ workers: 1 }))).toBe(
-      "1 worker",
+      "up to 1 worker",
     );
   });
 

--- a/src/tui/composer-switch/composer-switch-worker-rows.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.ts
@@ -1,7 +1,3 @@
-import {
-  FUSION_WORKERS_MAX,
-  FUSION_WORKERS_MIN,
-} from "../../config/llm-run-mode-config.js";
 import type { TuiState } from "../tui-state.js";
 import {
   localSliceLoadingRows,
@@ -21,17 +17,18 @@ import {
  * it through the local-models orchestrator, which never touches
  * `activeTextProvider`, so fusion stays effective across the pick.
  *
- * The count rows mirror `llm.runMode.fusion.workers` and, in the same
- * write, `localModels.managed.parallel` — the llama-server slot count
- * that lets N workers actually run side by side rather than queue on
- * the server. A running daemon keeps its old slot count until it is
- * restarted, which the orchestrator says in a notice.
+ * There are no count rows. How many workers a fan-out runs is the
+ * orchestrator's call per call, bounded by what the machine serves —
+ * `localModels.managed.parallel: "auto"` derives the slot count from the
+ * context the daemon launches with (`worker-slots.ts`), and the `###
+ * fusion` block states it so the model chooses against a real number.
+ * An operator picking it from a list was choosing for two parties that
+ * both know better: the machine, which knows its capacity, and the
+ * model, which knows how divisible this job is.
  */
 export function selectWorkerRows(
   state: TuiState,
 ): readonly ComposerSwitchRow[] {
-  const workers = state.providersPanel.runMode?.workers ?? 2;
-  const external = state.localModelsPanel.configMode === "external";
   // The panel's own `active` flag, not the LLM pane's row: that one
   // means "local-llama is the chat route", which under fusion it never
   // is — the cloud orchestrator holds that seat. What matters here is
@@ -45,22 +42,9 @@ export function selectWorkerRows(
       active: row.active,
       intent: { kind: "fusionWorkerModel" as const, modelId: row.id },
     }));
-  const counts: ComposerSwitchRow[] = [];
-  for (let n = FUSION_WORKERS_MIN; n <= FUSION_WORKERS_MAX; n += 1) {
-    counts.push({
-      id: `worker:count:${n}`,
-      label: `${n} worker${n === 1 ? "" : "s"}`,
-      detail: external
-        ? "external server — set --parallel yourself"
-        : `llama-server --parallel ${n} · restart to apply`,
-      active: n === workers,
-      intent: { kind: "fusionWorkers" as const, workers: n },
-    });
-  }
   return [
     ...localSliceLoadingRows(state),
     ...models,
-    ...counts,
     {
       id: "worker:model:download-more",
       label: "Download more models…",
@@ -71,9 +55,16 @@ export function selectWorkerRows(
   ];
 }
 
-/** The fourth control's word on the meta bar, `null` off the fusion route. */
+/**
+ * The fourth control's word on the meta bar, `null` off the fusion route.
+ *
+ * "up to N", not "N workers": the number is what this machine can serve
+ * at once, and how many of them a given turn actually spends is the
+ * orchestrator's decision on that turn. The old wording read as a
+ * setting, which is precisely what it no longer is.
+ */
 export function selectComposerWorkersLabel(state: TuiState): string | null {
   const runMode = state.providersPanel.runMode;
   if (runMode?.effective !== "fusion") return null;
-  return `${runMode.workers} worker${runMode.workers === 1 ? "" : "s"}`;
+  return `up to ${runMode.workers} worker${runMode.workers === 1 ? "" : "s"}`;
 }

--- a/src/tui/persist-run-mode.test.ts
+++ b/src/tui/persist-run-mode.test.ts
@@ -135,6 +135,8 @@ describe("setRunModeInConfig", () => {
         RunModePersistError,
       );
     }
-    expect(getConfig().localModels.managed.parallel).toBe(2);
+    // Untouched means untouched: the slot count is still the machine's
+    // to decide, which is what `"auto"` says.
+    expect(getConfig().localModels.managed.parallel).toBe("auto");
   });
 });

--- a/src/tui/run-mode/run-mode-orchestrator.test.ts
+++ b/src/tui/run-mode/run-mode-orchestrator.test.ts
@@ -200,9 +200,16 @@ describe("RunModeOrchestrator.setMode", () => {
     );
   });
 
-  it("setWorkers says nothing about restarting when the count did not move", () => {
+  it("setWorkers says nothing about restarting when the pin did not move", () => {
+    // Against `"auto"` a number always moves the slot count — it pins
+    // what the machine was deciding — so the quiet case is a re-pin to
+    // the number already written.
     seed(BOTH_LEGS);
     const app = harness();
+    // Pin it first: against `"auto"` a number always moves the slot
+    // count, so the quiet case is a re-pin to what is already written.
+    app.orchestrator.setWorkers(2);
+    app.actions.length = 0;
     app.orchestrator.setWorkers(2);
     const line = app.actions.find((a) => a.type === "runtime_info") as {
       line: string;
@@ -214,7 +221,7 @@ describe("RunModeOrchestrator.setMode", () => {
     seed(BOTH_LEGS);
     const app = harness();
     app.orchestrator.setWorkers(99);
-    expect(getConfig().localModels.managed.parallel).toBe(2);
+    expect(getConfig().localModels.managed.parallel).toBe("auto");
     expect(app.actions.find((a) => a.type === "composer_notice")).toMatchObject(
       {
         text: expect.stringMatching(/workers must be an integer 1-8/),


### PR DESCRIPTION
Stacked on #391 (the orchestration loop); the diff to review here is the last commit.

Nobody should be picking the worker count from a list in the composer. It is two decisions and neither of them is the operator's:

- **how many workers this machine can serve at once** — the machine knows;
- **how many a given job is worth splitting into** — the orchestrator knows, once it has read the job.

### The machine half

`localModels.managed.parallel` accepts `"auto"` and defaults to it (config **v63**).

llama.cpp divides `--ctx-size` between `--parallel` slots, and a slot smaller than a worker's own prompt cannot serve one — the stable prefix alone is ~5.2k tokens. So the count is how many times `MIN_SLOT_CONTEXT` (16,384, the same figure `MIN_AUTO_CONTEXT` uses and for the same reason) fits in the context the daemon is actually launched with, capped at 8, and **1 on a CPU-only launch** where concurrent slots share the same cores and both legs just finish late together.

That context is already sized from VRAM by `context-size.ts`, so a bigger machine widens the pool on its own — no new hardware probe, nothing to configure. Resolved inside `daemon-lifecycle`, where the effective context is known; both launch sites keep passing the config value straight through.

**Migration.** Every pre-v63 file carries a `parallel` the schema wrote, not the operator — almost always the old default `2`. Reading that as a deliberate pin would freeze every existing install at two workers forever, which is the setting this change exists to stop asking about. So a pre-v63 `2` reads as `"auto"`; any other number is someone's choice and is kept, as is a `2` written at v63 or later.

### The model half

A `fusion.delegate` call that names no `maxWorkers` now gets the machine's capacity instead of `llm.runMode.fusion.workers`. The pool notice was reworded to match: it names the slot count as *where the number comes from*, not as a knob to go and raise.

### The UI

The count rows are gone from the composer's fourth control. Its meta-bar label reads **"up to N workers"** — N is the ceiling, not a promise about this turn. The worker *model* rows stay, because which model runs the workers is a real choice. `/runmode workers N` survives as the pin for an external server, an unusual model, or a benchmark.

### Verified

`npx tsc --noEmit` clean. New `worker-slots.test.ts` (7 cases: the share arithmetic, the floor of one, the ceiling, CPU, the unknown-context fallback, and both branches of the pin). Config tests cover the new default and both sides of the migration. Every test that pinned the old contract was updated to the new one rather than deleted — the composer rows, the delegate's fallback, the pool notice, and `setWorkers`' quiet case. Full suite: 8932 passing, with the known macOS-only `send-message-concurrency` flake (fails identically on v0.5.6 on this machine, green in CI).