### PR TITLE
fix(fusion): make the workers do the work

### DIFF
--- a/grammars/tool-call.gbnf
+++ b/grammars/tool-call.gbnf
@@ -5,13 +5,24 @@
 root ::= tool-call-array
 tool-call ::= "{" ws "\"tool\"" ws ":" ws tool-name ws "," ws "\"args\"" ws ":" ws object ws "}"
 tool-call-array ::= "[" ws tool-call ( ws "," ws tool-call ){0,15} ws "]"
-tool-name ::= browser-tool | os-tool | discovery-tool | memory-tool | tasks-tool | vision-tool | mcp-native-tool | mcp-server-tool | "\"reply\"" | "\"finish\""
+tool-name ::= browser-tool | os-tool | discovery-tool | memory-tool | tasks-tool | vision-tool | fusion-tool | mcp-native-tool | mcp-server-tool | "\"reply\"" | "\"finish\""
 browser-tool ::= "\"browser." ( "navigate" | "click" | "type" | "read_aria" | "search" | "tabs" | "scroll" ) "\""
-os-tool ::= "\"os." ( "shell.run" | "fs.read" | "fs.read_document" | "fs.write" | "fs.trash" | "fs.list" | "fs.grep" | "fs.glob" | "fs.locate_project" | "fs.edit" | "fs.hash" | "fs.diff" | "fs.patch" | "fs.watch" | "fs.archive.list" | "fs.archive.read_entry" | "fs.archive.extract" | "http.request" | "web.search" | "web.fetch" | "git.status" | "git.log" | "git.diff" | "git.show" | "git.blame" | "git.branch" | "proc.list" | "proc.kill" | "clipboard.read" | "clipboard.write" | "window.list" | "window.focus" | "notify" | "email.inbox" | "email.send" ) "\""
+os-tool ::= "\"os." ( "shell.run" | "fs.read" | "fs.read_document" | "fs.write" | "fs.trash" | "fs.list" | "fs.grep" | "fs.glob" | "fs.locate_project" | "fs.edit" | "fs.hash" | "fs.diff" | "fs.patch" | "fs.watch" | "fs.archive.list" | "fs.archive.read_entry" | "fs.archive.extract" | "http.request" | "web.search" | "web.fetch" | "git.status" | "git.log" | "git.diff" | "git.show" | "git.blame" | "git.branch" | "git.init" | "git.add" | "git.commit" | "git.checkout" | "git.clone" | "git.remote" | "git.fetch" | "git.pull" | "git.push" | "proc.list" | "proc.kill" | "clipboard.read" | "clipboard.write" | "window.list" | "window.focus" | "notify" | "email.inbox" | "email.send" ) "\""
 discovery-tool ::= "\"skill." ( "view" | "run_script" ) "\"" | "\"tool.view\""
 memory-tool ::= "\"memory." ( "profile.set" | "profile.remove" | "profile.list" | "profile.history" | "notes.store" | "notes.recall" | "notes.forget" | "lessons.recall" | "procedures.recall" ) "\""
 tasks-tool ::= "\"tasks." ( "schedule" | "cron" | "list" | "cancel" | "show" ) "\""
 vision-tool ::= "\"vision.describe\""
+# Fusion's fan-out. Listed here for the same reason `tasks.*` is: the
+# grammar is the local model's whole vocabulary of tool names, and a
+# name missing from it cannot be emitted at all. A LOCAL orchestrator
+# is the case that needs it — it reasoned "I need to call
+# fusion.delegate", the constrained sampler had no such name, and it
+# was pushed into `finish` instead, reporting a fan-out that never
+# happened. Unconditional, like `tasks.*`: availability is the
+# registry's business, not the sampler's, and a fusion worker (which is
+# also grammar-constrained) is refused by `fusion.delegate` itself when
+# it tries to fan out again.
+fusion-tool ::= "\"fusion.delegate\""
 # Native MCP discovery / resource / prompt tools — always available.
 mcp-native-tool ::= "\"mcp." ( "resource.list" | "resource.read" | "prompt.list" | "prompt.get" ) "\""
 # Per-server MCP tool branch. The static fallback (`mcp.<any>.<any>`)

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1205,8 +1205,8 @@ export class AgentLoop {
               ? {
                   isFusionOrchestrator: () => true,
                   fusionState: () => fusionState,
-                  onDelegated: (result) => {
-                    fusionState = recordDelegation(fusionState, result);
+                  onDelegated: () => {
+                    fusionState = recordDelegation(fusionState);
                   },
                 }
               : {}),

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -1,3 +1,7 @@
+import {
+  emptyFusionOrchestratorState,
+  recordDelegation,
+} from "./fusion-orchestrator-mode.js";
 import type {
   CompletionResult,
   StreamChunk,
@@ -879,7 +883,7 @@ export class AgentLoop {
     // and must never close on the hands it is meant to free.
     const fusionOrchestratorTurn =
       (this.deps.isFusionMode?.() ?? false) && options.ephemeral !== true;
-    let fusionDelegatedThisTurn = false;
+    let fusionState = emptyFusionOrchestratorState();
 
     let reason: AgentLoopReason = "max_steps";
     let stepsTaken = 0;
@@ -1200,9 +1204,9 @@ export class AgentLoop {
             ...(fusionOrchestratorTurn
               ? {
                   isFusionOrchestrator: () => true,
-                  hasDelegated: () => fusionDelegatedThisTurn,
-                  onDelegated: () => {
-                    fusionDelegatedThisTurn = true;
+                  fusionState: () => fusionState,
+                  onDelegated: (result) => {
+                    fusionState = recordDelegation(fusionState, result);
                   },
                 }
               : {}),

--- a/src/agent/agent-loop.ts
+++ b/src/agent/agent-loop.ts
@@ -93,6 +93,11 @@ export interface AgentLoopDependencies {
    * (embedders, tests) means "not fusion", which gates nothing.
    */
   isFusionMode?: () => boolean;
+  /**
+   * Drop the fan-out approval a previous turn on this session earned.
+   * See `approval/fanout-scope.ts`: the answer is scoped to one job.
+   */
+  clearFanoutTurnGrant?: (sessionId: string) => void;
   slotManager: SlotManager;
   grammar: string;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
@@ -884,6 +889,12 @@ export class AgentLoop {
     const fusionOrchestratorTurn =
       (this.deps.isFusionMode?.() ?? false) && options.ephemeral !== true;
     let fusionState = emptyFusionOrchestratorState();
+    // A fan-out approval stands for the turn that asked for it and no
+    // longer. Cleared here rather than when the turn ends so an aborted
+    // or crashed turn cannot leave authority behind for the next one.
+    if (fusionOrchestratorTurn) {
+      this.deps.clearFanoutTurnGrant?.(session.id);
+    }
 
     let reason: AgentLoopReason = "max_steps";
     let stepsTaken = 0;

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -1186,7 +1186,7 @@ describe("the fusion orchestrator gate in the executor", () => {
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        hasDelegated: () => false,
+        fusionState: () => ({ delegations: 0, handedUp: 0 }),
       },
     );
     expect(run).not.toHaveBeenCalled();
@@ -1203,7 +1203,7 @@ describe("the fusion orchestrator gate in the executor", () => {
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        hasDelegated: () => true,
+        fusionState: () => ({ delegations: 1, handedUp: 1 }),
       },
     );
     expect(run).toHaveBeenCalledTimes(1);
@@ -1218,16 +1218,17 @@ describe("the fusion orchestrator gate in the executor", () => {
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        hasDelegated: () => false,
+        fusionState: () => ({ delegations: 0, handedUp: 0 }),
       },
     );
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  it("marks the turn as delegated when the fan-out comes back", async () => {
-    // However it went: a fan-out whose workers all failed still leaves
-    // the orchestrator holding results it must be able to act on.
-    let delegated = false;
+  it("hands the fan-out's own result to the turn's ledger", async () => {
+    // The result, not a flag: what unlocks a mutation is how many tasks
+    // came back `needs_orchestrator`, and the ledger must read the same
+    // per-task statuses the model is about to read.
+    let seen: unknown = null;
     const registry = buildRegistry(
       { "fusion.delegate": async () => okResult("fusion.delegate") },
       false,
@@ -1238,13 +1239,13 @@ describe("the fusion orchestrator gate in the executor", () => {
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        hasDelegated: () => delegated,
-        onDelegated: () => {
-          delegated = true;
+        fusionState: () => ({ delegations: 0, handedUp: 0 }),
+        onDelegated: (result) => {
+          seen = result;
         },
       },
     );
-    expect(delegated).toBe(true);
+    expect(seen).toMatchObject({ tool: "fusion.delegate" });
   });
 
   it("gates nothing when the turn is not the orchestrator's", async () => {

--- a/src/agent/batch-executor.test.ts
+++ b/src/agent/batch-executor.test.ts
@@ -1186,7 +1186,7 @@ describe("the fusion orchestrator gate in the executor", () => {
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        fusionState: () => ({ delegations: 0, handedUp: 0 }),
+        fusionState: () => ({ delegations: 0 }),
       },
     );
     expect(run).not.toHaveBeenCalled();
@@ -1194,19 +1194,24 @@ describe("the fusion orchestrator gate in the executor", () => {
     expect(out.results[0]?.compressed?.summary).toContain("fusion.delegate");
   });
 
-  it("dispatches the same call once the turn has delegated", async () => {
+  it("keeps refusing after a fan-out — there is no circumstance", async () => {
+    // The gate had two escapes before this: a latch on any completed
+    // fan-out, then an allowance for tasks a worker handed up. At
+    // approval level 1 four of six tasks came back handed up, so the
+    // second escape was the main road. Neither exists now.
     const run = vi.fn(async () => okResult("os.fs.write"));
     const registry = buildRegistry({ "os.fs.write": run }, false);
-    await executeBatch(
+    const out = await executeBatch(
       toBatchInputs([{ tool: "os.fs.write", args: { path: "a" } }]),
       registry,
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        fusionState: () => ({ delegations: 1, handedUp: 1 }),
+        fusionState: () => ({ delegations: 3 }),
       },
     );
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).not.toHaveBeenCalled();
+    expect(out.results[0]?.compressed?.status).toBe("error");
   });
 
   it("leaves reads alone while the turn is still planning", async () => {
@@ -1218,7 +1223,7 @@ describe("the fusion orchestrator gate in the executor", () => {
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        fusionState: () => ({ delegations: 0, handedUp: 0 }),
+        fusionState: () => ({ delegations: 0 }),
       },
     );
     expect(run).toHaveBeenCalledTimes(1);
@@ -1239,7 +1244,7 @@ describe("the fusion orchestrator gate in the executor", () => {
       {
         ...ctx(ctrl.signal),
         isFusionOrchestrator: () => true,
-        fusionState: () => ({ delegations: 0, handedUp: 0 }),
+        fusionState: () => ({ delegations: 0 }),
         onDelegated: (result) => {
           seen = result;
         },

--- a/src/agent/batch-executor.ts
+++ b/src/agent/batch-executor.ts
@@ -1,5 +1,9 @@
 import { checkPlanMode } from "./plan-mode.js";
-import { checkFusionOrchestrator } from "./fusion-orchestrator-mode.js";
+import {
+  checkFusionOrchestrator,
+  emptyFusionOrchestratorState,
+  type FusionOrchestratorState,
+} from "./fusion-orchestrator-mode.js";
 import type { ToolCallPayload } from "../llm/grammar/tool-call-grammar.js";
 import {
   compressToolResult,
@@ -135,10 +139,10 @@ export interface BatchExecutionContext {
    * `fusion-orchestrator-mode.ts`.
    */
   isFusionOrchestrator?: () => boolean;
-  /** Whether this turn has already completed a `fusion.delegate` call. */
-  hasDelegated?: () => boolean;
-  /** Called once a `fusion.delegate` call comes back, however it went. */
-  onDelegated?: () => void;
+  /** What this turn has delegated and what came back — see `fusion-orchestrator-mode.ts`. */
+  fusionState?: () => FusionOrchestratorState;
+  /** Called with a `fusion.delegate` result so the turn's ledger can fold it in. */
+  onDelegated?: (result: CompressedToolResult) => void;
   /**
    * Names of skills already present in `SessionState.loadedSkills`. A
    * `skill.view` call targeting one of these is short-circuited with a
@@ -415,10 +419,12 @@ export async function executeBatch(
       compressed,
       durationMs,
     };
-    // A fan-out that came back — whatever the workers made of it — opens
-    // the orchestrator's own write gate for the rest of the turn, so it
-    // can merge what it got and run the parts workers had to hand up.
-    if (input.call.tool === "fusion.delegate") ctx.onDelegated?.();
+    // A fan-out that came back is folded into the turn's ledger: how
+    // many tasks a worker handed up is what decides whether the
+    // orchestrator may run anything itself. The result is passed whole
+    // rather than a flag, so the ledger reads the same per-task
+    // statuses the model is about to read.
+    if (input.call.tool === "fusion.delegate") ctx.onDelegated?.(compressed);
     // Record the real outcome so the next step's gate sees a completed
     // (args + result) entry. Terminal verbs are not tracked.
     if (ctx.tracker && input.resourceClass !== "terminal") {
@@ -593,9 +599,11 @@ function runFusionOrchestratorGate(
   ctx: BatchExecutionContext,
 ): { proceed: boolean; vetoResult?: CompressedToolResult } {
   if (!ctx.isFusionOrchestrator?.()) return { proceed: true };
-  const verdict = checkFusionOrchestrator(input.call.tool, registry, {
-    delegated: ctx.hasDelegated?.() ?? false,
-  });
+  const verdict = checkFusionOrchestrator(
+    input.call.tool,
+    registry,
+    ctx.fusionState?.() ?? emptyFusionOrchestratorState(),
+  );
   if (verdict.allowed) return { proceed: true };
   return { proceed: false, vetoResult: verdict.refusal! };
 }

--- a/src/agent/fusion-orchestrator-mode.test.ts
+++ b/src/agent/fusion-orchestrator-mode.test.ts
@@ -31,10 +31,8 @@ const REGISTRY = registryWith({
 });
 
 const BEFORE = emptyFusionOrchestratorState();
-/** One fan-out done, nothing handed up — the observed failure case. */
-const AFTER_EMPTY = { delegations: 1, handedUp: 0 };
-/** A worker stopped on an approval it cannot request. */
-const AFTER_HANDED_UP = { delegations: 1, handedUp: 1 };
+/** One fan-out done, however it went. */
+const AFTER = { delegations: 1 };
 
 describe("the fusion orchestrator gate", () => {
   it("lets the orchestrator read while it is still planning", () => {
@@ -75,27 +73,26 @@ describe("the fusion orchestrator gate", () => {
     }
   });
 
-  it("stays shut after a fan-out that handed nothing up", () => {
-    // The failure this gate was rewritten for: a fan-out came back with
-    // one task `needs_orchestrator` and two `cancelled`, and the old
-    // latch let the orchestrator write fifteen files. A delegation that
-    // was merely attempted is not a licence to do the work.
+  it("stays shut after a fan-out, whatever came back", () => {
+    // The failure this gate was rewritten for, twice. First a latch that
+    // opened on any completed fan-out; then an escape for tasks returned
+    // `needs_orchestrator`, which at approval level 1 was FOUR of six
+    // tasks — the escape became the main road and thirteen writes went
+    // through it. There is no circumstance now.
     for (const tool of ["os.fs.write", "os.shell.run"]) {
-      const verdict = checkFusionOrchestrator(tool, REGISTRY, AFTER_EMPTY);
+      const verdict = checkFusionOrchestrator(tool, REGISTRY, AFTER);
       expect(verdict.allowed).toBe(false);
-      expect(verdict.refusal?.summary).toContain("send it out again");
+      expect(verdict.refusal?.summary).toContain("Send it out again");
     }
   });
 
-  it("opens only for work a worker handed up", () => {
-    // The one thing the orchestrator has that the workers do not is a
-    // person to ask. `needs_orchestrator` is a worker saying it hit an
-    // approval it cannot request.
-    for (const tool of ["os.fs.write", "os.shell.run"]) {
-      expect(
-        checkFusionOrchestrator(tool, REGISTRY, AFTER_HANDED_UP).allowed,
-      ).toBe(true);
-    }
+  it("tells a blocked task to come back with its paths named", () => {
+    // `needs_orchestrator` now means "the operator did not authorise
+    // that directory", and the answer is another fan-out whose brief
+    // names the paths, so the prompt can offer the right scope.
+    const verdict = checkFusionOrchestrator("os.fs.write", REGISTRY, AFTER);
+    expect(verdict.refusal?.summary).toContain("needs_orchestrator");
+    expect(verdict.refusal?.summary).toContain("files");
   });
 
   it("does not take an MCP tool's word for being read-only", () => {
@@ -106,9 +103,8 @@ describe("the fusion orchestrator gate", () => {
       checkFusionOrchestrator("mcp.notion.search", REGISTRY, BEFORE).allowed,
     ).toBe(false);
     expect(
-      checkFusionOrchestrator("mcp.notion.search", REGISTRY, AFTER_HANDED_UP)
-        .allowed,
-    ).toBe(true);
+      checkFusionOrchestrator("mcp.notion.search", REGISTRY, AFTER).allowed,
+    ).toBe(false);
   });
 
   it("passes an unknown tool through untouched", () => {
@@ -128,52 +124,15 @@ describe("the fusion orchestrator gate", () => {
 });
 
 describe("recordDelegation", () => {
-  function result(statuses: string[]) {
-    return {
-      tool: "fusion.delegate",
-      status: "ok" as const,
-      summary: "",
-      details: { tasks: statuses.map((status, i) => ({ id: `t${i}`, status })) },
-      truncated: false,
-    };
-  }
-
-  it("counts the tasks a worker handed up, not the fan-outs", () => {
-    // `fusion.delegate` returns ok even when every worker failed —
-    // partial results are the value of a fan-out — so the count that
-    // matters is per task, and only one status means "a worker could
-    // not do this because it has no person to ask".
-    const after = recordDelegation(
-      emptyFusionOrchestratorState(),
-      result(["ok", "cancelled", "needs_orchestrator", "failed"]),
-    );
-    expect(after).toEqual({ delegations: 1, handedUp: 1 });
-  });
-
-  it("reads a fan-out where everything failed as nothing handed up", () => {
-    const after = recordDelegation(
-      emptyFusionOrchestratorState(),
-      result(["cancelled", "cancelled", "failed"]),
-    );
-    expect(after).toEqual({ delegations: 1, handedUp: 0 });
-  });
-
-  it("survives a result with no task list at all", () => {
-    // A refusal, a malformed result, a compressed error: the ledger
-    // still advances its fan-out count and unlocks nothing.
-    const after = recordDelegation(emptyFusionOrchestratorState(), {
-      tool: "fusion.delegate",
-      status: "error",
-      summary: "not fusion",
-      details: {},
-      truncated: false,
-    });
-    expect(after).toEqual({ delegations: 1, handedUp: 0 });
-  });
-
-  it("accumulates across fan-outs", () => {
-    let state = recordDelegation(emptyFusionOrchestratorState(), result(["ok"]));
-    state = recordDelegation(state, result(["needs_orchestrator"]));
-    expect(state).toEqual({ delegations: 2, handedUp: 1 });
+  it("counts fan-outs and unlocks nothing", () => {
+    // The result used to be inspected for `needs_orchestrator` tasks.
+    // Nothing in it can open the gate now, so nothing is read out of it.
+    let state = recordDelegation(emptyFusionOrchestratorState());
+    expect(state).toEqual({ delegations: 1 });
+    state = recordDelegation(state);
+    expect(state).toEqual({ delegations: 2 });
+    expect(
+      checkFusionOrchestrator("os.fs.write", REGISTRY, state).allowed,
+    ).toBe(false);
   });
 });

--- a/src/agent/fusion-orchestrator-mode.test.ts
+++ b/src/agent/fusion-orchestrator-mode.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   checkFusionOrchestrator,
+  emptyFusionOrchestratorState,
+  recordDelegation,
   refusalFor,
 } from "./fusion-orchestrator-mode.js";
 
@@ -19,6 +21,7 @@ function registryWith(
 }
 
 const REGISTRY = registryWith({
+  "mcp.notion.search": { readonly: true },
   "os.fs.read": { readonly: true },
   "os.fs.write": { readonly: false },
   "os.shell.run": { readonly: false },
@@ -27,8 +30,11 @@ const REGISTRY = registryWith({
   finish: { readonly: false },
 });
 
-const BEFORE = { delegated: false };
-const AFTER = { delegated: true };
+const BEFORE = emptyFusionOrchestratorState();
+/** One fan-out done, nothing handed up — the observed failure case. */
+const AFTER_EMPTY = { delegations: 1, handedUp: 0 };
+/** A worker stopped on an approval it cannot request. */
+const AFTER_HANDED_UP = { delegations: 1, handedUp: 1 };
 
 describe("the fusion orchestrator gate", () => {
   it("lets the orchestrator read while it is still planning", () => {
@@ -49,7 +55,7 @@ describe("the fusion orchestrator gate", () => {
       expect(verdict.refusal?.summary).toContain("fusion.delegate");
       expect(verdict.refusal?.details).toMatchObject({
         fusion_orchestrator: true,
-        delegated: false,
+        delegations: 0,
       });
     }
   });
@@ -69,12 +75,40 @@ describe("the fusion orchestrator gate", () => {
     }
   });
 
-  it("opens up once the workers have reported", () => {
-    // Integration is the orchestrator's own job, and so is anything a
-    // worker had to hand up for approval. Both are writes.
+  it("stays shut after a fan-out that handed nothing up", () => {
+    // The failure this gate was rewritten for: a fan-out came back with
+    // one task `needs_orchestrator` and two `cancelled`, and the old
+    // latch let the orchestrator write fifteen files. A delegation that
+    // was merely attempted is not a licence to do the work.
     for (const tool of ["os.fs.write", "os.shell.run"]) {
-      expect(checkFusionOrchestrator(tool, REGISTRY, AFTER).allowed).toBe(true);
+      const verdict = checkFusionOrchestrator(tool, REGISTRY, AFTER_EMPTY);
+      expect(verdict.allowed).toBe(false);
+      expect(verdict.refusal?.summary).toContain("send it out again");
     }
+  });
+
+  it("opens only for work a worker handed up", () => {
+    // The one thing the orchestrator has that the workers do not is a
+    // person to ask. `needs_orchestrator` is a worker saying it hit an
+    // approval it cannot request.
+    for (const tool of ["os.fs.write", "os.shell.run"]) {
+      expect(
+        checkFusionOrchestrator(tool, REGISTRY, AFTER_HANDED_UP).allowed,
+      ).toBe(true);
+    }
+  });
+
+  it("does not take an MCP tool's word for being read-only", () => {
+    // `readonly` on an MCP descriptor is the server's own
+    // `readOnlyHint` / `destructiveHint` — third-party wire data. A
+    // server could opt itself out of the rule by shipping one flag.
+    expect(
+      checkFusionOrchestrator("mcp.notion.search", REGISTRY, BEFORE).allowed,
+    ).toBe(false);
+    expect(
+      checkFusionOrchestrator("mcp.notion.search", REGISTRY, AFTER_HANDED_UP)
+        .allowed,
+    ).toBe(true);
   });
 
   it("passes an unknown tool through untouched", () => {
@@ -87,8 +121,59 @@ describe("the fusion orchestrator gate", () => {
   });
 
   it("names the tool it refused", () => {
-    const refusal = refusalFor("os.fs.write");
+    const refusal = refusalFor("os.fs.write", BEFORE);
     expect(refusal.tool).toBe("os.fs.write");
     expect(refusal.summary).toContain("`os.fs.write`");
+  });
+});
+
+describe("recordDelegation", () => {
+  function result(statuses: string[]) {
+    return {
+      tool: "fusion.delegate",
+      status: "ok" as const,
+      summary: "",
+      details: { tasks: statuses.map((status, i) => ({ id: `t${i}`, status })) },
+      truncated: false,
+    };
+  }
+
+  it("counts the tasks a worker handed up, not the fan-outs", () => {
+    // `fusion.delegate` returns ok even when every worker failed —
+    // partial results are the value of a fan-out — so the count that
+    // matters is per task, and only one status means "a worker could
+    // not do this because it has no person to ask".
+    const after = recordDelegation(
+      emptyFusionOrchestratorState(),
+      result(["ok", "cancelled", "needs_orchestrator", "failed"]),
+    );
+    expect(after).toEqual({ delegations: 1, handedUp: 1 });
+  });
+
+  it("reads a fan-out where everything failed as nothing handed up", () => {
+    const after = recordDelegation(
+      emptyFusionOrchestratorState(),
+      result(["cancelled", "cancelled", "failed"]),
+    );
+    expect(after).toEqual({ delegations: 1, handedUp: 0 });
+  });
+
+  it("survives a result with no task list at all", () => {
+    // A refusal, a malformed result, a compressed error: the ledger
+    // still advances its fan-out count and unlocks nothing.
+    const after = recordDelegation(emptyFusionOrchestratorState(), {
+      tool: "fusion.delegate",
+      status: "error",
+      summary: "not fusion",
+      details: {},
+      truncated: false,
+    });
+    expect(after).toEqual({ delegations: 1, handedUp: 0 });
+  });
+
+  it("accumulates across fan-outs", () => {
+    let state = recordDelegation(emptyFusionOrchestratorState(), result(["ok"]));
+    state = recordDelegation(state, result(["needs_orchestrator"]));
+    expect(state).toEqual({ delegations: 2, handedUp: 1 });
   });
 });

--- a/src/agent/fusion-orchestrator-mode.ts
+++ b/src/agent/fusion-orchestrator-mode.ts
@@ -21,14 +21,22 @@ import type { ToolRegistry } from "../tools/tool-registry.js";
  * every one of them. A latch that opens on "something was attempted"
  * is not a rule about who does the work.
  *
- * **The rule now.** A mutation is allowed only while the turn is
- * holding work a worker physically could not do — a task that came back
- * `needs_orchestrator`, which is what a worker reports when it hit an
- * approval it cannot request (`FUSION_WORKER_APPROVAL_REFUSED`). That
- * is the one thing the orchestrator has that the workers do not: a
- * person at the other end. Everything else — the first draft, the
- * rewrite, the file the worker timed out on — goes back out as another
- * fan-out.
+ * **The rule now: nothing.** The orchestrator does not mutate anything,
+ * in any circumstance, for the whole turn. Read, delegate, reply.
+ *
+ * The version before this one allowed a mutation while the turn held a
+ * task returned `needs_orchestrator` — work a worker could not do
+ * because it had no operator to ask. A session showed why that fails:
+ * FOUR of six tasks came back that way, because at approval level 1 a
+ * worker cannot write at all, and each of their replies said "the
+ * orchestrator must run these steps". The escape hatch became the main
+ * road, and thirteen writes went through it.
+ *
+ * That hole is closed at its source instead — the operator now
+ * authorises a fan-out once and its workers write inside a named
+ * directory (`approval/fanout-scope.ts`), so `needs_orchestrator` means
+ * "this needs a wider scope than you approved", and the answer to it is
+ * another fan-out, not a takeover.
  *
  * **Why a refusal and not a hidden tool.** Descriptor visibility is not
  * capability: the only membership check at execution is against the
@@ -61,20 +69,18 @@ export interface FusionOrchestratorVerdict {
  * batch executor as each fan-out returns.
  */
 export interface FusionOrchestratorState {
-  /** Completed `fusion.delegate` calls this turn, however they went. */
-  delegations: number;
   /**
-   * Tasks that came back `needs_orchestrator` — a worker stopped
-   * because it needed an approval it cannot ask for. This, and only
-   * this, is what unlocks a mutation: the work a worker could not do
-   * because it has no person to ask.
+   * Completed `fusion.delegate` calls this turn, however they went.
+   * Nothing is unlocked by it — it only shapes the refusal, which reads
+   * differently before the first fan-out ("plan and delegate") and after
+   * one ("send the rework back out").
    */
-  handedUp: number;
+  delegations: number;
 }
 
 /** A turn that has not delegated yet. */
 export function emptyFusionOrchestratorState(): FusionOrchestratorState {
-  return { delegations: 0, handedUp: 0 };
+  return { delegations: 0 };
 }
 
 /**
@@ -114,7 +120,6 @@ export function checkFusionOrchestrator(
   }
   if (!registry.has(tool)) return { allowed: true };
   if (!mutates(tool, registry)) return { allowed: true };
-  if (state.handedUp > 0) return { allowed: true };
   return { allowed: false, refusal: refusalFor(tool, state) };
 }
 
@@ -135,21 +140,20 @@ export function refusalFor(
 ): CompressedToolResult {
   const summary =
     state.delegations === 0
-      ? `fusion is on and this turn has not delegated yet, so \`${tool}\` was ` +
-        `not run. You are the orchestrator: the workers do the doing. ` +
-        `Finish reading — every read-only tool still works — decide the ` +
-        `approach, then split the work and call \`fusion.delegate\`: one ` +
-        `task per independent part, each with the exact paths, what counts ` +
-        `as done, and the answer format you want back.`
+      ? `fusion is on, so \`${tool}\` was not run: you plan, the workers ` +
+        `build. Finish reading — every read-only tool still works — ` +
+        `decide the approach, then call \`fusion.delegate\` with one task ` +
+        `per independent part, each naming the exact paths it produces in ` +
+        `\`files\`, what counts as done, and the answer format you want.`
       : `\`${tool}\` was not run. You have delegated ${state.delegations} ` +
-        `time(s) this turn and no worker handed anything up, so there is ` +
-        `nothing here that only you can do — doing the work yourself is ` +
-        `the one thing this mode exists to prevent. If a part came back ` +
-        `\`failed\`, \`cancelled\` or weak, send it out again with ` +
-        `\`fusion.delegate\`: say what was wrong with the last attempt, ` +
-        `what to change, and what "good" looks like. Split a part that ` +
-        `timed out into smaller ones. Only work a worker returned as ` +
-        `\`needs_orchestrator\` is yours to run.`;
+        `time(s) this turn; building the result yourself is the one thing ` +
+        `this mode exists to prevent, however the last fan-out went. Send ` +
+        `it out again with \`fusion.delegate\`: say what was wrong with ` +
+        `the previous attempt, what to change, and what "good" looks ` +
+        `like. Split a part that timed out into smaller ones. A task that ` +
+        `came back \`needs_orchestrator\` was blocked by an approval — ` +
+        `re-send it with the paths in \`files\` so the operator can ` +
+        `authorise that directory when the fan-out asks.`;
   return {
     tool,
     status: "error",
@@ -158,33 +162,20 @@ export function refusalFor(
       fusion_orchestrator: true,
       tool,
       delegations: state.delegations,
-      handed_up: state.handedUp,
     },
     truncated: false,
   };
 }
 
 /**
- * Fold a completed `fusion.delegate` result into the turn's ledger.
+ * Count a completed `fusion.delegate` call.
  *
- * Reads the per-task statuses out of the tool result rather than being
- * told by the caller: the executor sees the `CompressedToolResult` and
- * nothing else, and a count passed alongside could drift from the
- * result the model is reading in the same step.
+ * The result is no longer inspected: nothing in it can unlock a
+ * mutation, so there is nothing to read out of it. The count survives
+ * only to shape the refusal text.
  */
 export function recordDelegation(
   state: FusionOrchestratorState,
-  result: CompressedToolResult,
 ): FusionOrchestratorState {
-  const tasks = (result.details as { tasks?: unknown } | undefined)?.tasks;
-  const handedUp = Array.isArray(tasks)
-    ? tasks.filter(
-        (task) =>
-          (task as { status?: unknown } | null)?.status === "needs_orchestrator",
-      ).length
-    : 0;
-  return {
-    delegations: state.delegations + 1,
-    handedUp: state.handedUp + handedUp,
-  };
+  return { delegations: state.delegations + 1 };
 }

--- a/src/agent/fusion-orchestrator-mode.ts
+++ b/src/agent/fusion-orchestrator-mode.ts
@@ -1,41 +1,46 @@
 import type { CompressedToolResult } from "../compressor/result-compressor.js";
+import { MCP_TOOL_PREFIX } from "../mcp/mcp-resource-class.js";
 import type { ToolRegistry } from "../tools/tool-registry.js";
 
 /**
  * Fusion's division of labour, enforced instead of merely asked for.
  *
- * In fusion mode the expensive cloud model is the orchestrator and the
- * local ones are the hands: it decides the approach, splits the work,
- * writes a self-contained brief per worker, reads what comes back,
- * integrates it, and sends rework back out. The `### fusion` block has
- * said so since the mode shipped — and a capable cloud model, handed a
- * catalog of forty tools, still reads the twelve files itself and never
- * fans anything out. Advice does not hold against that; the model is
- * doing what it is good at.
+ * In fusion mode the orchestrator plans, splits the job, briefs the
+ * workers, reads what comes back, judges it, and sends weak parts out
+ * again. The workers do the doing. The `### fusion` block has said so
+ * since the mode shipped, and a capable cloud model handed a catalog of
+ * forty tools still builds the thing itself.
  *
- * So the first mutation of a fusion turn is refused until the turn has
- * delegated at least once. Read the code, plan, then send the doing to
- * the workers.
+ * **What the first version of this gate got wrong.** It opened for the
+ * rest of the turn as soon as one `fusion.delegate` call completed —
+ * and `fusion.delegate` returns `ok` even when every worker failed, by
+ * design (partial results are the value of a fan-out). A real session
+ * proved the consequence: the fan-out came back with one task
+ * `needs_orchestrator` and two `cancelled`, and the orchestrator then
+ * wrote fifteen files and ran five commands itself. The gate permitted
+ * every one of them. A latch that opens on "something was attempted"
+ * is not a rule about who does the work.
  *
- * **Why a refusal and not a hidden descriptor.** Removing tools from the
- * catalog mid-turn rewrites the stable prefix and drops the session's KV
- * cache (see `effectiveToolDescriptors` in bootstrap). A refusal costs
- * one tool result and reads as an instruction — the same trade plan mode
- * makes, and the same one `fusion.delegate` already makes when a worker
- * calls it.
+ * **The rule now.** A mutation is allowed only while the turn is
+ * holding work a worker physically could not do — a task that came back
+ * `needs_orchestrator`, which is what a worker reports when it hit an
+ * approval it cannot request (`FUSION_WORKER_APPROVAL_REFUSED`). That
+ * is the one thing the orchestrator has that the workers do not: a
+ * person at the other end. Everything else — the first draft, the
+ * rewrite, the file the worker timed out on — goes back out as another
+ * fan-out.
  *
- * **Why it lifts after the first fan-out.** Two things genuinely belong
- * to the orchestrator afterwards: integration — merging what came back,
- * which is a write it must be able to make — and anything a worker
- * handed up because it needed approval, which workers cannot request
- * (`FUSION_WORKER_APPROVAL_REFUSED`). Keeping the gate closed for the
- * whole turn would strand both. Rework goes back to the workers because
- * the guidance says so; that part stays advice, because "this write is
- * rework rather than integration" is not a thing the runtime can see.
+ * **Why a refusal and not a hidden tool.** Descriptor visibility is not
+ * capability: the only membership check at execution is against the
+ * registry, and a model that writes a tool call as text still reaches
+ * `registry.invoke` through the step executor's JSON fallback. Hiding
+ * the descriptor would also rewrite the stable prefix and drop the
+ * session's KV cache. A refusal costs one tool result, reads as an
+ * instruction, and cannot be walked around.
  *
  * **What is never gated:** read-only tools (planning *is* reading),
  * `fusion.delegate` itself, and the terminal verbs — vetoing `reply`
- * would veto the turn's exit.
+ * would veto the turn's own exit.
  */
 
 /** Terminal verbs, never gated. Mirrors `plan-mode.ts`, deliberately. */
@@ -51,56 +56,135 @@ export interface FusionOrchestratorVerdict {
   refusal?: CompressedToolResult;
 }
 
+/**
+ * What this turn has done so far. Held by `runTurn`, advanced by the
+ * batch executor as each fan-out returns.
+ */
 export interface FusionOrchestratorState {
-  /** Whether this turn has already completed a `fusion.delegate` call. */
-  delegated: boolean;
+  /** Completed `fusion.delegate` calls this turn, however they went. */
+  delegations: number;
+  /**
+   * Tasks that came back `needs_orchestrator` — a worker stopped
+   * because it needed an approval it cannot ask for. This, and only
+   * this, is what unlocks a mutation: the work a worker could not do
+   * because it has no person to ask.
+   */
+  handedUp: number;
+}
+
+/** A turn that has not delegated yet. */
+export function emptyFusionOrchestratorState(): FusionOrchestratorState {
+  return { delegations: 0, handedUp: 0 };
+}
+
+/**
+ * Whether a call changes anything outside this process.
+ *
+ * `registry.readonly` for native tools, which declare it honestly. NOT
+ * for MCP tools: theirs is derived from the server's own
+ * `readOnlyHint` / `destructiveHint` (`mcp-tool-adapter.ts`), which is
+ * third-party wire data — the adapter's own comment says it cannot be
+ * trusted for batch safety, and a gate about who may change the world
+ * has even less business trusting it. An MCP tool is treated as
+ * mutating whatever it claims, which fails closed: the cost is that an
+ * orchestrator cannot call a genuinely read-only MCP tool before it
+ * delegates, and the alternative is a server that opts itself out of
+ * the rule by shipping one flag.
+ */
+function mutates(tool: string, registry: Pick<ToolRegistry, "get">): boolean {
+  if (tool.startsWith(MCP_TOOL_PREFIX)) return true;
+  return !registry.get(tool).readonly;
 }
 
 /**
  * Decide whether `tool` may run on the orchestrator's own turn.
  *
- * An unknown tool is allowed through untouched, for the reason plan mode
- * does the same: the step executor's unknown-tool path has the better
- * message, and answering "delegate first" to a typo sends the model
- * looking for the wrong problem.
+ * An unknown tool is allowed through untouched, for the reason plan
+ * mode does the same: the step executor's unknown-tool path has the
+ * better message, and answering "delegate first" to a typo sends the
+ * model looking for the wrong problem.
  */
 export function checkFusionOrchestrator(
   tool: string,
   registry: Pick<ToolRegistry, "get" | "has">,
   state: FusionOrchestratorState,
 ): FusionOrchestratorVerdict {
-  if (state.delegated) return { allowed: true };
   if (TERMINAL_TOOLS.has(tool) || tool === DELEGATE_TOOL) {
     return { allowed: true };
   }
   if (!registry.has(tool)) return { allowed: true };
-  if (registry.get(tool).readonly) return { allowed: true };
-  return { allowed: false, refusal: refusalFor(tool) };
+  if (!mutates(tool, registry)) return { allowed: true };
+  if (state.handedUp > 0) return { allowed: true };
+  return { allowed: false, refusal: refusalFor(tool, state) };
 }
 
 /**
  * What the model is told.
  *
- * Same three parts plan mode's refusal has, in the same order: the call
- * did not happen, why, and the exit. The exit is the whole point — a
- * bare "not permitted" reads as a broken tool and gets retried, while
- * naming the shape of the brief turns the refusal into the instruction
- * the orchestrator needed in the first place.
+ * Two different sentences, because the model is in two different
+ * situations and the exit is different in each. Before any fan-out the
+ * instruction is "plan and delegate". After one, the model is holding
+ * results it does not like — and the thing it must not conclude is
+ * "the tool is broken, I will do it myself", which is exactly what it
+ * did when this gate let it. So that branch names the rework loop and
+ * says what a re-delegation brief should carry.
  */
-export function refusalFor(tool: string): CompressedToolResult {
+export function refusalFor(
+  tool: string,
+  state: FusionOrchestratorState,
+): CompressedToolResult {
+  const summary =
+    state.delegations === 0
+      ? `fusion is on and this turn has not delegated yet, so \`${tool}\` was ` +
+        `not run. You are the orchestrator: the workers do the doing. ` +
+        `Finish reading — every read-only tool still works — decide the ` +
+        `approach, then split the work and call \`fusion.delegate\`: one ` +
+        `task per independent part, each with the exact paths, what counts ` +
+        `as done, and the answer format you want back.`
+      : `\`${tool}\` was not run. You have delegated ${state.delegations} ` +
+        `time(s) this turn and no worker handed anything up, so there is ` +
+        `nothing here that only you can do — doing the work yourself is ` +
+        `the one thing this mode exists to prevent. If a part came back ` +
+        `\`failed\`, \`cancelled\` or weak, send it out again with ` +
+        `\`fusion.delegate\`: say what was wrong with the last attempt, ` +
+        `what to change, and what "good" looks like. Split a part that ` +
+        `timed out into smaller ones. Only work a worker returned as ` +
+        `\`needs_orchestrator\` is yours to run.`;
   return {
     tool,
     status: "error",
-    summary:
-      `fusion is on and this turn has not delegated yet, so \`${tool}\` ` +
-      `was not run. You are the orchestrator: the local workers do the ` +
-      `doing. Finish reading (every read-only tool still works), decide ` +
-      `the approach, then split the work and call \`fusion.delegate\` ` +
-      `— one task per independent part, each with the exact paths, what ` +
-      `counts as done, and the answer format you want back. Once the ` +
-      `workers report, you can write again: merge their results, and ` +
-      `send rework back out rather than doing it yourself.`,
-    details: { fusion_orchestrator: true, tool, delegated: false },
+    summary,
+    details: {
+      fusion_orchestrator: true,
+      tool,
+      delegations: state.delegations,
+      handed_up: state.handedUp,
+    },
     truncated: false,
+  };
+}
+
+/**
+ * Fold a completed `fusion.delegate` result into the turn's ledger.
+ *
+ * Reads the per-task statuses out of the tool result rather than being
+ * told by the caller: the executor sees the `CompressedToolResult` and
+ * nothing else, and a count passed alongside could drift from the
+ * result the model is reading in the same step.
+ */
+export function recordDelegation(
+  state: FusionOrchestratorState,
+  result: CompressedToolResult,
+): FusionOrchestratorState {
+  const tasks = (result.details as { tasks?: unknown } | undefined)?.tasks;
+  const handedUp = Array.isArray(tasks)
+    ? tasks.filter(
+        (task) =>
+          (task as { status?: unknown } | null)?.status === "needs_orchestrator",
+      ).length
+    : 0;
+  return {
+    delegations: state.delegations + 1,
+    handedUp: state.handedUp + handedUp,
   };
 }

--- a/src/agent/step-executor.ts
+++ b/src/agent/step-executor.ts
@@ -1,3 +1,4 @@
+import { resolveToolName } from "./tool-name-resolution.js";
 import {
   extractReasoning,
   parseToolCalls,
@@ -168,8 +169,8 @@ export interface StepDependencies {
    * gates nothing.
    */
   isFusionOrchestrator?: () => boolean;
-  hasDelegated?: () => boolean;
-  onDelegated?: () => void;
+  fusionState?: () => import("./fusion-orchestrator-mode.js").FusionOrchestratorState;
+  onDelegated?: (result: CompressedToolResult) => void;
   slotManager: SlotManager;
   llmComplete: (params: LlmStreamParams) => Promise<CompletionResult>;
   /**
@@ -1020,12 +1021,26 @@ async function executeStepInner(
   // bootstrap-time configuration mismatch, not a transient grammar
   // failure — replaying the prompt would not change the registry.
   for (const call of calls) {
-    if (!deps.registry.has(call.tool)) {
+    if (deps.registry.has(call.tool)) continue;
+    // A near miss on the separator is not a missing tool. Qualified
+    // names travel over the OpenAI wire as `__` and a model writing the
+    // escaped form from memory lands on `fusion_delegate` — every
+    // character right, one underscore short. That ended a whole turn in
+    // a real session, twice in a row. Resolve the obvious forms before
+    // treating the name as unknown; anything that still does not
+    // resolve throws exactly as it did.
+    const resolved = resolveToolName(call.tool, deps.registry);
+    if (resolved === null) {
       throw new ToolExecutionError(
         call.tool,
         `tool not registered in this agent: ${call.tool}`,
       );
     }
+    deps.logger?.debug?.("tool name resolved to its registered form", {
+      emitted: call.tool,
+      resolved,
+    });
+    call.tool = resolved;
   }
 
   // Emit one `tool_call_parsed` per call. Single-call steps preserve the
@@ -1057,7 +1072,7 @@ async function executeStepInner(
     ...(deps.isFusionOrchestrator
       ? {
           isFusionOrchestrator: deps.isFusionOrchestrator,
-          ...(deps.hasDelegated ? { hasDelegated: deps.hasDelegated } : {}),
+          ...(deps.fusionState ? { fusionState: deps.fusionState } : {}),
           ...(deps.onDelegated ? { onDelegated: deps.onDelegated } : {}),
         }
       : {}),

--- a/src/agent/tool-name-resolution.test.ts
+++ b/src/agent/tool-name-resolution.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { ToolRegistry } from "../tools/tool-registry.js";
+import { resolveToolName } from "./tool-name-resolution.js";
+
+function registry(...names: string[]): ToolRegistry {
+  const reg = new ToolRegistry();
+  for (const name of names) {
+    reg.register({
+      name,
+      description: name,
+      readonly: true,
+      run: async () => ({
+        tool: name,
+        status: "ok" as const,
+        summary: "",
+        details: {},
+        truncated: false,
+      }),
+    });
+  }
+  return reg;
+}
+
+const REG = registry(
+  "fusion.delegate",
+  "os.fs.write",
+  "os.fs.trash",
+  "reply",
+);
+
+describe("resolveToolName", () => {
+  it("returns an exact name untouched", () => {
+    expect(resolveToolName("os.fs.write", REG)).toBe("os.fs.write");
+    expect(resolveToolName("reply", REG)).toBe("reply");
+  });
+
+  it("fixes the separator a model got one underscore short", () => {
+    // The observed failure: `fusion.delegate` travels the OpenAI wire as
+    // `fusion__delegate`, the model wrote it from memory as
+    // `fusion_delegate`, and the turn died on the membership check.
+    expect(resolveToolName("fusion_delegate", REG)).toBe("fusion.delegate");
+    expect(resolveToolName("os_fs_write", REG)).toBe("os.fs.write");
+  });
+
+  it("resolves a name that arrived still escaped", () => {
+    // The text-JSON fallback path does not run `nameUnescape`.
+    expect(resolveToolName("fusion__delegate", REG)).toBe("fusion.delegate");
+  });
+
+  it("resolves case on its own and over a fixed separator", () => {
+    expect(resolveToolName("OS.FS.WRITE", REG)).toBe("os.fs.write");
+    expect(resolveToolName("Fusion_Delegate", REG)).toBe("fusion.delegate");
+  });
+
+  it("refuses to guess between near neighbours", () => {
+    // Not fuzzy matching. `os.fs.write` must never resolve to
+    // `os.fs.trash` because the two are close — a tool that deletes is
+    // one edit away from a tool that writes.
+    expect(resolveToolName("os.fs.writ", REG)).toBeNull();
+    expect(resolveToolName("os.fs.wrote", REG)).toBeNull();
+    expect(resolveToolName("fs.write", REG)).toBeNull();
+  });
+
+  it("returns null for a name that is nothing like a registered tool", () => {
+    expect(resolveToolName("summon_daemon", REG)).toBeNull();
+    expect(resolveToolName("", REG)).toBeNull();
+  });
+});

--- a/src/agent/tool-name-resolution.ts
+++ b/src/agent/tool-name-resolution.ts
@@ -1,0 +1,49 @@
+import type { ToolRegistry } from "../tools/tool-registry.js";
+
+/**
+ * Resolve a tool name the model emitted to one the registry holds.
+ *
+ * Qualified names carry dots — `fusion.delegate`, `os.fs.write` — and
+ * the OpenAI wire format forbids them, so they travel as `__` and come
+ * back through `nameUnescape`. A model that writes the escaped form
+ * from memory rather than copying it gets the separator wrong, and the
+ * near miss is not a typo in the usual sense: every character of the
+ * name is right.
+ *
+ * That cost a real session its entire turn. The model emitted
+ * `fusion_delegate`, one underscore short of the escape, twice; the
+ * membership check in the step executor throws for the whole batch, so
+ * a 30-minute turn ended with `reason=failed` over a separator.
+ *
+ * The candidates are deliberately narrow — separator confusion and
+ * case, nothing else. This is not fuzzy matching: `os.fs.write` must
+ * never resolve to `os.fs.trash` because the two are close. A name that
+ * does not resolve exactly, or by fixing the separator it was clearly
+ * trying to use, is still unknown and still fails.
+ */
+export function resolveToolName(
+  name: string,
+  registry: Pick<ToolRegistry, "has" | "list">,
+): string | null {
+  if (registry.has(name)) return name;
+
+  // `fusion_delegate` → `fusion.delegate`, `os_fs_write` → `os.fs.write`.
+  // Tried before `__` because a single-underscore name is the common
+  // miss and the double form is what `nameUnescape` already handled.
+  const singleToDot = name.replace(/_/g, ".");
+  if (singleToDot !== name && registry.has(singleToDot)) return singleToDot;
+
+  // A name that arrived still escaped: the text-JSON fallback path does
+  // not run `nameUnescape`, so `fusion__delegate` can reach here whole.
+  const doubleToDot = name.replace(/__/g, ".");
+  if (doubleToDot !== name && registry.has(doubleToDot)) return doubleToDot;
+
+  // Case only, over the two forms above as well — some models
+  // capitalise the first letter of a tool name.
+  const lower = name.toLowerCase();
+  for (const { name: candidate } of registry.list()) {
+    if (candidate.toLowerCase() === lower) return candidate;
+    if (candidate.toLowerCase() === singleToDot.toLowerCase()) return candidate;
+  }
+  return null;
+}

--- a/src/approval/approval-gate.ts
+++ b/src/approval/approval-gate.ts
@@ -1,3 +1,4 @@
+import { FanoutScopeRegistry } from "./fanout-scope.js";
 import { randomUUID } from "node:crypto";
 import {
   clampApprovalLevel,
@@ -150,6 +151,18 @@ export class ApprovalGate {
   >();
   /** Per-session prompt policies, keyed like the grants. See `SessionApprovalPolicy`. */
   private readonly policiesBySession = new Map<string, SessionApprovalPolicy>();
+
+  /**
+   * Directories a session may write in without asking — see
+   * `fanout-scope.ts`. Lives on the gate because every caller that can
+   * ask for an approval already holds the gate, so nothing new has to be
+   * threaded through the fs tools to reach it.
+   *
+   * Read by `requireFsApproval`, not by `request()`: the scope is about
+   * paths, and paths are known one layer up, where the fs funnel has
+   * already resolved them.
+   */
+  readonly fanoutScopes = new FanoutScopeRegistry();
 
   constructor(options: { emit: ApprovalEmitter; level?: ApprovalLevel }) {
     this.emitter = options.emit;

--- a/src/approval/approval-level.ts
+++ b/src/approval/approval-level.ts
@@ -38,6 +38,15 @@ export type ApprovalCategory =
   | "publish"
   /** Mail leaving the agent's own inbox on the operator's behalf. */
   | "email"
+  /**
+   * A fusion fan-out: several worker agents about to run at once, and
+   * the one question the operator is asked about them. Approving it
+   * authorises every worker in that fan-out to write inside a stated
+   * directory without asking again (see `approval/fanout-scope.ts`), so
+   * it sits at level 4 beside `shell` — a fan-out writes, and no grant
+   * from an unrelated prompt should be able to silence it.
+   */
+  | "fusion_fanout"
   | "other";
 
 /**
@@ -77,6 +86,7 @@ const AUTO_APPROVE_FROM_LEVEL: Record<ApprovalCategory, ApprovalLevel> = {
   proc_kill: 4,
   publish: 4,
   git_remote: 4,
+  fusion_fanout: 4,
   browser_nonweb: 5,
   trust_config: 5,
   email: 5,
@@ -133,6 +143,11 @@ const GRANTABLE_CATEGORY: Record<ApprovalCategory, boolean> = {
   // "always allow publishing this session" has said exactly that.
   publish: true,
   git_remote: true,
+  // A fan-out authorises workers to write in a directory it names, so a
+  // session grant would hand every LATER fan-out — with different tasks
+  // and a different directory — the same authority silently. The whole
+  // point of the question is that the operator sees this task list.
+  fusion_fanout: false,
   browser_nonweb: true,
   trust_config: false,
   // A session grant would let the agent mail anyone for the rest of
@@ -162,6 +177,7 @@ export const APPROVAL_CATEGORY_LABELS: Record<ApprovalCategory, string> = {
   proc_kill: "process kill",
   publish: "publish · GitHub",
   git_remote: "git · remote",
+  fusion_fanout: "fusion · fan-out",
   browser_nonweb: "browser · non-web URL",
   trust_config: "agent trust config",
   email: "e-mail send",

--- a/src/approval/approval-level.ts
+++ b/src/approval/approval-level.ts
@@ -41,10 +41,11 @@ export type ApprovalCategory =
   /**
    * A fusion fan-out: several worker agents about to run at once, and
    * the one question the operator is asked about them. Approving it
-   * authorises every worker in that fan-out to write inside a stated
-   * directory without asking again (see `approval/fanout-scope.ts`), so
-   * it sits at level 4 beside `shell` — a fan-out writes, and no grant
-   * from an unrelated prompt should be able to silence it.
+   * authorises every worker in that fan-out to write files AND run
+   * commands inside a stated directory without asking again (see
+   * `approval/fanout-scope.ts`), so it sits at level 4 beside `shell` —
+   * that is exactly the authority it hands out, and no grant from an
+   * unrelated prompt should be able to silence it.
    */
   | "fusion_fanout"
   | "other";

--- a/src/approval/fanout-scope.test.ts
+++ b/src/approval/fanout-scope.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { FanoutScopeRegistry, isInside } from "./fanout-scope.js";
+
+describe("FanoutScopeRegistry", () => {
+  it("allows a path inside a granted directory", () => {
+    const reg = new FanoutScopeRegistry();
+    reg.grant("s-w-1", ["/tmp/rel-2"]);
+    expect(reg.allows("s-w-1", ["/tmp/rel-2/cart.js"])).toBe(true);
+    expect(reg.allows("s-w-1", ["/tmp/rel-2/deep/nested.js"])).toBe(true);
+  });
+
+  it("refuses a path outside it", () => {
+    const reg = new FanoutScopeRegistry();
+    reg.grant("s-w-1", ["/tmp/rel-2"]);
+    expect(reg.allows("s-w-1", ["/etc/passwd"])).toBe(false);
+    expect(reg.allows("s-w-1", ["/tmp/rel-2-backup/x.js"])).toBe(false);
+  });
+
+  it("is all or nothing across a call's paths", () => {
+    // A call that writes three files, one of them outside the scope, is
+    // not a call the operator authorised.
+    const reg = new FanoutScopeRegistry();
+    reg.grant("s-w-1", ["/tmp/rel-2"]);
+    expect(
+      reg.allows("s-w-1", ["/tmp/rel-2/a.js", "/tmp/elsewhere/b.js"]),
+    ).toBe(false);
+  });
+
+  it("never leaks between sessions", () => {
+    // Worker sessions each get their own grant deliberately; a parent's
+    // authority is not a worker's.
+    const reg = new FanoutScopeRegistry();
+    reg.grant("s-w-1", ["/tmp/rel-2"]);
+    expect(reg.allows("s-w-2", ["/tmp/rel-2/cart.js"])).toBe(false);
+  });
+
+  it("grants nothing for an empty or relative scope", () => {
+    const reg = new FanoutScopeRegistry();
+    reg.grant("s-w-1", []);
+    expect(reg.allows("s-w-1", ["/tmp/x"])).toBe(false);
+    reg.grant("s-w-2", ["relative/dir"]);
+    expect(reg.allows("s-w-2", ["/tmp/x"])).toBe(false);
+  });
+
+  it("refuses an empty path list", () => {
+    const reg = new FanoutScopeRegistry();
+    reg.grant("s-w-1", ["/tmp/rel-2"]);
+    expect(reg.allows("s-w-1", [])).toBe(false);
+  });
+
+  it("forgets a session on clear", () => {
+    const reg = new FanoutScopeRegistry();
+    reg.grant("s-w-1", ["/tmp/rel-2"]);
+    reg.clear("s-w-1");
+    expect(reg.allows("s-w-1", ["/tmp/rel-2/cart.js"])).toBe(false);
+    expect(reg.scopeFor("s-w-1")).toEqual([]);
+  });
+});
+
+describe("isInside", () => {
+  it("counts the directory itself", () => {
+    expect(isInside("/tmp/x", "/tmp/x")).toBe(true);
+  });
+
+  it("rejects a sibling that merely shares a prefix", () => {
+    expect(isInside("/tmp/x", "/tmp/xy")).toBe(false);
+  });
+
+  it("rejects a parent", () => {
+    expect(isInside("/tmp/x", "/tmp")).toBe(false);
+  });
+});

--- a/src/approval/fanout-scope.test.ts
+++ b/src/approval/fanout-scope.test.ts
@@ -70,3 +70,47 @@ describe("isInside", () => {
     expect(isInside("/tmp/x", "/tmp")).toBe(false);
   });
 });
+describe("the turn-scoped grant", () => {
+  it("answers for every later fan-out of the same turn", () => {
+    const scopes = new FanoutScopeRegistry();
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/rel"])).toBe(false);
+    scopes.grantForTurn("s-1", ["/tmp/rel"]);
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/rel"])).toBe(true);
+    // Deeper inside the same directory is the same permission — this is
+    // the review pass re-delegating into a subfolder it just read.
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/rel/src"])).toBe(true);
+  });
+
+  it("asks again for a directory nobody approved", () => {
+    const scopes = new FanoutScopeRegistry();
+    scopes.grantForTurn("s-1", ["/tmp/rel"]);
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/other"])).toBe(false);
+    // Boundary, not prefix.
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/rel-backup"])).toBe(false);
+    // All of them or none: one new directory in the list is a new
+    // question, whatever the others were.
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/rel", "/tmp/other"])).toBe(
+      false,
+    );
+  });
+
+  it("does not leak between sessions, or outlive the turn", () => {
+    const scopes = new FanoutScopeRegistry();
+    scopes.grantForTurn("s-1", ["/tmp/rel"]);
+    expect(scopes.turnGrantCovers("s-2", ["/tmp/rel"])).toBe(false);
+    scopes.clearTurnGrant("s-1");
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/rel"])).toBe(false);
+  });
+
+  it("keeps the turn answer apart from a worker's own scope", () => {
+    // Different lifetimes, different maps: clearing the worker grant in
+    // the fan-out's `finally` must not take the turn's answer with it,
+    // or every fan-out would ask again and the fix would be invisible.
+    const scopes = new FanoutScopeRegistry();
+    scopes.grantForTurn("s-1", ["/tmp/rel"]);
+    scopes.grant("s-w-1", ["/tmp/rel"]);
+    scopes.clear("s-w-1");
+    expect(scopes.allows("s-w-1", ["/tmp/rel/a.js"])).toBe(false);
+    expect(scopes.turnGrantCovers("s-1", ["/tmp/rel"])).toBe(true);
+  });
+});

--- a/src/approval/fanout-scope.ts
+++ b/src/approval/fanout-scope.ts
@@ -1,0 +1,83 @@
+import { isAbsolute, relative, resolve } from "node:path";
+
+/**
+ * Which directories a session's tool calls may write in without asking.
+ *
+ * Fusion's workers are the reason this exists. A worker turn has no
+ * operator at the other end — the TUI is showing the parent session — so
+ * `worker-runner.ts` installs a refuse policy and every approval-gated
+ * call dies on it. At approval level 1 that is every write, and a real
+ * session proved the consequence: six workers, zero files, and an
+ * orchestrator left as the only party able to act.
+ *
+ * The answer the operator chose is one question per fan-out rather than
+ * one per call: `fusion.delegate` asks once, naming the tasks and the
+ * directory they will write in, and every worker in that fan-out then
+ * writes inside it unprompted.
+ *
+ * **Why this is not an `ApprovalGate` grant.** The gate's grants are
+ * keyed by category, and `recordGrant` takes the granted value from the
+ * pending request, so there is nowhere to put a path. Categories are
+ * also the wrong unit: a fan-out writing to `/tmp/rel-2` is outside the
+ * workspace, and the category wide enough to cover it (`other`) would
+ * authorise writing anywhere at all. A directory is the honest scope, so
+ * a directory is what is stored.
+ *
+ * Scopes are per session id, in memory, and cleared when the fan-out
+ * ends — the same lifetime and the same `finally` as the refuse policy
+ * they sit beside.
+ */
+export class FanoutScopeRegistry {
+  private readonly dirsBySession = new Map<string, readonly string[]>();
+
+  /**
+   * Authorise `dirs` (absolute, already resolved) for `sessionId`.
+   * Replaces any previous grant: a session runs one fan-out task.
+   */
+  grant(sessionId: string, dirs: readonly string[]): void {
+    const absolute = dirs.filter((dir) => isAbsolute(dir));
+    if (absolute.length === 0) {
+      this.dirsBySession.delete(sessionId);
+      return;
+    }
+    this.dirsBySession.set(sessionId, absolute);
+  }
+
+  /** Drop a session's scope. Safe to call when nothing was granted. */
+  clear(sessionId: string): void {
+    this.dirsBySession.delete(sessionId);
+  }
+
+  /**
+   * Whether every one of `paths` sits inside a granted directory.
+   *
+   * All or nothing on purpose: a call that writes three files, one of
+   * them outside the scope, is not a call the operator authorised. It
+   * goes to the gate, where the refuse policy turns it into a task the
+   * orchestrator must re-delegate.
+   */
+  allows(sessionId: string, paths: readonly string[]): boolean {
+    const dirs = this.dirsBySession.get(sessionId);
+    if (dirs === undefined || paths.length === 0) return false;
+    return paths.every((path) =>
+      dirs.some((dir) => isInside(dir, resolve(path))),
+    );
+  }
+
+  /** The granted directories, for a prompt or a diagnostic. */
+  scopeFor(sessionId: string): readonly string[] {
+    return this.dirsBySession.get(sessionId) ?? [];
+  }
+}
+
+/**
+ * Boundary-safe containment: `child` equals `parent` or lives under it.
+ *
+ * `relative()` rather than `startsWith`, so `/tmp/rel-2-backup` is not
+ * read as living inside `/tmp/rel-2`.
+ */
+export function isInside(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  if (rel === "") return true;
+  return !rel.startsWith("..") && !isAbsolute(rel);
+}

--- a/src/approval/fanout-scope.ts
+++ b/src/approval/fanout-scope.ts
@@ -23,12 +23,22 @@ import { isAbsolute, relative, resolve } from "node:path";
  * authorise writing anywhere at all. A directory is the honest scope, so
  * a directory is what is stored.
  *
- * Scopes are per session id, in memory, and cleared when the fan-out
- * ends — the same lifetime and the same `finally` as the refuse policy
- * they sit beside.
+ * Two lifetimes live here, because the operator asked for two.
+ *
+ * A **worker** scope is per worker session and dies with the fan-out —
+ * the same `finally` as the refuse policy beside it.
+ *
+ * A **turn** scope is per orchestrator session and survives until the
+ * turn ends. It exists because a turn is one job: an orchestrator that
+ * reviews and re-delegates asks for five fan-outs to build one library,
+ * and answering the same question five times is not consent, it is
+ * attrition. The operator authorises the directory once and every later
+ * fan-out of that turn inherits it — but only if it stays inside what
+ * was approved. A fan-out reaching somewhere new asks again.
  */
 export class FanoutScopeRegistry {
   private readonly dirsBySession = new Map<string, readonly string[]>();
+  private readonly turnScopeBySession = new Map<string, readonly string[]>();
 
   /**
    * Authorise `dirs` (absolute, already resolved) for `sessionId`.
@@ -67,6 +77,43 @@ export class FanoutScopeRegistry {
   /** The granted directories, for a prompt or a diagnostic. */
   scopeFor(sessionId: string): readonly string[] {
     return this.dirsBySession.get(sessionId) ?? [];
+  }
+
+  /**
+   * Remember what this turn's operator already authorised, so the next
+   * fan-out of the same turn does not ask again.
+   */
+  grantForTurn(sessionId: string, dirs: readonly string[]): void {
+    const absolute = dirs.filter((dir) => isAbsolute(dir));
+    if (absolute.length === 0) return;
+    const merged = new Set([
+      ...(this.turnScopeBySession.get(sessionId) ?? []),
+      ...absolute,
+    ]);
+    this.turnScopeBySession.set(sessionId, [...merged]);
+  }
+
+  /**
+   * Whether this turn's standing answer already covers `dirs`.
+   *
+   * Containment, not equality: a later fan-out writing deeper inside an
+   * approved directory is the same permission. One reaching outside it
+   * is a new question, and gets asked.
+   */
+  turnGrantCovers(sessionId: string, dirs: readonly string[]): boolean {
+    const approved = this.turnScopeBySession.get(sessionId);
+    if (approved === undefined || dirs.length === 0) return false;
+    return dirs.every((dir) =>
+      approved.some((root) => isInside(root, resolve(dir))),
+    );
+  }
+
+  /**
+   * Forget a turn's standing answer. Called when a turn starts, so the
+   * authority never outlives the job it was given for.
+   */
+  clearTurnGrant(sessionId: string): void {
+    this.turnScopeBySession.delete(sessionId);
   }
 }
 

--- a/src/config/llm-run-mode-config.ts
+++ b/src/config/llm-run-mode-config.ts
@@ -77,7 +77,22 @@ export const FUSION_WORKERS_MIN = 1;
 export const FUSION_WORKERS_MAX = 8;
 export const DEFAULT_FUSION_WORKERS = 2;
 export const DEFAULT_FUSION_WORKER_MAX_STEPS = 40;
-export const DEFAULT_FUSION_WORKER_TIMEOUT_MS = 600_000;
+/**
+ * How long one worker may take before its leg is cancelled.
+ *
+ * 20 minutes, up from 10. The old figure was a guess and it cut real
+ * work in half: in the session that exposed it, two of three tasks were
+ * `cancelled` at exactly 600s — a 12B model writing six files and their
+ * tests, queued behind another worker on a single slot. The orchestrator
+ * read that as "the workers cannot do this" and built the deliverable
+ * itself, which is the failure this mode exists to prevent.
+ *
+ * The cost of being generous here is bounded: a worker that is stuck
+ * rather than slow still ends, and the orchestrator still gets a task
+ * it can re-delegate in smaller pieces. The cost of being tight is a
+ * fan-out that looks broken.
+ */
+export const DEFAULT_FUSION_WORKER_TIMEOUT_MS = 1_200_000;
 
 export type RunModeProviderRef = { readonly id: string; readonly kind: string };
 

--- a/src/config/llm-run-mode-config.ts
+++ b/src/config/llm-run-mode-config.ts
@@ -80,19 +80,19 @@ export const DEFAULT_FUSION_WORKER_MAX_STEPS = 40;
 /**
  * How long one worker may take before its leg is cancelled.
  *
- * 20 minutes, up from 10. The old figure was a guess and it cut real
- * work in half: in the session that exposed it, two of three tasks were
- * `cancelled` at exactly 600s — a 12B model writing six files and their
- * tests, queued behind another worker on a single slot. The orchestrator
- * read that as "the workers cannot do this" and built the deliverable
- * itself, which is the failure this mode exists to prevent.
+ * 45 minutes, and both earlier figures were guesses that cut real work
+ * in half. At 600s two of three tasks died; at 1200s a worker that had
+ * already written four of its six files was cancelled mid-run, and
+ * another was cut after writing one. Neither was stuck — a 12B model
+ * writing a module and its tests takes the time it takes.
  *
- * The cost of being generous here is bounded: a worker that is stuck
- * rather than slow still ends, and the orchestrator still gets a task
- * it can re-delegate in smaller pieces. The cost of being tight is a
- * fan-out that looks broken.
+ * The asymmetry is the argument. A worker that is genuinely stuck still
+ * ends, and the orchestrator gets a task it can split and re-send; a
+ * worker cut while working loses everything it had not yet written and
+ * teaches the orchestrator that the fan-out does not work, which is how
+ * a turn ends with the cloud model doing the job itself.
  */
-export const DEFAULT_FUSION_WORKER_TIMEOUT_MS = 1_200_000;
+export const DEFAULT_FUSION_WORKER_TIMEOUT_MS = 2_700_000;
 
 export type RunModeProviderRef = { readonly id: string; readonly kind: string };
 

--- a/src/llm/grammar/build-grammar.test.ts
+++ b/src/llm/grammar/build-grammar.test.ts
@@ -97,6 +97,45 @@ describe("buildGrammar", () => {
   });
 });
 
+describe("fusion.delegate in the local-model grammar", () => {
+  /**
+   * The grammar is the local model's ENTIRE vocabulary of tool names: a
+   * name that is not in it cannot be sampled, whatever the catalog says.
+   *
+   * This went unnoticed for as long as the orchestrator was always a
+   * cloud provider, which carries a native `tools` payload and no
+   * grammar. The moment the legs swap and a local model orchestrates,
+   * the one tool the whole mode depends on was the one it could not
+   * emit: the trace shows it reasoning "I need to call fusion.delegate"
+   * and then emitting `finish`, reporting a fan-out that never ran.
+   */
+  it("admits the fan-out a local orchestrator has to call", async () => {
+    for (const profile of [
+      PLAIN_INSTRUCT_PROFILE,
+      QWEN_THINK_PROFILE,
+      GEMMA4_THINK_PROFILE,
+    ]) {
+      const grammar = await buildGrammar(profile);
+      const toolName =
+        grammar.split("\n").find((l) => l.startsWith("tool-name ::=")) ?? "";
+      expect(toolName, profile.id).toContain("fusion-tool");
+      expect(grammar, profile.id).toMatch(
+        /^fusion-tool ::= "\\"fusion\.delegate\\""$/m,
+      );
+    }
+  });
+
+  it("keeps it out of the browser rule, so disabling the browser cannot take it away", async () => {
+    const grammar = await buildGrammar(PLAIN_INSTRUCT_PROFILE, undefined, {
+      browserEnabled: false,
+    });
+    const toolName =
+      grammar.split("\n").find((l) => l.startsWith("tool-name ::=")) ?? "";
+    expect(toolName).toContain("fusion-tool");
+    expect(toolName).not.toContain("browser-tool");
+  });
+});
+
 describe("os-tool names the local-model grammar admits", () => {
   it("includes the agent's e-mail tools — a descriptor the grammar cannot emit is a tool local models cannot call", () => {
     const { readFileSync } = require("node:fs") as typeof import("node:fs");
@@ -109,6 +148,34 @@ describe("os-tool names the local-model grammar admits", () => {
       grammar.split("\n").find((l) => l.startsWith("os-tool ::=")) ?? "";
     for (const name of ["email.inbox", "email.send", "notify", "web.fetch"]) {
       expect(osToolLine).toContain(`"${name}"`);
+    }
+  });
+
+  it("includes the git WRITE tools, not just the read half", () => {
+    // Same class of bug as the missing `fusion.delegate`: the local-first
+    // git tools were registered and described, and the grammar still only
+    // named the read half — so a local model could inspect a repository
+    // and never commit to one, with nothing in the logs saying why.
+    const { readFileSync } = require("node:fs") as typeof import("node:fs");
+    const { resolve } = require("node:path") as typeof import("node:path");
+    const grammar = readFileSync(
+      resolve(__dirname, "../../../grammars/tool-call.gbnf"),
+      "utf8",
+    );
+    const osToolLine =
+      grammar.split("\n").find((l) => l.startsWith("os-tool ::=")) ?? "";
+    for (const name of [
+      "git.init",
+      "git.add",
+      "git.commit",
+      "git.checkout",
+      "git.clone",
+      "git.remote",
+      "git.fetch",
+      "git.pull",
+      "git.push",
+    ]) {
+      expect(osToolLine, name).toContain(`"${name}"`);
     }
   });
 });

--- a/src/llm/run-mode/resolve-run-mode.test.ts
+++ b/src/llm/run-mode/resolve-run-mode.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import type { UserLlmRunModeConfig } from "../../config/llm-run-mode-config.js";
+import {
+  DEFAULT_FUSION_WORKER_TIMEOUT_MS,
+  type UserLlmRunModeConfig,
+} from "../../config/llm-run-mode-config.js";
 import type { ResolvedLlmConfig } from "../provider/registry/provider-types.js";
 import { resolveRunMode } from "./resolve-run-mode.js";
 
@@ -187,7 +190,7 @@ describe("resolveRunMode", () => {
       {
         workers: 2,
         workerMaxSteps: 40,
-        workerTimeoutMs: 600_000,
+        workerTimeoutMs: DEFAULT_FUSION_WORKER_TIMEOUT_MS,
       },
     );
     expect(

--- a/src/local-llm/worker-slots.test.ts
+++ b/src/local-llm/worker-slots.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SLOTS,
   MAX_AUTO_SLOTS,
+  MIN_GPU_SLOTS,
   MIN_SLOT_CONTEXT,
   resolveConfiguredSlots,
   resolveWorkerSlots,
@@ -11,17 +12,29 @@ describe("resolveWorkerSlots", () => {
   it("gives one slot per worth-having share of the context", () => {
     // The context is divided between slots, so the count is how many
     // times a usable slot fits in what the daemon was given.
-    expect(resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT, cpuOnly: false })).toBe(1);
     expect(resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 3, cpuOnly: false })).toBe(3);
     expect(
       resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT * 3 + 5_000, cpuOnly: false }),
     ).toBe(3);
   });
 
-  it("never returns zero, however small the context", () => {
-    // A machine that can only serve one worker still serves one; the
-    // fan-out then runs its tasks in sequence rather than not at all.
-    expect(resolveWorkerSlots({ contextSize: 4_096, cpuOnly: false })).toBe(1);
+  it("never falls to a fan-out of one on a GPU", () => {
+    // A fan-out of one is the orchestrator queueing behind itself: all
+    // of the delegation overhead, none of the parallelism. The old
+    // formula produced exactly that on a 12B model's ~16k context, and
+    // the run it ruined ended with the orchestrator doing the work
+    // itself. Two narrow slots beat one wide one here, because a
+    // truncated worker comes back as a task to re-delegate while a
+    // serialised one comes back as a timeout.
+    expect(resolveWorkerSlots({ contextSize: 4_096, cpuOnly: false })).toBe(
+      MIN_GPU_SLOTS,
+    );
+    expect(
+      resolveWorkerSlots({ contextSize: MIN_SLOT_CONTEXT, cpuOnly: false }),
+    ).toBe(MIN_GPU_SLOTS);
+    expect(
+      resolveWorkerSlots({ contextSize: 16_384, cpuOnly: false }),
+    ).toBe(MIN_GPU_SLOTS);
   });
 
   it("stops at the ceiling on a very large context", () => {

--- a/src/local-llm/worker-slots.ts
+++ b/src/local-llm/worker-slots.ts
@@ -27,12 +27,22 @@
  */
 
 /**
- * Tokens a worker slot needs to be useful. Same figure as
- * `MIN_AUTO_CONTEXT`, and for the same reason: below it a worker has
- * room for the prefix and not much else, so it truncates mid-tool-call
- * and reports a failure the orchestrator then has to re-delegate.
+ * Tokens a worker slot needs to be useful.
+ *
+ * Measured, not guessed: a worker's stable prefix in a real session was
+ * 7,388 tokens, and its brief plus the file it is working on is the
+ * rest. 8k is that floor with room to finish a tool call.
+ *
+ * It was 16,384 — `MIN_AUTO_CONTEXT`, borrowed on the assumption that a
+ * worker needs what a chat session needs. It does not, and the
+ * borrowed number did real damage: a 12B model whose auto-context
+ * lands at ~16-24k divided to exactly ONE slot, so every fan-out ran
+ * sequentially. In the session that exposed it, three tasks queued
+ * behind each other and two died on the worker timeout — after which
+ * the orchestrator gave up on the workers and built everything itself.
+ * A conservative number in the wrong place is not conservative.
  */
-export const MIN_SLOT_CONTEXT = 16_384;
+export const MIN_SLOT_CONTEXT = 8_192;
 
 /**
  * Ceiling on the derived count. Past a handful of slots the local server
@@ -46,6 +56,18 @@ export const MAX_AUTO_SLOTS = 8;
 
 /** What a launch with nothing known falls back to — the historical default. */
 export const DEFAULT_SLOTS = 2;
+
+/**
+ * Floor for a GPU launch.
+ *
+ * A fan-out of one is not a fan-out — it is the orchestrator waiting in
+ * a queue it built itself, paying the delegation overhead for none of
+ * the parallelism. Two slots on a context that can only really afford
+ * one is the better failure: each worker gets a smaller share and may
+ * truncate, which comes back as a task to re-delegate, where being
+ * serialised comes back as a timeout and a mode that looks broken.
+ */
+export const MIN_GPU_SLOTS = 2;
 
 export interface WorkerSlotsInput {
   /**
@@ -70,7 +92,7 @@ export function resolveWorkerSlots(input: WorkerSlotsInput): number {
   const ctx = input.contextSize;
   if (ctx === null || !Number.isFinite(ctx) || ctx <= 0) return DEFAULT_SLOTS;
   const fits = Math.floor(ctx / MIN_SLOT_CONTEXT);
-  return Math.max(1, Math.min(fits, MAX_AUTO_SLOTS));
+  return Math.max(MIN_GPU_SLOTS, Math.min(fits, MAX_AUTO_SLOTS));
 }
 
 /**

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -62,11 +62,11 @@ export function isFusionActive(
 export const FUSION_GUIDANCE = [
   "You orchestrate the workers: read enough to decide, plan, delegate the doing, review what comes back.",
   "Plan in the open, then delegate in the same turn — never stop at the plan: list the independent, self-contained parts, sized so a big one gets its own worker and small ones share.",
-  "One task per part, in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
-  "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
-  "Tools that change things are refused for you unless a worker handed one up (`needs_orchestrator`) — the mode working, not a fault. What you would rather fix yourself is a task to send out again.",
+  "One task per part, in one `fusion.delegate` call. List the paths a task will produce in its `files` — the operator is asked once, about those directories, and that answer is what lets the workers write. Each `instructions` must stand alone: workers have no memory of this conversation and cannot ask you anything.",
+  "You choose `maxWorkers` per call; prefer sending more parts over doing any yourself.",
+  "Tools that change things are refused for you, always: the workers build, you do not. That is the mode working, not a fault.",
   "Keep the design and the judgement: read every reply against its brief.",
-  "Rework goes back out: anything `failed`, `cancelled` or not good enough is another `fusion.delegate` saying what was wrong and what good looks like. Keep going until you would sign off on it.",
+  "Rework goes back out: anything `failed`, `cancelled`, `needs_orchestrator` or just not good enough is another `fusion.delegate` saying what was wrong and what good looks like. Keep going until you would sign off on it.",
   "Yours alone: the decision you were asked for, a part that only makes sense with this conversation in front of it, and anything needing operator approval — workers cannot reach the user.",
   "Call `fusion.delegate` on its own, never alongside other tool calls — it runs several turns internally.",
 ].join("\n");

--- a/src/prompt/fusion-guidance.ts
+++ b/src/prompt/fusion-guidance.ts
@@ -60,15 +60,15 @@ export function isFusionActive(
  * exactly the block a machine-less build renders.
  */
 export const FUSION_GUIDANCE = [
-  "You orchestrate local workers: read enough to decide, plan, delegate the doing, review what comes back, integrate it.",
-  "Plan in the open, then delegate in the same turn — never stop at the plan: list the independent, self-contained parts with what each touches and how big it is, sized so a big one gets its own worker and small ones share.",
-  "Send one task per part in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
+  "You orchestrate the workers: read enough to decide, plan, delegate the doing, review what comes back.",
+  "Plan in the open, then delegate in the same turn — never stop at the plan: list the independent, self-contained parts, sized so a big one gets its own worker and small ones share.",
+  "One task per part, in one `fusion.delegate` call. Each task's `instructions` must stand alone: exact paths, what counts as done, the answer format. Workers have no memory of this conversation and cannot ask you anything.",
   "You choose `maxWorkers` per call, capped only by the task count and what this machine serves; prefer sending more parts over doing any yourself.",
-  "Until this turn has delegated once, tools that change things are refused for you — the mode working, not a fault.",
-  "Keep the design, the judgement and the integration: read every reply against its brief, then merge the parts yourself.",
-  "Rework goes back out: anything `failed`, `needs_orchestrator`, or that you want refactored becomes another `fusion.delegate` saying what was wrong.",
+  "Tools that change things are refused for you unless a worker handed one up (`needs_orchestrator`) — the mode working, not a fault. What you would rather fix yourself is a task to send out again.",
+  "Keep the design and the judgement: read every reply against its brief.",
+  "Rework goes back out: anything `failed`, `cancelled` or not good enough is another `fusion.delegate` saying what was wrong and what good looks like. Keep going until you would sign off on it.",
   "Yours alone: the decision you were asked for, a part that only makes sense with this conversation in front of it, and anything needing operator approval — workers cannot reach the user.",
-  "Call `fusion.delegate` on its own, never alongside other tool calls — it runs several turns internally and takes a while.",
+  "Call `fusion.delegate` on its own, never alongside other tool calls — it runs several turns internally.",
 ].join("\n");
 
 /**

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -2987,6 +2987,7 @@ export async function createAgentRuntime(
         runTurn(session, userMessage, turnOptions),
       createEphemeralSession,
       approvals,
+      approvalRequired: dangerous.approvalRequired,
       slotManager,
       resolveRunMode: resolveCurrentRunMode,
       workerSupportsSlotAffinity: (providerId) =>

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -2310,6 +2310,8 @@ export async function createAgentRuntime(
     // reads, so the tool the orchestrator is being pushed towards is
     // always in the catalog when the push happens.
     isFusionMode: () => resolveCurrentRunMode().effective === "fusion",
+    clearFanoutTurnGrant: (sessionId: string) =>
+      approvals.fanoutScopes.clearTurnGrant(sessionId),
     slotManager,
     grammar,
     llmComplete,

--- a/src/tools/fusion/delegate-args.test.ts
+++ b/src/tools/fusion/delegate-args.test.ts
@@ -174,4 +174,26 @@ describe("parseDelegateArgs", () => {
       ).not.toThrow();
     }
   });
+  it("accepts a task list that arrived as JSON text", () => {
+    // What the text-JSON transport produces when the model quotes the
+    // array: the plan is right, the quoting is not.
+    const parsed = parseDelegateArgs({
+      tasks: JSON.stringify([
+        { id: "a", title: "A", instructions: "do a", files: ["/tmp/x/a.js"] },
+      ]),
+    });
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.tasks).toHaveLength(1);
+    expect(parsed.tasks?.[0]?.id).toBe("a");
+    expect(parsed.tasks?.[0]?.files).toEqual(["/tmp/x/a.js"]);
+  });
+
+  it("still refuses a string that is not a task list at all", () => {
+    expect(parseDelegateArgs({ tasks: "build the thing" }).error).toMatch(
+      /tasks must be an array/,
+    );
+    expect(parseDelegateArgs({ tasks: '{"id":"a"}' }).error).toMatch(
+      /tasks must be an array/,
+    );
+  });
 });

--- a/src/tools/fusion/delegate-args.ts
+++ b/src/tools/fusion/delegate-args.ts
@@ -85,10 +85,44 @@ function readMaxWorkers(value: unknown): number | null | string {
  * call comes back as `{ ok: false, error }` for the tool to render as a
  * `status: "error"` result the orchestrator can act on.
  */
+/**
+ * The task list, whether it arrived as an array or as JSON in a string.
+ *
+ * Models hand this argument over as a string often enough to matter: in
+ * one observed run, three of seven fan-outs died on
+ * `tasks must be an array`, each costing the turn a step and the
+ * operator a minute. The value was a perfectly good JSON array with
+ * quotes around it — the native-tools layer stringifies a nested
+ * structure, or the model writes it that way itself.
+ *
+ * Rejecting that is pedantry with a cost. Parsing it is two lines, and
+ * anything that does not parse to an array still fails exactly as
+ * before.
+ */
+/**
+ * Accept a `tasks` argument that arrived as JSON *text* rather than as a
+ * JSON array.
+ *
+ * Not a courtesy: a 12B orchestrator on the text-JSON transport writes
+ * `"tasks": "[{...}]"` often enough that a whole run died on
+ * `tasks must be an array` — the plan was right, the quoting was not,
+ * and refusing it taught the model nothing it could act on. Parsing the
+ * string costs one `JSON.parse`; anything that does not parse falls
+ * through unchanged and gets the same error it got before.
+ */
+function readTaskList(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
 export function parseDelegateArgs(
   raw: Record<string, unknown>,
 ): ParsedDelegateArgs {
-  const rawTasks = raw.tasks;
+  const rawTasks = readTaskList(raw.tasks);
   if (!Array.isArray(rawTasks)) {
     return fail("tasks must be an array of { id, title, instructions }");
   }

--- a/src/tools/fusion/fanout-paths.test.ts
+++ b/src/tools/fusion/fanout-paths.test.ts
@@ -1,0 +1,100 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+import { collapseScope, resolveFanoutScope } from "./fanout-paths.js";
+import type { DelegateTask } from "./delegate-args.js";
+
+function task(patch: Partial<DelegateTask> = {}): DelegateTask {
+  return {
+    id: "t1",
+    title: "Write a module",
+    instructions: "Do the thing.",
+    ...patch,
+  };
+}
+
+const CWD = "/repo";
+
+describe("resolveFanoutScope", () => {
+  it("takes the directories a brief names in `files`", () => {
+    const scope = resolveFanoutScope(
+      [task({ files: ["/tmp/rel-2/cart.js", "/tmp/rel-2/cart.test.js"] })],
+      CWD,
+    );
+    expect(scope).toContain("/tmp/rel-2");
+  });
+
+  it("reads paths out of the prose when `files` is empty", () => {
+    // The session that exposed all of this: the orchestrator wrote every
+    // path into the instructions and left `files` unset. Refusing to
+    // read that would mean no scope and no fix.
+    const scope = resolveFanoutScope(
+      [
+        task({
+          instructions:
+            "Create directory /tmp/rel-2 if needed. Write two files:\n" +
+            "1. /tmp/rel-2/cart.js — export function addItem(cart, item).\n" +
+            "2. /tmp/rel-2/cart.test.js — use node:test.",
+        }),
+      ],
+      CWD,
+    );
+    expect(scope).toContain("/tmp/rel-2");
+  });
+
+  it("does not mistake prose for paths", () => {
+    // A loose pattern over a model's writing finds version numbers and
+    // sentence fragments, and every false positive widens what the
+    // operator is about to authorise.
+    const scope = resolveFanoutScope(
+      [
+        task({
+          instructions:
+            "Use node:test. Target v1.2.3 of the spec. Cover e.g. the empty case.",
+        }),
+      ],
+      CWD,
+    );
+    expect(scope).toEqual([CWD]);
+  });
+
+  it("always includes the working directory as the floor", () => {
+    expect(resolveFanoutScope([task()], CWD)).toEqual([CWD]);
+  });
+
+  it("resolves a relative path against the working directory", () => {
+    const scope = resolveFanoutScope([task({ files: ["./src/a.ts"] })], CWD);
+    expect(scope).toEqual(["/repo"]);
+  });
+});
+
+describe("collapseScope", () => {
+  it("keeps the shallowest directory that covers the others", () => {
+    expect(collapseScope(["/tmp/x/sub", "/tmp/x", "/tmp/x/sub/deeper"])).toEqual(
+      ["/tmp/x"],
+    );
+  });
+
+  it("keeps genuinely separate roots apart", () => {
+    expect(collapseScope(["/tmp/a", "/tmp/b"]).sort()).toEqual([
+      "/tmp/a",
+      "/tmp/b",
+    ]);
+  });
+
+  it("does not treat a sibling with a shared prefix as contained", () => {
+    // `/tmp/rel-2-backup` is not inside `/tmp/rel-2`, however the
+    // strings compare.
+    expect(collapseScope(["/tmp/rel-2", "/tmp/rel-2-backup"]).sort()).toEqual([
+      "/tmp/rel-2",
+      "/tmp/rel-2-backup",
+    ]);
+  });
+
+  it("refuses roots too broad to hand to a fan-out", () => {
+    // One prompt authorises several workers to write unattended. `/` and
+    // the home directory are not scopes, they are the absence of one.
+    expect(collapseScope(["/"])).toEqual([]);
+    expect(collapseScope([homedir()])).toEqual([]);
+  });
+});

--- a/src/tools/fusion/fanout-paths.ts
+++ b/src/tools/fusion/fanout-paths.ts
@@ -1,0 +1,103 @@
+import { dirname, isAbsolute, resolve, sep } from "node:path";
+import { homedir } from "node:os";
+
+import { isInside } from "../../approval/fanout-scope.js";
+import { resolveUserPath } from "../os/expand-home.js";
+import type { DelegateTask } from "./delegate-args.js";
+
+/**
+ * Where a fan-out is about to write — the directory the operator is
+ * asked about once, and the scope its workers then inherit.
+ *
+ * There is no field that states this, so it is derived, in this order:
+ *
+ * 1. **`task.files`.** The brief's own list of paths. This is the answer
+ *    when the orchestrator fills it in, and the `### fusion` guidance now
+ *    tells it to.
+ * 2. **Paths written in the instructions.** In the session that exposed
+ *    all of this, the orchestrator put every path in prose —
+ *    `"Write two files: /tmp/rel-2/cart.js …"` — and left `files` empty.
+ *    Refusing to read that would have meant no scope and no fix, so a
+ *    deliberately strict pattern picks absolute paths out of the text.
+ * 3. **The working directory**, as the floor. A fan-out that names
+ *    nothing still needs somewhere to work.
+ *
+ * Then the directories are collapsed to their shallowest members, so a
+ * fan-out writing `/tmp/x/a.js` and `/tmp/x/sub/b.js` is one scope, not
+ * two.
+ */
+
+/**
+ * Absolute paths, or `./`-relative ones carrying a file extension.
+ *
+ * Strict on purpose. This runs over a model's prose, where a loose
+ * pattern would find version numbers, package names and sentence
+ * fragments, and every false positive widens what the operator is about
+ * to authorise. A miss is cheap — the working directory still floors the
+ * scope — so the pattern errs towards missing.
+ */
+const PATH_IN_PROSE =
+  /(?:^|[\s"'`(])((?:\/|\.\/|~\/)[\w.@+-]+(?:\/[\w.@+-]+)*\.[A-Za-z0-9]{1,8})/g;
+
+/** Roots too broad to hand to a fan-out, however the brief was written. */
+function isTooBroad(dir: string): boolean {
+  const home = homedir();
+  return dir === sep || dir === home || dir === resolve(home, "..");
+}
+
+function collectFromText(text: string, workingDir: string): string[] {
+  const out: string[] = [];
+  for (const match of text.matchAll(PATH_IN_PROSE)) {
+    const raw = match[1];
+    if (raw === undefined) continue;
+    try {
+      out.push(resolveUserPath(raw, workingDir));
+    } catch {
+      // `resolveUserPath` throws only on a Unix-absolute path under
+      // Windows. A path we cannot resolve is a path we will not grant.
+    }
+  }
+  return out;
+}
+
+/**
+ * Collapse directories to the shallowest that cover them all, and drop
+ * anything too broad to authorise.
+ */
+export function collapseScope(dirs: readonly string[]): string[] {
+  const unique = [...new Set(dirs)].filter((dir) => !isTooBroad(dir));
+  const roots: string[] = [];
+  for (const dir of unique.sort((a, b) => a.length - b.length)) {
+    if (!roots.some((root) => isInside(root, dir))) roots.push(dir);
+  }
+  return roots;
+}
+
+/**
+ * The directories a fan-out may write in, or an empty array when the
+ * brief gives nothing safe to grant — in which case the workers keep
+ * asking (and being refused), which the operator sees immediately as
+ * every task coming back `needs_orchestrator`.
+ */
+export function resolveFanoutScope(
+  tasks: readonly DelegateTask[],
+  workingDir: string,
+): string[] {
+  const paths: string[] = [];
+  for (const task of tasks) {
+    for (const file of task.files ?? []) {
+      try {
+        paths.push(resolveUserPath(file, workingDir));
+      } catch {
+        // See `collectFromText`.
+      }
+    }
+    paths.push(...collectFromText(task.instructions, workingDir));
+    if (task.deliverable) {
+      paths.push(...collectFromText(task.deliverable, workingDir));
+    }
+  }
+  const dirs = paths.map((path) => (isAbsolute(path) ? dirname(path) : path));
+  dirs.push(workingDir);
+  return collapseScope(dirs);
+}

--- a/src/tools/fusion/fusion-delegate.integration.test.ts
+++ b/src/tools/fusion/fusion-delegate.integration.test.ts
@@ -164,20 +164,40 @@ describe("fusion.delegate end to end", () => {
               title: "Read two",
               instructions: "Read notes.txt again",
             },
-            { id: "t3", title: "Write one", instructions: "Write out.txt" },
+            {
+              id: "t3",
+              title: "Write one",
+              instructions: "Write out.txt",
+              files: ["out.txt"],
+            },
           ]),
         );
       }
       return completion(replyCall("merged all three parts"));
     };
 
+    let runtimeRef: Awaited<ReturnType<typeof createAgentRuntime>> | null = null;
     const runtime = await createAgentRuntime({
       workingDir,
       // Level 1 prompts for everything an approval gate covers.
       approvalLevel: 1,
       handlers: {
         onAgentEvent: (event, sessionId) => events.push({ event, sessionId }),
-        onApprovalRequest: (request) => approvals.push(request),
+        onApprovalRequest: (request) => {
+          approvals.push(request);
+          // The fan-out's own question is the one an operator answers;
+          // answering it here is what authorises the workers to write.
+          // Anything else is left pending on purpose, so a stray worker
+          // prompt would show up as a timeout rather than pass quietly.
+          if (request.category === "fusion_fanout") {
+            queueMicrotask(() =>
+              runtimeRef?.approvals.resolve({
+                approvalId: request.approvalId,
+                approved: true,
+              }),
+            );
+          }
+        },
       },
       overrides: {
         browserBackend: backend,
@@ -185,6 +205,7 @@ describe("fusion.delegate end to end", () => {
         llamaComplete,
       },
     });
+    runtimeRef = runtime;
     // A fusion boot is cloud-active, so the local `/props` probe is
     // deferred and the pool starts at one slot. The real runtime widens
     // it inside `warmWorkerBackend`; with the HTTP layer faked away
@@ -261,10 +282,13 @@ describe("fusion.delegate end to end", () => {
         expect(runtime.sessionStore.load(workerId)).toBeNull();
       }
 
-      // The write was refused, not parked: at level 1 an ordinary
-      // session would have raised a prompt, and there is no operator
-      // watching a worker session to answer one.
-      expect(approvals).toHaveLength(0);
+      // Exactly one question for the whole fan-out — the operator is
+      // asked before any worker starts and not again. A worker that had
+      // to ask for itself would show up as a second request here (and,
+      // having nobody to answer it, as a refusal on its task row).
+      expect(approvals).toHaveLength(1);
+      expect(approvals[0]?.category).toBe("fusion_fanout");
+      expect(approvals[0]?.sessionId).toBe(parent.id);
       // The per-task rows ride on the tool result's `details`, which the
       // transcript does not keep — read them off the event stream, the
       // same channel a host UI would.
@@ -281,8 +305,13 @@ describe("fusion.delegate end to end", () => {
       expect(rows.map((r) => r.id)).toEqual(["t1", "t2", "t3"]);
       expect(rows[0]!.status).toBe("ok");
       expect(rows[1]!.status).toBe("ok");
-      expect(rows[2]!.status).toBe("needs_orchestrator");
+      // The write lands. Before the fan-out prompt existed this row came
+      // back `needs_orchestrator` at level 1 — a worker cannot ask, so
+      // every write died — and that refusal is what pushed the whole job
+      // back onto the orchestrator. One operator answer now covers it.
+      expect(rows[2]!.status).toBe("ok");
       expect(rows[2]!.tools.byTool["os.fs.write"]).toBe(1);
+      expect(rows[2]!.tools.errors).toBe(0);
     } finally {
       await runtime.shutdown();
     }

--- a/src/tools/fusion/fusion-delegate.test.ts
+++ b/src/tools/fusion/fusion-delegate.test.ts
@@ -424,4 +424,89 @@ describe("fusion.delegate", () => {
     );
     expect((await tool.run({ tasks: TASKS }, ctx())).status).toBe("ok");
   });
+  it("asks the operator once per turn, not once per fan-out", async () => {
+    // The operator's complaint, in one test: a turn that reviews and
+    // re-delegates used to raise the same question on every pass.
+    const asked: Array<{ category: string; resources?: readonly string[] }> =
+      [];
+    const scopes = new FanoutScopeRegistry();
+    const d = deps({
+      approvalRequired: true,
+      approvals: {
+        setSessionPolicy: () => {},
+        clearSessionPolicy: () => {},
+        fanoutScopes: scopes,
+        request: async (req: {
+          category: string;
+          affectedResources?: readonly string[];
+        }) => {
+          asked.push({
+            category: req.category,
+            ...(req.affectedResources
+              ? { resources: req.affectedResources }
+              : {}),
+          });
+          return { approved: true };
+        },
+      } as unknown as FusionDelegateDeps["approvals"],
+    });
+    const tool = buildFusionDelegateTool(d);
+    const tasks = [
+      { id: "t1", title: "One", instructions: "Write /repo/src/a.js" },
+    ];
+    const first = await tool.run({ tasks }, ctx());
+    expect(first.status).not.toBe("error");
+    expect(asked).toHaveLength(1);
+    expect(asked[0]?.category).toBe("fusion_fanout");
+
+    // The review pass: same turn, same directory, no second question.
+    const second = await tool.run(
+      {
+        tasks: [{ id: "t2", title: "Two", instructions: "Fix /repo/src/a.js" }],
+      },
+      ctx(),
+    );
+    expect(second.status).not.toBe("error");
+    expect(asked).toHaveLength(1);
+  });
+
+  it("asks again when a later fan-out reaches outside what was approved", async () => {
+    const asked: string[] = [];
+    const scopes = new FanoutScopeRegistry();
+    const d = deps({
+      approvalRequired: true,
+      approvals: {
+        setSessionPolicy: () => {},
+        clearSessionPolicy: () => {},
+        fanoutScopes: scopes,
+        request: async (req: { affectedResources?: readonly string[] }) => {
+          asked.push((req.affectedResources ?? []).join(","));
+          return { approved: true };
+        },
+      } as unknown as FusionDelegateDeps["approvals"],
+    });
+    const tool = buildFusionDelegateTool(d);
+    await tool.run(
+      {
+        tasks: [
+          { id: "t1", title: "One", instructions: "x", files: ["/repo/a.js"] },
+        ],
+      },
+      ctx(),
+    );
+    await tool.run(
+      {
+        tasks: [
+          {
+            id: "t2",
+            title: "Two",
+            instructions: "x",
+            files: ["/elsewhere/b.js"],
+          },
+        ],
+      },
+      ctx(),
+    );
+    expect(asked).toHaveLength(2);
+  });
 });

--- a/src/tools/fusion/fusion-delegate.test.ts
+++ b/src/tools/fusion/fusion-delegate.test.ts
@@ -1,3 +1,4 @@
+import { FanoutScopeRegistry } from "../../approval/fanout-scope.js";
 import { describe, expect, it, vi } from "vitest";
 
 import type { RunTurnResult } from "../../agent/agent-loop.js";
@@ -53,7 +54,13 @@ function deps(over: Partial<FusionDelegateDeps> = {}): FusionDelegateDeps {
         metadata: { fusionWorker: { ...meta } },
       });
     },
-    approvals: { setSessionPolicy: () => {}, clearSessionPolicy: () => {} },
+    approvals: {
+      setSessionPolicy: () => {},
+      clearSessionPolicy: () => {},
+      fanoutScopes: new FanoutScopeRegistry(),
+    },
+    // The documented test seam: exercise the fan-out without a gate.
+    approvalRequired: false,
     emitEvent: () => {},
     workingDir: "/repo",
     slotManager: { poolSize: () => 4 },

--- a/src/tools/fusion/fusion-delegate.ts
+++ b/src/tools/fusion/fusion-delegate.ts
@@ -1,3 +1,6 @@
+import type { ApprovalGate } from "../../approval/approval-gate.js";
+import { requireApproval } from "../../approval/dangerous-tool.js";
+import { resolveFanoutScope } from "./fanout-paths.js";
 import { compressToolResult } from "../../compressor/result-compressor.js";
 import type { CompressedToolResult } from "../../compressor/result-compressor.js";
 import type { ResolvedRunMode } from "../../llm/run-mode/index.js";
@@ -15,6 +18,12 @@ import {
 export const FUSION_DELEGATE_TOOL = "fusion.delegate";
 
 export interface FusionDelegateDeps extends WorkerRunnerDeps {
+  /**
+   * Whether the fan-out asks the operator before it runs. Same seam as
+   * every other dangerous tool: production passes `true`, tests pass
+   * `false` to exercise the fan-out without a gate.
+   */
+  approvalRequired: boolean;
   slotManager: Pick<SlotManager, "poolSize">;
   /** Live read — the operator can leave fusion mid-turn. */
   resolveRunMode: () => ResolvedRunMode;
@@ -75,6 +84,29 @@ function error(
  * the wrong place to decide. The bounds that remain are physical: the
  * task count, and the server's request slots on a slot-affine leg.
  */
+/**
+ * What the operator reads before authorising a fan-out.
+ *
+ * The task titles, not a count: one prompt stands in for every write
+ * these workers make, so the thing being approved has to be legible as
+ * work, not as a number. The scope is stated last because it is the part
+ * the answer actually grants.
+ */
+export function describeFanoutPreview(
+  tasks: readonly { title: string }[],
+  writeScope: readonly string[],
+): string {
+  const lines = tasks.map((task) => `  • ${task.title}`);
+  const scope =
+    writeScope.length > 0
+      ? [`may write in:`, ...writeScope.map((dir) => `  ${dir}`)]
+      : [
+          `no writable directory could be derived from the briefs, so the`,
+          `workers will still have to hand every write back up.`,
+        ];
+  return [...lines, "", ...scope].join("\n");
+}
+
 export function buildFusionDelegateTool(
   deps: FusionDelegateDeps,
 ): ToolDefinition {
@@ -172,6 +204,33 @@ export function buildFusionDelegateTool(
         tool: FUSION_DELEGATE_TOOL,
       });
 
+      // One question for the whole fan-out, asked before a single worker
+      // starts. A worker has no operator to ask — that is what made the
+      // mode unusable below full trust, with every write refused and the
+      // orchestrator left as the only party able to act — so the
+      // operator is asked here instead, once, with the task list and the
+      // directory in front of them.
+      const writeScope = resolveFanoutScope(parsed.tasks, ctx.workingDir);
+      try {
+        await requireApproval(
+          { approvals: deps.approvals as ApprovalGate, approvalRequired: deps.approvalRequired },
+          {
+            sessionId: ctx.sessionId,
+            tool: FUSION_DELEGATE_TOOL,
+            category: "fusion_fanout",
+            reason: `${parsed.tasks.length} task${parsed.tasks.length === 1 ? "" : "s"} to ${maxWorkers} worker${maxWorkers === 1 ? "" : "s"} on ${workerModel}`,
+            preview: describeFanoutPreview(parsed.tasks, writeScope),
+            affectedResources: [...writeScope],
+          },
+          ctx.signal,
+        );
+      } catch (err) {
+        return error(
+          `the fan-out was not approved: ${err instanceof Error ? err.message : String(err)}`,
+          { reason: "fan-out-denied" },
+        );
+      }
+
       let results: WorkerTaskResult[];
       try {
         results = await runWorkerTasks(deps, {
@@ -182,6 +241,7 @@ export function buildFusionDelegateTool(
           workerModel,
           workerMaxSteps: mode.workerMaxSteps,
           workerTimeoutMs: mode.workerTimeoutMs,
+          writeScope,
           signal: ctx.signal,
         });
       } catch (err) {

--- a/src/tools/fusion/fusion-delegate.ts
+++ b/src/tools/fusion/fusion-delegate.ts
@@ -99,7 +99,10 @@ export function describeFanoutPreview(
   const lines = tasks.map((task) => `  • ${task.title}`);
   const scope =
     writeScope.length > 0
-      ? [`may write in:`, ...writeScope.map((dir) => `  ${dir}`)]
+      ? [
+          `may write files and run commands in:`,
+          ...writeScope.map((dir) => `  ${dir}`),
+        ]
       : [
           `no writable directory could be derived from the briefs, so the`,
           `workers will still have to hand every write back up.`,
@@ -211,19 +214,35 @@ export function buildFusionDelegateTool(
       // operator is asked here instead, once, with the task list and the
       // directory in front of them.
       const writeScope = resolveFanoutScope(parsed.tasks, ctx.workingDir);
+      // A turn is one job. An orchestrator that reviews and re-delegates
+      // runs five fan-outs to build one library, and asking the same
+      // question five times is attrition, not consent. The operator's
+      // answer stands for the rest of the turn as long as later fan-outs
+      // stay inside the directories it named; one reaching somewhere new
+      // asks again.
+      const alreadyApproved =
+        deps.approvals.fanoutScopes?.turnGrantCovers(
+          ctx.sessionId,
+          writeScope,
+        ) ?? false;
       try {
-        await requireApproval(
-          { approvals: deps.approvals as ApprovalGate, approvalRequired: deps.approvalRequired },
-          {
-            sessionId: ctx.sessionId,
-            tool: FUSION_DELEGATE_TOOL,
-            category: "fusion_fanout",
-            reason: `${parsed.tasks.length} task${parsed.tasks.length === 1 ? "" : "s"} to ${maxWorkers} worker${maxWorkers === 1 ? "" : "s"} on ${workerModel}`,
-            preview: describeFanoutPreview(parsed.tasks, writeScope),
-            affectedResources: [...writeScope],
-          },
-          ctx.signal,
-        );
+        if (!alreadyApproved)
+          await requireApproval(
+            {
+              approvals: deps.approvals as ApprovalGate,
+              approvalRequired: deps.approvalRequired,
+            },
+            {
+              sessionId: ctx.sessionId,
+              tool: FUSION_DELEGATE_TOOL,
+              category: "fusion_fanout",
+              reason: `${parsed.tasks.length} task${parsed.tasks.length === 1 ? "" : "s"} to ${maxWorkers} worker${maxWorkers === 1 ? "" : "s"} on ${workerModel}`,
+              preview: describeFanoutPreview(parsed.tasks, writeScope),
+              affectedResources: [...writeScope],
+            },
+            ctx.signal,
+          );
+        deps.approvals.fanoutScopes?.grantForTurn(ctx.sessionId, writeScope);
       } catch (err) {
         return error(
           `the fan-out was not approved: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/tools/fusion/worker-prompt.test.ts
+++ b/src/tools/fusion/worker-prompt.test.ts
@@ -50,7 +50,7 @@ describe("renderWorkerBrief", () => {
   it("names the approval refusal so the model recognises the result", () => {
     const brief = renderWorkerBrief(TASK, { workingDir: "/repo" });
     expect(brief).toContain(FUSION_WORKER_APPROVAL_MARKER);
-    expect(brief).toMatch(/exactly what must be run or written/);
+    expect(brief).toMatch(/exactly what was blocked and where/);
   });
 
   it("says the reply is the whole handover, and bounds it", () => {

--- a/src/tools/fusion/worker-prompt.ts
+++ b/src/tools/fusion/worker-prompt.ts
@@ -44,8 +44,8 @@ export function renderWorkerBrief(
     ``,
     `RULES:`,
     `- Work autonomously. Never ask a question and never wait for confirmation — there is no user on this session. If something is ambiguous, take the most reasonable reading and say what you assumed in your reply.`,
-    `- \`os.fs.write\` creates any missing parent directories itself. Do not run \`mkdir\` first: a shell command needs an approval you cannot get, so it costs you a step and returns nothing.`,
-    `- The operator authorised this fan-out to write in the directories the task names, so writing there just works. Anything outside them is refused, not queued: a tool result carrying "${FUSION_WORKER_APPROVAL_MARKER}" means nobody can approve it here. Stop retrying it and say in your reply exactly what was blocked and where, so the orchestrator can re-send the task with that path named — it cannot run the action for you.`,
+    `- \`os.fs.write\` creates any missing parent directories itself, so \`mkdir\` is never needed before a write.`,
+    `- The operator authorised this fan-out to write files AND run commands in the directories the task names, so working there needs no permission: write the files, run the build, run the tests, read the output. Anything outside them is refused, not queued: a tool result carrying "${FUSION_WORKER_APPROVAL_MARKER}" means nobody can approve it here. Stop retrying it and say in your reply exactly what was blocked and where, so the orchestrator can re-send the task with that path named — it cannot run the action for you.`,
     `- Finish with \`reply\` carrying the concise result of this task (about ${WORKER_REPLY_CHAR_BUDGET} characters at most). That reply is the ONLY thing the orchestrator receives — findings, file paths, decisions and anything it needs to merge your part must be inside it.`,
   );
   return lines.join("\n");

--- a/src/tools/fusion/worker-prompt.ts
+++ b/src/tools/fusion/worker-prompt.ts
@@ -44,7 +44,8 @@ export function renderWorkerBrief(
     ``,
     `RULES:`,
     `- Work autonomously. Never ask a question and never wait for confirmation — there is no user on this session. If something is ambiguous, take the most reasonable reading and say what you assumed in your reply.`,
-    `- Approval-gated actions are refused for you, not queued. A tool result carrying "${FUSION_WORKER_APPROVAL_MARKER}" means nobody can approve it here: stop retrying that action and state in your reply exactly what must be run or written, so the orchestrator can do it.`,
+    `- \`os.fs.write\` creates any missing parent directories itself. Do not run \`mkdir\` first: a shell command needs an approval you cannot get, so it costs you a step and returns nothing.`,
+    `- The operator authorised this fan-out to write in the directories the task names, so writing there just works. Anything outside them is refused, not queued: a tool result carrying "${FUSION_WORKER_APPROVAL_MARKER}" means nobody can approve it here. Stop retrying it and say in your reply exactly what was blocked and where, so the orchestrator can re-send the task with that path named — it cannot run the action for you.`,
     `- Finish with \`reply\` carrying the concise result of this task (about ${WORKER_REPLY_CHAR_BUDGET} characters at most). That reply is the ONLY thing the orchestrator receives — findings, file paths, decisions and anything it needs to merge your part must be inside it.`,
   );
   return lines.join("\n");

--- a/src/tools/fusion/worker-runner.ts
+++ b/src/tools/fusion/worker-runner.ts
@@ -40,7 +40,8 @@ export interface WorkerRunnerDeps {
   ) => Promise<RunTurnResult>;
   /** `runtime.createEphemeralSession` — in-memory, never persisted. */
   createEphemeralSession: (meta: FusionWorkerMeta) => SessionState;
-  approvals: Pick<ApprovalGate, "setSessionPolicy" | "clearSessionPolicy">;
+  approvals: Pick<ApprovalGate, "setSessionPolicy" | "clearSessionPolicy"> &
+    Partial<Pick<ApprovalGate, "fanoutScopes">>;
   /** Progress into the PARENT session's frame. */
   emitEvent: (sessionId: string, event: AgentLoopEvent) => void;
   workingDir: string;
@@ -62,6 +63,14 @@ export interface RunWorkerTasksOptions {
   workerModel: string;
   workerMaxSteps: number;
   workerTimeoutMs: number;
+  /**
+   * Directories these workers may write in without asking, as approved
+   * by the operator on this fan-out's own prompt. Empty means nothing
+   * was authorised — the workers then hit the refuse policy on every
+   * write, exactly as they did before the fan-out prompt existed, and
+   * the operator sees it as every task returning `needs_orchestrator`.
+   */
+  writeScope?: readonly string[];
   signal: AbortSignal;
 }
 
@@ -187,6 +196,15 @@ async function runOneTask(
     onPrompt: "refuse",
     reason: FUSION_WORKER_APPROVAL_REFUSED,
   });
+  // …and the half that lets it work at all. The operator answered one
+  // question at the fan-out naming these directories; inside them this
+  // worker writes unprompted. The refuse policy above still catches
+  // everything else, so straying outside the scope comes back as
+  // `needs_orchestrator` — a task to re-delegate, not a dead worker.
+  const writeScope = options.writeScope ?? [];
+  if (writeScope.length > 0) {
+    deps.approvals.fanoutScopes?.grant(session.id, writeScope);
+  }
 
   let result: WorkerTaskResult;
   try {
@@ -240,6 +258,7 @@ async function runOneTask(
     // Always: the gate is process-wide and a stale refusal policy keyed
     // to a dead session is a slow leak, not a visible bug.
     deps.approvals.clearSessionPolicy(session.id);
+    deps.approvals.fanoutScopes?.clear(session.id);
   }
 
   // Keep the feed paired: a turn that died before it ever stepped never

--- a/src/tools/fusion/worker-tool-policy.ts
+++ b/src/tools/fusion/worker-tool-policy.ts
@@ -46,10 +46,19 @@ export function isWorkerVisibleTool(name: string): boolean {
  * showing the orchestrator's session — so the tool result tells the
  * model to hand the exact action back up rather than park the turn on a
  * question nobody will answer.
+ *
+ * "Back up" no longer means "the orchestrator does it". The orchestrator
+ * is refused every mutating tool for the whole turn, so the only thing
+ * it can do with a blocked path is name it in the next fan-out, where
+ * the operator is asked to widen the scope. The wording says so, because
+ * a worker that reports "the orchestrator must run this" is describing a
+ * step that will never happen.
  */
 export const FUSION_WORKER_APPROVAL_REFUSED =
   "this step needs operator approval, which a worker cannot request. " +
-  "Stop and, in your reply, state exactly what must be run or written so the orchestrator can do it.";
+  "It is outside the directories this fan-out was authorised for. Stop and, in your reply, " +
+  "name the exact path so the orchestrator can send the task out again with that path in `files` — " +
+  "it cannot run the action itself.";
 
 /**
  * The stable substring of the refusal that survives rewording of the

--- a/src/tools/os/fs-require-approval.ts
+++ b/src/tools/os/fs-require-approval.ts
@@ -115,6 +115,19 @@ export async function requireFsApproval(
       ? { trustConfigPaths: request.trustConfigPaths }
       : {}),
   });
+  // A fan-out the operator authorised once covers every write its
+  // workers make inside the directory that prompt named — except the
+  // agent's own trust surface. `trust_config` is never grantable by any
+  // other route either (`GRANTABLE_CATEGORY`), and a fan-out whose scope
+  // happens to contain `config.json` or `.env` must not become the way
+  // around that: the operator approved a directory of work, not a
+  // change to what the agent is allowed to do next.
+  if (
+    category !== "trust_config" &&
+    options.approvals.fanoutScopes.allows(request.sessionId, request.paths)
+  ) {
+    return { category };
+  }
   const outcome = await requireApproval(
     options,
     {

--- a/src/tools/os/os-tools.test.ts
+++ b/src/tools/os/os-tools.test.ts
@@ -201,6 +201,44 @@ describe("os.shell.run", () => {
     expect(approvals).toBe(0);
   });
 
+  it("runs a command inside an approved fan-out scope without asking", async () => {
+    // A worker's whole reason to exist is to finish a task, and half
+    // the tasks worth delegating end in "run the tests". The operator
+    // approved a directory for this fan-out; a command whose `cwd` is
+    // inside it is the same permission, and the refuse policy on a
+    // worker session means asking would simply kill the call.
+    let approvals = 0;
+    const gate = new ApprovalGate({
+      emit: (req) => {
+        approvals += 1;
+        gate.reject(req.approvalId, "should not ask");
+      },
+    });
+    gate.fanoutScopes.grant("test-session", [dir]);
+    const tool = buildOsShellTool({ approvals: gate, approvalRequired: true });
+    const result = await tool.run(
+      { cmd: "node", args: ["-e", "process.stdout.write('hi')"] },
+      makeCtx(dir),
+    );
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("hi");
+    expect(approvals).toBe(0);
+  });
+
+  it("still asks for a command outside the approved scope", async () => {
+    const gate = new ApprovalGate({
+      emit: (req) => gate.reject(req.approvalId, "no"),
+    });
+    gate.fanoutScopes.grant("test-session", [join(dir, "inside")]);
+    const tool = buildOsShellTool({ approvals: gate, approvalRequired: true });
+    await expect(
+      tool.run(
+        { cmd: "node", args: ["-e", "process.stdout.write('hi')"] },
+        makeCtx(dir),
+      ),
+    ).rejects.toMatchObject({ name: "ApprovalDeniedError" });
+  });
+
   it("executes echo and captures stdout when approved", async () => {
     const gate = new ApprovalGate({
       emit: (req) =>

--- a/src/tools/os/shell.ts
+++ b/src/tools/os/shell.ts
@@ -278,7 +278,16 @@ export function buildOsShellTool(options: OsShellToolOptions): ToolDefinition {
         });
       }
 
-      if (guardVerdict.action === "approval_required") {
+      // A fan-out the operator authorised may also run commands, but
+      // only in the directory they saw: `cwd` inside the scope, and the
+      // guard's own hardline blocks still fire above this (a `block`
+      // verdict never reaches here). The command line itself is free
+      // text and cannot be scoped, so the directory is the whole of the
+      // promise — which is why the fan-out prompt says "and run commands
+      // in" rather than something broader.
+      const scopedByFanout =
+        options.approvals.fanoutScopes?.allows(ctx.sessionId, [cwd]) ?? false;
+      if (guardVerdict.action === "approval_required" && !scopedByFanout) {
         // Shape grant unit: the normalised binary the guard itself keyed
         // on (basename, lowercased), so `[a]` covers exactly the argv[0]
         // that would run: `git`, not `/usr/bin/GIT` or a path. Withheld

--- a/src/tui/commands/dispatch-run-mode.test.ts
+++ b/src/tui/commands/dispatch-run-mode.test.ts
@@ -52,4 +52,14 @@ describe("parseRunModeCommand", () => {
     expect(out.error).toContain('"hybrid"');
     expect(out.error).toContain(RUN_MODE_USAGE);
   });
+  it("reads `swap` as the leg trade, not as a mode name", () => {
+    expect(parseRunModeCommand("swap")).toEqual({
+      openSwitch: false,
+      swap: true,
+    });
+    expect(parseRunModeCommand(" SWAP ")).toEqual({
+      openSwitch: false,
+      swap: true,
+    });
+  });
 });

--- a/src/tui/commands/dispatch-run-mode.ts
+++ b/src/tui/commands/dispatch-run-mode.ts
@@ -12,6 +12,8 @@ export interface RunModeCommand {
   readonly mode?: RunModeName;
   /** `/runmode status`. */
   readonly status?: boolean;
+  /** `/runmode swap`: trade the orchestrator leg for the worker leg. */
+  readonly swap?: boolean;
   /** `/runmode workers N`. */
   readonly workers?: number;
   /** Usage line for anything else. */
@@ -19,7 +21,7 @@ export interface RunModeCommand {
 }
 
 export const RUN_MODE_USAGE =
-  "usage: /runmode (opens the switch) · /runmode local|cloud|fusion · /runmode workers N · /runmode status";
+  "usage: /runmode (opens the switch) · /runmode local|cloud|fusion · /runmode swap · /runmode workers N · /runmode status";
 
 /**
  * Parse the arguments of `/runmode`. Split out of
@@ -32,6 +34,7 @@ export function parseRunModeCommand(rawArgs: string): RunModeCommand {
   const args = rawArgs.trim().toLowerCase();
   if (args.length === 0) return { openSwitch: true };
   if (args === "status") return { openSwitch: false, status: true };
+  if (args === "swap") return { openSwitch: false, swap: true };
   const workers = /^workers\s+(\d+)$/.exec(args);
   if (workers) {
     const n = Number(workers[1]);

--- a/src/tui/commands/run-mode-verb.ts
+++ b/src/tui/commands/run-mode-verb.ts
@@ -30,6 +30,10 @@ export function runRunModeVerb(
     });
     return;
   }
+  if (verb === "swap") {
+    callbacks.onFusionLegsSwapRequested?.();
+    return;
+  }
   activateComposerSwitchRow(
     backendSwitchRow(state, verb),
     state,

--- a/src/tui/commands/slash-command-handler.ts
+++ b/src/tui/commands/slash-command-handler.ts
@@ -133,7 +133,8 @@ export interface SlashDispatchResult {
    * resolves to. Both need the live state / orchestrator, which only the
    * caller (`submit-handler.ts`) can reach.
    */
-  readonly runModeVerb?: import("../../config/index.js").RunModeName | "status";
+  readonly runModeVerb?:
+    import("../../config/index.js").RunModeName | "status" | "swap";
   /** `/runmode workers N`: persist the fusion worker count. */
   readonly runModeWorkers?: number;
 }
@@ -339,6 +340,7 @@ export function dispatchSlashCommand(buffer: string): SlashDispatchResult {
       }
       if (cmd.workers !== undefined)
         return pureActions([], { runModeWorkers: cmd.workers });
+      if (cmd.swap) return pureActions([], { runModeVerb: "swap" });
       return pureActions([], { runModeVerb: cmd.status ? "status" : cmd.mode });
     }
     default:

--- a/src/tui/components/prompt-meta-bar.tsx
+++ b/src/tui/components/prompt-meta-bar.tsx
@@ -1,6 +1,9 @@
 import { Box, Text } from "ink";
 import type { ReactElement } from "react";
-import { ComposerMetaControls } from "../composer-switch/composer-meta-controls.js";
+import {
+  ComposerMetaControls,
+  LEG_SEPARATOR,
+} from "../composer-switch/composer-meta-controls.js";
 import type { ComposerBackendMeta } from "../composer-switch/composer-backend-selectors.js";
 import { fusionBarGround } from "../theme/fusion-tint.js";
 import { theme } from "../theme/theme.js";
@@ -110,12 +113,13 @@ const MODEL_LABEL_MAX_LEN = 32;
 export const META_SLOT_SHRINK = 40;
 
 /**
- * Separator `runModeModelSummary` puts between the two fusion legs.
- * Matched here rather than imported as a run-mode concept: this file
- * only needs to know that a label can be a pair, so that it can spend
- * its budget on both halves instead of on the first one.
+ * Separator `selectPromptLlmMeta` puts between the two fusion legs.
+ * The same constant the controls split on — this file spends the label
+ * budget on both halves, `ComposerMetaControls` hangs the swap button
+ * on the seam, and one of them moving without the other would leave a
+ * pair that truncates as a pair but no longer comes apart.
  */
-const PAIR_SEPARATOR = " ⇄ ";
+const PAIR_SEPARATOR = LEG_SEPARATOR;
 
 export function PromptMetaBar({
   leftSlot,

--- a/src/tui/composer-switch/composer-meta-controls.tsx
+++ b/src/tui/composer-switch/composer-meta-controls.tsx
@@ -10,6 +10,17 @@ import { BackendControl } from "./composer-backend-control.js";
 import type { ComposerBackendMeta } from "./composer-backend-selectors.js";
 import type { ComposerSwitchKind } from "./composer-switch-state.js";
 
+/**
+ * What `selectPromptLlmMeta` puts between the two fusion legs.
+ *
+ * It lives here, and `prompt-meta-bar.tsx` imports it, because the two
+ * uses have to agree: that file splits the pair to spend the label
+ * budget on both halves, this one splits it to hang the swap button on
+ * the seam. One of them moving alone would leave a pair that truncates
+ * as a pair but no longer comes apart.
+ */
+export const LEG_SEPARATOR = " ⇄ ";
+
 /** What the model slot says when the local route has no weights on disk. */
 export const DOWNLOAD_MODEL_LABEL = "download model";
 
@@ -79,6 +90,7 @@ export function ComposerMetaControls({
   mouseLayer,
 }: ComposerMetaControlsProps): ReactElement | null {
   if (!backend && !provider && !model && !needsModelDownload) return null;
+  const pair = model && !needsModelDownload ? splitLegs(model) : null;
   return (
     <>
       {backend ? (
@@ -103,6 +115,25 @@ export function ComposerMetaControls({
           lead={Boolean(backend || provider)}
           mouseLayer={mouseLayer}
         />
+      ) : pair ? (
+        <>
+          <Control
+            kind="model"
+            label={pair[0]}
+            lead={Boolean(backend || provider)}
+            shrink={3}
+            fusion={fusion}
+            mouseLayer={mouseLayer}
+          />
+          <SwapLegsControl fusion={fusion} mouseLayer={mouseLayer} />
+          <Control
+            kind="workers"
+            label={pair[1]}
+            shrink={3}
+            fusion={fusion}
+            mouseLayer={mouseLayer}
+          />
+        </>
       ) : model ? (
         <Control
           kind="model"
@@ -163,6 +194,61 @@ function DownloadModelControl({
       </Text>
     </Box>
   );
+}
+
+/**
+ * The glyph between the two fusion legs, as a button: one click trades
+ * the orchestrator for the workers and back.
+ *
+ * It sits where the separator already was, so the row costs nothing it
+ * did not cost before — the pair was always drawn as `A ⇄ B`; the
+ * only change is that the three characters in the middle now answer to
+ * a press. `/runmode swap` is the same move from the keyboard, because
+ * a control only a mouse can reach is not a control in a terminal app.
+ */
+function SwapLegsControl({
+  fusion,
+  mouseLayer,
+}: {
+  fusion: boolean;
+  mouseLayer?: number;
+}): ReactElement {
+  const mouse = useMouseCommands();
+  const ref = useMouseTarget(
+    (hit) => {
+      if (!mouse || !isPrimaryPress(hit.event)) return false;
+      mouse.callbacks.onFusionLegsSwapRequested?.();
+      return true;
+    },
+    mouseLayer === undefined ? {} : { layer: mouseLayer },
+  );
+  return (
+    // Rigid: the arrows are the only thing on the row that says which
+    // half is which, so they must not be what the row gives up when it
+    // runs out of columns.
+    <Box ref={ref} flexShrink={0}>
+      <Text
+        color={fusion ? fusionSurfaceInk() : theme.colors.railForeground}
+        wrap="truncate"
+      >
+        {LEG_SEPARATOR}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * Split `A ⇄ B` into its two legs. Anything else — a single model
+ * name, a label that happens to contain the glyph without the spaces —
+ * comes back `null` and is drawn as one control, exactly as before.
+ */
+function splitLegs(label: string): readonly [string, string] | null {
+  const at = label.indexOf(LEG_SEPARATOR);
+  if (at < 0) return null;
+  const left = label.slice(0, at);
+  const right = label.slice(at + LEG_SEPARATOR.length);
+  if (left.length === 0 || right.length === 0) return null;
+  return [left, right];
 }
 
 function Control({

--- a/src/tui/composer-switch/composer-switch-app.test.tsx
+++ b/src/tui/composer-switch/composer-switch-app.test.tsx
@@ -136,6 +136,65 @@ function mountApp() {
   };
 }
 
+/**
+ * The same app on the fusion route: two legs pinned, so the model slot
+ * is drawn as `orchestrator ⇄ worker` and the glyph between them is the
+ * swap button.
+ */
+function mountFusionApp() {
+  const bus = makeTuiEventBus();
+  const mouse = makeMouseSource();
+  const swaps: number[] = [];
+  const { lastFrame, unmount } = render(
+    <TuiApp
+      session={SESSION}
+      bus={bus}
+      callbacks={
+        {
+          onApprovalDecision: () => {},
+          onAbort: () => {},
+          onQuit: () => {},
+          onMessageSubmitted: () => {},
+          onFusionLegsSwapRequested: () => swaps.push(1),
+        } as TuiAppCallbacks
+      }
+      mouse={mouse}
+    />,
+  );
+  bus.emit({
+    type: "providers_refresh",
+    runMode: {
+      stored: "fusion",
+      effective: "fusion",
+      orchestratorProviderId: "openrouter",
+      orchestratorModel: "claude-opus-5",
+      workerProviderId: "local-llama",
+      workerModel: "qwen-3.5-4b",
+      workers: 2,
+      workerMaxSteps: 40,
+      workerTimeoutMs: 600_000,
+      primaryProviderId: "openrouter",
+      degraded: null,
+    },
+    rows: [
+      providerRow({ isActiveText: true }),
+      providerRow({
+        id: "local-llama",
+        kind: "llama-server",
+        hasApiKey: false,
+        chatModel: null,
+        chatModelOptions: [],
+      }),
+    ],
+  });
+  return {
+    frame: () => strip(lastFrame() ?? ""),
+    mouse,
+    swaps: () => swaps.length,
+    unmount,
+  };
+}
+
 describe("the composer's route controls inside the app", () => {
   it("states the route as backend, provider, model", async () => {
     const app = mountApp();
@@ -272,6 +331,47 @@ describe("the composer's route controls inside the app", () => {
     app.stdin.write("hello");
     await waitUntil(() => app.frame().includes("hello"), "the typed buffer");
     expect(app.frame()).not.toContain("zzz");
+    app.unmount();
+  });
+  it("trades the two fusion legs when the ⇄ between them is clicked", async () => {
+    // The operator's move: one click puts the local model in charge and
+    // sends the cloud one to the workers. Before this the glyph was
+    // inert punctuation inside the model label, and the only way across
+    // was two trips through two different switches.
+    const app = mountFusionApp();
+    await waitUntil(
+      () => app.frame().includes("claude-opus-5 ⇄ qwen-3.5-4b"),
+      "the fusion pair",
+    );
+    await clickUntil(
+      app.mouse,
+      () => {
+        const at = locate(app.frame(), "⇄");
+        return { x: at.x, y: at.y };
+      },
+      () => app.swaps() > 0,
+      "click on the swap glyph",
+    );
+    expect(app.swaps()).toBeGreaterThan(0);
+    app.unmount();
+  });
+
+  it("keeps the two halves apart: clicking a leg opens that leg's switch", async () => {
+    const app = mountFusionApp();
+    await waitUntil(
+      () => app.frame().includes("claude-opus-5 ⇄ qwen-3.5-4b"),
+      "the fusion pair",
+    );
+    await clickUntil(
+      app.mouse,
+      () => locate(app.frame(), "qwen-3.5-4b"),
+      () => app.frame().includes("WORKERS"),
+      "click on the worker half",
+    );
+    // Not the orchestrator's model switch: the right-hand half names
+    // the worker leg, so that is the list it opens.
+    expect(app.frame()).not.toContain("MODEL");
+    expect(app.swaps()).toBe(0);
     app.unmount();
   });
 });

--- a/src/tui/llm-panel/llm-panel-selectors.test.ts
+++ b/src/tui/llm-panel/llm-panel-selectors.test.ts
@@ -427,4 +427,63 @@ describe("local model rows during a pull", () => {
       }),
     );
   });
+  it("names a LOCAL orchestrator by its model, not by the provider id", () => {
+    // The legs are one click apart now (the composer's ⇄), so this is an
+    // everyday shape rather than a hand-edited config. A llama-server row
+    // carries no `chatModel`, and the label used to fall through to the
+    // provider id: `local-llama ⇄ anthropic/claude-opus-5`.
+    const base = createInitialTuiState(fakeSession());
+    const state = {
+      ...base,
+      localModelsPanel: {
+        ...base.localModelsPanel,
+        configMode: "managed" as const,
+        activeModelId: "qwen-3.5-4b" as LocalModelDef["id"],
+      },
+      providersPanel: {
+        ...base.providersPanel,
+        runMode: {
+          stored: "fusion" as const,
+          effective: "fusion" as const,
+          orchestratorProviderId: "local-llama",
+          orchestratorModel: null,
+          workerProviderId: "openrouter",
+          workerModel: null,
+          workers: 2,
+          workerMaxSteps: 40,
+          workerTimeoutMs: 600_000,
+          primaryProviderId: "local-llama",
+          degraded: null,
+        },
+        rows: [
+          {
+            id: "local-llama",
+            kind: "llama-server" as const,
+            isActiveText: true,
+            isActiveEmbedding: false,
+            hasApiKey: false,
+            baseUrl: null,
+            subscriptionCli: null,
+            chatModel: null,
+            embeddingModel: null,
+          },
+          {
+            id: "openrouter",
+            kind: "openrouter" as const,
+            isActiveText: false,
+            isActiveEmbedding: false,
+            hasApiKey: true,
+            baseUrl: null,
+            subscriptionCli: null,
+            chatModel: "openai/gpt-4o-mini",
+            embeddingModel: null,
+          },
+        ],
+      },
+    };
+    expect(selectPromptLlmMeta(state)).toEqual({
+      model: "qwen-3.5-4b ⇄ openai/gpt-4o-mini",
+      provider: "local-llama",
+    });
+  });
 });

--- a/src/tui/llm-panel/llm-panel-selectors.ts
+++ b/src/tui/llm-panel/llm-panel-selectors.ts
@@ -194,11 +194,21 @@ export function selectPromptLlmMeta(state: TuiState): PromptLlmMeta {
       state.providersPanel.rows.find(
         (row) => row.id === runMode.orchestratorProviderId,
       ) ?? null;
-    const orchestrator =
-      runMode.orchestratorModel ??
-      orchestratorRow?.chatModel ??
-      runMode.orchestratorProviderId ??
-      "cloud";
+    // Symmetric with the worker half below, because the legs are now one
+    // click apart: a LOCAL orchestrator is named by the model the managed
+    // daemon serves, not by `chatModel` — a llama-server row has none, so
+    // the label fell through to the provider id and the strip read
+    // `local-llama ⇄ anthropic/claude…` after a swap.
+    const orchestratorIsLocal = orchestratorRow?.kind === "llama-server";
+    const orchestrator = orchestratorIsLocal
+      ? (runMode.orchestratorModel ??
+        state.localModelsPanel.activeModelId ??
+        state.llmHealth.model ??
+        "local")
+      : (runMode.orchestratorModel ??
+        orchestratorRow?.chatModel ??
+        runMode.orchestratorProviderId ??
+        "cloud");
     // The worker half is labelled from the worker LEG, not from the
     // local daemon: with the legs swapped the workers run in the cloud,
     // and naming the idle local model there is the same lie the

--- a/src/tui/run-mode/fusion-intro.test.ts
+++ b/src/tui/run-mode/fusion-intro.test.ts
@@ -21,7 +21,7 @@ describe("describeFusionIntro", () => {
   it("opens with the mark, then the sentence", () => {
     const text = describeFusionIntro(rm);
     expect(text.startsWith(FUSION_MARK)).toBe(true);
-    expect(text).toContain("Fusion is on.");
+    expect(text).toContain("Fusion splits the work between two models");
   });
 
   it("keeps the mark small and rectangular so a short pane still fits it", () => {
@@ -30,29 +30,51 @@ describe("describeFusionIntro", () => {
     for (const line of lines) expect(line.length).toBeLessThanOrEqual(30);
   });
 
+  it("draws a tree: the one that plans on top, the ones that do below", () => {
+    // The shape is the explanation. The old mark put two nodes side by
+    // side and labelled them `cloud` and `local`, which stopped being
+    // true the day either seat could hold either kind.
+    const lines = FUSION_MARK.split("\n");
+    expect(lines[0]).toContain("orchestrator");
+    expect(lines[0]).toContain("\u25cf");
+    expect(lines[3]).toContain("workers");
+    expect(lines[3]).toContain("\u25cb");
+    expect(FUSION_MARK).not.toContain("cloud");
+    expect(FUSION_MARK).not.toContain("local");
+  });
+
   it("draws the mark from glyphs the rest of the chrome already uses", () => {
     // Anything outside this set risks a double-width cell, which would
     // shear the mark on the terminals the TUI supports.
-    expect(FUSION_MARK).toMatch(/^[\s●○⇄╭╮╰╯─┤├a-z]+$/);
+    expect(FUSION_MARK).toMatch(/^[\s\u25cf\u25cb\u2502\u250c\u2510\u253c\u2500a-z]+$/);
   });
 
   it("names both legs it actually resolved, not the abstraction", () => {
     const text = describeFusionIntro(rm);
     expect(text).toContain("anthropic/claude-sonnet-4.5");
-    expect(text).toContain("3 × qwen-3.5-4b");
+    expect(text).toContain("qwen-3.5-4b");
   });
 
-  it("says how to pick the two models and how to change the worker count", () => {
+  it("states the width as the orchestrator's call, not a setting", () => {
+    // The count left the composer with v63: the machine sizes the pool
+    // and the orchestrator sizes each fan-out inside it. An intro that
+    // told the operator to go and set a number would be describing a
+    // control that is not there.
     const text = describeFusionIntro(rm);
-    expect(text).toContain("ctrl+r");
-    expect(text).toContain("Workers");
-    expect(text).toContain("/runmode workers N");
-    expect(text).toMatch(/restart the local daemon/);
+    expect(text).toMatch(/not a setting/);
+    expect(text).toMatch(/sizes each fan-out/);
+    expect(text).not.toMatch(/\/runmode workers/);
+  });
+
+  it("says either seat takes either kind, and invites the pairing", () => {
+    const text = describeFusionIntro(rm);
+    expect(text).toMatch(/Either seat takes either kind/);
+    expect(text).toMatch(/local model plans while cloud workers execute/);
+    expect(text).toMatch(/Two cloud models/);
   });
 
   it("says what a worker is and what it cannot do", () => {
     const text = describeFusionIntro(rm);
-    expect(text).toMatch(/in parallel/);
     expect(text).toMatch(/cannot reach you or ask for approval/);
   });
 
@@ -70,6 +92,6 @@ describe("describeFusionIntro", () => {
       workerModel: null,
     });
     expect(text).toContain("openrouter");
-    expect(text).toContain("the local model");
+    expect(text).toContain("local-llama");
   });
 });

--- a/src/tui/run-mode/fusion-intro.ts
+++ b/src/tui/run-mode/fusion-intro.ts
@@ -15,38 +15,44 @@ import type { ResolvedRunMode } from "../../llm/run-mode/index.js";
  * different orchestrator, say) — see `RunModeOrchestrator.setMode`.
  */
 /**
- * The mark that opens the intro: two bodies bound into one core.
+ * The mark that opens the intro: a tree, because that is the shape of
+ * the thing — one model on top deciding, several underneath doing.
  *
- * Built from glyphs the TUI already relies on elsewhere (`●`, `○`, `⇄`
- * and box drawing), so it renders on the same terminals the rest of the
- * chrome does — a fancier mark drawn from block or geometric shapes
- * risks double-width cells, and a mark that reflows is worse than no
- * mark. Four lines: big enough to read as a device, small enough that it
- * does not push the instructions off a short pane.
+ * The old mark drew two nodes side by side labelled `cloud` and
+ * `local`, which stopped being true the day either seat could hold
+ * either kind. Nothing here encodes where a model runs: `●` is the one
+ * that plans, `○` are the ones that execute, and the count is an emblem
+ * rather than a readout — a fan-out sizes itself per job.
+ *
+ * Built from box-drawing and geometric glyphs the TUI already relies on
+ * elsewhere, so it renders on the same terminals the rest of the chrome
+ * does; nothing here is double-width, so it cannot reflow.
  */
 export const FUSION_MARK = [
-  "        ╭───╮",
-  "  ●─────┤ ⇄ ├─────○",
-  "        ╰───╯",
-  "  cloud           local",
+  "        \u25cf  orchestrator",
+  "        \u2502",
+  "   \u250c\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2510",
+  "   \u25cb    \u25cb    \u25cb  workers",
 ].join("\n");
 
 export function describeFusionIntro(rm: ResolvedRunMode): string {
   const orchestrator =
     rm.orchestratorModel ?? rm.orchestratorProviderId ?? "your cloud provider";
-  const worker = rm.workerModel ?? "the local model";
-  const workers = rm.workers;
+  const worker = rm.workerModel ?? rm.workerProviderId ?? "the local model";
   return [
     FUSION_MARK,
     "",
-    "Fusion is on. Two models run this chat: a cloud one that thinks, and local ones that do the bulk.",
+    "Fusion splits the work between two models: one decides, the other does.",
     "",
-    `Orchestrator — ${orchestrator}. It plans, writes the instructions for each part, then reviews and merges what comes back.`,
-    `Workers — ${workers} × ${worker}, on your machine, in parallel. Each takes one self-contained part (reading files, first drafts, boilerplate, tests, searches) and reports back. They cannot reach you or ask for approval; anything that needs a person comes back up to the orchestrator.`,
+    `Right now \u2014 ${orchestrator} plans. It reads enough to choose an approach, breaks the job into self-contained parts, writes the brief for each, then reads what comes back, judges it, and sends anything weak out again.`,
+    `${worker} executes: each worker takes one part and reports. They cannot reach you or ask for approval, so anything needing a person comes back up.`,
     "",
-    "Pick both models with ctrl+r: Provider and Model set the cloud orchestrator, Workers sets the local model and how many run at once.",
-    "Change the count there or with /runmode workers N (1-8). It also sets the llama-server slot count, so restart the local daemon to apply it — without the slots, extra workers just queue.",
+    "How many run at once is not a setting. The orchestrator sizes each fan-out to the job at hand, up to what this machine can serve.",
     "",
-    "/runmode status says what is resolved right now; /runmode cloud or /runmode local leaves fusion.",
+    "Either seat takes either kind, and the pairing is the interesting part. Cloud planning with local workers is the usual one: sharp judgement, cheap bulk. Invert it and a local model plans while cloud workers execute \u2014 your reasoning never leaves the machine and you rent only the lifting. Two cloud models work as well, a careful one directing a fast one; so does a big local model directing a small one.",
+    "",
+    "Worth playing with: a result is only as good as the model that did the work, and only as sensible as the model that planned it. Move that line and the output changes character.",
+    "",
+    "ctrl+r picks both seats \u2014 each row says whether it runs local or in the cloud. /runmode status says what is resolved right now; /runmode cloud or /runmode local leaves fusion.",
   ].join("\n");
 }

--- a/src/tui/run-mode/run-mode-orchestrator.test.ts
+++ b/src/tui/run-mode/run-mode-orchestrator.test.ts
@@ -115,9 +115,7 @@ describe("RunModeOrchestrator.setMode", () => {
     expect(notice).toBeDefined();
     // Not "needs a cloud provider": either leg may be cloud or local
     // now, so what is missing is a second provider, not a kind.
-    expect((notice as { text: string }).text).toMatch(
-      /needs two providers/,
-    );
+    expect((notice as { text: string }).text).toMatch(/needs two providers/);
   });
 
   it("fusion: refuses when the only provider would have to fill both legs", async () => {
@@ -291,5 +289,66 @@ describe("RunModeOrchestrator.setMode", () => {
     expect(app.actions.filter((a) => a.type === "system_message")).toHaveLength(
       0,
     );
+  });
+  it("swap: trades the two legs, and the active provider follows the orchestrator", async () => {
+    seed(BOTH_LEGS);
+    const app = harness();
+    await app.orchestrator.setMode("fusion");
+    expect(getConfig().llm?.runMode?.fusion?.orchestratorProvider).toBe(
+      "openrouter",
+    );
+
+    await app.orchestrator.swapLegs();
+    const fusion = getConfig().llm?.runMode?.fusion;
+    expect(fusion?.orchestratorProvider).toBe("local-llama");
+    expect(fusion?.workerProvider).toBe("openrouter");
+    // The non-contradiction rule: `resolveRunMode` only honours fusion
+    // while the active provider IS the orchestrator, so a swap that
+    // moved the pins alone would drop the mode on the next read.
+    expect(getConfig().llm?.activeTextProvider).toBe("local-llama");
+    expect(app.orchestrator.current().effective).toBe("fusion");
+  });
+
+  it("swap: carries the per-leg model pins across with them", async () => {
+    seed({
+      ...BOTH_LEGS,
+      activeTextProvider: "openrouter",
+    });
+    writeUserConfigFileSync(getUserConfigPath(stateDir), {
+      ...USER_CONFIG_DEFAULTS,
+      llm: {
+        ...BOTH_LEGS,
+        activeTextProvider: "openrouter",
+        runMode: {
+          mode: "fusion",
+          fusion: {
+            orchestratorProvider: "openrouter",
+            workerProvider: "local-llama",
+            orchestratorModel: "cloud-label",
+            workerModel: "local-label",
+          },
+        },
+      },
+    });
+    resetConfigCache();
+    const app = harness();
+    await app.orchestrator.swapLegs();
+    const fusion = getConfig().llm?.runMode?.fusion;
+    // They are per-leg labels. Left where they were, both halves of the
+    // composer would name the side that is no longer there.
+    expect(fusion?.orchestratorModel).toBe("local-label");
+    expect(fusion?.workerModel).toBe("cloud-label");
+  });
+
+  it("swap: refuses in one sentence when the route is not fusion", async () => {
+    seed({ ...BOTH_LEGS, activeTextProvider: "openrouter" });
+    const app = harness();
+    await app.orchestrator.swapLegs();
+    expect(getConfig().llm?.runMode?.fusion).toBeUndefined();
+    expect(
+      app.actions.some(
+        (a) => a.type === "composer_notice" && /swap needs fusion/.test(a.text),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/tui/run-mode/run-mode-orchestrator.test.ts
+++ b/src/tui/run-mode/run-mode-orchestrator.test.ts
@@ -273,7 +273,9 @@ describe("RunModeOrchestrator.setMode", () => {
     await app.orchestrator.setMode("fusion");
     const intro = app.actions.filter((a) => a.type === "system_message");
     expect(intro).toHaveLength(1);
-    expect((intro[0] as { text: string }).text).toContain("Fusion is on.");
+    expect((intro[0] as { text: string }).text).toContain(
+      "Fusion splits the work between two models",
+    );
     // Re-applying fusion (e.g. re-pinning the orchestrator) says nothing.
     app.actions.length = 0;
     await app.orchestrator.setMode("fusion");

--- a/src/tui/run-mode/run-mode-orchestrator.ts
+++ b/src/tui/run-mode/run-mode-orchestrator.ts
@@ -189,6 +189,46 @@ export class RunModeOrchestrator {
   }
 
   /**
+   * Trade the two legs: the orchestrator provider becomes the worker
+   * provider and back. One write, through `setMode`, so the pins and
+   * `llm.activeTextProvider` move together — the active provider must
+   * follow the orchestrator or the next read drops out of fusion.
+   *
+   * The informational model pins ride along. They are per-leg labels
+   * (`orchestratorModel` / `workerModel`), so leaving them where they
+   * were would make both halves of the composer name the wrong side.
+   * The TUI never writes them, but a hand-edited config may.
+   */
+  async swapLegs(): Promise<void> {
+    const resolved = resolveLlmConfig(getConfig());
+    const rm = resolveRunMode(resolved);
+    if (rm.stored !== "fusion") {
+      this.refuse("swap needs fusion — pick it first (`/runmode fusion`)");
+      return;
+    }
+    const orchestrator = rm.orchestratorProviderId;
+    const worker = rm.workerProviderId;
+    if (orchestrator === null || worker === null || orchestrator === worker) {
+      this.refuse(
+        describeRunModeDegradation({
+          reason: "no-second-provider",
+          requested: "fusion",
+        }),
+      );
+      return;
+    }
+    const pinned = resolved.runMode?.fusion;
+    await this.setMode("fusion", {
+      fusion: {
+        orchestratorProvider: worker,
+        workerProvider: orchestrator,
+        orchestratorModel: pinned?.workerModel,
+        workerModel: pinned?.orchestratorModel,
+      },
+    });
+  }
+
+  /**
    * The worker count, and with it the llama-server slot count. A daemon
    * that is already up keeps the slot count it was launched with, so the
    * notice says how to apply the new one — a silent write here would

--- a/src/tui/tui-app.tsx
+++ b/src/tui/tui-app.tsx
@@ -475,6 +475,11 @@ export interface TuiAppCallbacks {
     opts?: import("./persist-run-mode.js").RunModeChangeOptions,
   ): void;
   /**
+   * The composer's `⇄` button / `/runmode swap`: trade the two fusion
+   * legs, so whatever is orchestrating starts executing and back.
+   */
+  onFusionLegsSwapRequested?(): void;
+  /**
    * Fusion's `workers` control / `/runmode workers N`: persist the
    * worker count and the matching llama-server slot count in one write,
    * without changing the mode.

--- a/src/tui/tui-command.ts
+++ b/src/tui/tui-command.ts
@@ -560,6 +560,7 @@ export async function tuiCommand(args: string[]): Promise<number> {
           void orchestrator.runMode.setMode(mode, opts),
         onFusionWorkersChangeRequested: (workers) =>
           orchestrator.runMode.setWorkers(workers),
+        onFusionLegsSwapRequested: () => void orchestrator.runMode.swapLegs(),
         onProvidersSelectChatModel: (providerId, modelId) =>
           void orchestrator.providers.selectChatModel(providerId, modelId),
         onProvidersChatModelPickerRequested: (providerId) =>


### PR DESCRIPTION
## Make fusion actually delegate

Fusion is meant to run in three beats: the orchestrator plans and briefs,
the workers do the job, the orchestrator reviews and sends back what is
weak. Beat 2 never happened — two consecutive sessions ended with the
cloud orchestrator writing every file itself, once overwriting a file a
worker had just written.

**The workers wrote nothing, and the harness is why.** A worker turn has
no operator at the other end, so `worker-runner` installs a refuse
policy; at approval level 1 that refuses *every* write. Six tasks, zero
files, four returning `needs_orchestrator` with replies saying "the
orchestrator must run these steps" — and the gate's handed-up escape
then waved all thirteen of its writes through. The orchestrator was not
ignoring the harness; the harness had made it the only party able to act.

### What this branch does

**One approval per fan-out, and workers that can act.** `fusion.delegate`
asks the operator once, before any worker starts, naming the task titles
and the directory the fan-out will write in. New category
`fusion_fanout`, level 4, deliberately **not** grantable — seeing the
task list is the entire point of asking. Approving it grants each worker
session that directory through a new `FanoutScopeRegistry`, consulted by
`requireFsApproval`, the single funnel every fs and git mutation already
passes through with absolute paths.

**The orchestrator never builds.** Every mutating tool is refused for the
whole orchestrator turn — read, delegate, reply, and nothing else.
Rework goes back out as another fan-out, so `needs_orchestrator` means
"send it again with the path named", not "take over".

**Workers may run commands too.** Half the tasks worth delegating end in
"run the build, run the tests". A command whose `cwd` is inside the
approved directory needs no second permission; the shell guard's
hardline blocks still fire above it.

**One question per turn, not one per fan-out.** A turn is one job: the
orchestrator that reviews and re-delegates ran five fan-outs to build one
library and asked five times. The answer now stands for the rest of the
turn while later fan-outs stay inside the directories it named, and is
dropped at the start of every turn.

**⇄ swaps the legs.** The glyph between the two model names is now a
button: one click puts the local model in charge and sends the cloud one
to the workers, pins and active provider and labels in one config write.
`/runmode swap` is the same move from the keyboard.

Plus, from the same run: a `tasks` argument that arrived as JSON *text*
parses instead of dying on "tasks must be an array", and the worker
timeout goes to 45 minutes — at 1200s a worker that had written four of
its six files was cancelled mid-run and lost the lot.

### Verified

`fusion-r3` on the built binary: orchestrator `os.fs.write` = 0, 9 gate
refusals, workers wrote all 13 files across 5 fan-outs with review in
between. Unit and integration coverage for the scope derivation, the
turn-scoped grant, the gate, shell-within-scope, the tasks-as-string
parse and the swap.

Suite: 9429 passing. One pre-existing failure on `main`
(`src/sidecar/send-message-concurrency.test.ts` — a third turn `m3`
leaks past the per-session controller); it fails identically on
`origin/main` and is unrelated to this branch.
