### PR TITLE
fix(telegram): only the lock's owner may release it

### DIFF
--- a/src/channels/telegram/telegram-channel.test.ts
+++ b/src/channels/telegram/telegram-channel.test.ts
@@ -16,6 +16,7 @@ import type { ChannelStatus } from "../../runtime/channel-status.js";
 import type { TaskReport } from "../../tasks/index.js";
 import { StructuredLogger } from "../../tracing/structured-logger.js";
 
+import { TelegramLockfile } from "./telegram-lockfile.js";
 import {
   TASK_REPORT_QUEUE_LIMIT,
   TelegramChannel,
@@ -364,6 +365,36 @@ describe("TelegramChannel", () => {
     await channel.start();
     expect(channel.state()).toBe("down");
     expect(channel.lastError()).toContain("lockfile held");
+  });
+
+  it("leaves the winner's lock file intact when start() loses the race", async () => {
+    // The bug this pins: start() releases from its catch block, and
+    // `release()` used to unlink the file unconditionally. So the
+    // process that LOST the race deleted the winner's lock on its way
+    // down; the winner kept polling from memory while the file was
+    // gone, and the next process acquired "successfully" -- two
+    // pollers on one token, stopped only by Telegram's 409.
+    //
+    // `process.ppid` stands in for the winner: certainly alive, and
+    // never this process, on POSIX and Windows alike.
+    const lockPath = join(dir, "telegram.lock");
+    writeFileSync(lockPath, String(process.ppid), "utf8");
+    const { factory, state } = makeBotFactory();
+    const channel = new TelegramChannel({
+      runtime: fakeRuntime(),
+      config: makeConfig(dir),
+      token: "1234:abcdef",
+      logger,
+      botFactory: factory,
+      lock: new TelegramLockfile(lockPath),
+    });
+
+    await channel.start();
+
+    expect(channel.state()).toBe("down");
+    expect(channel.lastError()).toContain("already running");
+    expect(state.startCalls).toBe(0);
+    expect(readFileSync(lockPath, "utf8")).toBe(String(process.ppid));
   });
 
   it("emits down with scrubbed error when getMe fails", async () => {

--- a/src/channels/telegram/telegram-lockfile.test.ts
+++ b/src/channels/telegram/telegram-lockfile.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   existsSync,
   mkdtempSync,
   readFileSync,
@@ -18,7 +19,11 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "atomic-tg-lock-"));
   path = join(dir, "telegram.lock");
 });
-afterEach(() => rmSync(dir, { recursive: true, force: true }));
+afterEach(() => {
+  // A 0o000 file from the unreadable-lock case still has to be
+  // removable, and its directory is ours, so force is enough.
+  rmSync(dir, { recursive: true, force: true });
+});
 
 describe("TelegramLockfile", () => {
   it("acquires and then releases its own lock", () => {
@@ -56,9 +61,57 @@ describe("TelegramLockfile", () => {
     { name: "garbage contents", write: "not-a-pid" },
     { name: "a dead pid", write: "999999" },
     { name: "a negative pid", write: "-1" },
-  ])("release() does not throw on $name", ({ write }) => {
+    { name: "a fractional pid", write: "12.34" },
+  ])("release() does not throw on $name, and removes nothing", ({ write }) => {
+    // Two assertions, because "did not throw" alone passes for a
+    // release() that deletes every one of these. Anything we cannot
+    // read as our own pid belongs to someone else until proven
+    // otherwise; acquire()'s stale branch reclaims the junk safely,
+    // so leaving it costs nothing and removing it can cost the token.
     if (write !== null) writeFileSync(path, write, "utf8");
     expect(() => new TelegramLockfile(path).release()).not.toThrow();
+    expect(existsSync(path)).toBe(write !== null);
+  });
+
+  // chmod is advisory for root and meaningless on Windows, so the
+  // unreadable case can only be staged where file modes bite.
+  const modesBite =
+    process.platform !== "win32" && (process.getuid?.() ?? 0) !== 0;
+
+  it.runIf(modesBite)(
+    "leaves an unreadable lock file alone instead of unlinking blind",
+    () => {
+      // The tempting shortcut is to treat a failed read as "nothing of
+      // ours is there" and unlink anyway. On POSIX that deletes the
+      // file regardless: unlink permission comes from the *directory*,
+      // which is ours, so an unreadable lock held by another user's
+      // atomic-agent would be swept away and its token handed to a
+      // second poller.
+      writeFileSync(path, String(process.ppid), "utf8");
+      chmodSync(path, 0o000);
+      try {
+        expect(() => new TelegramLockfile(path).release()).not.toThrow();
+        expect(existsSync(path)).toBe(true);
+      } finally {
+        chmodSync(path, 0o600);
+      }
+    },
+  );
+
+  it.runIf(modesBite)("stays silent when the unlink itself fails", () => {
+    // The other half of the contract: the read can succeed and the
+    // unlink still fail -- a read-only state dir, or the holder's own
+    // stop() landing between the two syscalls. release() is called
+    // from failure paths that must not acquire a second failure.
+    const lock = new TelegramLockfile(path);
+    lock.acquire();
+    chmodSync(dir, 0o500);
+    try {
+      expect(() => lock.release()).not.toThrow();
+      expect(existsSync(path)).toBe(true);
+    } finally {
+      chmodSync(dir, 0o700);
+    }
   });
 
   it("still reclaims a stale lock on acquire()", () => {

--- a/src/channels/telegram/telegram-lockfile.test.ts
+++ b/src/channels/telegram/telegram-lockfile.test.ts
@@ -1,0 +1,75 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { TelegramLockfile } from "./telegram-lockfile.js";
+
+let dir: string;
+let path: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "atomic-tg-lock-"));
+  path = join(dir, "telegram.lock");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("TelegramLockfile", () => {
+  it("acquires and then releases its own lock", () => {
+    const lock = new TelegramLockfile(path);
+    lock.acquire();
+    expect(readFileSync(path, "utf8")).toBe(String(process.pid));
+    lock.release();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("leaves a lock owned by another process alone", () => {
+    // The regression this pins: the loser of an acquire() race releases
+    // from `TelegramChannel.start()`'s catch block. Deleting the file
+    // there erases the WINNER's lock, so a third process acquires
+    // cleanly and two pollers end up on one token -- the 409 the
+    // lockfile exists to prevent.
+    writeFileSync(path, String(process.ppid), "utf8");
+    new TelegramLockfile(path).release();
+    expect(readFileSync(path, "utf8")).toBe(String(process.ppid));
+  });
+
+  it("does not delete a live holder's lock when acquire() was refused", () => {
+    // End-to-end at the lockfile level: acquire() throws, the caller
+    // releases in its failure path, the holder's file survives.
+    writeFileSync(path, String(process.ppid), "utf8");
+    const loser = new TelegramLockfile(path);
+    expect(() => loser.acquire()).toThrow(/already running/);
+    loser.release();
+    expect(readFileSync(path, "utf8")).toBe(String(process.ppid));
+  });
+
+  it.each([
+    { name: "missing file", write: null },
+    { name: "empty file", write: "" },
+    { name: "garbage contents", write: "not-a-pid" },
+    { name: "a dead pid", write: "999999" },
+    { name: "a negative pid", write: "-1" },
+  ])("release() does not throw on $name", ({ write }) => {
+    if (write !== null) writeFileSync(path, write, "utf8");
+    expect(() => new TelegramLockfile(path).release()).not.toThrow();
+  });
+
+  it("still reclaims a stale lock on acquire()", () => {
+    // Guarding release() must not touch the reclaim path: a dead
+    // holder's file is still taken over, or a crash would wedge the
+    // channel until someone deleted the file by hand.
+    writeFileSync(path, "999999", "utf8");
+    const lock = new TelegramLockfile(path);
+    expect(() => lock.acquire()).not.toThrow();
+    expect(readFileSync(path, "utf8")).toBe(String(process.pid));
+    lock.release();
+    expect(existsSync(path)).toBe(false);
+  });
+});

--- a/src/channels/telegram/telegram-lockfile.ts
+++ b/src/channels/telegram/telegram-lockfile.ts
@@ -9,10 +9,17 @@ import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
  *
  * `acquire()` throws when another live process holds the file. Stale
  * locks (PID dead) are reclaimed transparently. `release()` is
- * best-effort and removes the file only when this process owns it — a
- * lingering file just means the next `acquire()` replaces it on the
- * stale-lock path, whereas removing someone else's lock hands the token
- * to a second poller.
+ * best-effort and removes the file only when this process owns it —
+ * removing someone else's lock hands the token to a second poller, and
+ * a file we leave behind is reclaimed by the next `acquire()` as long
+ * as its PID is dead.
+ *
+ * The residual case, shared with `DiscordLockfile`: a holder killed
+ * without releasing leaves a PID the OS may later recycle onto an
+ * unrelated process. `acquire()` then sees a live PID and keeps
+ * refusing, so the channel stays down until the file is deleted by
+ * hand. That is the deliberate trade — a rare manual unwedge beats
+ * silently allowing two pollers on one token.
  */
 export interface ChannelLock {
   acquire(): void;

--- a/src/channels/telegram/telegram-lockfile.ts
+++ b/src/channels/telegram/telegram-lockfile.ts
@@ -1,5 +1,5 @@
 import { formatChannelLockHeld } from "../channel-lock-error.js";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
 
 /**
  * Single-instance enforcement primitive used by the Telegram channel.
@@ -9,8 +9,10 @@ import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
  *
  * `acquire()` throws when another live process holds the file. Stale
  * locks (PID dead) are reclaimed transparently. `release()` is
- * best-effort — a lingering file just means the next `acquire()`
- * replaces it on the stale-lock path.
+ * best-effort and removes the file only when this process owns it — a
+ * lingering file just means the next `acquire()` replaces it on the
+ * stale-lock path, whereas removing someone else's lock hands the token
+ * to a second poller.
  */
 export interface ChannelLock {
   acquire(): void;
@@ -50,10 +52,22 @@ export class TelegramLockfile implements ChannelLock {
 
   release(): void {
     try {
-      if (existsSync(this.path)) unlinkSync(this.path);
+      // Only the owner may remove the file. Deleting it on sight is
+      // worse than leaving it: the process that LOSES the acquire()
+      // race releases from `TelegramChannel.start()`'s catch block, so
+      // an unguarded release erases the WINNER's lock. The winner keeps
+      // polling — its state is in memory — while the file is gone, so
+      // the next process acquires "successfully" and two pollers share
+      // one token. That is the 409 this class exists to prevent.
+      const holder = Number.parseInt(
+        readFileSync(this.path, "utf8").trim(),
+        10,
+      );
+      if (holder === process.pid) unlinkSync(this.path);
     } catch {
-      // best-effort — a lingering file just means the next start
-      // replaces it via the stale-lock branch above
+      // best-effort — a missing or unreadable file leaves nothing of
+      // ours to remove, and a lingering one is replaced by the next
+      // start via the stale-lock branch above
     }
   }
 }


### PR DESCRIPTION
## The defect

`TelegramLockfile.release()` (`src/channels/telegram/telegram-lockfile.ts:51` on `main` @ 56078641) unlinked the lock file whenever it existed, with no check that the PID inside was this process:

```ts
release(): void { try { if (existsSync(this.path)) unlinkSync(this.path); } catch {} }
```

That is fine for the owner and wrong for everybody else. The sequence that loses the file:

1. Process A calls `TelegramChannel.start()`; `this.lock.acquire()` (`src/channels/telegram/telegram-channel.ts:239`) writes `telegram.lock` with A's PID and A starts polling.
2. Process B starts on the same token. `acquire()` sees a live foreign PID and throws `channel-locked: already running in another atomic-agent (pid A)`.
3. `start()`'s catch block (`src/channels/telegram/telegram-channel.ts:340-346`) calls `this.lock.release()` — the correct thing to do when *you* took the lock, but B never did. The unguarded `release()` deletes **A's** file.
4. A keeps polling: its state is in memory, nothing tells it the file is gone.
5. Process C now calls `acquire()`, finds no file, and starts polling too.

Two `getUpdates` loops on one token — the 409 Conflict the class doc comment names as the thing it exists to prevent, now enforced only by Telegram's servers.

## The Discord asymmetry

`DiscordLockfile.release()` (`src/channels/discord/discord-lockfile.ts:37-44`) has always had the guard:

```ts
if (this.readPid() === process.pid) unlinkSync(this.path);
```

and its test suite pins it (`src/channels/discord/discord-lockfile.test.ts:48` — "does not delete a lock owned by someone else on release"). The Telegram twin simply never grew it.

## What changed

`release()` now reads the PID and unlinks only when it is ours. `existsSync` is gone — a missing file throws `ENOENT` from `readFileSync` into the same best-effort `catch`, so the behaviour on a missing/unreadable/garbage file is unchanged (still silent, still no throw). The class doc comment says why leaving a foreign lock behind is the safe failure mode.

All three `release()` call sites in `telegram-channel.ts` were checked, and the guard is a no-op for the legitimate ones because this process wrote the file it is removing:

- `:342` the `start()` catch block — the buggy path. Now a no-op when `acquire()` was the thing that threw; still removes our own lock when the failure came later (`getMe`/`botFactory` threw *after* a successful acquire), which the existing "emits down with scrubbed error when getMe fails" test covers.
- `:372` `handlePollingStopped()` — we hold the lock, file still removed, pinned by "releases the lock when the poller dies, so a restart can re-acquire".
- `:422` `stop()`, wrapped in the `logger.warn` — we hold the lock, file still removed.

## Deliberately left alone

- **`acquire()`** — stale-lock reclaim, the parse, and the `formatChannelLockHeld` message are byte-identical.
- **The Discord side** — untouched.
- **The duplication between the two lockfiles.** I looked at hoisting one implementation into `src/channels/channel-lock-error.ts` (or a new shared `ChannelLockfile`) behind the existing `ChannelLock` interface, and decided against it here: the two `acquire()` bodies are *not* actually equivalent. Telegram parses with `Number.parseInt` + `Number.isFinite` (so `"123abc"` reads as PID 123), Discord with `Number` + `Number.isInteger` (so `"123abc"` is a corrupt lock to reclaim), and Telegram's `isAlive` counts `EACCES` as alive while Discord's does not. Unifying them means changing `acquire()` semantics on one side or the other, which is a bigger and less obviously-safe change than the bug being fixed. The duplication therefore remains; the two `release()` implementations are now at least behaviourally identical.

## Tests

New `src/channels/telegram/telegram-lockfile.test.ts` (9 cases): owner acquire/release round-trip; a lock holding a different live PID surviving `release()`; the full loser path (`acquire()` throws, caller releases, holder's file intact); a table over missing / empty / garbage / dead-PID / negative-PID files all not throwing; and stale-lock reclaim still working. `process.ppid` is the "certainly alive, certainly not me" PID — portable on POSIX and Windows, and the same stand-in the Discord suite already uses.

New case in `telegram-channel.test.ts`: "leaves the winner's lock file intact when start() loses the race" — a real `TelegramLockfile` over a temp-dir file pre-seeded with `process.ppid`, driven through `TelegramChannel.start()` with the suite's existing fake bot factory. Asserts the channel goes `down` with the lock-conflict reason, that the bot never started, and that the holder's file is still on disk.

```
npx vitest run src/channels/telegram
  15 files, 240 tests passed
npm run lint (tsc --noEmit)
  clean
```

**Non-vacuous check:** with the test files kept and only `telegram-lockfile.ts` reverted to `main`, 3 tests fail and 52 pass:

- `telegram-lockfile.test.ts > leaves a lock owned by another process alone` — ENOENT, file deleted
- `telegram-lockfile.test.ts > does not delete a live holder's lock when acquire() was refused` — ENOENT
- `telegram-channel.test.ts > leaves the winner's lock file intact when start() loses the race` — ENOENT

The full suite was not used as a gate (it carries ~10 known flaky failures unrelated to this change).

## Provenance

Found by audit while documenting the channel lock behaviour for a separate change, not from a user report. No reproduction in the wild is known; the window is narrow (it needs a second process to start while a first one is polling), but the outcome — duplicate replies and duplicate side effects from a doubled turn — is bad enough to be worth the guard.
