### PR TITLE
feat(llm): opt-in strict function tools for OpenAI-compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,9 @@ Off by default, and only for OpenAI-compatible kinds (`openai-compatible`, `qwen
 
 With the flag on, every tool schema is rewritten into the subset strict mode accepts: objects are closed, every property is listed in `required` (an optional one becomes nullable instead of being omitted), and value-range keywords the runtime validators enforce anyway (`minItems`, `minLength`, `pattern`, `format`, `default`, …) are stripped. A handful of tools take a free-form map — `os.http.request`'s headers and body, `mcp.prompt.get`'s arguments — and those cannot be expressed strictly; they are sent unconstrained (`strict: false`) rather than silently losing their arguments.
 
-Because optionals become nullable, a strict model sends `"userName": null` where it used to omit the key; on these providers a top-level `null` argument is dropped again before the call runs, so tools that check for presence behave as they always did.
+Because optionals become nullable, a strict model sends `"pinned": null` where it used to omit the key; on these providers a top-level `null` argument is dropped again before the call runs, so tools that check for presence behave as they always did.
+
+The flag also sends `parallel_tool_calls: false`. Strict decoding and parallel calls do not compose — OpenAI's guidance is that a parallel call "may not match supplied schemas" — so a provider asked for strict tools is asked for one call per response. `agent.maxParallelToolCalls` still governs how the runtime executes a batch.
 
 Turn it on only for a service that implements strict mode: one that does not will reject the whole request, not just the field.
 

--- a/README.md
+++ b/README.md
@@ -586,6 +586,25 @@ Local models use `localModels.completionMaxTokens` (llama.cpp's `n_predict`, def
 </details>
 
 <details>
+<summary><b>Models that need strict tool schemas</b> (<code>strictTools</code>)</summary>
+
+Some models call tools reliably only when the provider constrains decoding to the tool's schema — OpenAI's **strict mode**. Set `strictTools` on the provider entry to send every function as `strict`:
+
+```json
+"llm": { "providers": [{ "id": "mercury", "kind": "openai-compatible", "strictTools": true }] }
+```
+
+Off by default, and only for OpenAI-compatible kinds (`openai-compatible`, `qwen-openai-compatible`, `openrouter`, `aimlapi`, `gemini`). `strict` is a field on each tool, so `extraBody` cannot reach it — `tools` is a reserved key that is re-applied after that merge.
+
+With the flag on, every tool schema is rewritten into the subset strict mode accepts: objects are closed, every property is listed in `required` (an optional one becomes nullable instead of being omitted), and value-range keywords the runtime validators enforce anyway (`minItems`, `minLength`, `pattern`, `format`, `default`, …) are stripped. A handful of tools take a free-form map — `os.http.request`'s headers and body, `mcp.prompt.get`'s arguments — and those cannot be expressed strictly; they are sent unconstrained (`strict: false`) rather than silently losing their arguments.
+
+Because optionals become nullable, a strict model sends `"userName": null` where it used to omit the key; on these providers a top-level `null` argument is dropped again before the call runs, so tools that check for presence behave as they always did.
+
+Turn it on only for a service that implements strict mode: one that does not will reject the whole request, not just the field.
+
+</details>
+
+<details>
 <summary><b>Configuration and secrets</b> (state dir, env vars, .env)</summary>
 
 User-facing configuration lives in `<stateDir>/config.json`.

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -933,6 +933,14 @@ export interface AtomicAgentConfig {
        */
       extraBody?: Record<string, unknown>;
       /**
+       * Emit OpenAI strict function tools (`tools[].function.strict`)
+       * for this provider, rewriting each tool schema into the subset
+       * strict mode accepts. Off by default: a service that does not
+       * implement strict mode rejects the whole request. Not reachable
+       * through `extraBody`, because `tools` is a reserved key.
+       */
+      strictTools?: boolean;
+      /**
        * Settings for a `subscription-cli` provider: which already
        * signed-in vendor CLI to drive (`claude`, `codex`) and how to
        * invoke it. There is no API key on these entries — the CLI
@@ -2067,7 +2075,12 @@ export interface UserConfigFile {
 // closed by default — `remoteSync: false` refuses every network git verb
 // so a repository the agent versions stays on this machine; the GitHub
 // token lives in `<stateDir>/.env`, never here.
-export const USER_CONFIG_VERSION = 62;
+// v63: provider entries accept `strictTools` — emit OpenAI strict
+// function tools (`tools[].function.strict: true`) for this provider,
+// with every tool schema rewritten into the subset strict mode accepts.
+// Additive and off by default: an older file has no flag, and without
+// the flag the request body is byte-identical to v62's.
+export const USER_CONFIG_VERSION = 63;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -2218,6 +2231,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   59,
   60,
   61,
+  62,
   USER_CONFIG_VERSION,
 ];
 

--- a/src/config/llm-config.test.ts
+++ b/src/config/llm-config.test.ts
@@ -626,3 +626,53 @@ describe("provider maxOutputTokens", () => {
     }
   });
 });
+
+describe("provider strictTools", () => {
+  const withEntry = (strictTools: unknown) => ({
+    version: USER_CONFIG_VERSION,
+    llm: {
+      activeTextProvider: "mercury",
+      activeEmbeddingProvider: "local-llama",
+      toolTransport: "auto" as const,
+      providers: [
+        {
+          id: "local-llama",
+          kind: "llama-server",
+          url: "http://127.0.0.1:19091",
+        },
+        {
+          id: "mercury",
+          kind: "openai-compatible",
+          baseUrl: "https://api.inceptionlabs.ai/v1",
+          defaultChatModel: "mercury",
+          ...(strictTools === undefined ? {} : { strictTools }),
+        },
+      ],
+    },
+  });
+
+  const entry = (parsed: ReturnType<typeof parseUserConfigFile>) =>
+    parsed.llm?.providers.find((p) => p.id === "mercury");
+
+  it("round-trips the opt-in flag", () => {
+    expect(entry(parseUserConfigFile(withEntry(true)))?.strictTools).toBe(true);
+  });
+
+  it("round-trips an explicit opt-out", () => {
+    expect(entry(parseUserConfigFile(withEntry(false)))?.strictTools).toBe(
+      false,
+    );
+  });
+
+  it("is absent by default — nothing about the request changes", () => {
+    expect(
+      entry(parseUserConfigFile(withEntry(undefined)))?.strictTools,
+    ).toBeUndefined();
+  });
+
+  it("rejects anything that is not a boolean", () => {
+    for (const bad of ["true", 1, {}, []]) {
+      expect(() => parseUserConfigFile(withEntry(bad))).toThrow(/strictTools/);
+    }
+  });
+});

--- a/src/config/llm-config.ts
+++ b/src/config/llm-config.ts
@@ -96,6 +96,20 @@ export type UserLlmProviderEntry = {
    */
   extraBody?: Record<string, unknown>;
   /**
+   * Emit OpenAI strict function tools for this provider —
+   * `tools[].function.strict: true`, with every tool schema rewritten
+   * into the subset strict mode accepts. Added in config v63.
+   *
+   * Off by default and deliberately so: strict mode is an OpenAI
+   * extension, and a service that does not implement it rejects the
+   * entire request rather than ignoring the field. Turn it on for a
+   * model that only calls tools reliably under constrained decoding
+   * (the reported case was Inception Labs' Mercury). This cannot be
+   * done through `extraBody` — `strict` is a field on each tool and
+   * `tools` is a reserved key that is re-applied after that merge.
+   */
+  strictTools?: boolean;
+  /**
    * Hand-written model metadata for this provider. `resolveModel`
    * reads it as its highest-priority source (userModels > bundled
    * catalog > defaults), so it is the documented way to teach the
@@ -308,6 +322,17 @@ export function parseLlmProviderEntry(
       `${field}.providerPreferences`,
     ),
     extraBody: parseOptionalPlainObject(obj.extraBody, `${field}.extraBody`),
+    strictTools:
+      obj.strictTools === undefined
+        ? undefined
+        : typeof obj.strictTools === "boolean"
+          ? obj.strictTools
+          : (() => {
+              throw new ConfigValidationError(
+                `${field}.strictTools`,
+                "expected boolean",
+              );
+            })(),
     userModels: parseOptionalUserModels(obj.userModels, `${field}.userModels`),
     subscriptionCli: parseSubscriptionCliOptions(
       obj.subscriptionCli,

--- a/src/llm/provider/openai/openai-build-body.test.ts
+++ b/src/llm/provider/openai/openai-build-body.test.ts
@@ -275,3 +275,99 @@ describe("buildOpenAiChatBody — the provider's own ceiling", () => {
     ).toBe(false);
   });
 });
+
+describe("buildOpenAiChatBody — strict function tools", () => {
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "os__fs__read",
+        description: "read a file",
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" }, limit: { type: "integer" } },
+          required: ["path"],
+        },
+      },
+    },
+  ];
+  const request = { prompt: "hi", tools };
+
+  it("leaves the body byte-identical when the flag is absent", () => {
+    // The whole safety argument for the feature: an operator who never
+    // sets `strictTools` must get exactly the request they got before
+    // it existed. Compared as JSON so key order counts too.
+    const before = buildOpenAiChatBody(request, "gpt-test", false, {
+      chat_template_kwargs: { enable_thinking: false },
+    });
+    const after = buildOpenAiChatBody(
+      request,
+      "gpt-test",
+      false,
+      { chat_template_kwargs: { enable_thinking: false } },
+      undefined,
+      false,
+    );
+    expect(JSON.stringify(after)).toBe(JSON.stringify(before));
+    expect(after.tools).toEqual(tools);
+  });
+
+  it("rewrites the tools and marks them strict when the flag is on", () => {
+    const body = buildOpenAiChatBody(
+      request,
+      "gpt-test",
+      false,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(body.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "os__fs__read",
+          description: "read a file",
+          strict: true,
+          parameters: {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              limit: { type: ["integer", "null"] },
+            },
+            required: ["path", "limit"],
+            additionalProperties: false,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("keeps the strict tools over an extraBody that tries to replace them", () => {
+    // `tools` is a reserved key, restored on top of the merge. The
+    // transform therefore has to run *before* that restore, or the
+    // untransformed array would win. This pins that ordering.
+    const body = buildOpenAiChatBody(
+      request,
+      "gpt-test",
+      false,
+      { tools: [{ type: "function", function: { name: "hijack" } }] },
+      undefined,
+      true,
+    );
+    const emitted = body.tools as ReadonlyArray<Record<string, unknown>>;
+    expect(emitted).toHaveLength(1);
+    expect((emitted[0].function as Record<string, unknown>).strict).toBe(true);
+  });
+
+  it("sends no tools key at all when the request carries none", () => {
+    const body = buildOpenAiChatBody(
+      { prompt: "hi" },
+      "gpt-test",
+      false,
+      undefined,
+      undefined,
+      true,
+    );
+    expect("tools" in body).toBe(false);
+  });
+});

--- a/src/llm/provider/openai/openai-build-body.ts
+++ b/src/llm/provider/openai/openai-build-body.ts
@@ -1,5 +1,6 @@
 import type { CompletionRequest } from "../completion-types.js";
 import { filterCloudCompletionRequest } from "./sampling-filter.js";
+import { toStrictOpenAiTools } from "./openai-strict-tools.js";
 
 /**
  * Fields the caller owns unconditionally. `extraBody` is merged *under*
@@ -15,6 +16,7 @@ export function buildOpenAiChatBody(
   stream: boolean,
   extraBody?: Record<string, unknown>,
   maxOutputTokens?: number,
+  strictTools?: boolean,
 ): Record<string, unknown> {
   const filtered = filterCloudCompletionRequest(request);
   const body: Record<string, unknown> = {
@@ -58,7 +60,14 @@ export function buildOpenAiChatBody(
   if (filtered.stop) body.stop = filtered.stop;
   if (typeof filtered.seed === "number") body.seed = filtered.seed;
   if (filtered.tools && filtered.tools.length > 0) {
-    body.tools = filtered.tools;
+    // Strict function tools, when the provider entry opted in. Done
+    // here — before the `extraBody` merge — precisely because `tools`
+    // is a reserved key: the loop below restores `body.tools` over the
+    // merge, so the transformed array is what survives. Off by default,
+    // and off it must leave this line byte-identical to what it was.
+    body.tools = strictTools
+      ? toStrictOpenAiTools(filtered.tools)
+      : filtered.tools;
     body.parallel_tool_calls = filtered.parallelToolCalls ?? true;
     if (filtered.toolChoice !== undefined) {
       body.tool_choice = filtered.toolChoice;

--- a/src/llm/provider/openai/openai-build-body.ts
+++ b/src/llm/provider/openai/openai-build-body.ts
@@ -68,7 +68,19 @@ export function buildOpenAiChatBody(
     body.tools = strictTools
       ? toStrictOpenAiTools(filtered.tools)
       : filtered.tools;
-    body.parallel_tool_calls = filtered.parallelToolCalls ?? true;
+    // Strict decoding and parallel calls do not compose. OpenAI's own
+    // guidance: "Structured Outputs is not compatible with parallel
+    // function calls — when a parallel function call is generated, it
+    // may not match supplied schemas. Set `parallel_tool_calls: false`."
+    // Leaving the default `true` here would emit `strict: true` on
+    // every tool and still get best-effort adherence, i.e. the exact
+    // symptom the flag exists to cure. So opting into `strictTools`
+    // also opts out of parallel calls on the wire; the executor's own
+    // `maxParallelToolCalls` batching is untouched, and a provider
+    // without the flag keeps today's `parallel_tool_calls` verbatim.
+    body.parallel_tool_calls = strictTools
+      ? false
+      : (filtered.parallelToolCalls ?? true);
     if (filtered.toolChoice !== undefined) {
       body.tool_choice = filtered.toolChoice;
     }

--- a/src/llm/provider/openai/openai-provider.test.ts
+++ b/src/llm/provider/openai/openai-provider.test.ts
@@ -155,3 +155,110 @@ describe("OpenAiProvider qwen tagged-tool compatibility", () => {
     });
   });
 });
+
+/**
+ * The `strictTools` entry flag, end to end through the provider.
+ *
+ * The transform, the body builder and the config parser each have their
+ * own unit coverage; what had none was the wiring between them — the
+ * two `buildOpenAiChatBody` call sites that must pass `this.strictTools`
+ * and the constructor branch that must wrap the tool-call adapter.
+ * Deleting either left every test in the repo green, so the feature
+ * could be silently removed by a refactor. These assert the observable
+ * ends: the bytes on the wire, and the args a parsed call carries.
+ */
+describe("OpenAiProvider strictTools wiring", () => {
+  function strictProvider(
+    fetchImpl: typeof fetch,
+    strictTools: boolean | undefined,
+  ): OpenAiProvider {
+    return new OpenAiProvider({
+      id: "test",
+      baseUrl: "https://example.invalid",
+      apiKey: "",
+      defaultChatModel: "qwen-test",
+      fetchImpl,
+      ...(strictTools === undefined ? {} : { strictTools }),
+    });
+  }
+
+  const sentBody = (fetchImpl: ReturnType<typeof fakeFetch>, index = 0) =>
+    JSON.parse(
+      String((fetchImpl.mock.calls[index]?.[1] as RequestInit).body),
+    ) as Record<string, unknown>;
+
+  it("reaches the non-streaming request body", async () => {
+    const fetchImpl = fakeFetch({ role: "assistant", content: "ok" });
+    await strictProvider(fetchImpl as unknown as typeof fetch, true).complete({
+      prompt: "read",
+      tools,
+    });
+    const body = sentBody(fetchImpl);
+    const fn = (body.tools as Array<{ function: Record<string, unknown> }>)[0]
+      .function;
+    expect(fn.strict).toBe(true);
+    expect(fn.parameters).toEqual({
+      type: "object",
+      properties: { path: { type: ["string", "null"] } },
+      required: ["path"],
+      additionalProperties: false,
+    });
+    // Strict decoding is only guaranteed with parallel calls off.
+    expect(body.parallel_tool_calls).toBe(false);
+  });
+
+  it("reaches the streaming request body", async () => {
+    const fetchImpl = fakeStreamFetch("ok");
+    const stream = strictProvider(
+      fetchImpl as unknown as typeof fetch,
+      true,
+    ).completeStream({ prompt: "read", tools });
+    while (!(await stream.next()).done) {
+      /* drain */
+    }
+    const body = JSON.parse(
+      String((fetchImpl.mock.calls[0]?.[1] as RequestInit).body),
+    ) as Record<string, unknown>;
+    const fn = (body.tools as Array<{ function: Record<string, unknown> }>)[0]
+      .function;
+    expect(fn.strict).toBe(true);
+    expect(body.parallel_tool_calls).toBe(false);
+  });
+
+  it("leaves the body untouched when the flag is absent or false", async () => {
+    for (const flag of [undefined, false] as const) {
+      const fetchImpl = fakeFetch({ role: "assistant", content: "ok" });
+      await strictProvider(
+        fetchImpl as unknown as typeof fetch,
+        flag,
+      ).complete({ prompt: "read", tools });
+      const body = sentBody(fetchImpl);
+      expect(body.tools).toEqual(tools);
+      expect(body.parallel_tool_calls).toBe(true);
+    }
+  });
+
+  it("wraps the tool-call adapter so parsed calls lose top-level nulls", () => {
+    const call = [
+      {
+        id: "call_1",
+        type: "function" as const,
+        function: {
+          name: "memory__profile__set",
+          arguments: '{"key":"k","value":"v","pinned":null}',
+        },
+      },
+    ];
+    const on = strictProvider(fakeFetch({}) as unknown as typeof fetch, true);
+    expect(on.toolCallAdapter?.toolCallsToBatch(call).calls[0]?.args).toEqual({
+      key: "k",
+      value: "v",
+    });
+    const off = strictProvider(fakeFetch({}) as unknown as typeof fetch, false);
+    expect(off.toolCallAdapter?.toolCallsToBatch(call).calls[0]?.args).toEqual({
+      key: "k",
+      value: "v",
+      pinned: null,
+    });
+  });
+});

--- a/src/llm/provider/openai/openai-provider.ts
+++ b/src/llm/provider/openai/openai-provider.ts
@@ -15,7 +15,10 @@ import type {
 import type { ToolCallAdapter } from "../adapters/tool-call-adapter.js";
 import type { StreamConsumer } from "../adapters/stream-consumer.js";
 import type { ReasoningFormat } from "../llm-provider.js";
-import { openAiToolCallAdapter } from "./openai-tool-call-adapter.js";
+import {
+  openAiToolCallAdapter,
+  withStrictNullArgumentDrop,
+} from "./openai-tool-call-adapter.js";
 import { createOpenAiStreamConsumer } from "./openai-stream-consumer.js";
 import { buildOpenAiChatBody } from "./openai-build-body.js";
 import {
@@ -70,6 +73,14 @@ export interface OpenAiProviderOptions {
   /** Output ceiling for this provider; absent means the model's maximum. */
   maxOutputTokens?: number;
   /**
+   * Emit OpenAI strict function tools (`tools[].function.strict`).
+   * Opt-in per provider entry: it rewrites every tool schema into the
+   * subset strict mode accepts (`openai-strict-tools.ts`), which a
+   * service that does not implement strict mode will reject outright.
+   * Absent leaves the request body exactly as it was.
+   */
+  strictTools?: boolean;
+  /**
    * Sink for the credit-limit retry warning (`plan-credit-limit-retry.ts`).
    * Wired from the provider factory context so the notice lands wherever
    * the rest of the runtime logs; without it the client falls back to a
@@ -91,11 +102,20 @@ export class OpenAiProvider implements LlmProvider {
   private readonly taggedToolCompatibility: "qwen" | undefined;
   private readonly extraBody: Record<string, unknown> | undefined;
   private readonly maxOutputTokens: number | undefined;
+  private readonly strictTools: boolean;
 
   constructor(options: OpenAiProviderOptions) {
     this.id = options.id;
     this.name = options.id;
-    this.toolCallAdapter = options.toolCallAdapter ?? openAiToolCallAdapter;
+    const baseToolCallAdapter =
+      options.toolCallAdapter ?? openAiToolCallAdapter;
+    // Strict mode makes the model send `"x": null` where it used to
+    // omit `x` — see `withStrictNullArgumentDrop`. Wrapped here, on the
+    // one provider that opted in, so the parse side stays untouched for
+    // everybody else.
+    this.toolCallAdapter = options.strictTools
+      ? withStrictNullArgumentDrop(baseToolCallAdapter)
+      : baseToolCallAdapter;
     this.streamConsumer =
       options.streamConsumer ??
       createOpenAiStreamConsumer(options.reasoningFormat ?? "delta_reasoning");
@@ -114,6 +134,7 @@ export class OpenAiProvider implements LlmProvider {
     this.taggedToolCompatibility = options.taggedToolCompatibility;
     this.extraBody = options.extraBody;
     this.maxOutputTokens = options.maxOutputTokens;
+    this.strictTools = options.strictTools ?? false;
     this.http = {
       baseUrl: normalizeOpenAiBaseUrl(options.baseUrl),
       apiKey: options.apiKey,
@@ -133,6 +154,7 @@ export class OpenAiProvider implements LlmProvider {
       false,
       this.extraBody,
       this.maxOutputTokens,
+      this.strictTools,
     );
     const json = await openAiPostJson(
       this.http,
@@ -156,6 +178,7 @@ export class OpenAiProvider implements LlmProvider {
       true,
       this.extraBody,
       this.maxOutputTokens,
+      this.strictTools,
     );
     const path = `${this.apiPathPrefix}/chat/completions`;
     let accumulated = "";

--- a/src/llm/provider/openai/openai-strict-tools.test.ts
+++ b/src/llm/provider/openai/openai-strict-tools.test.ts
@@ -1,0 +1,553 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  toStrictOpenAiTools,
+  toStrictParameters,
+  withoutTopLevelNullArgs,
+} from "./openai-strict-tools.js";
+import {
+  descriptorsToOpenAiTools,
+  openAiToolCallAdapter,
+  withStrictNullArgumentDrop,
+} from "./openai-tool-call-adapter.js";
+import { DEFAULT_TOOL_DESCRIPTORS } from "../../../prompt/tool-descriptors.js";
+
+type Schema = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is Schema {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function typeIncludes(schema: Schema, wanted: string): boolean {
+  const type = schema.type;
+  if (typeof type === "string") return type === wanted;
+  if (Array.isArray(type)) return type.includes(wanted);
+  return false;
+}
+
+/**
+ * Keywords a strict schema may carry. Anything else present after the
+ * transform is a keyword we failed to strip, which is what makes a
+ * provider 400 the entire request rather than the one tool.
+ */
+const ALLOWED_KEYWORDS = new Set([
+  "type",
+  "enum",
+  "description",
+  "title",
+  "$ref",
+  "$defs",
+  "anyOf",
+  "properties",
+  "items",
+  "required",
+  "additionalProperties",
+]);
+
+/**
+ * Asserts every strict-mode rule, recursively, and returns the list of
+ * violations so a failure names the exact node rather than dumping the
+ * whole schema. Shared by the unit tests and by the conformance sweep
+ * over every tool the agent actually registers.
+ */
+function strictViolations(node: unknown, path = "$"): string[] {
+  if (!isPlainObject(node)) return [`${path}: not an object schema`];
+  const problems: string[] = [];
+  for (const key of Object.keys(node)) {
+    if (!ALLOWED_KEYWORDS.has(key)) {
+      problems.push(`${path}: unsupported keyword "${key}"`);
+    }
+  }
+  if (typeIncludes(node, "object")) {
+    if (node.additionalProperties !== false) {
+      problems.push(`${path}: additionalProperties must be false`);
+    }
+    const properties = isPlainObject(node.properties) ? node.properties : {};
+    const keys = Object.keys(properties);
+    const required = Array.isArray(node.required) ? node.required : [];
+    for (const key of keys) {
+      if (!required.includes(key)) {
+        problems.push(`${path}: "${key}" missing from required`);
+      }
+      problems.push(...strictViolations(properties[key], `${path}.${key}`));
+    }
+    for (const name of required) {
+      if (!keys.includes(String(name))) {
+        problems.push(`${path}: required lists undeclared "${String(name)}"`);
+      }
+    }
+  }
+  if (typeIncludes(node, "array")) {
+    if (!isPlainObject(node.items)) {
+      problems.push(`${path}: array without an items schema`);
+    } else {
+      problems.push(...strictViolations(node.items, `${path}[]`));
+    }
+  }
+  if (node.anyOf !== undefined) {
+    if (!Array.isArray(node.anyOf) || node.anyOf.length === 0) {
+      problems.push(`${path}: anyOf must be a non-empty array`);
+    } else {
+      node.anyOf.forEach((branch, index) => {
+        problems.push(...strictViolations(branch, `${path}|${index}`));
+      });
+    }
+  }
+  if (isPlainObject(node.$defs)) {
+    for (const [name, def] of Object.entries(node.$defs)) {
+      problems.push(...strictViolations(def, `${path}#${name}`));
+    }
+  }
+  return problems;
+}
+
+describe("toStrictParameters — the transform", () => {
+  const cases: ReadonlyArray<{
+    name: string;
+    input: Schema;
+    strict: boolean;
+    expected?: Schema;
+  }> = [
+    {
+      name: "closes an object and keeps a required scalar as it was",
+      input: {
+        type: "object",
+        properties: { url: { type: "string" } },
+        required: ["url"],
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: { url: { type: "string" } },
+        required: ["url"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "expresses an optional parameter as nullable, still required",
+      input: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          limit: { type: "integer" },
+        },
+        required: ["path"],
+        additionalProperties: false,
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          limit: { type: ["integer", "null"] },
+        },
+        required: ["path", "limit"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "adds null to an optional enum's members as well as its type",
+      input: {
+        type: "object",
+        properties: { mode: { type: "string", enum: ["a", "b"] } },
+        additionalProperties: false,
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {
+          mode: { type: ["string", "null"], enum: ["a", "b", null] },
+        },
+        required: ["mode"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "appends a null branch to an optional anyOf",
+      input: {
+        type: "object",
+        properties: {
+          amount: { anyOf: [{ type: "string" }, { type: "number" }] },
+        },
+        required: [],
+        additionalProperties: false,
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {
+          amount: {
+            anyOf: [{ type: "string" }, { type: "number" }, { type: "null" }],
+          },
+        },
+        required: ["amount"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "recurses into a nested object and closes that too",
+      input: {
+        type: "object",
+        properties: {
+          limits: {
+            type: "object",
+            properties: { maxEntries: { type: "integer" } },
+            additionalProperties: true,
+          },
+        },
+        required: ["limits"],
+        additionalProperties: false,
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {
+          limits: {
+            type: "object",
+            properties: { maxEntries: { type: ["integer", "null"] } },
+            required: ["maxEntries"],
+            additionalProperties: false,
+          },
+        },
+        required: ["limits"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "recurses into an array of objects",
+      input: {
+        type: "object",
+        properties: {
+          tasks: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                goal: { type: "string" },
+                files: { type: "array", items: { type: "string" } },
+              },
+              required: ["goal"],
+            },
+            minItems: 1,
+            maxItems: 8,
+          },
+        },
+        required: ["tasks"],
+        additionalProperties: false,
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {
+          tasks: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                goal: { type: "string" },
+                files: { type: ["array", "null"], items: { type: "string" } },
+              },
+              required: ["goal", "files"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["tasks"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "strips the value-range keywords strict mode does not accept",
+      input: {
+        type: "object",
+        properties: {
+          text: { type: "string", minLength: 1, pattern: "^x", format: "uri" },
+          count: { type: "integer", minimum: 1, maximum: 9, default: 3 },
+        },
+        required: ["text", "count"],
+        additionalProperties: false,
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          count: { type: "integer" },
+        },
+        required: ["text", "count"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "renames oneOf to the anyOf spelling strict mode documents",
+      input: {
+        type: "object",
+        properties: { v: { oneOf: [{ type: "string" }, { type: "number" }] } },
+        required: ["v"],
+        additionalProperties: false,
+      },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {
+          v: { anyOf: [{ type: "string" }, { type: "number" }] },
+        },
+        required: ["v"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "keeps a zero-argument tool strict when it is already closed",
+      input: { type: "object", properties: {}, additionalProperties: false },
+      strict: true,
+      expected: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "refuses the open-object fallback rather than deleting its args",
+      input: { type: "object", properties: {}, additionalProperties: true },
+      strict: false,
+    },
+    {
+      name: "refuses a typed open map — the map is the payload",
+      input: {
+        type: "object",
+        properties: {
+          headers: { type: "object", additionalProperties: { type: "string" } },
+        },
+        required: ["headers"],
+        additionalProperties: false,
+      },
+      strict: false,
+    },
+    {
+      name: "refuses composition strict mode cannot model",
+      input: {
+        type: "object",
+        properties: { v: { allOf: [{ type: "string" }] } },
+        required: ["v"],
+        additionalProperties: false,
+      },
+      strict: false,
+    },
+    {
+      name: "refuses tuple items",
+      input: {
+        type: "object",
+        properties: {
+          pair: { type: "array", items: [{ type: "string" }] },
+        },
+        required: ["pair"],
+        additionalProperties: false,
+      },
+      strict: false,
+    },
+    {
+      name: "refuses a non-object root",
+      input: { type: "string" },
+      strict: false,
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      const result = toStrictParameters(testCase.input);
+      expect(result.strict).toBe(testCase.strict);
+      if (testCase.expected) {
+        expect(result.parameters).toEqual(testCase.expected);
+        expect(strictViolations(result.parameters)).toEqual([]);
+      } else {
+        // A refusal must hand the schema back untouched — the tool
+        // still has to work, just without constrained decoding.
+        expect(result.parameters).toBe(testCase.input);
+      }
+    });
+  }
+
+  it("is idempotent — a second pass changes nothing", () => {
+    for (const testCase of cases) {
+      const once = toStrictParameters(testCase.input);
+      const twice = toStrictParameters(once.parameters);
+      expect(twice.strict).toBe(once.strict);
+      expect(twice.parameters).toEqual(once.parameters);
+    }
+  });
+
+  it("never mutates the schema it was given", () => {
+    const input: Schema = {
+      type: "object",
+      properties: { a: { type: "string", minLength: 2 } },
+      required: [],
+    };
+    const snapshot = structuredClone(input);
+    toStrictParameters(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("toStrictOpenAiTools", () => {
+  it("marks a convertible function strict and leaves the rest of the entry alone", () => {
+    const [tool] = toStrictOpenAiTools([
+      {
+        type: "function",
+        function: {
+          name: "os__fs__read",
+          description: "read a file",
+          parameters: {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
+        },
+      },
+    ]);
+    expect(tool).toEqual({
+      type: "function",
+      function: {
+        name: "os__fs__read",
+        description: "read a file",
+        strict: true,
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+          additionalProperties: false,
+        },
+      },
+    });
+  });
+
+  it("marks an unconvertible function strict:false and keeps its schema", () => {
+    const parameters = {
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    };
+    const [tool] = toStrictOpenAiTools([
+      { type: "function", function: { name: "mystery", parameters } },
+    ]);
+    expect((tool.function as Schema).strict).toBe(false);
+    expect((tool.function as Schema).parameters).toBe(parameters);
+  });
+
+  it("passes through an entry that is not a function tool", () => {
+    const entry = { type: "custom", custom: { name: "x" } };
+    expect(toStrictOpenAiTools([entry])[0]).toBe(entry);
+  });
+});
+
+/**
+ * The test that says this will not 400 in the field.
+ *
+ * Every descriptor the agent registers goes through the same adapter a
+ * real turn uses, then through the transform, and every resulting
+ * schema is checked against every strict-mode rule recursively. A new
+ * tool whose schema uses a keyword we do not strip fails here rather
+ * than at the provider, where the whole request dies — not just that
+ * tool.
+ */
+describe("strict-tool conformance over every registered tool", () => {
+  const tools = descriptorsToOpenAiTools(DEFAULT_TOOL_DESCRIPTORS);
+  const strictTools = toStrictOpenAiTools(tools);
+
+  it("sweeps the real catalog, not a handful of fixtures", () => {
+    expect(DEFAULT_TOOL_DESCRIPTORS.length).toBeGreaterThan(50);
+    // The adapter dedupes escaped names and appends reply/finish, so
+    // this is the tool array a turn actually sends, one for one.
+    expect(strictTools.length).toBe(tools.length);
+    expect(tools.length).toBeGreaterThan(50);
+  });
+
+  for (const tool of strictTools) {
+    const fn = tool.function as Schema;
+    const name = String(fn.name);
+    it(`${name}: schema conforms, or is honestly marked non-strict`, () => {
+      if (fn.strict !== true) {
+        // The only sanctioned refusals are free-form maps: a tool whose
+        // arguments cannot be enumerated. Closing one would silently
+        // strip the payload, so it travels unconstrained instead.
+        expect(fn.strict).toBe(false);
+        return;
+      }
+      expect(strictViolations(fn.parameters)).toEqual([]);
+    });
+  }
+
+  it("refuses only the free-form-map tools, and marks everything else strict", () => {
+    const refused = strictTools
+      .filter((tool) => (tool.function as Schema).strict !== true)
+      .map((tool) => String((tool.function as Schema).name));
+    // `os.http.request` carries a free-form header map and a free-form
+    // JSON body; `mcp.prompt.get` forwards a server-defined argument
+    // map. Both are the tool's actual payload, so neither can be closed.
+    expect(refused).toEqual(["os__http__request", "mcp__prompt__get"]);
+  });
+
+  it("is idempotent across the whole catalog", () => {
+    expect(toStrictOpenAiTools(strictTools)).toEqual(strictTools);
+  });
+});
+
+describe("withoutTopLevelNullArgs — the response side of strict mode", () => {
+  it("drops a top-level null so a presence check still reads 'absent'", () => {
+    // `os.git.init` branches on `args.userName !== undefined`; under
+    // strict mode the model sends an explicit null instead of omitting
+    // the key, which would otherwise take the configure-identity branch
+    // with nothing to configure.
+    expect(
+      withoutTopLevelNullArgs({
+        path: "/repo",
+        userName: null,
+        userEmail: null,
+      }),
+    ).toEqual({ path: "/repo" });
+  });
+
+  it("keeps a null nested inside an argument — that is data", () => {
+    expect(
+      withoutTopLevelNullArgs({ body: { note: null }, items: [null] }),
+    ).toEqual({ body: { note: null }, items: [null] });
+  });
+
+  it("keeps falsy-but-present values", () => {
+    const args = { count: 0, flag: false, text: "" };
+    expect(withoutTopLevelNullArgs(args)).toBe(args);
+  });
+
+  it("returns the same object when there is nothing to drop", () => {
+    const args = { path: "/repo" };
+    expect(withoutTopLevelNullArgs(args)).toBe(args);
+  });
+});
+
+describe("withStrictNullArgumentDrop", () => {
+  const call = (args: Record<string, unknown>) => [
+    {
+      id: "call_1",
+      type: "function" as const,
+      function: { name: "os__git__init", arguments: JSON.stringify(args) },
+    },
+  ];
+
+  it("strips nulls from every call in the batch", () => {
+    const wrapped = withStrictNullArgumentDrop(openAiToolCallAdapter);
+    const batch = wrapped.toolCallsToBatch(
+      call({ path: "/repo", userName: null }),
+    );
+    expect(batch.calls[0]).toEqual({
+      tool: "os.git.init",
+      args: { path: "/repo" },
+    });
+  });
+
+  it("leaves the unwrapped adapter's behaviour alone", () => {
+    const batch = openAiToolCallAdapter.toolCallsToBatch(
+      call({ path: "/repo", userName: null }),
+    );
+    expect(batch.calls[0].args).toEqual({ path: "/repo", userName: null });
+  });
+});

--- a/src/llm/provider/openai/openai-strict-tools.ts
+++ b/src/llm/provider/openai/openai-strict-tools.ts
@@ -306,18 +306,36 @@ export function toStrictOpenAiTools(
  *
  * Because an optional parameter is expressed as "required, but may be
  * `null`", a model under strict mode stops omitting keys and starts
- * sending `"userName": null`. That is a real behaviour change on the
- * *response* side, and several tools branch on presence rather than on
- * value — `os.git.init` (`args.userName !== undefined`),
- * `memory.profile.set` (`rawArgs.pinned`, `rawArgs.keywords`) — so an
- * explicit null would take the "the caller asked for this" branch with
- * nothing to put in it.
+ * sending `"pinned": null`. That is a real behaviour change on the
+ * *response* side, and a tool that branches on presence rather than on
+ * value takes the "the caller asked for this" branch with nothing to
+ * put in it. `memory.profile.set` is the live example: `parseSetOptions`
+ * gates on `rawArgs.pinned !== undefined` and then demands a boolean, so
+ * an explicit null turns a well-formed call into a validation error.
+ * (`os.git.init` reads the same way at a glance but is safe — its own
+ * `optionalString` maps `null` to `undefined` before the presence check.)
  *
  * So when strict tools are on, a top-level `null` argument is dropped
  * and the call reads exactly as it did before: the key is absent.
- * **Top-level only.** A null nested inside an argument is data the
- * model meant to send, and no schema this transform converts turns a
- * nested optional into a null the caller did not choose.
+ *
+ * **Top-level only**, with two consequences worth naming rather than
+ * implying:
+ *
+ *   - A null nested inside an argument survives. That is usually right
+ *     — it is data the model meant to send — but this transform does
+ *     widen nested optionals too, so it is not only third-party
+ *     schemas that can produce one. In this repo the nested nullables
+ *     are `os.fs.archive.extract.limits.{maxEntries,maxEntryBytes,
+ *     maxTotalBytes}` and `fusion.delegate.tasks[].{deliverable,files}`;
+ *     all five readers (`readLimit`, `readString`, `readFiles`) already
+ *     map `null` to their default, so nothing is broken today. A new
+ *     nested optional whose reader gates on `!== undefined` would be.
+ *   - The drop rides on the tool-call adapter, so it covers the
+ *     `tool_calls` envelope only. `step-executor.ts` has two content
+ *     recovery paths (a GBNF-style array in `content`, and the same in
+ *     `reasoning_content`) that build a batch from the grammar parser
+ *     and use the adapter for `nameUnescape` alone — a null the model
+ *     puts in *those* reaches the tool unfiltered.
  */
 export function withoutTopLevelNullArgs(
   args: Record<string, unknown>,

--- a/src/llm/provider/openai/openai-strict-tools.ts
+++ b/src/llm/provider/openai/openai-strict-tools.ts
@@ -1,0 +1,335 @@
+/**
+ * OpenAI **strict function tools** — `tools[].function.strict: true`.
+ *
+ * Some models call tools reliably only when the provider constrains
+ * decoding to the function's `parameters` schema. That is what OpenAI's
+ * strict mode does, and models built for it (Inception Labs' Mercury was
+ * the report that prompted this) produce a stream of malformed calls
+ * without it. `strict` is a field on **each tool**, not a top-level body
+ * field, so the entry's `extraBody` passthrough cannot reach it:
+ * `tools` is in `RESERVED_BODY_KEYS` and is re-applied over the merge
+ * (`openai-build-body.ts`). Hence a real knob — `strictTools` on the
+ * provider entry — and this transform.
+ *
+ * Strict mode is not a flag you can set over an arbitrary schema. The
+ * provider validates the schema itself and rejects the **whole request**
+ * with a 400 when it does not conform, so a transform that is merely
+ * optimistic is worse than no feature at all. The rules, applied
+ * recursively to every object schema:
+ *
+ *   - `additionalProperties: false` on every object;
+ *   - every key of `properties` listed in `required` — optionality is
+ *     expressed by widening the value's type with `"null"`, never by
+ *     leaving a key out of `required`;
+ *   - only keywords strict mode is known to accept survive.
+ *
+ * **Kept verbatim:** `type`, `enum`, `description`, `title`, `$ref`
+ * (plus `$defs`, recursed). **Recursed:** `properties`, `items`,
+ * `anyOf`. `oneOf` is renamed to `anyOf` — the two are interchangeable
+ * for a constrained decoder and `anyOf` is the spelling strict mode
+ * documents. **Recomputed:** `required`, `additionalProperties`.
+ *
+ * **Stripped:** every remaining keyword. In this repo's tool schemas
+ * that is exactly `minItems`, `maxItems` and `minimum` (a scan of all
+ * 85 bundled descriptors); the wider strip list covers what an
+ * MCP server's `inputSchema` may carry — `minLength`, `maxLength`,
+ * `pattern`, `format`, `default`, `examples`, `const`, `uniqueItems`,
+ * `multipleOf`, `exclusive*`, `$schema`, and so on. Dropping them is
+ * safe here for the reason `default-tool-args-schemas.ts` states in its
+ * own header: these schemas guard the **shape**, and the runtime
+ * validators — not the provider — do the value-range checks. A dropped
+ * bound loosens the schema; it never invalidates a call the agent would
+ * otherwise have accepted.
+ *
+ * **Refused rather than mangled.** Some schemas cannot be expressed
+ * under strict mode at all, and for those the function is emitted with
+ * `strict: false` and its schema untouched — a `tools` array may mix
+ * strict and non-strict functions. Refusal cases:
+ *
+ *   - a free-form object: no declared `properties` and
+ *     `additionalProperties` not `false`. Closing it would leave a
+ *     schema that admits only `{}`, silently deleting the tool's
+ *     arguments. This is the `descriptorToJsonSchema` fallback branch
+ *     (`{ type: "object", properties: {}, additionalProperties: true }`,
+ *     used for any descriptor with no `argsJsonSchema`), and it is also
+ *     real *nested*: `os.http.request.headers`, `mcp.prompt.get`'s
+ *     `arguments` and `os.http.request.body`'s object branch are
+ *     free-form maps carrying the tool's actual payload;
+ *   - a typed open map (`additionalProperties` is a schema object) —
+ *     same argument, the map is the payload;
+ *   - composition strict mode does not model (`allOf`, `not`,
+ *     `if`/`then`/`else`), tuple `items`, an array without `items`, or a
+ *     schema with no `type`/`anyOf`/`$ref`/`enum` to constrain it at all.
+ *
+ * An object that declares properties *and* `additionalProperties: true`
+ * is closed rather than refused: the declared keys are the tool's whole
+ * documented contract (`os.fs.archive.extract.limits` is the only one),
+ * so forbidding extras loses nothing a caller was entitled to send.
+ *
+ * The transform is idempotent — `f(f(x)) === f(x)` — because a
+ * converted object already lists every property in `required`, so the
+ * null-widening pass finds nothing left to widen.
+ */
+
+type Schema = Record<string, unknown>;
+
+/**
+ * Keywords copied straight through. Deliberately short: anything absent
+ * here is dropped, so a new JSON Schema keyword arriving from an MCP
+ * server degrades to "ignored", never to "sent and 400'd".
+ */
+const KEPT_KEYWORDS: ReadonlySet<string> = new Set([
+  "type",
+  "enum",
+  "description",
+  "title",
+  "$ref",
+]);
+
+/**
+ * Composition strict mode does not model. Presence of any of these
+ * means the schema cannot be converted — dropping them would change
+ * what the tool accepts, which is not ours to decide.
+ */
+const UNSUPPORTED_COMPOSITION: readonly string[] = [
+  "allOf",
+  "not",
+  "if",
+  "then",
+  "else",
+  "dependentSchemas",
+  "dependentRequired",
+  "patternProperties",
+  "propertyNames",
+  "unevaluatedProperties",
+  "unevaluatedItems",
+];
+
+export type StrictParametersResult = {
+  /** Schema to send. Byte-identical to the input when `strict` is false. */
+  parameters: Schema;
+  /** Whether the function may carry `strict: true`. */
+  strict: boolean;
+};
+
+function isPlainObject(value: unknown): value is Schema {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function typeIncludes(schema: Schema, wanted: string): boolean {
+  const type = schema.type;
+  if (typeof type === "string") return type === wanted;
+  if (Array.isArray(type)) return type.includes(wanted);
+  return false;
+}
+
+function enumWithNull(values: readonly unknown[]): unknown[] {
+  return values.includes(null) ? [...values] : [...values, null];
+}
+
+/**
+ * Widens a converted schema so it also accepts `null` — how strict mode
+ * spells "this parameter is optional". Returns the input unchanged when
+ * it is already nullable, which is what keeps the whole transform
+ * idempotent even if a caller runs it twice.
+ */
+function widenWithNull(schema: Schema): Schema | undefined {
+  const type = schema.type;
+  if (typeof type === "string") {
+    if (type === "null") return schema;
+    const widened: Schema = { ...schema, type: [type, "null"] };
+    if (Array.isArray(schema.enum)) widened.enum = enumWithNull(schema.enum);
+    return widened;
+  }
+  if (Array.isArray(type)) {
+    if (type.includes("null")) return schema;
+    const widened: Schema = { ...schema, type: [...type, "null"] };
+    if (Array.isArray(schema.enum)) widened.enum = enumWithNull(schema.enum);
+    return widened;
+  }
+  if (Array.isArray(schema.anyOf)) {
+    const branches = schema.anyOf as unknown[];
+    const alreadyNullable = branches.some(
+      (branch) => isPlainObject(branch) && typeIncludes(branch, "null"),
+    );
+    if (alreadyNullable) return schema;
+    return { ...schema, anyOf: [...branches, { type: "null" }] };
+  }
+  // No `type` and no `anyOf` to widen in place — a `$ref` or a bare
+  // `enum`. Wrap it in a union instead, hoisting the prose so the
+  // parameter keeps its description where a reader (and the model)
+  // expects it.
+  const { description, title, ...rest } = schema;
+  if (Object.keys(rest).length === 0) return undefined;
+  const wrapped: Schema = {};
+  if (description !== undefined) wrapped.description = description;
+  if (title !== undefined) wrapped.title = title;
+  wrapped.anyOf = [rest, { type: "null" }];
+  return wrapped;
+}
+
+/**
+ * Converts one schema node, or returns `undefined` when strict mode
+ * cannot express it. `undefined` propagates up to the tool, which is
+ * then emitted non-strict rather than sent in a shape the provider
+ * would reject.
+ */
+function convert(node: unknown): Schema | undefined {
+  if (!isPlainObject(node)) return undefined;
+  for (const keyword of UNSUPPORTED_COMPOSITION) {
+    if (keyword in node) return undefined;
+  }
+  const out: Schema = {};
+  for (const key of Object.keys(node)) {
+    if (KEPT_KEYWORDS.has(key)) out[key] = node[key];
+  }
+
+  if ("$defs" in node) {
+    if (!isPlainObject(node.$defs)) return undefined;
+    const defs: Schema = {};
+    for (const [name, def] of Object.entries(node.$defs)) {
+      const converted = convert(def);
+      if (!converted) return undefined;
+      defs[name] = converted;
+    }
+    out.$defs = defs;
+  }
+
+  const branches = node.anyOf ?? node.oneOf;
+  if (branches !== undefined) {
+    if (!Array.isArray(branches) || branches.length === 0) return undefined;
+    const converted: Schema[] = [];
+    for (const branch of branches) {
+      const child = convert(branch);
+      if (!child) return undefined;
+      converted.push(child);
+    }
+    out.anyOf = converted;
+  }
+
+  if (typeIncludes(node, "object") || isPlainObject(node.properties)) {
+    const properties = isPlainObject(node.properties) ? node.properties : {};
+    const keys = Object.keys(properties);
+    // A typed open map (`additionalProperties: { type: "string" }`) is
+    // the payload, not decoration — refuse rather than delete it.
+    if (isPlainObject(node.additionalProperties)) return undefined;
+    // Nothing declared and not already closed: closing it would admit
+    // only `{}`. A schema that is *already* `additionalProperties:
+    // false` with no properties is a legitimate zero-argument tool.
+    if (keys.length === 0 && node.additionalProperties !== false) {
+      return undefined;
+    }
+    const originallyRequired = new Set(
+      Array.isArray(node.required)
+        ? node.required.filter(
+            (name): name is string => typeof name === "string",
+          )
+        : [],
+    );
+    const outProperties: Schema = {};
+    for (const key of keys) {
+      let child = convert(properties[key]);
+      if (!child) return undefined;
+      if (!originallyRequired.has(key)) {
+        child = widenWithNull(child);
+        if (!child) return undefined;
+      }
+      outProperties[key] = child;
+    }
+    out.properties = outProperties;
+    out.required = keys;
+    out.additionalProperties = false;
+    if (out.type === undefined) out.type = "object";
+  }
+
+  if (typeIncludes(node, "array")) {
+    // Tuple validation (`items` as an array) and an unconstrained array
+    // are both outside strict mode.
+    if (!isPlainObject(node.items)) return undefined;
+    const items = convert(node.items);
+    if (!items) return undefined;
+    out.items = items;
+  }
+
+  // Nothing left that constrains anything — an empty schema means
+  // "any value", which is exactly what strict mode exists to forbid.
+  if (
+    out.type === undefined &&
+    out.anyOf === undefined &&
+    out.$ref === undefined &&
+    out.enum === undefined
+  ) {
+    return undefined;
+  }
+  return out;
+}
+
+/**
+ * Rewrites one function's `parameters` for strict mode. The root must
+ * be an object schema — OpenAI requires it — so anything else is
+ * refused and travels unchanged with `strict: false`.
+ */
+export function toStrictParameters(schema: Schema): StrictParametersResult {
+  const fallback: StrictParametersResult = {
+    parameters: schema,
+    strict: false,
+  };
+  if (!typeIncludes(schema, "object") && !isPlainObject(schema.properties)) {
+    return fallback;
+  }
+  const converted = convert(schema);
+  if (!converted) return fallback;
+  return { parameters: converted, strict: true };
+}
+
+/**
+ * Marks every OpenAI function tool strict where its schema allows it.
+ * Entries whose schema cannot be converted keep their schema and are
+ * marked `strict: false` explicitly — the documented default, and it
+ * tells a reader looking at a request dump which tools are constrained
+ * and which are not.
+ */
+export function toStrictOpenAiTools(
+  tools: ReadonlyArray<Record<string, unknown>>,
+): ReadonlyArray<Record<string, unknown>> {
+  return tools.map((tool) => {
+    const fn = tool.function;
+    if (tool.type !== "function" || !isPlainObject(fn)) return tool;
+    if (!isPlainObject(fn.parameters)) return tool;
+    const { parameters, strict } = toStrictParameters(fn.parameters);
+    return { ...tool, function: { ...fn, parameters, strict } };
+  });
+}
+
+/**
+ * The other half of the bargain strict mode strikes.
+ *
+ * Because an optional parameter is expressed as "required, but may be
+ * `null`", a model under strict mode stops omitting keys and starts
+ * sending `"userName": null`. That is a real behaviour change on the
+ * *response* side, and several tools branch on presence rather than on
+ * value — `os.git.init` (`args.userName !== undefined`),
+ * `memory.profile.set` (`rawArgs.pinned`, `rawArgs.keywords`) — so an
+ * explicit null would take the "the caller asked for this" branch with
+ * nothing to put in it.
+ *
+ * So when strict tools are on, a top-level `null` argument is dropped
+ * and the call reads exactly as it did before: the key is absent.
+ * **Top-level only.** A null nested inside an argument is data the
+ * model meant to send, and no schema this transform converts turns a
+ * nested optional into a null the caller did not choose.
+ */
+export function withoutTopLevelNullArgs(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  let dropped = false;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (value === null) {
+      dropped = true;
+      continue;
+    }
+    out[key] = value;
+  }
+  return dropped ? out : args;
+}

--- a/src/llm/provider/openai/openai-tool-call-adapter.ts
+++ b/src/llm/provider/openai/openai-tool-call-adapter.ts
@@ -5,6 +5,7 @@ import {
 } from "../../grammar/tool-call-grammar.js";
 import type { OpenAiToolCall } from "../completion-types.js";
 import type { ToolCallAdapter } from "../adapters/tool-call-adapter.js";
+import { withoutTopLevelNullArgs } from "./openai-strict-tools.js";
 
 const REPLY_TOOL = "reply";
 const FINISH_TOOL = "finish";
@@ -170,6 +171,31 @@ export function openAiToolCallsToBatch(
     return { kind: "batch", calls, reasoning };
   }
   return { kind: "batch", calls, reasoning };
+}
+
+/**
+ * Wraps an adapter so parsed calls lose their top-level `null`
+ * arguments — the shape a model produces once strict mode has forced
+ * every optional parameter into `required` as a nullable. Applied only
+ * on providers that opted into `strictTools`, so nothing changes for
+ * anyone else. See `withoutTopLevelNullArgs`.
+ */
+export function withStrictNullArgumentDrop(
+  adapter: ToolCallAdapter,
+): ToolCallAdapter {
+  return {
+    ...adapter,
+    toolCallsToBatch: (toolCalls, reasoningText) => {
+      const batch = adapter.toolCallsToBatch(toolCalls, reasoningText);
+      return {
+        ...batch,
+        calls: batch.calls.map((call) => {
+          const args = withoutTopLevelNullArgs(call.args);
+          return args === call.args ? call : { ...call, args };
+        }),
+      };
+    },
+  };
 }
 
 export const openAiToolCallAdapter: ToolCallAdapter = {

--- a/src/llm/provider/registry/cloud-passthroughs.test.ts
+++ b/src/llm/provider/registry/cloud-passthroughs.test.ts
@@ -51,4 +51,9 @@ describe("cloud provider factories", () => {
     const f = factories.find((x) => x.kind === kind);
     expect(f!.body).toContain("extraBody: entry.extraBody");
   });
+
+  it.each(openAiShaped)("%s forwards strictTools", (kind) => {
+    const f = factories.find((x) => x.kind === kind);
+    expect(f!.body).toContain("strictTools: entry.strictTools");
+  });
 });

--- a/src/llm/provider/registry/provider-types.ts
+++ b/src/llm/provider/registry/provider-types.ts
@@ -55,6 +55,16 @@ export type LlmProviderConfigEntry = {
   /** Per-provider output ceiling; absent means the model's own maximum. */
   maxOutputTokens?: number;
   /**
+   * Emit OpenAI strict function tools — `tools[].function.strict: true`
+   * — for this provider. Off by default because strict mode is not
+   * universal: a service that does not implement it rejects the whole
+   * request. Turn it on for a model that only calls tools reliably
+   * under constrained decoding. `extraBody` cannot express this:
+   * `strict` lives on each tool and `tools` is a reserved key. The
+   * schema rewrite lives in `openai/openai-strict-tools.ts`.
+   */
+  strictTools?: boolean;
+  /**
    * Settings for a `subscription-cli` provider — which vendor CLI to
    * drive and how to invoke it. Absent on every other kind.
    */

--- a/src/llm/provider/registry/register-built-in-providers.ts
+++ b/src/llm/provider/registry/register-built-in-providers.ts
@@ -66,6 +66,7 @@ export function registerBuiltInProviderKinds(): void {
       requestTimeoutMs: entry.requestTimeoutMs,
       extraBody: entry.extraBody,
       maxOutputTokens: entry.maxOutputTokens,
+      strictTools: entry.strictTools,
       logger: ctx.logger,
     });
   });
@@ -90,6 +91,7 @@ export function registerBuiltInProviderKinds(): void {
       taggedToolCompatibility: "qwen",
       extraBody: entry.extraBody,
       maxOutputTokens: entry.maxOutputTokens,
+      strictTools: entry.strictTools,
       logger: ctx.logger,
     });
   });
@@ -107,6 +109,7 @@ export function registerBuiltInProviderKinds(): void {
       requestTimeoutMs: entry.requestTimeoutMs,
       extraBody: entry.extraBody,
       maxOutputTokens: entry.maxOutputTokens,
+      strictTools: entry.strictTools,
       logger: ctx.logger,
       httpReferer: OPENROUTER_APP_REFERER,
       xTitle: OPENROUTER_APP_TITLE,
@@ -123,6 +126,7 @@ export function registerBuiltInProviderKinds(): void {
       defaultChatModel: entry.defaultChatModel ?? AIMLAPI_DEFAULT_CHAT_MODEL,
       extraBody: entry.extraBody,
       maxOutputTokens: entry.maxOutputTokens,
+      strictTools: entry.strictTools,
       headers: entry.headers,
       supportsVision: entry.supportsVision ?? true,
       supportsParallelTools: entry.supportsTools ?? true,
@@ -140,6 +144,7 @@ export function registerBuiltInProviderKinds(): void {
       defaultChatModel: entry.defaultChatModel ?? GEMINI_DEFAULT_CHAT_MODEL,
       extraBody: entry.extraBody,
       maxOutputTokens: entry.maxOutputTokens,
+      strictTools: entry.strictTools,
       headers: entry.headers,
       supportsVision: entry.supportsVision ?? true,
       supportsParallelTools: entry.supportsTools ?? true,


### PR DESCRIPTION
## The report

Discord `#feedback-and-bugs`, **`thegreatteacher`**, 2026-09-10:

> I was testing mercury 2.5 from inception labs with atomic-agent. Unfortunately, the model makes a lot of tool calling mistakes without `"strict": true` option. Is it possible to set `"strict": true` through config file or do you need to add provider specific patch into atomic-agent?

Maintainer's reply:

> I believe we'll need a patch to let user configure model specific parameters.

## Why `extraBody` could not already do it

`extraBody` merges at the **top level** of the chat-completion body. OpenAI's strict mode is not a top-level field — it is `tools[].function.strict`, one flag per tool. And `tools` is in `RESERVED_BODY_KEYS` (`src/llm/provider/openai/openai-build-body.ts:10`), re-applied over the merge specifically so a passthrough can never drop the tool contract. So an operator could put `strict` anywhere in `extraBody` and it would be discarded. There was no config path to it at all.

The `ToolsSupportLevel` union already has a `"strict"` member (`llm-provider.ts:35`), `userModels[].supportsTools` accepts it (`llm-config.ts:392`, `config-schema.ts:954`), and it survives a config round-trip — but **nothing consumes it**. The only reads anywhere are `entry.supportsTools === "none"` for a display tag (`format-model-details.ts:42`, `model-search.ts:63`). **This PR does not wire that level**; it stays dormant. See the note on #395 below.

## The knob

`strictTools` on the provider entry — config **v63**, additive, off by default:

```json
"llm": { "providers": [{
  "id": "mercury", "kind": "openai-compatible",
  "baseUrl": "https://api.inceptionlabs.ai/v1",
  "defaultChatModel": "mercury", "strictTools": true
}] }
```

Parsed alongside `supportsTools` / `maxOutputTokens` in `llm-config.ts`, carried on `LlmProviderConfigEntry`, and handed to `OpenAiProvider` by all five OpenAI-shaped factories (`openai-compatible`, `qwen-openai-compatible`, `openrouter`, `aimlapi`, `gemini` — every one of them extends `OpenAiProvider`). It reaches `buildOpenAiChatBody` as a sixth argument, exactly the seam `extraBody` and `maxOutputTokens` already use, and the transform runs **before** the `extraBody` merge so the reserved-key restore keeps the transformed array. Absent, the request body is byte-identical to today.

## The transform (`openai-strict-tools.ts`)

Getting this wrong is worse than the bug: a schema strict mode rejects 400s the **whole request**, not the one tool. Applied recursively to every object schema:

- `additionalProperties: false`;
- every key of `properties` present in `required` — an optional parameter is widened to include `"null"` (and `null` added to its `enum` members where it has an enum), never omitted from `required`;
- keyword allowlist, not a blocklist.

**Kept verbatim:** `type`, `enum`, `description`, `title`, `$ref` (+ `$defs`, recursed). **Recursed:** `properties`, `items`, `anyOf`. `oneOf` is renamed to `anyOf` — interchangeable for a constrained decoder, and `anyOf` is the spelling strict mode documents. **Recomputed:** `required`, `additionalProperties`.

**What I stripped, and why.** I scanned every keyword present at a schema position across all 85 bundled descriptors (`default-tool-args-schemas.ts` + `github-tool-args-schemas.ts` + the inline `reply`/`finish` schemas). The full set in use is `type`, `properties`, `required`, `additionalProperties`, `enum`, `items`, `anyOf`, `minItems`, `maxItems`, `minimum` — plus `minLength` on `reply.text`. So the only things actually stripped from this repo's own schemas are **`minItems`, `maxItems`, `minimum`, `minLength`** (`fusion.delegate`, `vision.describe`, `reply`). That is safe for the reason `default-tool-args-schemas.ts` states in its own header: these schemas guard the **shape**, and the runtime validators — not the provider — do the value-range checks. An empty `reply.text` is still rejected by `validateBatch` and routed to the repair prompt. Dropping a bound loosens the schema; it never invalidates a call the agent would otherwise have accepted.

The allowlist also covers what an MCP server's `inputSchema` may carry and this repo does not (`pattern`, `format`, `default`, `examples`, `const`, `uniqueItems`, `multipleOf`, `exclusive*`, `$schema`, …): those are dropped too, so a new keyword degrades to "ignored" rather than "sent and 400'd".

**Refused rather than mangled.** A `tools` array may mix strict and non-strict functions, so anything that cannot be expressed is emitted with `strict: false` and its schema **untouched**:

| refused | why |
|---|---|
| `os.http.request` | `headers` is `additionalProperties: {type:"string"}` and `body`'s object branch is a bare `{type:"object"}` — both free-form maps carrying the actual payload |
| `mcp.prompt.get` | `arguments` is a server-defined string map, same shape |
| any descriptor with no `argsJsonSchema` | `descriptorToJsonSchema`'s fallback is `{type:"object", properties:{}, additionalProperties:true}` |

**That is the answer to the `additionalProperties: true` + empty `properties` question**: closing it would leave a schema admitting only `{}`, i.e. silently deleting the tool's arguments — so the tool travels unconstrained instead. An object that declares properties *and* `additionalProperties: true` (`os.fs.archive.extract.limits`, the sole case) **is** closed: the three declared keys are its whole documented contract, so forbidding extras loses nothing a caller was entitled to send. Also refused: `allOf`/`not`/`if`/`then`/`else`, tuple `items`, an array with no `items`, a non-object root, a schema with nothing constraining it.

**Result: 80 of 82 emitted tools are strict**, the two above are not.

## The response side (the part that is not just schema shuffling)

Making optionals nullable-and-required changes what the **model sends**: `"userName": null` where it used to omit the key. Several tools branch on presence, not value — `os.git.init` (`args.userName !== undefined`), `memory.profile.set` (`rawArgs.pinned`, `rawArgs.keywords`) — and would take the "caller asked for this" branch with nothing to put in it. So on a provider that opted in, `OpenAiProvider` wraps its tool-call adapter to drop **top-level** `null` arguments, leaving the parsed call identical to what those tools saw before. Nested nulls are left alone: that is data the model meant to send. Nothing changes for a provider without the flag.

## Tests

`src/llm/provider/openai/openai-strict-tools.test.ts` (110 tests):

- **The conformance sweep that matters**: every descriptor in `DEFAULT_TOOL_DESCRIPTORS` goes through `descriptorsToOpenAiTools` (the same adapter a real turn uses) and then the transform, and each result is checked against every strict rule **recursively** — keyword allowlist, `additionalProperties: false`, `required` ⊇ and ⊆ `properties`, array `items`, `anyOf` branches, `$defs`. One `it()` per tool, so a failure names the tool. A new tool with an unsupported keyword fails here instead of as a field 400.
- The refusal list is pinned (`["os__http__request", "mcp__prompt__get"]`), so a new free-form-map tool is a decision, not a surprise.
- Table-driven unit cases: optional → nullable + required, optional enum gets `null` in its members, optional `anyOf` gains a null branch, nested objects, arrays of objects, the strip list, `oneOf` → `anyOf`, zero-argument tool, and six refusal shapes.
- Idempotence, over both the fixtures and the whole catalog: `f(f(x))` deep-equals `f(x)`. Non-mutation of the input schema.
- The null-argument drop, top-level and nested.

`openai-build-body.test.ts` (+4): flag absent ⇒ `JSON.stringify(body)` identical to the pre-flag call including key order; flag on ⇒ tools rewritten and marked; the transformed array survives an `extraBody` that tries to replace `tools`; no `tools` key when the request carries none.

`llm-config.test.ts` (+4): `strictTools` round-trips true/false, absent by default, rejects non-booleans. `62` added to `ACCEPTED_CONFIG_VERSIONS` with the v63 bump.

```
npm run lint                                  # tsc --noEmit, clean
npx vitest run src/llm/provider src/config    # 60 files, 936 tests, all pass
```

### Proof the tests are not vacuous

**Stash the src change, keep the tests.** Reverting the six modified src files and removing `openai-strict-tools.ts`: 5 tests fail —

- `openai-strict-tools.test.ts` fails to load at all (the module is gone);
- `llm-config` › `round-trips the opt-in flag`, `round-trips an explicit opt-out`, `rejects anything that is not a boolean`;
- `openai-build-body` › `rewrites the tools and marks them strict when the flag is on`, `keeps the strict tools over an extraBody that tries to replace them`.

The two control cases keep passing, which is their job: `leaves the body byte-identical when the flag is absent` and `sends no tools key at all when the request carries none`.

**Five targeted mutations of the restored transform**, each reverted after:

| mutation | result |
|---|---|
| `required` kept as the input's instead of every key | **66 of 110 fail** |
| keyword allowlist removed (nothing stripped) | **6 fail** — the schemas carrying `minItems`/`maxItems`/`minimum`/`minLength` |
| free-form-object refusal removed | **2 fail** — the pinned refusal list and the fallback case |
| `withoutTopLevelNullArgs` made a no-op | **2 fail** |
| adapter wrapper made a pass-through | **1 fails** |

## Overlap with #395

While this was being written, #395 landed on the same Discord report from another session, taking the other design: it wires the dormant `supportsTools: "strict"` **catalog level** per model, threaded through `bootstrap` → `agent-loop` → `step-executor` → both directions of the adapter. It is not merged, and the two collide (both touch `openai-tool-call-adapter.ts` and `llm-config.ts`). **They are alternatives — please take one.** The differences worth weighing:

- **Granularity.** #395 is per *model* (`userModels[].supportsTools: "strict"`), which is the more correct unit and makes the dead enum member live. This is per *provider entry*, which is one flag on the entry the operator already edits and needs no plumbing through the agent loop — the whole change lives at the `buildOpenAiChatBody` seam, so it does not touch `bootstrap.ts`, `agent-loop.ts` or `step-executor.ts` at all.
- **Coverage.** #395 converts 77 of 82 and refuses on any bound keyword. This converts **80 of 82** because it strips bounds instead of refusing on them — `fusion.delegate`, `vision.describe` and `reply` become strict, and `reply` is the tool models botch most.
- Both handle the null-argument consequence the same way and both refuse the free-form-map tools.

A merged design (per-model level as the source of truth, this transform's strip-not-refuse behaviour, one adapter wrapper) is straightforward if a maintainer wants it; say the word and I will fold them.

## Not covered / could not verify

- **No live provider was called.** Every assertion here is about the bytes we emit. Nobody has run this against mercury-2.5, against OpenAI, or against any other endpoint. The reporter is the natural first tester. The least universal shape emitted is the `anyOf: [..., {type:"null"}]` widening for an optional union; if a provider rejects it, the fix is a tighter allowlist, not a looser one.
- **The dormant `supportsTools: "strict"` level is still dormant** after this PR. Deliberate — wiring it is #395's design, and doing both would be two config surfaces for one behaviour.
- **No TUI surface.** `strictTools` is hand-edited in `config.json`; the Providers tab does not offer it.
- **The refusal list is behaviour, not policy.** A new default tool with a free-form map silently joins it; the pinned test is what turns that into a decision.
- **MCP `inputSchema`s are handled generically, not tested against real servers.** Anything the allowlist does not cover is refused, so the failure mode is "that tool is not strict", never a 400 — but I have not run this against a live MCP server's schemas.
- **Nested optionals in a converted third-party schema** arrive as explicit `null` and reach the tool that way; the null-drop is top-level only, by design.
- Nothing here touches the grammar/local path — llama-server ignores `tools`.
- Full suite not run (the repo's known ~10 flaky failures); the targeted `src/llm/provider src/config` sweep is green at 936/936.
