### PR TITLE
feat(fusion): two slots, either kind — pick who orchestrates and who executes

### DIFF
--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -76,6 +76,13 @@ export interface AgentLoopDependencies {
    * gate uses for `approvalRequired`.
    */
   isPlanMode?: () => boolean;
+  /**
+   * Whether the run mode resolves to fusion right now. Read per turn,
+   * for the reason `isPlanMode` is read per call: the operator can flip
+   * the mode between turns and the next turn should honour it. Absent
+   * (embedders, tests) means "not fusion", which gates nothing.
+   */
+  isFusionMode?: () => boolean;
   slotManager: SlotManager;
   grammar: string;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
@@ -838,6 +845,14 @@ export class AgentLoop {
       }
     }
 
+    // Fusion's division of labour is per TURN, not per session: each
+    // turn starts owing a plan and a fan-out before it may write. An
+    // ephemeral turn is a worker's own — the gate is the orchestrator's
+    // and must never close on the hands it is meant to free.
+    const fusionOrchestratorTurn =
+      (this.deps.isFusionMode?.() ?? false) && options.ephemeral !== true;
+    let fusionDelegatedThisTurn = false;
+
     let reason: AgentLoopReason = "max_steps";
     let stepsTaken = 0;
     let runError: Error | null = null;
@@ -1105,6 +1120,15 @@ export class AgentLoop {
             registry: this.deps.registry,
             ...(this.deps.isPlanMode
               ? { isPlanMode: this.deps.isPlanMode }
+              : {}),
+            ...(fusionOrchestratorTurn
+              ? {
+                  isFusionOrchestrator: () => true,
+                  hasDelegated: () => fusionDelegatedThisTurn,
+                  onDelegated: () => {
+                    fusionDelegatedThisTurn = true;
+                  },
+                }
               : {}),
             slotManager: this.deps.slotManager,
             grammar: activeGrammar,

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -1170,3 +1170,92 @@ describe("test-repeat gate (issue #118)", () => {
     ).toBeUndefined();
   });
 });
+
+describe("the fusion orchestrator gate in the executor", () => {
+  const ctrl = new AbortController();
+
+  it("fills a held-back mutation's slot instead of dispatching it", async () => {
+    // The refusal has to arrive as this call's RESULT: the model reads
+    // tool results, not runtime state, and a dropped call would leave it
+    // waiting for an answer that never comes.
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    const out = await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => false,
+      },
+    );
+    expect(run).not.toHaveBeenCalled();
+    expect(out.results[0]?.compressed?.status).toBe("error");
+    expect(out.results[0]?.compressed?.summary).toContain("fusion.delegate");
+  });
+
+  it("dispatches the same call once the turn has delegated", async () => {
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => true,
+      },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves reads alone while the turn is still planning", async () => {
+    const run = vi.fn(async () => okResult("os.fs.read"));
+    const registry = buildRegistry({ "os.fs.read": run }, true);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.read", args: { path: "a" } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => false,
+      },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the turn as delegated when the fan-out comes back", async () => {
+    // However it went: a fan-out whose workers all failed still leaves
+    // the orchestrator holding results it must be able to act on.
+    let delegated = false;
+    const registry = buildRegistry(
+      { "fusion.delegate": async () => okResult("fusion.delegate") },
+      false,
+    );
+    await executeBatch(
+      toBatchInputs([{ tool: "fusion.delegate", args: { tasks: [] } }]),
+      registry,
+      {
+        ...ctx(ctrl.signal),
+        isFusionOrchestrator: () => true,
+        hasDelegated: () => delegated,
+        onDelegated: () => {
+          delegated = true;
+        },
+      },
+    );
+    expect(delegated).toBe(true);
+  });
+
+  it("gates nothing when the turn is not the orchestrator's", async () => {
+    // A worker's own turn, and every non-fusion run mode.
+    const run = vi.fn(async () => okResult("os.fs.write"));
+    const registry = buildRegistry({ "os.fs.write": run }, false);
+    await executeBatch(
+      toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
+      registry,
+      { ...ctx(ctrl.signal), isFusionOrchestrator: () => false },
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -1,4 +1,5 @@
 import { checkPlanMode } from "./plan-mode.js";
+import { checkFusionOrchestrator } from "./fusion-orchestrator-mode.js";
 import type { ToolCallPayload } from "../llm/grammar/tool-call-grammar.js";
 import {
   compressToolResult,
@@ -127,6 +128,17 @@ export interface BatchExecutionContext {
    * the operator flips it mid-session. Absent ⇒ plan mode is off.
    */
   isPlanMode?: () => boolean;
+  /**
+   * True while this turn is the ORCHESTRATOR's turn in fusion mode (not
+   * a worker's, not another run mode). When it is, mutations are held
+   * back until the turn has fanned work out at least once — see
+   * `fusion-orchestrator-mode.ts`.
+   */
+  isFusionOrchestrator?: () => boolean;
+  /** Whether this turn has already completed a `fusion.delegate` call. */
+  hasDelegated?: () => boolean;
+  /** Called once a `fusion.delegate` call comes back, however it went. */
+  onDelegated?: () => void;
   /**
    * Names of skills already present in `SessionState.loadedSkills`. A
    * `skill.view` call targeting one of these is short-circuited with a
@@ -291,6 +303,25 @@ export async function executeBatch(
       });
       continue;
     }
+    // Then fusion's division of labour, for the same reason in the same
+    // order: a mutation held back until the turn has delegated must not
+    // spend a slot in the loop tracker either.
+    const fusion = runFusionOrchestratorGate(input, registry, ctx);
+    if (!fusion.proceed && fusion.vetoResult) {
+      ctx.onCallStarted?.({ batchIndex: input.batchIndex, batchSize });
+      slots[input.batchIndex] = {
+        ...slots[input.batchIndex]!,
+        compressed: fusion.vetoResult,
+        durationMs: 0,
+      };
+      ctx.onCallFinished?.({
+        batchIndex: input.batchIndex,
+        batchSize,
+        result: fusion.vetoResult,
+        durationMs: 0,
+      });
+      continue;
+    }
     const gate = runSyncLoopGate(input, ctx, loopSignals);
     if (!gate.proceed && gate.vetoResult) {
       ctx.onCallStarted?.({ batchIndex: input.batchIndex, batchSize });
@@ -384,6 +415,10 @@ export async function executeBatch(
       compressed,
       durationMs,
     };
+    // A fan-out that came back — whatever the workers made of it — opens
+    // the orchestrator's own write gate for the rest of the turn, so it
+    // can merge what it got and run the parts workers had to hand up.
+    if (input.call.tool === "fusion.delegate") ctx.onDelegated?.();
     // Record the real outcome so the next step's gate sees a completed
     // (args + result) entry. Terminal verbs are not tracked.
     if (ctx.tracker && input.resourceClass !== "terminal") {
@@ -542,6 +577,25 @@ function runPlanModeGate(
 ): { proceed: boolean; vetoResult?: CompressedToolResult } {
   if (!ctx.isPlanMode?.()) return { proceed: true };
   const verdict = checkPlanMode(input.call.tool, registry);
+  if (verdict.allowed) return { proceed: true };
+  return { proceed: false, vetoResult: verdict.refusal! };
+}
+
+/**
+ * Fusion's division of labour. Sits beside the plan-mode gate because it
+ * answers the same kind of question — is this call going to run at all —
+ * and it runs after it: plan mode is the operator's explicit "not yet",
+ * and that outranks a mode's internal shape.
+ */
+function runFusionOrchestratorGate(
+  input: BatchCallInput,
+  registry: ToolRegistry,
+  ctx: BatchExecutionContext,
+): { proceed: boolean; vetoResult?: CompressedToolResult } {
+  if (!ctx.isFusionOrchestrator?.()) return { proceed: true };
+  const verdict = checkFusionOrchestrator(input.call.tool, registry, {
+    delegated: ctx.hasDelegated?.() ?? false,
+  });
   if (verdict.allowed) return { proceed: true };
   return { proceed: false, vetoResult: verdict.refusal! };
 }

--- a/src/agent/fusion-orchestrator-mode.test.ts
+++ b/src/agent/fusion-orchestrator-mode.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkFusionOrchestrator,
+  refusalFor,
+} from "./fusion-orchestrator-mode.js";
+
+/** The two facts the gate reads off a tool: does it exist, does it mutate. */
+function registryWith(
+  tools: Record<string, { readonly: boolean }>,
+): { get: (n: string) => { readonly: boolean }; has: (n: string) => boolean } {
+  return {
+    has: (name) => name in tools,
+    get: (name) => {
+      const tool = tools[name];
+      if (!tool) throw new Error(`unknown tool ${name}`);
+      return tool;
+    },
+  };
+}
+
+const REGISTRY = registryWith({
+  "os.fs.read": { readonly: true },
+  "os.fs.write": { readonly: false },
+  "os.shell.run": { readonly: false },
+  "fusion.delegate": { readonly: false },
+  reply: { readonly: false },
+  finish: { readonly: false },
+});
+
+const BEFORE = { delegated: false };
+const AFTER = { delegated: true };
+
+describe("the fusion orchestrator gate", () => {
+  it("lets the orchestrator read while it is still planning", () => {
+    // Planning *is* reading: a gate that blocked it would leave the
+    // model choosing a split it has no basis for.
+    expect(checkFusionOrchestrator("os.fs.read", REGISTRY, BEFORE).allowed).toBe(
+      true,
+    );
+  });
+
+  it("holds back the first mutation until the turn has delegated", () => {
+    for (const tool of ["os.fs.write", "os.shell.run"]) {
+      const verdict = checkFusionOrchestrator(tool, REGISTRY, BEFORE);
+      expect(verdict.allowed).toBe(false);
+      expect(verdict.refusal?.status).toBe("error");
+      // The exit matters more than the veto: a bare refusal reads as a
+      // broken tool and gets retried.
+      expect(verdict.refusal?.summary).toContain("fusion.delegate");
+      expect(verdict.refusal?.details).toMatchObject({
+        fusion_orchestrator: true,
+        delegated: false,
+      });
+    }
+  });
+
+  it("never gates the fan-out itself", () => {
+    // The one call the refusal points at cannot be the one it blocks.
+    expect(
+      checkFusionOrchestrator("fusion.delegate", REGISTRY, BEFORE).allowed,
+    ).toBe(true);
+  });
+
+  it("never gates the terminal verbs", () => {
+    // Vetoing `reply` would veto the turn's own exit — the mistake
+    // plan mode documents and avoids for the same reason.
+    for (const tool of ["reply", "finish"]) {
+      expect(checkFusionOrchestrator(tool, REGISTRY, BEFORE).allowed).toBe(true);
+    }
+  });
+
+  it("opens up once the workers have reported", () => {
+    // Integration is the orchestrator's own job, and so is anything a
+    // worker had to hand up for approval. Both are writes.
+    for (const tool of ["os.fs.write", "os.shell.run"]) {
+      expect(checkFusionOrchestrator(tool, REGISTRY, AFTER).allowed).toBe(true);
+    }
+  });
+
+  it("passes an unknown tool through untouched", () => {
+    // The executor's unknown-tool path has the better message, and
+    // answering "delegate first" to a typo sends the model hunting for
+    // the wrong problem.
+    expect(
+      checkFusionOrchestrator("os.fs.wirte", REGISTRY, BEFORE).allowed,
+    ).toBe(true);
+  });
+
+  it("names the tool it refused", () => {
+    const refusal = refusalFor("os.fs.write");
+    expect(refusal.tool).toBe("os.fs.write");
+    expect(refusal.summary).toContain("`os.fs.write`");
+  });
+});

--- a/src/agent/fusion-orchestrator-mode.ts
+++ b/src/agent/fusion-orchestrator-mode.ts
@@ -1,0 +1,106 @@
+import type { CompressedToolResult } from "../compressor/result-compressor.js";
+import type { ToolRegistry } from "../tools/tool-registry.js";
+
+/**
+ * Fusion's division of labour, enforced instead of merely asked for.
+ *
+ * In fusion mode the expensive cloud model is the orchestrator and the
+ * local ones are the hands: it decides the approach, splits the work,
+ * writes a self-contained brief per worker, reads what comes back,
+ * integrates it, and sends rework back out. The `### fusion` block has
+ * said so since the mode shipped — and a capable cloud model, handed a
+ * catalog of forty tools, still reads the twelve files itself and never
+ * fans anything out. Advice does not hold against that; the model is
+ * doing what it is good at.
+ *
+ * So the first mutation of a fusion turn is refused until the turn has
+ * delegated at least once. Read the code, plan, then send the doing to
+ * the workers.
+ *
+ * **Why a refusal and not a hidden descriptor.** Removing tools from the
+ * catalog mid-turn rewrites the stable prefix and drops the session's KV
+ * cache (see `effectiveToolDescriptors` in bootstrap). A refusal costs
+ * one tool result and reads as an instruction — the same trade plan mode
+ * makes, and the same one `fusion.delegate` already makes when a worker
+ * calls it.
+ *
+ * **Why it lifts after the first fan-out.** Two things genuinely belong
+ * to the orchestrator afterwards: integration — merging what came back,
+ * which is a write it must be able to make — and anything a worker
+ * handed up because it needed approval, which workers cannot request
+ * (`FUSION_WORKER_APPROVAL_REFUSED`). Keeping the gate closed for the
+ * whole turn would strand both. Rework goes back to the workers because
+ * the guidance says so; that part stays advice, because "this write is
+ * rework rather than integration" is not a thing the runtime can see.
+ *
+ * **What is never gated:** read-only tools (planning *is* reading),
+ * `fusion.delegate` itself, and the terminal verbs — vetoing `reply`
+ * would veto the turn's exit.
+ */
+
+/** Terminal verbs, never gated. Mirrors `plan-mode.ts`, deliberately. */
+const TERMINAL_TOOLS: ReadonlySet<string> = new Set(["reply", "finish"]);
+
+/** The fan-out itself: the one call this gate exists to steer towards. */
+const DELEGATE_TOOL = "fusion.delegate";
+
+export interface FusionOrchestratorVerdict {
+  /** False when the call must not reach the registry. */
+  allowed: boolean;
+  /** The result to fill the call's slot with. Present iff `allowed` is false. */
+  refusal?: CompressedToolResult;
+}
+
+export interface FusionOrchestratorState {
+  /** Whether this turn has already completed a `fusion.delegate` call. */
+  delegated: boolean;
+}
+
+/**
+ * Decide whether `tool` may run on the orchestrator's own turn.
+ *
+ * An unknown tool is allowed through untouched, for the reason plan mode
+ * does the same: the step executor's unknown-tool path has the better
+ * message, and answering "delegate first" to a typo sends the model
+ * looking for the wrong problem.
+ */
+export function checkFusionOrchestrator(
+  tool: string,
+  registry: Pick<ToolRegistry, "get" | "has">,
+  state: FusionOrchestratorState,
+): FusionOrchestratorVerdict {
+  if (state.delegated) return { allowed: true };
+  if (TERMINAL_TOOLS.has(tool) || tool === DELEGATE_TOOL) {
+    return { allowed: true };
+  }
+  if (!registry.has(tool)) return { allowed: true };
+  if (registry.get(tool).readonly) return { allowed: true };
+  return { allowed: false, refusal: refusalFor(tool) };
+}
+
+/**
+ * What the model is told.
+ *
+ * Same three parts plan mode's refusal has, in the same order: the call
+ * did not happen, why, and the exit. The exit is the whole point — a
+ * bare "not permitted" reads as a broken tool and gets retried, while
+ * naming the shape of the brief turns the refusal into the instruction
+ * the orchestrator needed in the first place.
+ */
+export function refusalFor(tool: string): CompressedToolResult {
+  return {
+    tool,
+    status: "error",
+    summary:
+      `fusion is on and this turn has not delegated yet, so \`${tool}\` ` +
+      `was not run. You are the orchestrator: the local workers do the ` +
+      `doing. Finish reading (every read-only tool still works), decide ` +
+      `the approach, then split the work and call \`fusion.delegate\` ` +
+      `— one task per independent part, each with the exact paths, what ` +
+      `counts as done, and the answer format you want back. Once the ` +
+      `workers report, you can write again: merge their results, and ` +
+      `send rework back out rather than doing it yourself.`,
+    details: { fusion_orchestrator: true, tool, delegated: false },
+    truncated: false,
+  };
+}

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -158,6 +158,15 @@ export interface StepDependencies {
    * as `BatchExecutionContext.isPlanMode`. Absent ⇒ off.
    */
   isPlanMode?: () => boolean;
+  /**
+   * Fusion's division of labour, forwarded to the batch context. Set by
+   * the loop only for an ORCHESTRATOR turn in fusion mode; a worker's
+   * own turn and every other run mode leave all three absent, which
+   * gates nothing.
+   */
+  isFusionOrchestrator?: () => boolean;
+  hasDelegated?: () => boolean;
+  onDelegated?: () => void;
   slotManager: SlotManager;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
   /**
@@ -1028,6 +1037,13 @@ async function executeStepInner(
     signal: ctx.signal,
     ...(deps.tracker ? { tracker: deps.tracker } : {}),
     ...(deps.isPlanMode ? { isPlanMode: deps.isPlanMode } : {}),
+    ...(deps.isFusionOrchestrator
+      ? {
+          isFusionOrchestrator: deps.isFusionOrchestrator,
+          ...(deps.hasDelegated ? { hasDelegated: deps.hasDelegated } : {}),
+          ...(deps.onDelegated ? { onDelegated: deps.onDelegated } : {}),
+        }
+      : {}),
     ...(batch.maxWaveSize !== undefined
       ? { maxWaveSize: batch.maxWaveSize }
       : {}),

--- a/src/config/config-schema.test.ts
+++ b/src/config/config-schema.test.ts
@@ -905,21 +905,49 @@ describe("parseUserConfigFile", () => {
     expect(parsed.localModels.managed.tensorSplit).toEqual([3, 1]);
   });
 
-  it("defaults localModels.managed.parallel to 2 (the pre-v52 hard-coded slot count)", () => {
+  it("defaults localModels.managed.parallel to auto (the machine decides)", () => {
+    // v63: the slot count stopped being an operator setting. `"auto"`
+    // resolves against the context the daemon actually launches with.
     expect(
       parseUserConfigFile({ version: USER_CONFIG_VERSION }).localModels.managed
         .parallel,
-    ).toBe(2);
-    expect(USER_CONFIG_DEFAULTS.localModels.managed.parallel).toBe(2);
+    ).toBe("auto");
+    expect(USER_CONFIG_DEFAULTS.localModels.managed.parallel).toBe("auto");
   });
 
-  it("migrates a v51 file by filling localModels.managed.parallel=2", () => {
+  it("reads a pre-v63 file's unchosen 2 as auto, and any other number as a pin", () => {
+    // Every pre-v63 file carries a `parallel` the schema wrote, not the
+    // operator. Reading the old default as a deliberate choice would
+    // freeze every existing install at two workers forever — the exact
+    // setting this version exists to stop asking about.
+    expect(
+      parseUserConfigFile({
+        version: 62,
+        localModels: { managed: { parallel: 2 } },
+      }).localModels.managed.parallel,
+    ).toBe("auto");
+    expect(
+      parseUserConfigFile({
+        version: 62,
+        localModels: { managed: { parallel: 6 } },
+      }).localModels.managed.parallel,
+    ).toBe(6);
+    // At v63 the operator's own 2 is theirs, and stays.
+    expect(
+      parseUserConfigFile({
+        version: USER_CONFIG_VERSION,
+        localModels: { managed: { parallel: 2 } },
+      }).localModels.managed.parallel,
+    ).toBe(2);
+  });
+
+  it("migrates a v51 file by filling localModels.managed.parallel=auto", () => {
     const parsed = parseUserConfigFile({
       version: 51,
       localModels: { managed: { port: 19091 } },
     });
     expect(parsed.version).toBe(USER_CONFIG_VERSION);
-    expect(parsed.localModels.managed.parallel).toBe(2);
+    expect(parsed.localModels.managed.parallel).toBe("auto");
   });
 
   it("keeps an explicit localModels.managed.parallel and bounds it to 1..8", () => {

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -1267,12 +1267,19 @@ export interface UserManagedLocalLlmConfig {
   tensorSplit: number[];
   /**
    * llama-server request slots (`--parallel`) for the managed chat
-   * daemon, 1..8. Default `2` — the value that was hard-coded before
-   * config v52, so older files launch byte-identically. Fusion workers
-   * run one per slot; raising this is what lets them run concurrently
-   * instead of queueing on the server. Applied on the next daemon start.
+   * daemon: `"auto"` (the default since config v63) or a pinned 1..8.
+   *
+   * Fusion workers run one per slot, so this is the ceiling on how many
+   * of them run at once rather than queueing. `"auto"` derives it from
+   * the context the daemon is launched with — llama.cpp divides that
+   * context between the slots, and a slot smaller than a worker's own
+   * prompt cannot serve one (see `worker-slots.ts`). That makes the
+   * number a property of the machine, which is the party that knows it.
+   *
+   * A pinned number is honoured as written: an external server, an
+   * unusual model, a benchmark. Applied on the next daemon start.
    */
-  parallel: number;
+  parallel: number | "auto";
   /**
    * Stop the managed chat daemon when the last CLI session exits.
    * `true` (default) — closing the terminal frees the RAM/VRAM the
@@ -2067,7 +2074,13 @@ export interface UserConfigFile {
 // closed by default — `remoteSync: false` refuses every network git verb
 // so a repository the agent versions stays on this machine; the GitHub
 // token lives in `<stateDir>/.env`, never here.
-export const USER_CONFIG_VERSION = 62;
+// v63: `localModels.managed.parallel` accepts `"auto"` and defaults to
+// it — the slot count is derived from the context the daemon launches
+// with instead of being an operator setting. A pre-v63 file whose value
+// is the old default `2` (which nobody chose — it was the schema's)
+// becomes `"auto"`; any other number is read as a deliberate pin and
+// kept.
+export const USER_CONFIG_VERSION = 63;
 
 /**
  * Config v21+ flips the full memory-v2 fabric on by default. Upgrades
@@ -2218,6 +2231,7 @@ const SUPPORTED_INPUT_VERSIONS: readonly number[] = [
   59,
   60,
   61,
+  62,
   USER_CONFIG_VERSION,
 ];
 
@@ -2237,7 +2251,7 @@ export const USER_CONFIG_DEFAULTS: UserConfigFile = {
       backendVariant: "auto",
       contextSize: 0,
       tensorSplit: [],
-      parallel: 2,
+      parallel: "auto",
     },
     embeddings: {
       enabled: false,
@@ -2995,6 +3009,44 @@ function parseMemoryV2FeatureEnabled(
     return true;
   }
   return parseBool(raw ?? defaultEnabled, field);
+}
+
+/** The slot count that was the schema's default, never an operator's choice. */
+const UNCHOSEN_PARALLEL = 2;
+
+/** First version where `parallel` means "let the machine decide" by default. */
+const AUTO_PARALLEL_VERSION = 63;
+
+/**
+ * `"auto"` (the machine decides, from the launch context) or a pinned
+ * 1..8.
+ *
+ * The migration is the interesting half. A pre-v63 file carries a
+ * `parallel` written by the schema, not by the operator — every file has
+ * one, and for almost all of them it is the old default `2`. Reading
+ * that as a deliberate pin would freeze every existing install at two
+ * workers forever, which is exactly the setting this version exists to
+ * stop asking about. So the old default becomes `"auto"`, and any other
+ * number is treated as something someone actually chose and kept.
+ */
+function resolveManagedParallel(
+  inputVersion: number,
+  raw: unknown,
+): number | "auto" {
+  if (raw === "auto") return "auto";
+  if (raw === null || raw === undefined) {
+    return USER_CONFIG_DEFAULTS.localModels.managed.parallel;
+  }
+  const pinned = parseBoundedPositiveInt(
+    raw,
+    "localModels.managed.parallel",
+    1,
+    8,
+  );
+  if (inputVersion < AUTO_PARALLEL_VERSION && pinned === UNCHOSEN_PARALLEL) {
+    return "auto";
+  }
+  return pinned;
 }
 
 function resolveManagedAutoUpdate(inputVersion: number, raw: unknown): boolean {
@@ -4058,12 +4110,7 @@ export function parseUserConfigFile(raw: unknown): UserConfigFile {
       rawManaged.tensorSplit,
       "localModels.managed.tensorSplit",
     ),
-    parallel: parseBoundedPositiveInt(
-      rawManaged.parallel ?? USER_CONFIG_DEFAULTS.localModels.managed.parallel,
-      "localModels.managed.parallel",
-      1,
-      8,
-    ),
+    parallel: resolveManagedParallel(version, rawManaged.parallel),
   };
 
   const rawEmbeddings =

--- a/src/config/llm-config.test.ts
+++ b/src/config/llm-config.test.ts
@@ -244,15 +244,27 @@ describe("llm-config", () => {
         workers: 3,
       },
     });
+    // A pin still has to name a configured provider — that is what the
+    // validation is for. Which KIND holds which leg is the operator's
+    // choice, so a local orchestrator parses.
     expect(() =>
+      parseUserConfigFile({
+        ...baseLlm(undefined),
+        llm: {
+          ...baseLlm(undefined).llm,
+          runMode: { fusion: { orchestratorProvider: "not-configured" } },
+        },
+      }),
+    ).toThrow(/llm\.runMode\.fusion\.orchestratorProvider/);
+    expect(
       parseUserConfigFile({
         ...baseLlm(undefined),
         llm: {
           ...baseLlm(undefined).llm,
           runMode: { fusion: { orchestratorProvider: "local-llama" } },
         },
-      }),
-    ).toThrow(/llm\.runMode\.fusion\.orchestratorProvider/);
+      }).llm?.runMode?.fusion?.orchestratorProvider,
+    ).toBe("local-llama");
   });
 
   it("omits runMode entirely when not configured", () => {

--- a/src/config/llm-run-mode-config.test.ts
+++ b/src/config/llm-run-mode-config.test.ts
@@ -86,26 +86,25 @@ describe("parseLlmRunModeConfig", () => {
     ).toEqual({ fusion: { orchestratorProvider: "claude-cli" } });
   });
 
-  it("rejects an orchestrator pin that names a llama-server provider", () => {
-    expect(() =>
-      parseLlmRunModeConfig(
-        { fusion: { orchestratorProvider: "local-llama" } },
-        providers,
-        "llm.runMode",
-      ),
-    ).toThrow(
-      /llm\.runMode\.fusion\.orchestratorProvider.*must be a cloud provider/,
+  it("accepts either kind on either leg", () => {
+    // The schema does not refuse a file, it refuses to BOOT on one, so
+    // a pairing it dislikes leaves the operator hand-editing JSON to
+    // start the app. Which model orchestrates and which executes is a
+    // choice; the schema's job is only that both ids exist.
+    const swapped = parseLlmRunModeConfig(
+      {
+        fusion: {
+          orchestratorProvider: "local-llama",
+          workerProvider: "openrouter",
+        },
+      },
+      providers,
+      "llm.runMode",
     );
-  });
-
-  it("rejects a worker pin that names a cloud provider", () => {
-    expect(() =>
-      parseLlmRunModeConfig(
-        { fusion: { workerProvider: "openrouter" } },
-        providers,
-        "llm.runMode",
-      ),
-    ).toThrow(/llm\.runMode\.fusion\.workerProvider.*must be llama-server/);
+    expect(swapped.fusion).toMatchObject({
+      orchestratorProvider: "local-llama",
+      workerProvider: "openrouter",
+    });
   });
 
   it("rejects a pin to a provider that is not configured", () => {

--- a/src/config/llm-run-mode-config.ts
+++ b/src/config/llm-run-mode-config.ts
@@ -85,7 +85,6 @@ function parseLegProviderId(
   raw: unknown,
   providers: ReadonlyArray<RunModeProviderRef>,
   field: string,
-  leg: "orchestrator" | "worker",
 ): string {
   if (typeof raw !== "string" || raw.length === 0) {
     throw new ConfigValidationError(field, "expected non-empty string");
@@ -97,19 +96,17 @@ function parseLegProviderId(
       `unknown provider id ${JSON.stringify(raw)}`,
     );
   }
-  const isLocal = entry.kind === LOCAL_PROVIDER_KIND;
-  if (leg === "orchestrator" && isLocal) {
-    throw new ConfigValidationError(
-      field,
-      `orchestrator must be a cloud provider, ${JSON.stringify(raw)} is ${LOCAL_PROVIDER_KIND}`,
-    );
-  }
-  if (leg === "worker" && !isLocal) {
-    throw new ConfigValidationError(
-      field,
-      `worker provider must be ${LOCAL_PROVIDER_KIND}, ${JSON.stringify(raw)} is ${entry.kind}`,
-    );
-  }
+  // Neither leg is nailed to a kind. Cloud orchestrator + local workers
+  // is the default pairing and the economics the mode was built for, but
+  // a local model planning for cloud executors is a legitimate setup and
+  // the schema is the wrong place to forbid it — it does not refuse a
+  // file, it refuses to BOOT on one, which is how an operator ends up
+  // hand-editing JSON to start the app again.
+  //
+  // What is still checked is that the id names a configured provider,
+  // above. The one pairing the runtime rejects — both legs on the same
+  // provider — is caught by `resolveRunMode`, which can see both at once
+  // and degrades instead of throwing.
   return raw;
 }
 
@@ -155,7 +152,6 @@ function parseFusion(
       obj.orchestratorProvider,
       providers,
       `${field}.orchestratorProvider`,
-      "orchestrator",
     );
   }
   if (obj.orchestratorModel !== undefined) {
@@ -169,7 +165,6 @@ function parseFusion(
       obj.workerProvider,
       providers,
       `${field}.workerProvider`,
-      "worker",
     );
   }
   if (obj.workerModel !== undefined) {

--- a/src/llm/run-mode/resolve-run-mode.test.ts
+++ b/src/llm/run-mode/resolve-run-mode.test.ts
@@ -101,7 +101,7 @@ describe("resolveRunMode", () => {
     expect(rm.orchestratorProviderId).toBeNull();
   });
 
-  it("degrades fusion with no llama-server provider to cloud-only", () => {
+  it("degrades fusion to cloud-only when there is no second provider", () => {
     const rm = resolveRunMode(
       llm("groq", { mode: "fusion" }, [
         {
@@ -113,7 +113,7 @@ describe("resolveRunMode", () => {
     );
     expect(rm.effective).toBe("cloud");
     expect(rm.degraded).toEqual({
-      reason: "no-local-provider",
+      reason: "no-second-provider",
       requested: "fusion",
     });
     expect(rm.workerProviderId).toBeNull();
@@ -198,5 +198,47 @@ describe("resolveRunMode", () => {
         }),
       ),
     ).toMatchObject({ workers: 5, workerMaxSteps: 10, workerTimeoutMs: 5_000 });
+  });
+});
+
+describe("resolveRunMode with the legs swapped", () => {
+  it("runs the orchestrator locally and the workers in the cloud when pinned that way", () => {
+    // The pairing fusion was built for is cloud thinking + local bulk,
+    // but neither leg is nailed to a kind: an operator who wants cheap
+    // local planning driving capable cloud executors gets it.
+    const rm = resolveRunMode(
+      llm(
+        "local-llama",
+        {
+          mode: "fusion",
+          fusion: {
+            orchestratorProvider: "local-llama",
+            workerProvider: "openrouter",
+          },
+        },
+        [
+          { id: "local-llama", kind: "llama-server", url: "http://127.0.0.1:8080" },
+          { id: "openrouter", kind: "openai-compatible", defaultChatModel: "sonnet" },
+        ],
+      ),
+    );
+    expect(rm.effective).toBe("fusion");
+    expect(rm.orchestratorProviderId).toBe("local-llama");
+    expect(rm.workerProviderId).toBe("openrouter");
+    expect(rm.degraded).toBeNull();
+  });
+
+  it("never puts the same provider on both legs by default", () => {
+    // One provider doing both halves is not a fan-out; it is the same
+    // model billed twice.
+    const rm = resolveRunMode(
+      llm("openrouter", { mode: "fusion" }, [
+        { id: "openrouter", kind: "openai-compatible", defaultChatModel: "sonnet" },
+        { id: "groq", kind: "openai-compatible", defaultChatModel: "llama-3.3" },
+      ]),
+    );
+    expect(rm.orchestratorProviderId).toBe("openrouter");
+    expect(rm.workerProviderId).toBe("groq");
+    expect(rm.effective).toBe("fusion");
   });
 });

--- a/src/llm/run-mode/resolve-run-mode.ts
+++ b/src/llm/run-mode/resolve-run-mode.ts
@@ -11,7 +11,7 @@ import type {
 } from "../provider/registry/provider-types.js";
 
 export type RunModeDegradationReason =
-  "no-cloud-provider" | "no-local-provider";
+  "no-cloud-provider" | "no-second-provider";
 
 export type RunModeDegradation = {
   reason: RunModeDegradationReason;
@@ -101,9 +101,19 @@ export function resolveRunMode(
     byId(fusion?.orchestratorProvider) ??
     (active !== undefined && !isLocalKind(active) ? active : undefined) ??
     resolved.providers.find((p) => !isLocalKind(p));
+  // Local first, because that is what fusion is usually for — cloud
+  // thinking, local bulk. But only as the DEFAULT: a pinned leg is
+  // honoured whatever its kind, so an operator can run the orchestrator
+  // locally and the workers in the cloud, or any other pairing their
+  // use case calls for. The one thing a leg may not be is the other
+  // leg: a fan-out to the model that is already doing the orchestrating
+  // buys nothing and doubles the bill.
   const worker =
     byId(fusion?.workerProvider) ??
-    resolved.providers.find((p) => isLocalKind(p));
+    resolved.providers.find(
+      (p) => isLocalKind(p) && p.id !== orchestrator?.id,
+    ) ??
+    resolved.providers.find((p) => p.id !== orchestrator?.id);
 
   const orchestratorProviderId = orchestrator?.id ?? null;
   const workerProviderId = worker?.id ?? null;
@@ -114,7 +124,9 @@ export function resolveRunMode(
     if (orchestratorProviderId === null) {
       degraded = { reason: "no-cloud-provider", requested: stored };
     } else if (workerProviderId === null) {
-      degraded = { reason: "no-local-provider", requested: stored };
+      // Two legs, two providers. Which kinds they are is the operator's
+      // business; that there are two of them is not negotiable.
+      degraded = { reason: "no-second-provider", requested: stored };
     } else if (resolved.activeTextProvider === orchestratorProviderId) {
       effective = "fusion";
     }

--- a/src/llm/run-mode/resolve-run-mode.ts
+++ b/src/llm/run-mode/resolve-run-mode.ts
@@ -151,8 +151,16 @@ export function resolveRunMode(
       orchestrator?.model ??
       null,
     workerProviderId,
+    // `managedModelId` is the model the LOCAL daemon serves, so it only
+    // describes the worker leg while that leg is the local one. With the
+    // legs swapped it is the name of an idle model on this machine, and
+    // every surface that shows it — the composer strip, the LLM pane —
+    // would be naming a model that runs nothing.
     workerModel:
-      fusion?.workerModel ?? opts.managedModelId ?? worker?.model ?? null,
+      fusion?.workerModel ??
+      (worker !== undefined && isLocalKind(worker)
+        ? (opts.managedModelId ?? worker.model ?? null)
+        : (worker?.defaultChatModel ?? worker?.model ?? null)),
     workers: fusion?.workers ?? DEFAULT_FUSION_WORKERS,
     workerMaxSteps: fusion?.workerMaxSteps ?? DEFAULT_FUSION_WORKER_MAX_STEPS,
     workerTimeoutMs:

--- a/src/llm/run-mode/run-mode-degradation.test.ts
+++ b/src/llm/run-mode/run-mode-degradation.test.ts
@@ -18,13 +18,14 @@ describe("describeRunModeDegradation", () => {
     ).toMatch(/^Cloud mode needs a cloud provider/);
   });
 
-  it("names the missing local leg", () => {
-    expect(
-      describeRunModeDegradation({
-        reason: "no-local-provider",
-        requested: "fusion",
-      }),
-    ).toMatch(/needs local workers.*Running cloud-only/);
+  it("names the missing second leg without prescribing its kind", () => {
+    // Either leg may be cloud or local; the requirement is two of them.
+    const line = describeRunModeDegradation({
+      reason: "no-second-provider",
+      requested: "fusion",
+    });
+    expect(line).toMatch(/needs two providers/);
+    expect(line).not.toMatch(/llama-server|local workers/);
   });
 
   it("always points at where to fix it", () => {

--- a/src/llm/run-mode/run-mode-degradation.ts
+++ b/src/llm/run-mode/run-mode-degradation.ts
@@ -15,7 +15,9 @@ export function describeRunModeDegradation(
       return degraded.requested === "fusion"
         ? "Fusion needs a cloud orchestrator — no cloud provider is configured. Staying on local. Add one in Manage → LLM → Cloud (or /llm)."
         : "Cloud mode needs a cloud provider — none is configured. Staying on local. Add one in Manage → LLM → Cloud (or /llm).";
-    case "no-local-provider":
-      return "Fusion needs local workers — no llama-server provider is configured. Running cloud-only.";
+    case "no-second-provider":
+      // Either leg may be cloud or local; what fusion cannot do is run
+      // both of them on the same provider.
+      return "Fusion needs two providers — one to orchestrate and one to run the workers. Only one is configured. Add another in Manage → LLM (or /llm).";
   }
 }

--- a/src/local-llm/daemon-lifecycle.ts
+++ b/src/local-llm/daemon-lifecycle.ts
@@ -1,3 +1,4 @@
+import { resolveConfiguredSlots } from "./worker-slots.js";
 import { execSync, spawn } from "node:child_process";
 import {
   closeSync,
@@ -73,10 +74,12 @@ export interface DaemonStartOptions {
    */
   tensorSplit?: readonly number[];
   /**
-   * Request slots (`localModels.managed.parallel`). Undefined keeps the
-   * historical `--parallel 2` so existing launches stay byte-identical.
+   * Request slots (`localModels.managed.parallel`): a pinned number, or
+   * `"auto"` to derive it from the context this launch actually gets
+   * (see `worker-slots.ts`). Undefined keeps the historical
+   * `--parallel 2` so an embedder's launch stays byte-identical.
    */
-  parallel?: number;
+  parallel?: number | "auto";
 }
 
 /**
@@ -110,7 +113,21 @@ export function buildLlamaServerArgs(
     "--cache-type-v",
     "turbo3",
     "--parallel",
-    String(opts.parallel ?? 2),
+    // Resolved here rather than at the call sites because this is where
+    // the *effective* context is known — the number of slots is how many
+    // usable shares that context divides into, and the callers pass the
+    // configured `0` (auto-size) straight through.
+    String(
+      opts.parallel === undefined
+        ? 2
+        : resolveConfiguredSlots(opts.parallel, {
+            contextSize:
+              effectiveContextSize && effectiveContextSize > 0
+                ? effectiveContextSize
+                : null,
+            cpuOnly: opts.device === "cpu",
+          }),
+    ),
     "-kvu",
     "-a",
     modelAlias,

--- a/src/local-llm/worker-slots.test.ts
+++ b/src/local-llm/worker-slots.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SLOTS,
+  MAX_AUTO_SLOTS,
+  MIN_SLOT_CONTEXT,
+  resolveConfiguredSlots,
+  resolveWorkerSlots,
+} from "./worker-slots.js";
+
+describe("resolveWorkerSlots", () => {
+  it("gives one slot per worth-having share of the context", () => {
+    // The context is divided between slots, so the count is how many
+    // times a usable slot fits in what the daemon was given.
+    expect(resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT, cpuOnly: false })).toBe(1);
+    expect(resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 3, cpuOnly: false })).toBe(3);
+    expect(
+      resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 3 + 5_000, cpuOnly: false }),
+    ).toBe(3);
+  });
+
+  it("never returns zero, however small the context", () => {
+    // A machine that can only serve one worker still serves one; the
+    // fan-out then runs its tasks in sequence rather than not at all.
+    expect(resolveWorkerSlots({ contextSize: 4_096, cpuOnly: false })).toBe(1);
+  });
+
+  it("stops at the ceiling on a very large context", () => {
+    expect(
+      resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 40, cpuOnly: false }),
+    ).toBe(MAX_AUTO_SLOTS);
+  });
+
+  it("serves one at a time on CPU", () => {
+    // Concurrency on shared cores buys nothing: both legs finish at the
+    // same time, both late.
+    expect(
+      resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 8, cpuOnly: true }),
+    ).toBe(1);
+  });
+
+  it("falls back to the historical default when the context is unknown", () => {
+    // No `--ctx-size` flag: llama.cpp picks, and this process does not
+    // learn the number. Guessing high here would be guessing with the
+    // operator's memory.
+    expect(resolveWorkerSlots({ contextSize: null, cpuOnly: false })).toBe(DEFAULT_SLOTS);
+    expect(resolveWorkerSlots({ contextSize: 0, cpuOnly: false })).toBe(DEFAULT_SLOTS);
+  });
+});
+
+describe("resolveConfiguredSlots", () => {
+  it("asks the machine for auto", () => {
+    expect(
+      resolveConfiguredSlots("auto", { contextSize: MIN_SLOT_CONTEXT * 4, cpuOnly: false }),
+    ).toBe(4);
+  });
+
+  it("honours a pinned number as written", () => {
+    // The escape hatch: an external server, an unusual model, a
+    // benchmark. A pin the runtime second-guessed would not be one.
+    expect(
+      resolveConfiguredSlots(6, { contextSize: MIN_SLOT_CONTEXT, cpuOnly: false }),
+    ).toBe(6);
+    expect(resolveConfiguredSlots(1, { contextSize: null, cpuOnly: true })).toBe(1);
+  });
+});

--- a/src/local-llm/worker-slots.ts
+++ b/src/local-llm/worker-slots.ts
@@ -1,0 +1,86 @@
+/**
+ * How many workers this machine can actually serve at once.
+ *
+ * The count used to be an operator setting — `localModels.managed.parallel`,
+ * default 2, edited from a list in the composer. That is the wrong party
+ * to ask. The number is not a preference: it is a property of the
+ * machine and the model loaded on it, and the operator choosing it means
+ * either a timid two on hardware that could serve six, or six on a
+ * server whose context cannot hold them.
+ *
+ * **What actually bounds it.** llama.cpp divides `--ctx-size` between
+ * `--parallel` slots: each slot gets `ctx / parallel` tokens, and a
+ * worker whose slot is smaller than its own prompt cannot run at all. A
+ * worker's prompt is the same stable prefix every turn carries (persona,
+ * tool catalog, capabilities — ~5.2k tokens on its own) plus the brief
+ * and whatever it reads, and it generates against
+ * `completionMaxTokens`. So the honest ceiling is how many times
+ * `MIN_SLOT_CONTEXT` fits in the context the daemon was actually given —
+ * which is itself already sized from VRAM by `context-size.ts`. Bigger
+ * machine, bigger context, more slots, with no new hardware probe and
+ * nothing for the operator to decide.
+ *
+ * The context is the binding constraint rather than VRAM directly
+ * because the KV cache for the whole context is allocated up front:
+ * splitting it four ways costs nothing extra in memory, it just makes
+ * each share smaller.
+ */
+
+/**
+ * Tokens a worker slot needs to be useful. Same figure as
+ * `MIN_AUTO_CONTEXT`, and for the same reason: below it a worker has
+ * room for the prefix and not much else, so it truncates mid-tool-call
+ * and reports a failure the orchestrator then has to re-delegate.
+ */
+export const MIN_SLOT_CONTEXT = 16_384;
+
+/**
+ * Ceiling on the derived count. Past a handful of slots the local server
+ * is sharing one set of weights and one memory bus between all of them:
+ * each leg gets slower in proportion, so the wall-clock win flattens
+ * while the failure modes (evicted KV, queued requests timing out) do
+ * not. Eight is generous for a single-GPU or unified-memory machine,
+ * which is what a managed daemon runs on.
+ */
+export const MAX_AUTO_SLOTS = 8;
+
+/** What a launch with nothing known falls back to — the historical default. */
+export const DEFAULT_SLOTS = 2;
+
+export interface WorkerSlotsInput {
+  /**
+   * The context the daemon is being launched with, in tokens. `null`
+   * when it is left to llama.cpp (no `--ctx-size` flag), where the model
+   * decides and this process does not know the number.
+   */
+  contextSize: number | null;
+  /** CPU-only launch (`-ngl 0`). */
+  cpuOnly: boolean;
+}
+
+/**
+ * The slot count for a managed launch.
+ *
+ * CPU-only is always one: concurrent slots there share the same cores,
+ * so two workers do not finish sooner than two in a row — they finish at
+ * the same time, both late, having doubled the memory traffic.
+ */
+export function resolveWorkerSlots(input: WorkerSlotsInput): number {
+  if (input.cpuOnly) return 1;
+  const ctx = input.contextSize;
+  if (ctx === null || !Number.isFinite(ctx) || ctx <= 0) return DEFAULT_SLOTS;
+  const fits = Math.floor(ctx / MIN_SLOT_CONTEXT);
+  return Math.max(1, Math.min(fits, MAX_AUTO_SLOTS));
+}
+
+/**
+ * Resolve the configured value, where `"auto"` means "ask the machine".
+ * A number the operator pinned is honoured as written — the escape hatch
+ * for an external server, an unusual model, or a benchmark.
+ */
+export function resolveConfiguredSlots(
+  configured: number | "auto",
+  input: WorkerSlotsInput,
+): number {
+  return configured === "auto" ? resolveWorkerSlots(input) : configured;
+}

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -61,7 +61,7 @@ export function isFusionActive(
  */
 export const FUSION_GUIDANCE = [
   "You orchestrate local workers: read enough to decide, plan, delegate the doing, review what comes back, integrate it.",
-  "Plan in the open: list the independent, self-contained parts, each with what it touches and how big it is. Size them — group small ones, give a big one its own worker.",
+  "Plan in the open, then delegate in the same turn — never stop at the plan: list the independent, self-contained parts with what each touches and how big it is, sized so a big one gets its own worker and small ones share.",
   "Send one task per part in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
   "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
   "Until this turn has delegated once, tools that change things are refused for you — the mode working, not a fault.",

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -60,13 +60,15 @@ export function isFusionActive(
  * exactly the block a machine-less build renders.
  */
 export const FUSION_GUIDANCE = [
-  "You orchestrate local worker agents: you plan and they execute. Decide the approach first, then delegate the independent bulk — reading many files, first drafts, boilerplate, tests, wide searches — with `fusion.delegate`.",
-  "Delegate whenever the work splits into independent, self-contained parts, and prefer sending more of them over doing the bulk yourself. You choose `maxWorkers` on each call: nothing caps it but the number of tasks and what this machine can serve.",
-  "Each task's `instructions` must stand alone: exact paths, what counts as done, and the format of the answer you want back. Workers have no memory of this conversation and cannot ask you anything.",
-  "Keep the design, the integration and the review yourself. Never delegate the decision you are being asked to make, or a part that only makes sense with this conversation in front of it — that part is yours to do.",
-  "Call `fusion.delegate` on its own, never alongside other tool calls in the same array — it runs several turns internally and takes a while.",
-  "Read every reply before you use it: verify what came back, merge it yourself, and redo or re-delegate any part that came back `failed` or `needs_orchestrator`.",
-  "Workers cannot reach the user and cannot get approval, so anything that needs a person — a shell command, a write at a low approval level — comes back to you to run.",
+  "You orchestrate local workers: read enough to decide, plan, delegate the doing, review what comes back, integrate it.",
+  "Plan in the open: list the independent, self-contained parts, each with what it touches and how big it is. Size them — group small ones, give a big one its own worker.",
+  "Send one task per part in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
+  "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
+  "Until this turn has delegated once, tools that change things are refused for you — the mode working, not a fault.",
+  "Keep the design, the judgement and the integration: read every reply against its brief, then merge the parts yourself.",
+  "Rework goes back out: anything `failed`, `needs_orchestrator`, or that you want refactored becomes another `fusion.delegate` saying what was wrong.",
+  "Yours alone: the decision you were asked for, a part that only makes sense with this conversation in front of it, and anything needing operator approval — workers cannot reach the user.",
+  "Call `fusion.delegate` on its own, never alongside other tool calls — it runs several turns internally and takes a while.",
 ].join("\n");
 
 /**

--- a/src/prompt/fusion-machine-facts.ts
+++ b/src/prompt/fusion-machine-facts.ts
@@ -63,6 +63,8 @@ export function resolveFusionMachineFacts(
   config: AtomicAgentConfig,
 ): FusionMachineFacts {
   const local = config.localModels;
+  const fusion = config.llm?.runMode?.fusion;
+  const providers = config.llm?.providers ?? [];
   // `--parallel` is only ours to state in managed mode: that is where
   // the runtime itself launches the daemon with `managed.parallel`. An
   // external server was started by the operator with flags this process
@@ -73,7 +75,18 @@ export function resolveFusionMachineFacts(
   // VRAM at start-up, well after the prefix is built). Unknown stays
   // unknown: a guessed slot count is a number the model would plan
   // against, which is the one thing this module refuses to produce.
-  const configured = local.mode === "managed" ? local.managed.parallel : null;
+  // Slots are a fact about the LOCAL daemon, so they only describe this
+  // fan-out when the local leg is the one running the workers. With
+  // cloud workers there is no slot pool to speak of — the width is
+  // whatever the provider will take concurrently — and stating a number
+  // from the idle daemon would be stating a number about the wrong
+  // machine.
+  const workersAreLocal =
+    fusion?.workerProvider === undefined ||
+    providers.find((p) => p.id === fusion.workerProvider)?.kind ===
+      "llama-server";
+  const configured =
+    workersAreLocal && local.mode === "managed" ? local.managed.parallel : null;
   const pinnedContext = local.mode === "managed" ? local.managed.contextSize : 0;
   const workerSlots =
     configured === null
@@ -88,8 +101,6 @@ export function resolveFusionMachineFacts(
   // resolver: the explicit pin, then the managed daemon's model, then
   // the `model` field of the llama-server provider entry the worker leg
   // names. Never an invented string.
-  const fusion = config.llm?.runMode?.fusion;
-  const providers = config.llm?.providers ?? [];
   const workerEntry =
     providers.find((p) => p.id === fusion?.workerProvider) ??
     providers.find((p) => p.kind === "llama-server");

--- a/src/prompt/fusion-machine-facts.ts
+++ b/src/prompt/fusion-machine-facts.ts
@@ -28,6 +28,7 @@
  */
 
 import type { AtomicAgentConfig } from "../config/config-schema.js";
+import { resolveWorkerSlots } from "../local-llm/worker-slots.js";
 
 export interface FusionMachineFacts {
   /**
@@ -66,7 +67,22 @@ export function resolveFusionMachineFacts(
   // the runtime itself launches the daemon with `managed.parallel`. An
   // external server was started by the operator with flags this process
   // never saw.
-  const workerSlots = local.mode === "managed" ? local.managed.parallel : null;
+  // `"auto"` is the default now, and it resolves against the context the
+  // daemon is launched with — which this process only knows when the
+  // operator pinned one (`contextSize: 0` means llama.cpp sizes it from
+  // VRAM at start-up, well after the prefix is built). Unknown stays
+  // unknown: a guessed slot count is a number the model would plan
+  // against, which is the one thing this module refuses to produce.
+  const configured = local.mode === "managed" ? local.managed.parallel : null;
+  const pinnedContext = local.mode === "managed" ? local.managed.contextSize : 0;
+  const workerSlots =
+    configured === null
+      ? null
+      : configured === "auto"
+        ? pinnedContext > 0
+          ? resolveWorkerSlots({ contextSize: pinnedContext, cpuOnly: false })
+          : null
+        : configured;
 
   // Same chain `resolveRunMode` uses for its worker label, minus the
   // resolver: the explicit pin, then the managed daemon's model, then

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -2303,6 +2303,10 @@ export async function createAgentRuntime(
     // gate is the single live switch rather than a boolean copied into
     // each tool registration.
     isPlanMode: () => planMode,
+    // The same live resolution the `fusion.delegate` descriptor gate
+    // reads, so the tool the orchestrator is being pushed towards is
+    // always in the catalog when the push happens.
+    isFusionMode: () => resolveCurrentRunMode().effective === "fusion",
     slotManager,
     grammar,
     llmComplete,

--- a/src/tools/fusion/fusion-delegate.test.ts
+++ b/src/tools/fusion/fusion-delegate.test.ts
@@ -274,13 +274,16 @@ describe("fusion.delegate", () => {
     expect(result.summary).not.toContain("localModels.managed.parallel");
   });
 
-  it("falls back to the configured `workers` when the call names none", async () => {
+  it("falls back to what the machine serves when the call names no width", async () => {
+    // Not to `runMode.fusion.workers`: the operator is not the party
+    // that knows how divisible this job is, and the slot pool is already
+    // the honest ceiling. A call that named nothing gets the capacity.
     const tool = buildFusionDelegateTool(
       deps({ slotManager: { poolSize: () => 8 } }),
     );
     const result = await tool.run({ tasks: sixTasks() }, ctx());
-    expect(result.details.maxWorkers).toBe(3);
-    expect(result.details.requestedWorkers).toBe(3);
+    expect(result.details.maxWorkers).toBe(6);
+    expect(result.details.requestedWorkers).toBe(8);
   });
 
   it("never runs more workers than there are tasks", async () => {
@@ -338,10 +341,13 @@ describe("fusion.delegate", () => {
       deps({ slotManager: { poolSize: () => 2 } }),
     );
     const result = await tool.run({ tasks: sixTasks(), maxWorkers: 6 }, ctx());
-    expect(result.summary).toContain("6 workers were wanted");
+    expect(result.summary).toContain("6 workers' worth of work was sent");
     expect(result.summary).toContain("2 request slots");
     expect(result.summary).toContain("only 2 ran at a time");
+    // The knob is still named, but as where the number comes from
+    // rather than as something to go and raise: it is `"auto"` now.
     expect(result.summary).toContain("localModels.managed.parallel");
+    expect(result.summary).toContain("comes from the machine");
   });
 
   it("says nothing about the pool when it was not what held the fan-out down", async () => {

--- a/src/tools/fusion/fusion-delegate.ts
+++ b/src/tools/fusion/fusion-delegate.ts
@@ -130,10 +130,21 @@ export function buildFusionDelegateTool(
       // on a slot-affine leg you cannot run more than the server has
       // request slots (the rest would queue and evict each other's KV
       // cache rather than run).
-      const requested = parsed.maxWorkers ?? mode.workers;
+      // A call that named no width gets the machine's capacity, not a
+      // number from a config file. The operator is not the party that
+      // knows how divisible this particular job is, and the slot pool is
+      // already the honest ceiling — `runMode.fusion.workers` survives
+      // only as a pin for someone who deliberately wrote one.
+      const requested =
+        parsed.maxWorkers ??
+        (Number.isFinite(poolSize) ? (poolSize as number) : mode.workers);
       const wanted = Math.max(1, Math.min(requested, parsed.tasks.length));
       const maxWorkers = Math.max(1, Math.min(wanted, poolSize));
-      const poolIsBinding = maxWorkers < wanted;
+      // The pool held this fan-out down when it ran fewer at a time than
+      // there was work for — whether the orchestrator asked for a wider
+      // number or simply had more tasks than the machine has slots.
+      const poolIsBinding =
+        maxWorkers < wanted || maxWorkers < parsed.tasks.length;
 
       // Labels, never guesses: the resolver's pin when it has one, the
       // provider id when it does not. Both legs are read from the same
@@ -202,7 +213,7 @@ export function buildFusionDelegateTool(
       // all three things it needs: what was wanted, what actually ran
       // concurrently, and the config key that changes the second number.
       const hint = poolIsBinding
-        ? `\n\nNote: ${wanted} workers were wanted for this fan-out but the local server has ${poolSize} request slot${poolSize === 1 ? "" : "s"}, so only ${maxWorkers} ran at a time and the rest queued — raise \`localModels.managed.parallel\` (llama-server \`--parallel\`) to widen it.`
+        ? `\n\nNote: ${Math.max(wanted, parsed.tasks.length)} workers' worth of work was sent but the local server has ${poolSize} request slot${poolSize === 1 ? "" : "s"}, so only ${maxWorkers} ran at a time and the rest queued. That number comes from the machine — llama-server divides its context between slots (\`localModels.managed.parallel\`, \`"auto"\` by default). Split into fewer, larger tasks if the queueing is costing more than the parallelism buys.`
         : "";
       return compressToolResult(
         {

--- a/src/tui/components/prompt-meta-bar.tsx
+++ b/src/tui/components/prompt-meta-bar.tsx
@@ -50,8 +50,6 @@ export interface PromptMetaBarProps {
   provider: string | null;
   /** Turns the model slot into a `download model` call to action. */
   needsModelDownload?: boolean;
-  /** Fusion's fourth control (`2 workers`); `null` off that route. */
-  workers?: string | null;
   /**
    * Re-skin the bar for the Fusion run mode: black ground, white ink,
    * orange accents — see `fusion-tint.ts`. The blue the bar normally
@@ -125,7 +123,6 @@ export function PromptMetaBar({
   model,
   provider,
   needsModelDownload,
-  workers,
   fusion = false,
   rightSlot,
   contextSlot,
@@ -159,7 +156,6 @@ export function PromptMetaBar({
           model={model}
           provider={provider}
           needsModelDownload={needsModelDownload ?? false}
-          workers={workers ?? null}
           fusion={fusion}
           mouseLayer={mouseLayer}
         />
@@ -187,7 +183,6 @@ interface MetaLeftProps {
   model: string | null;
   provider: string | null;
   needsModelDownload: boolean;
-  workers: string | null;
   fusion: boolean;
   mouseLayer?: number;
 }
@@ -218,7 +213,6 @@ function MetaLeft({
   model,
   provider,
   needsModelDownload,
-  workers,
   fusion,
   mouseLayer,
 }: MetaLeftProps): ReactElement {
@@ -269,7 +263,6 @@ function MetaLeft({
         provider={provider}
         model={cleanModel}
         needsModelDownload={needsModelDownload}
-        workers={workers}
         fusion={fusion}
         mouseLayer={mouseLayer}
       />

--- a/src/tui/components/prompt-shell.tsx
+++ b/src/tui/components/prompt-shell.tsx
@@ -84,8 +84,6 @@ export interface PromptShellProps extends Omit<
    * managed-local route with nothing on disk to run.
    */
   needsModelDownload?: boolean;
-  /** Fusion's fourth control (`2 workers`); `null` off that route. */
-  workers?: string | null;
   /**
    * Optional content rendered at the start of the action bar, before the
    * model/provider labels. Used by the chat surface to show the live
@@ -120,7 +118,6 @@ export function PromptShell(props: PromptShellProps): ReactElement {
     model,
     provider,
     needsModelDownload,
-    workers,
     leftSlot,
     rightSlot,
     contextSlot,
@@ -264,7 +261,6 @@ export function PromptShell(props: PromptShellProps): ReactElement {
           model={model ?? null}
           provider={provider ?? null}
           needsModelDownload={needsModelDownload ?? false}
-          workers={workers ?? null}
           fusion={fusion}
           rightSlot={rightSlot ?? null}
           contextSlot={contextSlot ?? null}

--- a/src/tui/composer-switch/composer-meta-controls.test.tsx
+++ b/src/tui/composer-switch/composer-meta-controls.test.tsx
@@ -141,24 +141,23 @@ describe("the composer's route line", () => {
     expect(out).not.toContain("healthy");
   });
 
-  it("adds the worker count as a fourth control on the fusion route", () => {
-    const { lastFrame, unmount } = render(
-      <Box>
-        <ComposerMetaControls
-          backend={{ kind: "fusion", status: "healthy" }}
-          provider="openrouter"
-          model="claude-opus-5 ⇄ qwen-3.5-4b"
-          workers="3 workers"
-        />
-      </Box>,
+  it("does not spend a segment on the worker count", () => {
+    // It was a capacity, not a choice, and it cost columns the route
+    // names needed — the screenshot that killed it showed `up to 2
+    // work…` colliding with the steer hint. Both legs are already named
+    // by the model segment, and the worker slot is one ←/→ away inside
+    // the popup.
+    const { lastFrame } = render(
+      <ComposerMetaControls
+        backend={{ label: "fusion", tone: "fusion" }}
+        provider="openrouter"
+        model="claude-opus-5 ⇄ qwen-3.5-4b"
+        fusion
+      />,
     );
-    const text = plain(lastFrame() ?? "");
-    unmount();
-    expect(text).toContain("3 workers");
-    // Last: where it runs, who serves it, which model, how many workers.
-    expect(text.indexOf("claude-opus-5")).toBeLessThan(
-      text.indexOf("3 workers"),
-    );
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toMatch(/worker/i);
+    expect(frame).toContain("qwen-3.5-4b");
   });
 
   it("draws no fourth control when there are no workers to count", () => {

--- a/src/tui/composer-switch/composer-meta-controls.tsx
+++ b/src/tui/composer-switch/composer-meta-controls.tsx
@@ -26,11 +26,6 @@ export interface ComposerMetaControlsProps {
   /** Paint on the Fusion surface: white ink, orange-warmed separators. */
   fusion?: boolean;
   /**
-   * Fusion's fourth control, `2 workers`: the local half of the route.
-   * `null` off the fusion route, where the strip has three controls.
-   */
-  workers?: string | null;
-  /**
    * Mouse layer the click targets register on. The composer floats over
    * the chat log with a `MOUSE_LAYER_PANEL` backstop behind it (see
    * `composer-overlay.tsx`), and a control left on the base layer would
@@ -80,7 +75,6 @@ export function ComposerMetaControls({
   provider,
   model,
   needsModelDownload = false,
-  workers = null,
   fusion = false,
   mouseLayer,
 }: ComposerMetaControlsProps): ReactElement | null {
@@ -115,16 +109,6 @@ export function ComposerMetaControls({
           label={model}
           lead={Boolean(backend || provider)}
           shrink={3}
-          fusion={fusion}
-          mouseLayer={mouseLayer}
-        />
-      ) : null}
-      {workers ? (
-        <Control
-          kind="workers"
-          label={workers}
-          lead={Boolean(backend || provider || model)}
-          shrink={2}
           fusion={fusion}
           mouseLayer={mouseLayer}
         />

--- a/src/tui/composer-switch/composer-switch-activate.test.ts
+++ b/src/tui/composer-switch/composer-switch-activate.test.ts
@@ -203,17 +203,20 @@ describe("the download deep link", () => {
 });
 
 describe("picking fusion", () => {
-  it("refuses with the pre-flight line when no cloud provider has a key", () => {
+  it("refuses with the pre-flight line when only one leg can answer", () => {
+    // `localState()` has the local leg and no keyed cloud one. Either
+    // kind may hold either slot now, so what is missing is a second
+    // provider — here, the one that would orchestrate.
     const app = harness(localState());
     app.pick("backend", "fusion");
     expect(app.callbacks.onRunModeChangeRequested).not.toHaveBeenCalled();
     expect(app.actions).toContainEqual({
       type: "composer_notice",
-      text: expect.stringMatching(/needs a cloud provider with a key/),
+      text: expect.stringMatching(/needs a second provider to orchestrate/),
     });
   });
 
-  it("refuses when nothing is downloaded for the workers", () => {
+  it("refuses when the second leg has nothing to run", () => {
     const base = cloudState();
     const state = {
       ...base,
@@ -228,7 +231,7 @@ describe("picking fusion", () => {
     expect(app.callbacks.onRunModeChangeRequested).not.toHaveBeenCalled();
     expect(app.actions).toContainEqual({
       type: "composer_notice",
-      text: expect.stringMatching(/needs a downloaded local model/),
+      text: expect.stringMatching(/needs a second provider/),
     });
   });
 

--- a/src/tui/composer-switch/composer-switch-activate.test.ts
+++ b/src/tui/composer-switch/composer-switch-activate.test.ts
@@ -337,12 +337,13 @@ describe("the fusion configurators", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("sends the worker count to the one writer that moves it with the slot count", () => {
+  it("offers no worker count to pick at all", () => {
+    // v63: the count left the composer. The machine sizes the slot pool
+    // (`managed.parallel: "auto"`) and the orchestrator sizes each
+    // fan-out inside it, so there is nothing here for a person to set.
     const app = harness(fusionState());
-    app.pick("workers", "4 workers");
-    expect(app.callbacks.onFusionWorkersChangeRequested).toHaveBeenCalledWith(
-      4,
-    );
+    expect(() => app.pick("workers", "4 workers")).toThrow();
+    expect(app.callbacks.onFusionWorkersChangeRequested).not.toHaveBeenCalled();
   });
 
   it("re-pins the orchestrator when a provider is picked under fusion", () => {

--- a/src/tui/composer-switch/composer-switch-activate.ts
+++ b/src/tui/composer-switch/composer-switch-activate.ts
@@ -69,7 +69,28 @@ export function activateComposerSwitchRow(
     return;
   }
   if (row.intent.kind === "fusionWorkerModel") {
+    // Picking a local model for the worker slot also claims the slot for
+    // the local provider: an operator who chose a model to run the
+    // workers on has said which leg runs them, and leaving the pin on a
+    // cloud provider would quietly ignore the pick.
+    if (state.providersPanel.runMode?.workerProviderId !== "local-llama") {
+      callbacks.onRunModeChangeRequested?.("fusion", {
+        fusion: { workerProvider: "local-llama" },
+      });
+    }
     activateWorkerModel(row.intent.modelId, state, callbacks);
+    return;
+  }
+  if (row.intent.kind === "fusionLeg") {
+    // One write moves the pin and, for the orchestrator, the active
+    // provider with it — `setMode` is the only path that keeps those
+    // two from contradicting each other.
+    callbacks.onRunModeChangeRequested?.("fusion", {
+      fusion:
+        row.intent.leg === "orchestrator"
+          ? { orchestratorProvider: row.intent.providerId }
+          : { workerProvider: row.intent.providerId },
+    });
     return;
   }
   if (row.intent.kind === "fusionWorkers") {

--- a/src/tui/composer-switch/composer-switch-rows.test.ts
+++ b/src/tui/composer-switch/composer-switch-rows.test.ts
@@ -124,7 +124,7 @@ describe("the switch rows", () => {
   it("puts the pre-flight blocker in the fusion row's detail column", () => {
     const rows = selectComposerSwitchRows(localState("managed"), "backend");
     expect(rows.find((row) => row.label === "fusion")?.detail).toMatch(
-      /needs a cloud provider with a key/,
+      /needs a second provider/,
     );
   });
 

--- a/src/tui/composer-switch/composer-switch-rows.ts
+++ b/src/tui/composer-switch/composer-switch-rows.ts
@@ -36,6 +36,17 @@ export type ComposerSwitchIntent =
   | { readonly kind: "localModelsPanel" }
   /** Fusion's `workers` control: the local model the workers run. */
   | { readonly kind: "fusionWorkerModel"; readonly modelId: LocalModelId }
+  /**
+   * Pin one of fusion's two legs to a provider — either leg, either
+   * kind. The default pairing is cloud orchestrator + local workers, but
+   * a local model planning for cloud executors is a legitimate use case
+   * and the composer is where it gets chosen.
+   */
+  | {
+      readonly kind: "fusionLeg";
+      readonly leg: "orchestrator" | "worker";
+      readonly providerId: string;
+    }
   /** Fusion's `workers` control: how many workers run at once. */
   | { readonly kind: "fusionWorkers"; readonly workers: number };
 
@@ -55,7 +66,7 @@ export interface ComposerSwitchRow {
 }
 
 /** Cloud providers the operator has actually added, in config order. */
-function configuredCloudProviders(state: TuiState) {
+export function configuredCloudProviders(state: TuiState) {
   return state.providersPanel.rows.filter((row) => row.kind !== "llama-server");
 }
 
@@ -127,17 +138,46 @@ export function backendSwitchRow(
 }
 
 function providerRows(state: TuiState): readonly ComposerSwitchRow[] {
+  const runMode = state.providersPanel.runMode;
+  const fusion = runMode?.effective === "fusion";
   const rows = configuredCloudProviders(state).map((provider) => ({
     id: `provider:${provider.id}`,
     label: provider.id,
-    detail: provider.hasApiKey
-      ? (provider.chatModel ?? "default model")
-      : "no API key",
-    active: provider.isActiveText,
+    detail: fusion
+      ? provider.hasApiKey
+        ? "orchestrator"
+        : "no API key"
+      : provider.hasApiKey
+        ? (provider.chatModel ?? "default model")
+        : "no API key",
+    active: fusion
+      ? provider.id === runMode?.orchestratorProviderId
+      : provider.isActiveText,
     intent: { kind: "llmRow" as const, row: cloudProviderRow(provider) },
   }));
+  // Under fusion this control is the ORCHESTRATOR slot, and a local
+  // model is allowed to hold it: cheap planning driving capable cloud
+  // executors is a pairing worth having. Off fusion the row would be a
+  // duplicate of the `local` backend route, so it is only drawn here.
+  const localLeg: ComposerSwitchRow[] =
+    fusion && state.localModelsPanel.rows.some((row) => row.downloaded)
+      ? [
+          {
+            id: "provider:local-llama",
+            label: "local-llama",
+            detail: "orchestrator · runs on this machine",
+            active: runMode?.orchestratorProviderId === "local-llama",
+            intent: {
+              kind: "fusionLeg" as const,
+              leg: "orchestrator" as const,
+              providerId: "local-llama",
+            },
+          },
+        ]
+      : [];
   return [
     ...rows,
+    ...localLeg,
     {
       id: "provider:add",
       label: "Add a new provider",

--- a/src/tui/composer-switch/composer-switch-worker-rows.test.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.test.ts
@@ -101,3 +101,23 @@ describe("the meta bar's worker label", () => {
     ).toBeNull();
   });
 });
+
+describe("the meta bar with the legs swapped", () => {
+  it("stops quoting a slot count when the workers are in the cloud", () => {
+    // `up to N` is llama-server's request-slot count. A cloud worker leg
+    // has no such pool, and the idle daemon's number would be a fact
+    // about the wrong machine.
+    const base = fusionState();
+    const state = {
+      ...base,
+      providersPanel: {
+        ...base.providersPanel,
+        runMode: {
+          ...base.providersPanel.runMode!,
+          workerProviderId: "aimlapi",
+        },
+      },
+    };
+    expect(selectComposerWorkersLabel(state)).toBe("cloud workers");
+  });
+});

--- a/src/tui/composer-switch/composer-switch-worker-rows.test.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.test.ts
@@ -12,59 +12,35 @@ import {
 } from "./composer-switch-worker-rows.js";
 
 describe("the workers switch", () => {
-  it("lists the downloaded local models, then every worker count, then the deep link", () => {
+  it("lists the downloaded local models, then the deep link — and no counts", () => {
+    // The count rows are gone with v63: how many workers run at once is
+    // the machine's answer (`managed.parallel: "auto"` derives it from
+    // the launch context) and how many a turn spends is the
+    // orchestrator's, per call. Neither is an operator's list.
     const rows = selectWorkerRows(fusionState());
     expect(rows[0]?.label).toBe("qwen-3.5-4b");
     expect(rows[0]?.detail).toBe("worker model");
-    expect(rows.slice(1, 9).map((row) => row.label)).toEqual([
-      "1 worker",
-      "2 workers",
-      "3 workers",
-      "4 workers",
-      "5 workers",
-      "6 workers",
-      "7 workers",
-      "8 workers",
+    expect(rows.map((row) => row.label)).toEqual([
+      "qwen-3.5-4b",
+      "Download more models…",
     ]);
-    expect(rows.at(-1)?.label).toBe("Download more models…");
+    expect(rows.some((row) => /worker(s)?$/.test(row.label))).toBe(false);
   });
 
-  it("marks the model in force and the count in force", () => {
+  it("marks the model in force", () => {
     const rows = selectWorkerRows(fusionState({ workers: 4 }));
     expect(rows.filter((row) => row.active).map((row) => row.label)).toEqual([
       "qwen-3.5-4b",
-      "4 workers",
     ]);
   });
 
-  it("carries the intents the activation path branches on", () => {
+  it("carries the one intent the activation path still branches on", () => {
     const rows = selectWorkerRows(fusionState());
     expect(rows.find((row) => row.label === "qwen-3.5-4b")?.intent).toEqual({
       kind: "fusionWorkerModel",
       modelId: "qwen-3.5-4b",
     });
-    expect(rows.find((row) => row.label === "3 workers")?.intent).toEqual({
-      kind: "fusionWorkers",
-      workers: 3,
-    });
-  });
-
-  it("says the slot count is the operator's problem on an external server", () => {
-    const base = fusionState();
-    const external = {
-      ...base,
-      localModelsPanel: {
-        ...base.localModelsPanel,
-        configMode: "external" as const,
-      },
-    };
-    expect(
-      selectWorkerRows(external).find((row) => row.label === "2 workers")
-        ?.detail,
-    ).toBe("external server — set --parallel yourself");
-    expect(
-      selectWorkerRows(base).find((row) => row.label === "2 workers")?.detail,
-    ).toBe("llama-server --parallel 2 · restart to apply");
+    expect(rows.some((row) => row.intent?.kind === "fusionWorkers")).toBe(false);
   });
 
   it("never offers a model that is not on disk", () => {
@@ -95,10 +71,12 @@ describe("the workers switch", () => {
 });
 
 describe("the meta bar's worker label", () => {
-  it("counts the workers on the fusion route", () => {
-    expect(selectComposerWorkersLabel(fusionState())).toBe("2 workers");
+  it("states the machine's capacity on the fusion route, not a setting", () => {
+    // "up to N": N is what this machine serves at once, not a number
+    // anyone picked and not a promise about this turn.
+    expect(selectComposerWorkersLabel(fusionState())).toBe("up to 2 workers");
     expect(selectComposerWorkersLabel(fusionState({ workers: 1 }))).toBe(
-      "1 worker",
+      "up to 1 worker",
     );
   });
 

--- a/src/tui/composer-switch/composer-switch-worker-rows.test.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.test.ts
@@ -6,10 +6,7 @@ import {
   localState,
 } from "./composer-switch-fixtures.js";
 import { selectComposerSwitchRows } from "./composer-switch-rows.js";
-import {
-  selectComposerWorkersLabel,
-  selectWorkerRows,
-} from "./composer-switch-worker-rows.js";
+import { selectWorkerRows } from "./composer-switch-worker-rows.js";
 
 describe("the workers switch", () => {
   it("offers both kinds for the worker slot, and no counts", () => {
@@ -83,41 +80,4 @@ describe("the workers switch", () => {
   });
 });
 
-describe("the meta bar's worker label", () => {
-  it("states the machine's capacity on the fusion route, not a setting", () => {
-    // "up to N": N is what this machine serves at once, not a number
-    // anyone picked and not a promise about this turn.
-    expect(selectComposerWorkersLabel(fusionState())).toBe("up to 2 workers");
-    expect(selectComposerWorkersLabel(fusionState({ workers: 1 }))).toBe(
-      "up to 1 worker",
-    );
-  });
 
-  it("says nothing anywhere else", () => {
-    expect(selectComposerWorkersLabel(cloudState())).toBeNull();
-    expect(selectComposerWorkersLabel(localState())).toBeNull();
-    expect(
-      selectComposerWorkersLabel(fusionState({ effective: "cloud" })),
-    ).toBeNull();
-  });
-});
-
-describe("the meta bar with the legs swapped", () => {
-  it("stops quoting a slot count when the workers are in the cloud", () => {
-    // `up to N` is llama-server's request-slot count. A cloud worker leg
-    // has no such pool, and the idle daemon's number would be a fact
-    // about the wrong machine.
-    const base = fusionState();
-    const state = {
-      ...base,
-      providersPanel: {
-        ...base.providersPanel,
-        runMode: {
-          ...base.providersPanel.runMode!,
-          workerProviderId: "aimlapi",
-        },
-      },
-    };
-    expect(selectComposerWorkersLabel(state)).toBe("cloud workers");
-  });
-});

--- a/src/tui/composer-switch/composer-switch-worker-rows.test.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.test.ts
@@ -12,19 +12,32 @@ import {
 } from "./composer-switch-worker-rows.js";
 
 describe("the workers switch", () => {
-  it("lists the downloaded local models, then the deep link — and no counts", () => {
-    // The count rows are gone with v63: how many workers run at once is
-    // the machine's answer (`managed.parallel: "auto"` derives it from
-    // the launch context) and how many a turn spends is the
-    // orchestrator's, per call. Neither is an operator's list.
+  it("offers both kinds for the worker slot, and no counts", () => {
+    // The slot takes either kind: the models on disk, and every cloud
+    // provider that is not already holding the orchestrator slot. The
+    // count rows are gone — the machine sizes the pool and the
+    // orchestrator sizes each fan-out.
     const rows = selectWorkerRows(fusionState());
     expect(rows[0]?.label).toBe("qwen-3.5-4b");
-    expect(rows[0]?.detail).toBe("worker model");
+    expect(rows[0]?.detail).toBe("workers · on this machine");
     expect(rows.map((row) => row.label)).toEqual([
       "qwen-3.5-4b",
+      "aimlapi",
       "Download more models…",
     ]);
+    expect(rows.find((row) => row.label === "aimlapi")?.intent).toEqual({
+      kind: "fusionLeg",
+      leg: "worker",
+      providerId: "aimlapi",
+    });
     expect(rows.some((row) => /worker(s)?$/.test(row.label))).toBe(false);
+  });
+
+  it("never offers the orchestrator's own provider as its workers", () => {
+    // Fanning out to the model that is doing the orchestrating buys
+    // nothing and doubles the bill.
+    const rows = selectWorkerRows(fusionState());
+    expect(rows.some((row) => row.label === "openrouter")).toBe(false);
   });
 
   it("marks the model in force", () => {

--- a/src/tui/composer-switch/composer-switch-worker-rows.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.ts
@@ -1,14 +1,17 @@
 import type { TuiState } from "../tui-state.js";
 import {
+  configuredCloudProviders,
   localSliceLoadingRows,
   type ComposerSwitchRow,
 } from "./composer-switch-rows.js";
 
 /**
  * The rows of the composer's fourth control, `workers` — drawn only on
- * the fusion route. Two things are configured here and nowhere else in
- * the composer: which local model the workers run, and how many may run
- * at once.
+ * the fusion route. This is fusion's second SLOT: who runs the workers.
+ * Either kind may hold it. The default pairing is a cloud orchestrator
+ * with local workers, because that is the economics the mode was built
+ * for, but the reverse — a local model planning, cloud models executing
+ * — is a real use case and is one Enter away here.
  *
  * The model rows are what is on disk, the same rule the local model
  * switch follows (a catalog row would put a multi-gigabyte download one
@@ -33,18 +36,40 @@ export function selectWorkerRows(
   // means "local-llama is the chat route", which under fusion it never
   // is — the cloud orchestrator holds that seat. What matters here is
   // which model the managed daemon serves.
+  const runMode = state.providersPanel.runMode;
+  const localHoldsTheSlot = runMode?.workerProviderId === "local-llama";
   const models = state.localModelsPanel.rows
     .filter((row) => row.downloaded)
     .map((row) => ({
       id: `worker:model:${row.id}`,
       label: row.id,
-      detail: "worker model",
-      active: row.active,
+      detail: "workers · on this machine",
+      // Active only when the local leg actually holds the slot: a
+      // downloaded model the workers are not running is not in force,
+      // however active the daemon considers it.
+      active: localHoldsTheSlot && row.active,
       intent: { kind: "fusionWorkerModel" as const, modelId: row.id },
+    }));
+  // The other kind of worker. A cloud provider here is the whole point
+  // of the slot being a slot: cheap local planning, capable cloud
+  // execution, chosen per use case rather than baked into the mode.
+  const cloud = configuredCloudProviders(state)
+    .filter((provider) => provider.id !== runMode?.orchestratorProviderId)
+    .map((provider) => ({
+      id: `worker:provider:${provider.id}`,
+      label: provider.id,
+      detail: provider.hasApiKey ? "workers · in the cloud" : "no API key",
+      active: runMode?.workerProviderId === provider.id,
+      intent: {
+        kind: "fusionLeg" as const,
+        leg: "worker" as const,
+        providerId: provider.id,
+      },
     }));
   return [
     ...localSliceLoadingRows(state),
     ...models,
+    ...cloud,
     {
       id: "worker:model:download-more",
       label: "Download more models…",

--- a/src/tui/composer-switch/composer-switch-worker-rows.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.ts
@@ -91,5 +91,13 @@ export function selectWorkerRows(
 export function selectComposerWorkersLabel(state: TuiState): string | null {
   const runMode = state.providersPanel.runMode;
   if (runMode?.effective !== "fusion") return null;
+  // The number is llama-server's slot count, so it only describes a
+  // local worker leg. With cloud workers there is no pool to cap at —
+  // the width is whatever the provider takes concurrently — and showing
+  // the idle daemon's number would be describing the wrong machine.
+  const workerRow = state.providersPanel.rows.find(
+    (row) => row.id === runMode.workerProviderId,
+  );
+  if (workerRow && workerRow.kind !== "llama-server") return "cloud workers";
   return `up to ${runMode.workers} worker${runMode.workers === 1 ? "" : "s"}`;
 }

--- a/src/tui/composer-switch/composer-switch-worker-rows.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.ts
@@ -79,25 +79,3 @@ export function selectWorkerRows(
     },
   ];
 }
-
-/**
- * The fourth control's word on the meta bar, `null` off the fusion route.
- *
- * "up to N", not "N workers": the number is what this machine can serve
- * at once, and how many of them a given turn actually spends is the
- * orchestrator's decision on that turn. The old wording read as a
- * setting, which is precisely what it no longer is.
- */
-export function selectComposerWorkersLabel(state: TuiState): string | null {
-  const runMode = state.providersPanel.runMode;
-  if (runMode?.effective !== "fusion") return null;
-  // The number is llama-server's slot count, so it only describes a
-  // local worker leg. With cloud workers there is no pool to cap at —
-  // the width is whatever the provider takes concurrently — and showing
-  // the idle daemon's number would be describing the wrong machine.
-  const workerRow = state.providersPanel.rows.find(
-    (row) => row.id === runMode.workerProviderId,
-  );
-  if (workerRow && workerRow.kind !== "llama-server") return "cloud workers";
-  return `up to ${runMode.workers} worker${runMode.workers === 1 ? "" : "s"}`;
-}

--- a/src/tui/composer-switch/composer-switch-worker-rows.ts
+++ b/src/tui/composer-switch/composer-switch-worker-rows.ts
@@ -1,7 +1,3 @@
-import {
-  FUSION_WORKERS_MAX,
-  FUSION_WORKERS_MIN,
-} from "../../config/llm-run-mode-config.js";
 import type { TuiState } from "../tui-state.js";
 import {
   localSliceLoadingRows,
@@ -21,17 +17,18 @@ import {
  * it through the local-models orchestrator, which never touches
  * `activeTextProvider`, so fusion stays effective across the pick.
  *
- * The count rows mirror `llm.runMode.fusion.workers` and, in the same
- * write, `localModels.managed.parallel` — the llama-server slot count
- * that lets N workers actually run side by side rather than queue on
- * the server. A running daemon keeps its old slot count until it is
- * restarted, which the orchestrator says in a notice.
+ * There are no count rows. How many workers a fan-out runs is the
+ * orchestrator's call per call, bounded by what the machine serves —
+ * `localModels.managed.parallel: "auto"` derives the slot count from the
+ * context the daemon launches with (`worker-slots.ts`), and the `###
+ * fusion` block states it so the model chooses against a real number.
+ * An operator picking it from a list was choosing for two parties that
+ * both know better: the machine, which knows its capacity, and the
+ * model, which knows how divisible this job is.
  */
 export function selectWorkerRows(
   state: TuiState,
 ): readonly ComposerSwitchRow[] {
-  const workers = state.providersPanel.runMode?.workers ?? 2;
-  const external = state.localModelsPanel.configMode === "external";
   // The panel's own `active` flag, not the LLM pane's row: that one
   // means "local-llama is the chat route", which under fusion it never
   // is — the cloud orchestrator holds that seat. What matters here is
@@ -45,22 +42,9 @@ export function selectWorkerRows(
       active: row.active,
       intent: { kind: "fusionWorkerModel" as const, modelId: row.id },
     }));
-  const counts: ComposerSwitchRow[] = [];
-  for (let n = FUSION_WORKERS_MIN; n <= FUSION_WORKERS_MAX; n += 1) {
-    counts.push({
-      id: `worker:count:${n}`,
-      label: `${n} worker${n === 1 ? "" : "s"}`,
-      detail: external
-        ? "external server — set --parallel yourself"
-        : `llama-server --parallel ${n} · restart to apply`,
-      active: n === workers,
-      intent: { kind: "fusionWorkers" as const, workers: n },
-    });
-  }
   return [
     ...localSliceLoadingRows(state),
     ...models,
-    ...counts,
     {
       id: "worker:model:download-more",
       label: "Download more models…",
@@ -71,9 +55,16 @@ export function selectWorkerRows(
   ];
 }
 
-/** The fourth control's word on the meta bar, `null` off the fusion route. */
+/**
+ * The fourth control's word on the meta bar, `null` off the fusion route.
+ *
+ * "up to N", not "N workers": the number is what this machine can serve
+ * at once, and how many of them a given turn actually spends is the
+ * orchestrator's decision on that turn. The old wording read as a
+ * setting, which is precisely what it no longer is.
+ */
 export function selectComposerWorkersLabel(state: TuiState): string | null {
   const runMode = state.providersPanel.runMode;
   if (runMode?.effective !== "fusion") return null;
-  return `${runMode.workers} worker${runMode.workers === 1 ? "" : "s"}`;
+  return `up to ${runMode.workers} worker${runMode.workers === 1 ? "" : "s"}`;
 }

--- a/src/tui/composer-switch/index.ts
+++ b/src/tui/composer-switch/index.ts
@@ -25,7 +25,6 @@ export {
 } from "./composer-backend-selectors.js";
 export { ComposerMetaControls } from "./composer-meta-controls.js";
 export {
-  selectComposerWorkersLabel,
   selectWorkerRows,
 } from "./composer-switch-worker-rows.js";
 export { ComposerSwitchPopup } from "./composer-switch-popup.js";

--- a/src/tui/llm-panel/llm-panel-selectors.ts
+++ b/src/tui/llm-panel/llm-panel-selectors.ts
@@ -199,11 +199,25 @@ export function selectPromptLlmMeta(state: TuiState): PromptLlmMeta {
       orchestratorRow?.chatModel ??
       runMode.orchestratorProviderId ??
       "cloud";
-    const worker =
-      runMode.workerModel ??
-      state.localModelsPanel.activeModelId ??
-      state.llmHealth.model ??
-      "local";
+    // The worker half is labelled from the worker LEG, not from the
+    // local daemon: with the legs swapped the workers run in the cloud,
+    // and naming the idle local model there is the same lie the
+    // orchestrator half used to tell.
+    const workerRow =
+      state.providersPanel.rows.find(
+        (row) => row.id === runMode.workerProviderId,
+      ) ?? null;
+    const workerIsLocal =
+      workerRow === null || workerRow.kind === "llama-server";
+    const worker = workerIsLocal
+      ? (runMode.workerModel ??
+        state.localModelsPanel.activeModelId ??
+        state.llmHealth.model ??
+        "local")
+      : (runMode.workerModel ??
+        workerRow.chatModel ??
+        runMode.workerProviderId ??
+        "cloud");
     return {
       model: `${orchestrator} ⇄ ${worker}`,
       provider: runMode.orchestratorProviderId ?? active?.id ?? null,

--- a/src/tui/persist-run-mode.test.ts
+++ b/src/tui/persist-run-mode.test.ts
@@ -135,6 +135,8 @@ describe("setRunModeInConfig", () => {
         RunModePersistError,
       );
     }
-    expect(getConfig().localModels.managed.parallel).toBe(2);
+    // Untouched means untouched: the slot count is still the machine's
+    // to decide, which is what `"auto"` says.
+    expect(getConfig().localModels.managed.parallel).toBe("auto");
   });
 });

--- a/src/tui/run-mode/fusion-preflight.test.ts
+++ b/src/tui/run-mode/fusion-preflight.test.ts
@@ -12,10 +12,16 @@ describe("describeFusionBlocker", () => {
     expect(describeFusionBlocker(fusionState())).toBeNull();
   });
 
-  it("names the missing cloud key first", () => {
+  it("names the second leg as missing when only the local one can answer", () => {
+    // `localState()` has the llama-server row and no keyed cloud one:
+    // one usable leg, so fusion is one provider short — and the one it
+    // is short of is the orchestrator, because the local leg is there.
     expect(describeFusionBlocker(localState())).toMatch(
-      /needs a cloud provider with a key/,
+      /needs a second provider to orchestrate/,
     );
+  });
+
+  it("counts a keyless cloud row as unable to answer", () => {
     const keyless = fusionState();
     const state = {
       ...keyless,
@@ -27,10 +33,13 @@ describe("describeFusionBlocker", () => {
         })),
       },
     };
-    expect(describeFusionBlocker(state)).toMatch(/Manage › LLM › Cloud/);
+    expect(describeFusionBlocker(state)).toMatch(/Manage › LLM/);
   });
 
-  it("names the missing local model once the snapshot has landed", () => {
+  it("names the missing second leg when nothing is downloaded", () => {
+    // A keyed cloud provider and a local row with an empty disk: the
+    // cloud leg can answer, the local one cannot, so the pair is short
+    // by one — whichever kind the operator fills it with.
     const base = cloudState();
     const state = {
       ...base,
@@ -40,9 +49,7 @@ describe("describeFusionBlocker", () => {
         lastRefreshedAt: 1,
       },
     };
-    expect(describeFusionBlocker(state)).toMatch(
-      /needs a downloaded local model/,
-    );
+    expect(describeFusionBlocker(state)).toMatch(/needs a second provider/);
   });
 
   it("abstains on the model check before the first snapshot", () => {

--- a/src/tui/run-mode/fusion-preflight.ts
+++ b/src/tui/run-mode/fusion-preflight.ts
@@ -16,18 +16,28 @@ import type { TuiState } from "../tui-state.js";
  * `rows` is indistinguishable from "nothing downloaded" before then.
  */
 export function describeFusionBlocker(state: TuiState): string | null {
-  const cloudReady = state.providersPanel.rows.some(
+  // Two legs, and either may be cloud or local — so the check is "are
+  // there two providers that could actually answer", not "is there a
+  // cloud one and a local one". A cloud row can answer when it has a
+  // key; the local row can answer when something is on disk.
+  const cloudReady = state.providersPanel.rows.filter(
     (row) => row.kind !== "llama-server" && row.hasApiKey,
-  );
-  if (!cloudReady) {
-    return "needs a cloud provider with a key — Manage › LLM › Cloud";
-  }
+  ).length;
   const local = state.localModelsPanel;
-  if (
-    local.lastRefreshedAt !== null &&
-    !local.rows.some((row) => row.downloaded)
-  ) {
-    return "needs a downloaded local model — Manage › LLM › Local";
+  // Abstains until the first snapshot lands, for the reason
+  // `selectComposerNeedsModelDownload` does: an empty `rows` is
+  // indistinguishable from "nothing downloaded" before then.
+  const localReady =
+    local.lastRefreshedAt === null || local.rows.some((row) => row.downloaded)
+      ? state.providersPanel.rows.filter((row) => row.kind === "llama-server")
+          .length
+      : 0;
+  if (cloudReady + localReady >= 2) return null;
+  if (cloudReady + localReady === 1 && localReady === 1) {
+    return "needs a second provider to orchestrate — Manage › LLM › Cloud";
   }
-  return null;
+  if (cloudReady + localReady === 1) {
+    return "needs a second provider for the workers — Manage › LLM";
+  }
+  return "needs two providers, one per leg — Manage › LLM";
 }

--- a/src/tui/run-mode/run-mode-orchestrator.test.ts
+++ b/src/tui/run-mode/run-mode-orchestrator.test.ts
@@ -105,7 +105,7 @@ describe("RunModeOrchestrator.setMode", () => {
     expect(app.actions.some((a) => a.type === "composer_notice")).toBe(false);
   });
 
-  it("fusion: refuses with the degradation sentence when there is no cloud provider", async () => {
+  it("fusion: refuses with the degradation sentence when only one provider exists", async () => {
     seed({ ...BOTH_LEGS, providers: [BOTH_LEGS!.providers[0]!] });
     const app = harness();
     await app.orchestrator.setMode("fusion");
@@ -113,12 +113,14 @@ describe("RunModeOrchestrator.setMode", () => {
     expect(app.setActive).not.toHaveBeenCalled();
     const notice = app.actions.find((a) => a.type === "composer_notice");
     expect(notice).toBeDefined();
+    // Not "needs a cloud provider": either leg may be cloud or local
+    // now, so what is missing is a second provider, not a kind.
     expect((notice as { text: string }).text).toMatch(
-      /needs a cloud orchestrator/,
+      /needs two providers/,
     );
   });
 
-  it("fusion: refuses when there is no llama-server provider", async () => {
+  it("fusion: refuses when the only provider would have to fill both legs", async () => {
     seed({
       ...BOTH_LEGS,
       activeTextProvider: "openrouter",
@@ -130,7 +132,7 @@ describe("RunModeOrchestrator.setMode", () => {
     expect(getConfig().llm?.runMode).toBeUndefined();
     expect(app.actions.find((a) => a.type === "composer_notice")).toMatchObject(
       {
-        text: expect.stringMatching(/needs local workers/),
+        text: expect.stringMatching(/needs two providers/),
       },
     );
   });

--- a/src/tui/run-mode/run-mode-orchestrator.test.ts
+++ b/src/tui/run-mode/run-mode-orchestrator.test.ts
@@ -200,9 +200,16 @@ describe("RunModeOrchestrator.setMode", () => {
     );
   });
 
-  it("setWorkers says nothing about restarting when the count did not move", () => {
+  it("setWorkers says nothing about restarting when the pin did not move", () => {
+    // Against `"auto"` a number always moves the slot count — it pins
+    // what the machine was deciding — so the quiet case is a re-pin to
+    // the number already written.
     seed(BOTH_LEGS);
     const app = harness();
+    // Pin it first: against `"auto"` a number always moves the slot
+    // count, so the quiet case is a re-pin to what is already written.
+    app.orchestrator.setWorkers(2);
+    app.actions.length = 0;
     app.orchestrator.setWorkers(2);
     const line = app.actions.find((a) => a.type === "runtime_info") as {
       line: string;
@@ -214,7 +221,7 @@ describe("RunModeOrchestrator.setMode", () => {
     seed(BOTH_LEGS);
     const app = harness();
     app.orchestrator.setWorkers(99);
-    expect(getConfig().localModels.managed.parallel).toBe(2);
+    expect(getConfig().localModels.managed.parallel).toBe("auto");
     expect(app.actions.find((a) => a.type === "composer_notice")).toMatchObject(
       {
         text: expect.stringMatching(/workers must be an integer 1-8/),

--- a/src/tui/run-mode/run-mode-orchestrator.ts
+++ b/src/tui/run-mode/run-mode-orchestrator.ts
@@ -76,11 +76,19 @@ export class RunModeOrchestrator {
     let leg: string | null;
     let fusion: RunModeChangeOptions["fusion"] = opts.fusion;
     if (mode === "fusion") {
+      // Cloud orchestrator is the DEFAULT, not the rule. An explicit pin
+      // wins whatever its kind — a local orchestrator driving cloud
+      // workers is a pairing an operator may well want (cheap planning,
+      // capable execution), and the runtime has no business overruling
+      // it. Without a pin the preference order is: the provider already
+      // active, then the first usable cloud one, then whatever the
+      // resolver last had.
       leg =
         opts.fusion?.orchestratorProvider ??
         (activeIsCloud ? resolved.activeTextProvider : null) ??
         this.firstUsableCloudProvider(resolved) ??
-        rm.orchestratorProviderId;
+        rm.orchestratorProviderId ??
+        resolved.activeTextProvider;
       if (leg === null || leg === undefined) {
         this.refuse(
           describeRunModeDegradation({
@@ -90,10 +98,15 @@ export class RunModeOrchestrator {
         );
         return;
       }
-      if (rm.workerProviderId === null) {
+      const workerLeg =
+        opts.fusion?.workerProvider ??
+        (rm.workerProviderId !== leg ? rm.workerProviderId : null) ??
+        resolved.providers.find((p) => p.id !== leg)?.id ??
+        null;
+      if (workerLeg === null) {
         this.refuse(
           describeRunModeDegradation({
-            reason: "no-local-provider",
+            reason: "no-second-provider",
             requested: mode,
           }),
         );
@@ -107,7 +120,7 @@ export class RunModeOrchestrator {
       fusion = {
         ...fusion,
         orchestratorProvider: leg,
-        workerProvider: opts.fusion?.workerProvider ?? rm.workerProviderId,
+        workerProvider: workerLeg,
       };
     } else if (mode === "cloud") {
       leg = activeIsCloud

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -59,7 +59,6 @@ import {
   runComposerSwitchRow,
   selectComposerBackend,
   selectComposerBackendMeta,
-  selectComposerWorkersLabel,
   selectComposerNeedsModelDownload,
   type ComposerSwitchRow,
 } from "./composer-switch/index.js";
@@ -1714,8 +1713,6 @@ export function TuiApp({
   // Managed-local with an empty catalog: the model slot becomes
   // `download model` and points at the pane that pulls one.
   const promptNeedsModelDownload = selectComposerNeedsModelDownload(state);
-  // Fusion's fourth control: the worker count, `null` on every other route.
-  const promptWorkers = selectComposerWorkersLabel(state);
   // A notice outranks the route for the couple of seconds it is up: it
   // is the answer to a keystroke the operator just made, and the route
   // is ambient.
@@ -2300,7 +2297,6 @@ export function TuiApp({
                         model={promptLlm.model}
                         provider={promptLlm.provider}
                         needsModelDownload={promptNeedsModelDownload}
-                        workers={promptWorkers}
                         leftSlot={promptLeftSlot}
                         rightSlot={promptRightSlot}
                         contextSlot={promptContextSlot}


### PR DESCRIPTION
Stacked on #398 (which stacks on #391); the diff to review here is the last commit.

Fusion assumed its pairing — cloud orchestrator, local workers. That is the right **default** and the economics the mode was built for, but it was baked in as a **rule**, and it did not have to be. Cheap local planning driving capable cloud executors is a real use case; so is a large local model orchestrating a small one.

So fusion now has two slots and either may hold either kind.

### What was actually enforcing the pairing

Three places, none of which needed to:

- **The resolver.** The worker leg defaulted to "the first llama-server provider, or nothing". It now still *prefers* a local provider — that is the default pairing — but a pinned leg is honoured whatever its kind, and the fallback is "any provider that is not the other leg".
- **`setMode`.** It forced the orchestrator onto a cloud provider and refused with `no-cloud-provider` when there wasn't one. An explicit pin now wins; without one the order is the active provider, then the first usable cloud one. The second leg is picked the same way, and the refusal only fires when there is no second provider at all.
- **The pre-flight.** It required *one of each*. It now counts legs that could actually answer — a keyed cloud row, or a local row with something on disk — and asks for two of them.

`no-local-provider` became `no-second-provider`, and its sentence stopped prescribing a kind.

### In the composer, the two controls are the two slots

- **Provider control = the orchestrator slot**: the cloud rows as before, plus `local-llama` when a model is on disk.
- **Workers control = the worker slot**: the models on disk, plus every cloud provider that is **not** already orchestrating. Fanning out to the model that is doing the orchestrating buys nothing and doubles the bill, so it is not offered.
- Picking a local model for the workers also claims the slot for the local leg — otherwise a pin left on a cloud provider would quietly ignore the pick.

### One honesty fix that came with it

The `### fusion` machine line states llama-server slot counts. Those are a fact about the local daemon, so it now states them only when the local leg is the one running the workers; with cloud workers there is no slot pool to describe and the idle daemon's number would be about the wrong machine.

### Verified

`npx tsc --noEmit` clean. New resolver tests for the swapped pairing (local orchestrator + cloud workers resolves to effective fusion with both legs pinned) and for two cloud providers never landing on the same leg. Every test that encoded the old assumption was rewritten to the new contract rather than deleted — the pre-flight's two blockers, `setMode`'s two refusals, the fusion row's detail column, and the worker rows. `src/tui`, `src/llm`, `src/prompt`, `src/tools/fusion`, `src/config`: 4756 passing.